### PR TITLE
feat: parallel pool execution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,7 @@ All artifacts live under `<experiment-root>/workspace/` (gitignored). When no `-
 | `runs/<run>/cluster/{package}/*.yaml` | `prepare.py` Phase 4 | `deploy.py` |
 | `runs/<run>/run_summary.md` | `prepare.py` Phase 5 | human review |
 | `runs/<run>/results/{phase}/` | `deploy.py collect` | `/sim2real-analyze` skill |
+| `runs/<run>/progress.json` | `deploy.py run` | `deploy.py status` |
 | `context/{scenario}/{hash}.md` | `prepare.py` Phase 2 | `prepare.py` Phase 2 (cache) |
 
 ## Development

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -134,7 +134,21 @@ python pipeline/deploy.py collect [--package NAME…]
 
 **`deploy.py run`** — assigns `(workload, package)` pairs to free namespace slots, polls for completion, collects results inline, and retries pairs that time out. Reads `progress.json` to resume interrupted runs. Requires `prepare.py --mode parallel`.
 
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--only PAIR` | — | Reset and run one specific pair key |
+| `--workload NAME` | — | Reset pairs matching this workload |
+| `--package NAME` | — | Reset pairs matching this package |
+| `--status STATE` | — | Reset pairs with this status (e.g. `failed`, `timed-out`) |
+| `--max-retries N` | 2 | Max retries for timed-out pairs |
+| `--poll-interval N` | 30 | Seconds between status polls |
+
 **`deploy.py status`** — prints the current state of all pairs from `workspace/runs/<run>/progress.json`.
+
+| Flag | Description |
+|------|-------------|
+| `--workload NAME` | Filter by workload name |
+| `--package NAME` | Filter by package name |
 
 **`deploy.py collect`** — extracts results from the cluster PVC and writes to `workspace/runs/<run>/results/{phase}/<workload>/`.
 

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -68,7 +68,7 @@ Writes `workspace/setup_config.json` and `workspace/runs/<run>/run_metadata.json
 6-phase state machine. Re-running skips completed phases.
 
 ```bash
-python pipeline/prepare.py [--force] [--rebuild-context] [--manifest PATH] [--run NAME]
+python pipeline/prepare.py [--force] [--rebuild-context] [--manifest PATH] [--run NAME] [--mode parallel|sequential]
 ```
 
 | Phase | Name | Skippable |
@@ -136,7 +136,7 @@ python pipeline/deploy.py collect [--package NAME…]
 
 **`deploy.py status`** — prints the current state of all pairs from `workspace/runs/<run>/progress.json`.
 
-**`deploy.py collect`** — polls PipelineRun status, extracts results from the cluster PVC, and writes to `workspace/runs/<run>/results/{baseline,treatment}/<workload>/`.
+**`deploy.py collect`** — extracts results from the cluster PVC and writes to `workspace/runs/<run>/results/{phase}/<workload>/`.
 
 ---
 

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -44,6 +44,7 @@ python pipeline/setup.py [flags]
 | Flag | Env var | Default |
 |------|---------|---------|
 | `--namespace NS` | `NAMESPACE` | interactive |
+| `--namespaces NS1,NS2,...` | — | — |
 | `--hf-token TOKEN` | `HF_TOKEN` | interactive |
 | `--registry REG` | — | interactive |
 | `--registry-user USER` | `QUAY_ROBOT_USERNAME` | interactive |
@@ -51,6 +52,8 @@ python pipeline/setup.py [flags]
 | `--run NAME` | — | `sim2real-YYYY-MM-DD` |
 | `--no-cluster` | — | false |
 | `--redeploy-tasks` | — | false |
+
+**`--namespaces NS1,NS2,...`** — provision multiple namespace slots for parallel pool execution. Each slot is bootstrapped identically to a single `--namespace`.
 
 **`--no-cluster`** — generates `setup_config.json` without touching the cluster; useful when cluster access comes later.
 
@@ -94,6 +97,10 @@ python pipeline/prepare.py validate-assembly   # run assembly checks standalone
 
 **`--rebuild-context`** — ignores SHA cache and re-assembles context.
 
+**`--mode parallel`** (default) — generates one shared Pipeline + one PipelineRun per `(workload, package)` pair; required for `deploy.py run`.
+
+**`--mode sequential`** — preserves legacy single-experiment pipeline behavior (one Pipeline + one PipelineRun for the whole run).
+
 Phase state is tracked per-run in `workspace/runs/<run>/.state.json`. Delete it (or use `--force`) to reset.
 
 ---
@@ -117,13 +124,19 @@ python pipeline/deploy.py [flags]
 
 **`--skip-build-epp`** — skips the image build; use when resubmitting after a failed PipelineRun without changing the scorer.
 
-**Collect results:**
+**Subcommands:**
 
 ```bash
+python pipeline/deploy.py run     [flags]   # orchestrate parallel pool execution across namespace slots
+python pipeline/deploy.py status            # show progress snapshot of all (workload, package) pairs
 python pipeline/deploy.py collect [--package NAME…]
 ```
 
-Polls PipelineRun status, extracts results from the cluster PVC, and writes to `workspace/runs/<run>/results/{baseline,treatment}/<workload>/`.
+**`deploy.py run`** — assigns `(workload, package)` pairs to free namespace slots, polls for completion, collects results inline, and retries pairs that time out. Reads `progress.json` to resume interrupted runs. Requires `prepare.py --mode parallel`.
+
+**`deploy.py status`** — prints the current state of all pairs from `workspace/runs/<run>/progress.json`.
+
+**`deploy.py collect`** — polls PipelineRun status, extracts results from the cluster PVC, and writes to `workspace/runs/<run>/results/{baseline,treatment}/<workload>/`.
 
 ---
 
@@ -175,6 +188,16 @@ context:
 ```
 
 All paths are relative to the repo root and validated at Phase 1.
+
+---
+
+## Parallel Pool Execution
+
+`setup.py --namespaces NS1,NS2,...` provisions N namespace slots, each bootstrapped identically. `prepare.py` (default `--mode parallel`) generates one shared Tekton Pipeline plus one PipelineRun per `(workload, package)` pair. `deploy.py run` orchestrates execution by assigning pairs to free slots, polling for completion, collecting results inline, and retrying on timeout. `deploy.py status` reads `workspace/runs/<run>/progress.json` and prints the current state of every pair.
+
+| Artifact | Written by | Read by |
+|----------|-----------|---------|
+| `runs/<run>/progress.json` | `deploy.py run` | `deploy.py status` |
 
 ---
 

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -436,12 +436,18 @@ def _fmt_size(b: int) -> str:
 
 def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
                               run_dir: Path,
-                              skip_logs: bool = False) -> dict[str, "Exception | None"]:
+                              skip_logs: bool = False,
+                              workload: "str | None" = None) -> dict[str, "Exception | None"]:
     """Extract results for one or more phases from data-pvc using a single pod.
 
     Data layout on PVC (written by run-workload-blis-observe):
       /data/{runName}/{phase}/{workloadName}/trace_header.yaml
       /data/{runName}/{phase}/{workloadName}/trace_data.csv
+
+    When *workload* is set, only that workload's subdirectory is copied for
+    each phase (used by inline collection during parallel pool execution).
+    When *workload* is None (default), the entire phase directory is copied
+    (used by `deploy.py collect` for bulk collection).
 
     When *skip_logs* is True, only trace files are copied (skipping vLLM and
     EPP log files which typically account for the bulk of the data).
@@ -508,38 +514,56 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
                 # Selective copy: trace files + epp_logs via kubectl cp per
                 # workload; skips vLLM server_logs which dominate data volume.
                 # BusyBox tar doesn't handle large streaming well, so use cp.
-                list_result = run(
-                    ["kubectl", "exec", pod_name, f"-n={namespace}", "--",
-                     "sh", "-c",
-                     f"ls /data/{run_name}/{phase}/"],
-                    check=False, capture=True,
-                )
-                if list_result.returncode != 0:
-                    errors[phase] = RuntimeError(
-                        f"failed to list workloads: {list_result.stderr.strip()}")
-                    continue
-                workloads = list_result.stdout.strip().split() if list_result.stdout.strip() else []
+                if workload:
+                    wl_names = [workload]
+                else:
+                    list_result = run(
+                        ["kubectl", "exec", pod_name, f"-n={namespace}", "--",
+                         "sh", "-c",
+                         f"ls /data/{run_name}/{phase}/"],
+                        check=False, capture=True,
+                    )
+                    if list_result.returncode != 0:
+                        errors[phase] = RuntimeError(
+                            f"failed to list workloads: {list_result.stderr.strip()}")
+                        continue
+                    wl_names = list_result.stdout.strip().split() if list_result.stdout.strip() else []
                 phase_errors = []
-                for workload in workloads:
-                    wl_dest = dest_dir / workload
+                for wl_name in wl_names:
+                    wl_dest = dest_dir / wl_name
                     wl_dest.mkdir(parents=True, exist_ok=True)
                     # Copy trace files
                     for fname in ("trace_data.csv", "trace_header.yaml", "epp_stream_done"):
-                        src = f"{namespace}/{pod_name}:/data/{run_name}/{phase}/{workload}/{fname}"
+                        src = f"{namespace}/{pod_name}:/data/{run_name}/{phase}/{wl_name}/{fname}"
                         r = run(["kubectl", "cp", src, str(wl_dest / fname), "--retries=3"],
                                 check=False, capture=True)
                         if r.returncode != 0 and "no such file" not in r.stderr.lower():
-                            phase_errors.append(f"{workload}/{fname}: {r.stderr.strip()}")
+                            phase_errors.append(f"{wl_name}/{fname}: {r.stderr.strip()}")
                     # Copy epp_logs directory
-                    epp_src = f"{namespace}/{pod_name}:/data/{run_name}/{phase}/{workload}/epp_logs/"
+                    epp_src = f"{namespace}/{pod_name}:/data/{run_name}/{phase}/{wl_name}/epp_logs/"
                     epp_dest = wl_dest / "epp_logs"
                     epp_dest.mkdir(exist_ok=True)
                     r = run(["kubectl", "cp", epp_src, str(epp_dest), "--retries=3"],
                             check=False, capture=True)
                     if r.returncode != 0 and "no such file" not in r.stderr.lower():
-                        phase_errors.append(f"{workload}/epp_logs: {r.stderr.strip()}")
+                        phase_errors.append(f"{wl_name}/epp_logs: {r.stderr.strip()}")
                 if phase_errors:
                     errors[phase] = RuntimeError("; ".join(phase_errors))
+                else:
+                    errors[phase] = None
+            elif workload:
+                # Workload-scoped full copy: only this workload's subdirectory.
+                wl_dest = dest_dir / workload
+                wl_dest.mkdir(parents=True, exist_ok=True)
+                result = run(
+                    ["kubectl", "cp",
+                     f"{namespace}/{pod_name}:/data/{run_name}/{phase}/{workload}/",
+                     str(wl_dest), "--retries=3"],
+                    check=False, capture=True,
+                )
+                if result.returncode != 0:
+                    errors[phase] = RuntimeError(
+                        f"kubectl cp failed: {result.stderr.strip()}")
                 else:
                     errors[phase] = None
             else:
@@ -732,6 +756,7 @@ def _collect_pair(pair_key: str, entry: dict, run_dir: Path) -> bool:
     """Collect results for a completed pair inline. Returns True on success."""
     namespace = entry.get("namespace", "")
     package = entry.get("package", "")
+    wl_name = entry.get("workload", "")
     run_name = run_dir.name
 
     if not namespace or not package:
@@ -744,6 +769,7 @@ def _collect_pair(pair_key: str, entry: dict, run_dir: Path) -> bool:
             namespace=namespace,
             run_dir=run_dir,
             skip_logs=False,
+            workload=wl_name or None,
         )
         return errors.get(package) is None
     except RuntimeError as e:

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -490,9 +490,7 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
         # ── Copy ────────────────────────────────────────────────────────
         for phase in phases:
             dest_dir = run_dir / "results" / phase
-            if dest_dir.exists():
-                shutil.rmtree(dest_dir)
-            dest_dir.mkdir(parents=True)
+            dest_dir.mkdir(parents=True, exist_ok=True)
 
             if skip_logs:
                 # Selective copy: trace files + epp_logs via kubectl cp per
@@ -802,19 +800,23 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                 entry["status"] = "pending"
         elif entry["status"] == "collecting":
             result_dir = run_dir / "results" / entry.get("package", "")
-            entry["status"] = "done" if result_dir.exists() else "running"
+            if result_dir.exists():
+                entry["status"] = "done"
+            else:
+                entry["status"] = "pending"
+                entry["namespace"] = None
     store.save(progress)
 
-    # Apply shared Pipeline (if present) to the primary namespace
+    # Apply shared Pipeline (if present) to ALL namespaces
     pipeline_yaml = next(cluster_dir.glob("sim2real-*.yaml"), None)
     if pipeline_yaml:
-        ns_primary = namespaces[0]
-        r = run(["kubectl", "apply", "-f", str(pipeline_yaml), "-n", ns_primary],
-                check=False, capture=True)
-        if r.returncode == 0:
-            ok(f"Applied shared Pipeline: {pipeline_yaml.name}")
-        else:
-            warn(f"Could not apply shared Pipeline: {r.stderr.strip()}")
+        for _ns in namespaces:
+            r = run(["kubectl", "apply", "-f", str(pipeline_yaml), "-n", _ns],
+                    check=False, capture=True)
+            if r.returncode == 0:
+                ok(f"Applied shared Pipeline to {_ns}: {pipeline_yaml.name}")
+            else:
+                warn(f"Could not apply shared Pipeline to {_ns}: {r.stderr.strip()}")
 
     # Track which namespace is assigned to which pair
     slots_busy: dict[str, str] = {
@@ -858,7 +860,9 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                 else:
                     warn(f"[{pair_key}] {entry['status']}")
 
-            elif status in ("Failed", "PipelineRunCancelled", "PipelineRunCouldntGetPipeline"):
+            elif status in ("Failed", "PipelineRunCancelled", "PipelineRunCouldntGetPipeline",
+                            "PipelineRunTimeout", "CreateRunFailed", "PipelineRunStopping",
+                            "PipelineRunStoppingTimeout"):
                 warn(f"[{pair_key}] hard failure ({status}) → failed")
                 entry["status"] = "failed"
                 entry["namespace"] = None
@@ -921,6 +925,11 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                     yaml.dump(pr_data, tf, default_flow_style=False)
                     tf_path = tf.name
                 pr_name = pr_data.get("metadata", {}).get("name", "")
+                # Delete any prior completed/failed PipelineRun before re-applying
+                if pr_name:
+                    run(["kubectl", "delete", "pipelinerun", pr_name, f"-n={ns}",
+                         "--ignore-not-found=true"],
+                        check=False, capture=True)
                 result = run(["kubectl", "apply", "-f", tf_path, "-n", ns],
                              check=False, capture=True)
             finally:

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -339,6 +339,49 @@ def _cmd_deploy(args, manifest: dict, run_dir: Path, setup_config: dict):
     _print_status(submitted, namespace)
 
 
+# ── Status command ───────────────────────────────────────────────────────────
+
+def _cmd_status(args, progress_path: Path) -> None:
+    """Print a snapshot table of all (workload, package) pair statuses."""
+    from pipeline.lib.progress import LocalProgressStore
+    store = LocalProgressStore(progress_path)
+    progress = store.load()
+
+    # Apply filters
+    pairs = dict(progress)
+    if getattr(args, "workload", None):
+        pairs = {k: v for k, v in pairs.items() if v.get("workload") == args.workload}
+    if getattr(args, "package", None):
+        pairs = {k: v for k, v in pairs.items() if v.get("package") == args.package}
+
+    if not pairs:
+        print("  0 pairs" + (" (no progress file)" if not progress_path.exists() else ""))
+        return
+
+    pair_w = max(len(k) for k in pairs) + 2
+    col_status = 12
+    col_slot = 14
+    col_retries = 7
+
+    header = (f"{'PAIR':<{pair_w}} {'STATUS':<{col_status}} {'SLOT':<{col_slot}} {'RETRIES':<{col_retries}}")
+    print()
+    print(header)
+    print("-" * len(header))
+
+    counts: dict[str, int] = {}
+    for key, entry in sorted(pairs.items()):
+        status = entry.get("status", "unknown")
+        slot = entry.get("namespace") or "—"
+        retries = entry.get("retries", 0)
+        counts[status] = counts.get(status, 0) + 1
+        print(f"{key:<{pair_w}} {status:<{col_status}} {slot:<{col_slot}} {retries}")
+
+    print()
+    summary_parts = [f"{v} {k}" for k, v in sorted(counts.items())]
+    print(f"  {len(pairs)} pairs: " + "  ".join(summary_parts))
+    print()
+
+
 # ── Collect command ──────────────────────────────────────────────────────────
 
 def _check_pipelinerun_status(pr_name: str, namespace: str) -> str:
@@ -619,6 +662,12 @@ Examples:
     collect_p.add_argument("--skip-logs", action="store_true", dest="skip_logs",
                            help="Skip vLLM and EPP log files, collect only traces")
 
+    status_p = sub.add_parser("status", help="Show progress of all (workload, package) pairs")
+    status_p.add_argument("--workload", metavar="NAME", help="Filter by workload name")
+    status_p.add_argument("--package",  metavar="NAME", help="Filter by package name")
+    status_p.add_argument("--live", action="store_true",
+                          help="Add CURRENT TASK column for running pairs (kubectl call per slot)")
+
     return p
 
 
@@ -649,7 +698,10 @@ def main():
         sys.exit(1)
 
     cmd = args.command
-    if cmd == "collect":
+    if cmd == "status":
+        progress_path = run_dir / "progress.json"
+        _cmd_status(args, progress_path)
+    elif cmd == "collect":
         _cmd_collect(args, manifest, run_dir, setup_config)
     else:
         _cmd_deploy(args, manifest, run_dir, setup_config)

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -298,24 +298,36 @@ def _cmd_deploy(args, manifest: dict, run_dir: Path, setup_config: dict):
 
     # Apply Pipeline definitions first so PipelineRuns can reference them
     step(2, "Apply Pipeline Definitions")
-    for pkg in sorted(packages):
-        # Apply all Pipeline YAMLs in the package dir (both raw compiled and sequential wrapper)
-        pipeline_yamls = [
-            cluster_dir / pkg / f"{pkg}-pipeline.yaml",
-            cluster_dir / pkg / f"sim2real-{pkg}-pipeline.yaml",
-        ]
-        applied_any = False
-        for pipeline_yaml in pipeline_yamls:
-            if pipeline_yaml.exists() and not pipeline_yaml.read_text().startswith("#"):
-                result = run(["kubectl", "apply", "-f", str(pipeline_yaml), "-n", namespace],
-                             check=False, capture=True)
-                if result.returncode != 0:
-                    err(f"kubectl apply failed for {pipeline_yaml.name}: {result.stderr}")
-                    sys.exit(1)
-                ok(f"Applied: {pipeline_yaml.name}")
-                applied_any = True
-        if not applied_any:
-            warn(f"No Pipeline definition for {pkg} — PipelineRuns may fail")
+    shared_pipelines = [p for p in cluster_dir.glob("sim2real-*.yaml")
+                        if not p.read_text().startswith("#")]
+    if shared_pipelines:
+        # Parallel layout: one shared Pipeline at cluster/sim2real-{run}.yaml
+        for pipeline_yaml in shared_pipelines:
+            result = run(["kubectl", "apply", "-f", str(pipeline_yaml), "-n", namespace],
+                         check=False, capture=True)
+            if result.returncode != 0:
+                err(f"kubectl apply failed for {pipeline_yaml.name}: {result.stderr}")
+                sys.exit(1)
+            ok(f"Applied: {pipeline_yaml.name}")
+    else:
+        # Sequential layout: Pipeline YAML lives inside each package subdirectory
+        for pkg in sorted(packages):
+            pipeline_yamls = [
+                cluster_dir / pkg / f"{pkg}-pipeline.yaml",
+                cluster_dir / pkg / f"sim2real-{pkg}-pipeline.yaml",
+            ]
+            applied_any = False
+            for pipeline_yaml in pipeline_yamls:
+                if pipeline_yaml.exists() and not pipeline_yaml.read_text().startswith("#"):
+                    result = run(["kubectl", "apply", "-f", str(pipeline_yaml), "-n", namespace],
+                                 check=False, capture=True)
+                    if result.returncode != 0:
+                        err(f"kubectl apply failed for {pipeline_yaml.name}: {result.stderr}")
+                        sys.exit(1)
+                    ok(f"Applied: {pipeline_yaml.name}")
+                    applied_any = True
+            if not applied_any:
+                warn(f"No Pipeline definition for {pkg} — PipelineRuns may fail")
 
     # Submit packages
     step(3, "Submit PipelineRuns")

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1036,8 +1036,6 @@ Examples:
     status_p = sub.add_parser("status", help="Show progress of all (workload, package) pairs")
     status_p.add_argument("--workload", metavar="NAME", help="Filter by workload name")
     status_p.add_argument("--package",  metavar="NAME", help="Filter by package name")
-    status_p.add_argument("--live", action="store_true",
-                          help="Add CURRENT TASK column for running pairs (kubectl call per slot)")
 
     run_p = sub.add_parser("run", help="Orchestrate parallel pool execution")
     run_p.add_argument("--only",         metavar="PAIR",  help="Reset and run one specific pair key")

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -693,6 +693,9 @@ def _check_slot_ready(namespace: str) -> tuple[bool, list[str]]:
 
     Checks: PVCs bound, HF secret present.
     Returns (ready, list_of_failure_reasons).
+
+    Note: Tekton tasks presence check is not yet implemented; assumes
+    ``setup.py`` has been run.
     """
     failures = []
 
@@ -912,14 +915,17 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                 if param["name"] == "namespace":
                     param["value"] = ns
 
-            with _tmp.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as tf:
-                yaml.dump(pr_data, tf, default_flow_style=False)
-                tf_path = tf.name
-
-            pr_name = pr_data.get("metadata", {}).get("name", "")
-            result = run(["kubectl", "apply", "-f", tf_path, "-n", ns],
-                         check=False, capture=True)
-            Path(tf_path).unlink(missing_ok=True)
+            tf_path = None
+            try:
+                with _tmp.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as tf:
+                    yaml.dump(pr_data, tf, default_flow_style=False)
+                    tf_path = tf.name
+                pr_name = pr_data.get("metadata", {}).get("name", "")
+                result = run(["kubectl", "apply", "-f", tf_path, "-n", ns],
+                             check=False, capture=True)
+            finally:
+                if tf_path:
+                    Path(tf_path).unlink(missing_ok=True)
 
             if result.returncode != 0:
                 warn(f"[{pair_key}] kubectl apply failed: {result.stderr.strip()}")

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -626,6 +626,324 @@ def _cmd_collect(args, manifest: dict, run_dir: Path, setup_config: dict):
     print()
 
 
+# ── Run helpers ─────────────────────────────────────────────────────────────
+
+def _load_pairs(cluster_dir: Path) -> dict:
+    """Discover all (workload, package) pairs from cluster/wl-*-*/ directories.
+
+    Returns dict keyed by pair name ("wl-{workload}-{package}") with metadata.
+    """
+    pairs = {}
+    if not cluster_dir.exists():
+        return pairs
+    for pair_dir in sorted(cluster_dir.iterdir()):
+        if not pair_dir.is_dir() or not pair_dir.name.startswith("wl-"):
+            continue
+        prs = list(pair_dir.glob("pipelinerun-*.yaml"))
+        if not prs:
+            continue
+        pr_path = prs[0]
+        try:
+            pr_data = yaml.safe_load(pr_path.read_text())
+        except Exception:
+            continue
+        pr_name = pr_data.get("metadata", {}).get("name", pr_path.stem)
+        params = {p["name"]: p["value"] for p in pr_data.get("spec", {}).get("params", [])}
+        workload = params.get("workloadName", "")
+        package = params.get("phase", "")
+        pairs[pair_dir.name] = {
+            "workload": workload,
+            "package": package,
+            "pr_name": pr_name,
+            "pr_path": str(pr_path),
+            "namespace": pr_data.get("metadata", {}).get("namespace", ""),
+        }
+    return pairs
+
+
+def _apply_run_filters(progress: dict, args) -> set:
+    """Return the set of pair keys that should be reset to 'pending'.
+
+    With no flags: returns empty set (resume — don't reset anything).
+    With flags: returns matching pairs.
+    """
+    only = getattr(args, "only", None)
+    workload = getattr(args, "workload", None)
+    package = getattr(args, "package", None)
+    status_filter = getattr(args, "status", None)
+
+    if only:
+        return {only} if only in progress else set()
+
+    if not any([workload, package, status_filter]):
+        return set()
+
+    candidates = set(progress.keys())
+    if workload:
+        candidates = {k for k in candidates if progress[k].get("workload") == workload}
+    if package:
+        candidates = {k for k in candidates if progress[k].get("package") == package}
+    if status_filter:
+        candidates = {k for k in candidates if progress[k].get("status") == status_filter}
+    return candidates
+
+
+def _check_slot_ready(namespace: str) -> tuple[bool, list[str]]:
+    """Check that a namespace slot is ready to accept a new PipelineRun.
+
+    Checks: PVCs bound, HF secret present.
+    Returns (ready, list_of_failure_reasons).
+    """
+    failures = []
+
+    for pvc in ["model-pvc", "data-pvc"]:
+        result = run(
+            ["kubectl", "get", "pvc", pvc, f"-n={namespace}",
+             "-o", "jsonpath={.status.phase}"],
+            check=False, capture=True,
+        )
+        if result.returncode != 0 or result.stdout.strip() != "Bound":
+            failures.append(f"PVC {pvc} not Bound in {namespace}")
+
+    result = run(
+        ["kubectl", "get", "secret", "hf-secret", f"-n={namespace}"],
+        check=False, capture=True,
+    )
+    if result.returncode != 0:
+        failures.append(f"Secret hf-secret missing in {namespace}")
+
+    return len(failures) == 0, failures
+
+
+def _collect_pair(pair_key: str, entry: dict, run_dir: Path) -> bool:
+    """Collect results for a completed pair inline. Returns True on success."""
+    namespace = entry.get("namespace", "")
+    package = entry.get("package", "")
+    run_name = run_dir.name
+
+    if not namespace or not package:
+        return False
+
+    try:
+        errors = _extract_phases_from_pvc(
+            phases=[package],
+            run_name=run_name,
+            namespace=namespace,
+            run_dir=run_dir,
+            skip_logs=False,
+        )
+        return errors.get(package) is None
+    except RuntimeError as e:
+        warn(f"Collection failed for {pair_key}: {e}")
+        return False
+
+
+def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
+    """Orchestrate parallel pool execution across namespace slots."""
+    import datetime as _dt
+    import tempfile as _tmp
+    from pipeline.lib.progress import LocalProgressStore
+
+    namespaces = setup_config.get("namespaces") or [setup_config.get("namespace", "")]
+    if not namespaces or not namespaces[0]:
+        err("No namespaces configured. Run setup.py with --namespaces."); sys.exit(1)
+
+    max_retries = getattr(args, "max_retries", 2)
+    poll_interval = getattr(args, "poll_interval", 30)
+
+    cluster_dir = run_dir / "cluster"
+    progress_path = run_dir / "progress.json"
+    store = LocalProgressStore(progress_path)
+
+    # Load or initialize progress
+    progress = store.load()
+    discovered = _load_pairs(cluster_dir)
+    if not discovered:
+        err("No pairs found in cluster/. Run prepare.py first."); sys.exit(1)
+
+    # Initialize new entries (first run or new pairs added)
+    for key, meta in discovered.items():
+        if key not in progress:
+            progress[key] = {
+                "workload": meta["workload"],
+                "package":  meta["package"],
+                "status":   "pending",
+                "namespace": None,
+                "retries":  0,
+            }
+
+    # Apply re-run filters — reset matched pairs to pending
+    to_reset = _apply_run_filters(progress, args)
+    for key in to_reset:
+        if key in progress:
+            progress[key]["status"] = "pending"
+            progress[key]["namespace"] = None
+    if to_reset:
+        store.save(progress)
+        info(f"Reset {len(to_reset)} pair(s) to pending")
+
+    # Reconcile 'running' entries against actual cluster state on resume
+    for key, entry in progress.items():
+        if entry["status"] == "running":
+            pr_meta = discovered.get(key, {})
+            pr_name = pr_meta.get("pr_name", "")
+            ns = entry.get("namespace") or ""
+            if pr_name and ns:
+                actual = _check_pipelinerun_status(pr_name, ns)
+                if actual == "Succeeded":
+                    entry["status"] = "collecting"
+                elif actual in ("Failed", "PipelineRunCancelled"):
+                    entry["status"] = "failed"
+                # If still "Running"/"Started", leave as "running" — will be monitored
+            else:
+                entry["status"] = "pending"
+        elif entry["status"] == "collecting":
+            result_dir = run_dir / "results" / entry.get("package", "")
+            entry["status"] = "done" if result_dir.exists() else "running"
+    store.save(progress)
+
+    # Apply shared Pipeline (if present) to the primary namespace
+    pipeline_yaml = next(cluster_dir.glob("sim2real-*.yaml"), None)
+    if pipeline_yaml:
+        ns_primary = namespaces[0]
+        r = run(["kubectl", "apply", "-f", str(pipeline_yaml), "-n", ns_primary],
+                check=False, capture=True)
+        if r.returncode == 0:
+            ok(f"Applied shared Pipeline: {pipeline_yaml.name}")
+        else:
+            warn(f"Could not apply shared Pipeline: {r.stderr.strip()}")
+
+    # Track which namespace is assigned to which pair
+    slots_busy: dict[str, str] = {
+        entry["namespace"]: key
+        for key, entry in progress.items()
+        if entry["status"] == "running" and entry.get("namespace")
+    }
+
+    def _pending_pairs() -> list[str]:
+        return [k for k, v in progress.items() if v["status"] == "pending"]
+
+    def _work_remaining() -> bool:
+        return any(v["status"] in ("pending", "running", "collecting")
+                   for v in progress.values())
+
+    timeout_hours = 4
+    info(f"Orchestrator: {len(discovered)} pairs, {len(namespaces)} slot(s)")
+
+    while _work_remaining() or slots_busy:
+
+        # ── Process completed/failed slots ───────────────────────────────
+        for ns in list(slots_busy):
+            pair_key = slots_busy[ns]
+            entry = progress[pair_key]
+            pr_meta = discovered.get(pair_key, {})
+            pr_name = pr_meta.get("pr_name", "")
+
+            status = _check_pipelinerun_status(pr_name, ns) if pr_name else "Unknown"
+
+            if status == "Succeeded":
+                info(f"[{pair_key}] Succeeded → collecting")
+                entry["status"] = "collecting"
+                store.save(progress)
+                ok_collect = _collect_pair(pair_key, entry, run_dir)
+                entry["status"] = "done" if ok_collect else "collect-failed"
+                entry["namespace"] = None
+                store.save(progress)
+                del slots_busy[ns]
+                if ok_collect:
+                    ok(f"[{pair_key}] {entry['status']}")
+                else:
+                    warn(f"[{pair_key}] {entry['status']}")
+
+            elif status in ("Failed", "PipelineRunCancelled", "PipelineRunCouldntGetPipeline"):
+                warn(f"[{pair_key}] hard failure ({status}) → failed")
+                entry["status"] = "failed"
+                entry["namespace"] = None
+                store.save(progress)
+                del slots_busy[ns]
+
+            elif status in ("Running", "Started"):
+                # Check for timeout
+                ts_result = run(
+                    ["kubectl", "get", "pipelinerun", pr_name, f"-n={ns}",
+                     "-o", "jsonpath={.metadata.creationTimestamp}"],
+                    check=False, capture=True,
+                )
+                if ts_result.returncode == 0 and ts_result.stdout.strip():
+                    try:
+                        created = _dt.datetime.fromisoformat(
+                            ts_result.stdout.strip().replace("Z", "+00:00"))
+                        age_h = (_dt.datetime.now(_dt.timezone.utc) - created).total_seconds() / 3600
+                        if age_h > timeout_hours:
+                            retries = entry.get("retries", 0)
+                            _cancel_and_delete_pipelinerun(pr_name, ns)
+                            if retries < max_retries:
+                                warn(f"[{pair_key}] timed out → requeue (attempt {retries + 1}/{max_retries})")
+                                entry["status"] = "pending"
+                                entry["retries"] = retries + 1
+                            else:
+                                warn(f"[{pair_key}] timed out, max retries → timed-out")
+                                entry["status"] = "timed-out"
+                            entry["namespace"] = None
+                            del slots_busy[ns]
+                            store.save(progress)
+                    except ValueError:
+                        pass
+
+        # ── Assign pending work to free slots ────────────────────────────
+        free_slots = [ns for ns in namespaces if ns not in slots_busy]
+        for ns, pair_key in zip(free_slots, _pending_pairs()):
+            ready, reasons = _check_slot_ready(ns)
+            if not ready:
+                warn(f"Slot {ns} not ready: {'; '.join(reasons)}")
+                continue
+
+            entry = progress[pair_key]
+            pr_meta = discovered.get(pair_key, {})
+            pr_path_str = pr_meta.get("pr_path", "")
+            if not pr_path_str:
+                warn(f"No PipelineRun path for {pair_key}"); continue
+
+            pr_data = yaml.safe_load(Path(pr_path_str).read_text())
+
+            # Rewrite namespace in the PipelineRun before applying
+            pr_data["metadata"]["namespace"] = ns
+            for param in pr_data.get("spec", {}).get("params", []):
+                if param["name"] == "namespace":
+                    param["value"] = ns
+
+            with _tmp.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as tf:
+                yaml.dump(pr_data, tf, default_flow_style=False)
+                tf_path = tf.name
+
+            pr_name = pr_data.get("metadata", {}).get("name", "")
+            result = run(["kubectl", "apply", "-f", tf_path, "-n", ns],
+                         check=False, capture=True)
+            Path(tf_path).unlink(missing_ok=True)
+
+            if result.returncode != 0:
+                warn(f"[{pair_key}] kubectl apply failed: {result.stderr.strip()}")
+                continue
+
+            entry["status"] = "running"
+            entry["namespace"] = ns
+            slots_busy[ns] = pair_key
+            store.save(progress)
+            ok(f"[{pair_key}] → {ns} ({pr_name})")
+
+        if _work_remaining() or slots_busy:
+            time.sleep(poll_interval)
+
+    # Final summary
+    counts: dict[str, int] = {}
+    for v in progress.values():
+        counts[v["status"]] = counts.get(v["status"], 0) + 1
+    print()
+    ok("Run complete: " + "  ".join(f"{v} {k}" for k, v in sorted(counts.items())))
+    print(f"  Progress: {progress_path}")
+    print()
+
+
 # ── CLI ──────────────────────────────────────────────────────────────────────
 
 def build_parser() -> argparse.ArgumentParser:
@@ -668,6 +986,16 @@ Examples:
     status_p.add_argument("--live", action="store_true",
                           help="Add CURRENT TASK column for running pairs (kubectl call per slot)")
 
+    run_p = sub.add_parser("run", help="Orchestrate parallel pool execution")
+    run_p.add_argument("--only",         metavar="PAIR",  help="Reset and run one specific pair key")
+    run_p.add_argument("--workload",     metavar="NAME",  help="Reset pairs matching this workload")
+    run_p.add_argument("--package",      metavar="NAME",  help="Reset pairs matching this package")
+    run_p.add_argument("--status",       metavar="STATE", help="Reset pairs with this status (e.g. failed, timed-out)")
+    run_p.add_argument("--max-retries",  type=int, default=2, dest="max_retries",
+                       help="Max retries for timed-out pairs [2]")
+    run_p.add_argument("--poll-interval", type=int, default=30, dest="poll_interval",
+                       help="Seconds between status polls [30]")
+
     return p
 
 
@@ -698,7 +1026,9 @@ def main():
         sys.exit(1)
 
     cmd = args.command
-    if cmd == "status":
+    if cmd == "run":
+        _cmd_run(args, run_dir, setup_config)
+    elif cmd == "status":
         progress_path = run_dir / "progress.json"
         _cmd_status(args, progress_path)
     elif cmd == "collect":

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -8,7 +8,6 @@ Use `deploy.py collect` to pull results for completed packages.
 import argparse
 import json
 import os
-import shutil
 import subprocess
 import sys
 import time

--- a/pipeline/lib/progress.py
+++ b/pipeline/lib/progress.py
@@ -1,6 +1,7 @@
 """Progress persistence for the parallel pool orchestrator."""
 from __future__ import annotations
 import json
+import tempfile
 from abc import ABC, abstractmethod
 from pathlib import Path
 
@@ -22,10 +23,18 @@ class LocalProgressStore(ProgressStore):
     def load(self) -> dict:
         if not self._path.exists():
             return {}
-        return json.loads(self._path.read_text())
+        try:
+            return json.loads(self._path.read_text())
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Corrupt progress file: {self._path}") from exc
 
     def save(self, data: dict) -> None:
         self._path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = self._path.with_suffix(".json.tmp")
-        tmp.write_text(json.dumps(data, indent=2))
-        tmp.rename(self._path)
+        fd, tmp = tempfile.mkstemp(dir=self._path.parent, suffix=".tmp")
+        try:
+            with open(fd, "w") as f:
+                json.dump(data, f, indent=2)
+            Path(tmp).replace(self._path)
+        except BaseException:
+            Path(tmp).unlink(missing_ok=True)
+            raise

--- a/pipeline/lib/progress.py
+++ b/pipeline/lib/progress.py
@@ -1,0 +1,31 @@
+"""Progress persistence for the parallel pool orchestrator."""
+from __future__ import annotations
+import json
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+
+class ProgressStore(ABC):
+    @abstractmethod
+    def load(self) -> dict:
+        """Return current progress dict, or {} if none exists."""
+
+    @abstractmethod
+    def save(self, data: dict) -> None:
+        """Atomically persist the full dict."""
+
+
+class LocalProgressStore(ProgressStore):
+    def __init__(self, path: Path) -> None:
+        self._path = Path(path)
+
+    def load(self) -> dict:
+        if not self._path.exists():
+            return {}
+        return json.loads(self._path.read_text())
+
+    def save(self, data: dict) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self._path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(data, indent=2))
+        tmp.rename(self._path)

--- a/pipeline/lib/tekton.py
+++ b/pipeline/lib/tekton.py
@@ -27,6 +27,7 @@ def compile_pipeline(
     phase: str,
     out_dir: Path,
     run_name: str = "",
+    tektonc_dir: Path | None = None,
 ) -> bool:
     """Compile a Tekton PipelineRun YAML for the given phase.
 
@@ -56,7 +57,8 @@ def compile_pipeline(
     out_dir.mkdir(parents=True, exist_ok=True)
     out_file = out_dir / (f"sim2real-{run_name}.yaml" if run_name else f"{phase}-pipeline.yaml")
 
-    tektonc = REPO_ROOT / "tektonc-data-collection" / "tektonc" / "tektonc.py"
+    tektonc_base = Path(tektonc_dir) if tektonc_dir else REPO_ROOT / "tektonc-data-collection"
+    tektonc = tektonc_base / "tektonc" / "tektonc.py"
     if not tektonc.exists():
         return False
 

--- a/pipeline/lib/tekton.py
+++ b/pipeline/lib/tekton.py
@@ -3,7 +3,6 @@
 Extracted from tools/transfer_cli.py compile-pipeline subcommand.
 """
 import copy
-import json
 import subprocess
 import sys
 import tempfile
@@ -27,6 +26,7 @@ def compile_pipeline(
     values_path: Path,
     phase: str,
     out_dir: Path,
+    run_name: str = "",
 ) -> bool:
     """Compile a Tekton PipelineRun YAML for the given phase.
 
@@ -54,7 +54,7 @@ def compile_pipeline(
         return False
 
     out_dir.mkdir(parents=True, exist_ok=True)
-    out_file = out_dir / f"{phase}-pipeline.yaml"
+    out_file = out_dir / (f"sim2real-{run_name}.yaml" if run_name else f"{phase}-pipeline.yaml")
 
     tektonc = REPO_ROOT / "tektonc-data-collection" / "tektonc" / "tektonc.py"
     if not tektonc.exists():
@@ -66,17 +66,7 @@ def compile_pipeline(
     except Exception:
         return False
 
-    values["phase"] = phase
-    gaie_key = "treatment" if phase == "treatment" else "baseline"
-    # Pre-serialize to JSON string so the template's `| tojson` produces a
-    # properly-quoted YAML scalar.  Without this, an empty dict renders as `{}`
-    # (a YAML mapping), which Tekton rejects for `type: string` params.
-    values["gaie_config"] = json.dumps(
-        values.get("stack", {}).get("gaie", {}).get(gaie_key, {}).get("helmValues", {})
-    )
-    values["inference_objectives"] = json.dumps(
-        values.get("stack", {}).get("gaie", {}).get("inferenceObjectives", [])
-    )
+    values["run_name"] = run_name if run_name else phase
 
     # Write augmented values to a temp file for tektonc
     tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False)
@@ -160,6 +150,55 @@ def make_pipelinerun(phase: str, workload: dict, run_name: str, namespace: str,
             "name": pr_name,
             "namespace": namespace,
         },
+        "spec": spec,
+    }
+
+
+def make_pipelinerun_parallel(
+    phase: str,
+    workload: dict,
+    run_name: str,
+    namespace: str,
+    pipeline_name: str,
+    gaie_config: str,
+    inference_objectives: str,
+    workspace_bindings: dict | None = None,
+) -> dict:
+    """Generate a PipelineRun for one (workload, package) pair in the parallel pool model.
+
+    Unlike make_pipelinerun(), this passes gaieConfig, inferenceObjectives, and phase
+    as params rather than baking them into the Pipeline at compile time.
+    """
+    wl_name = workload.get("name", workload.get("workload_name", "unknown"))
+    safe_name = wl_name.replace("_", "-")
+    pr_name = f"{phase}-{safe_name}-{run_name}"
+
+    wl_spec = {k: v for k, v in workload.items() if k != "workload_name"}
+    wl_spec_str = yaml.dump(wl_spec, default_flow_style=True).strip()
+
+    spec: dict = {
+        "pipelineRef": {"name": pipeline_name},
+        "params": [
+            {"name": "experimentId",          "value": run_name},
+            {"name": "runName",               "value": run_name},
+            {"name": "namespace",             "value": namespace},
+            {"name": "phase",                 "value": phase},
+            {"name": "gaieConfig",            "value": gaie_config},
+            {"name": "inferenceObjectives",   "value": inference_objectives},
+            {"name": "workloadName",          "value": wl_name},
+            {"name": "workloadSpec",          "value": wl_spec_str},
+        ],
+        "timeouts": {"pipeline": "4h"},
+    }
+
+    if workspace_bindings is not None:
+        ws_names = list(workspace_bindings.keys())
+        spec["workspaces"] = _apply_workspace_bindings(ws_names, workspace_bindings)
+
+    return {
+        "apiVersion": "tekton.dev/v1",
+        "kind": "PipelineRun",
+        "metadata": {"name": pr_name, "namespace": namespace},
         "spec": spec,
     }
 

--- a/pipeline/prepare.py
+++ b/pipeline/prepare.py
@@ -552,7 +552,9 @@ def _compile_cluster_packages_parallel(
     cluster_dir.mkdir(parents=True, exist_ok=True)
 
     # Compile one Pipeline for the whole experiment (not per-phase)
-    ok_flag = compile_pipeline(template_dir, values_path, "baseline", cluster_dir, run_name=run_name)
+    tektonc_dir = setup_config.get("tektonc_dir")
+    ok_flag = compile_pipeline(template_dir, values_path, "baseline", cluster_dir, run_name=run_name,
+                               tektonc_dir=Path(tektonc_dir) if tektonc_dir else None)
     shared_pipeline_path = cluster_dir / f"sim2real-{run_name}.yaml"
     if not ok_flag:
         warn("compile_pipeline failed; writing stub")
@@ -642,7 +644,9 @@ def _compile_cluster_packages(args, run_dir: Path, resolved: dict, values_path: 
         # Compile Tekton Pipeline YAML for this phase
         pr_path = pkg_dir / f"{package}-pipeline.yaml"
         if tektonc_dir.exists():
-            ok_flag = compile_pipeline(tektonc_dir, values_path, package, pkg_dir)
+            sc_tektonc_dir = setup_config.get("tektonc_dir")
+            ok_flag = compile_pipeline(tektonc_dir, values_path, package, pkg_dir,
+                                       tektonc_dir=Path(sc_tektonc_dir) if sc_tektonc_dir else None)
             if not ok_flag:
                 warn(f"compile_pipeline failed for {package}; writing stub")
                 pr_path.write_text(f"# compile_pipeline failed for {package}\n")

--- a/pipeline/prepare.py
+++ b/pipeline/prepare.py
@@ -30,7 +30,7 @@ from pipeline.lib.manifest import load_manifest, ManifestError
 from pipeline.lib.state_machine import StateMachine
 from pipeline.lib.context_builder import build_context
 from pipeline.lib.values import _deep_merge, merge_values
-from pipeline.lib.tekton import compile_pipeline, make_experiment_pipeline, make_phase_pipeline, make_standby_pipeline
+from pipeline.lib.tekton import compile_pipeline, make_experiment_pipeline, make_phase_pipeline, make_standby_pipeline, make_pipelinerun_parallel
 
 # ── Repo layout ──────────────────────────────────────────────────────────────
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -396,7 +396,19 @@ def _phase_assembly(args, state: StateMachine, manifest: dict, run_dir: Path,
 
     # 4e: Compile cluster YAMLs per package
     setup_config = _load_setup_config()
-    _compile_cluster_packages(args, run_dir, resolved, values_path, setup_config)
+    mode = getattr(args, "mode", "parallel")
+    if mode == "parallel":
+        tektonc_dir = _resolve_template_dir(args, EXPERIMENT_ROOT)
+        _compile_cluster_packages_parallel(
+            run_dir=run_dir,
+            resolved=resolved,
+            values_path=values_path,
+            setup_config=setup_config,
+            run_name=run_dir.name,
+            template_dir=tektonc_dir,
+        )
+    else:
+        _compile_cluster_packages(args, run_dir, resolved, values_path, setup_config)
 
     # 4f: Verify generated/ directory (created by translation skill)
     _verify_generated_dir(run_dir)
@@ -510,6 +522,87 @@ def _generate_algorithm_values(manifest: dict, resolved: dict, out_path: Path):
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(yaml.dump(alg_values, default_flow_style=False, sort_keys=False))
+
+
+def _compile_cluster_packages_parallel(
+    run_dir: Path, resolved: dict, values_path: Path,
+    setup_config: dict, run_name: str, template_dir: Path,
+):
+    """Generate one shared Pipeline + one PipelineRun per (workload, package) pair.
+
+    Output layout:
+      cluster/sim2real-{run_name}.yaml                       — shared Pipeline
+      cluster/wl-{workload}-{package}/
+        pipelinerun-{workload}-{package}.yaml                — one per pair
+    """
+    cluster_dir = run_dir / "cluster"
+    namespace = setup_config.get("namespace", "default")
+    if not setup_config.get("namespace"):
+        warn("namespace not found in setup_config.json; using 'default'")
+    ws_bindings = setup_config.get("workspaces") or {}
+    pipeline_name = f"sim2real-{run_name}"
+
+    values = yaml.safe_load(values_path.read_text())
+    workloads = values.get("observe", {}).get("workloads", [])
+
+    if not workloads:
+        warn("No workloads defined — cannot generate parallel PipelineRuns")
+        return
+
+    cluster_dir.mkdir(parents=True, exist_ok=True)
+
+    # Compile one Pipeline for the whole experiment (not per-phase)
+    ok_flag = compile_pipeline(template_dir, values_path, "baseline", cluster_dir, run_name=run_name)
+    shared_pipeline_path = cluster_dir / f"sim2real-{run_name}.yaml"
+    if not ok_flag:
+        warn("compile_pipeline failed; writing stub")
+        shared_pipeline_path.write_text(f"# compile_pipeline failed for {run_name}\n")
+
+    # Build gaie configs per package
+    gaie_values = values.get("stack", {}).get("gaie", {})
+    package_configs: dict[str, tuple[str, str]] = {}
+    for pkg in ["baseline", "treatment"]:
+        gaie_cfg = json.dumps(gaie_values.get(pkg, {}).get("helmValues", {}))
+        objectives = json.dumps(gaie_values.get("inferenceObjectives", []))
+        package_configs[pkg] = (gaie_cfg, objectives)
+
+    # Inject workload_name from manifest when missing
+    si_path = run_dir / "skill_input.json"
+    if si_path.exists():
+        try:
+            si = json.loads(si_path.read_text())
+            manifest_data = yaml.safe_load(Path(si["manifest_path"]).read_text()) or {}
+            wl_paths = manifest_data.get("workloads", [])
+            for i, wl in enumerate(workloads):
+                if "name" not in wl and "workload_name" not in wl and i < len(wl_paths):
+                    wl["workload_name"] = Path(wl_paths[i]).stem
+        except Exception:
+            pass
+
+    # Generate one PipelineRun per (workload, package) pair
+    for pkg in ["baseline", "treatment"]:
+        gaie_cfg, objectives = package_configs[pkg]
+        for wl in workloads:
+            wl_name = wl.get("name", wl.get("workload_name", "unknown"))
+            safe_wl = wl_name.replace("_", "-")
+            pair_dir = cluster_dir / f"wl-{safe_wl}-{pkg}"
+            pair_dir.mkdir(parents=True, exist_ok=True)
+
+            pr = make_pipelinerun_parallel(
+                phase=pkg,
+                workload=wl,
+                run_name=run_name,
+                namespace=namespace,
+                pipeline_name=pipeline_name,
+                gaie_config=gaie_cfg,
+                inference_objectives=objectives,
+                workspace_bindings=ws_bindings if ws_bindings else None,
+            )
+            pr_path = pair_dir / f"pipelinerun-{safe_wl}-{pkg}.yaml"
+            pr_path.write_text(yaml.dump(pr, default_flow_style=False, allow_unicode=True))
+
+    ok(f"Parallel cluster packages: {_display_path(cluster_dir)} "
+       f"({len(workloads) * 2} PipelineRuns)")
 
 
 def _compile_cluster_packages(args, run_dir: Path, resolved: dict, values_path: Path,
@@ -893,6 +986,9 @@ def build_parser() -> argparse.ArgumentParser:
                    help="Root of the experiment repo (default: current directory)")
     p.add_argument("--pipeline-template", metavar="PATH", dest="pipeline_template",
                    help="Override Tekton pipeline template (directory or pipeline.yaml.j2 path)")
+    p.add_argument("--mode", choices=["parallel", "sequential"], default="parallel",
+                   help="parallel: one PipelineRun per (workload,package) pair (default). "
+                        "sequential: legacy combined experiment pipeline.")
 
     sub = p.add_subparsers(dest="command")
     sub.add_parser("context", help="Rebuild context cache only")

--- a/pipeline/setup.py
+++ b/pipeline/setup.py
@@ -243,8 +243,9 @@ def collect_config(args: argparse.Namespace) -> tuple[SetupConfig, Path, str]:
         info("Loading defaults from previous setup_config.json")
 
     # Resolve namespace list
-    if getattr(args, "namespaces", None):
-        namespaces = [n.strip() for n in args.namespaces.split(",") if n.strip()]
+    namespaces_raw = args.namespaces or os.environ.get("NAMESPACES", "")
+    if namespaces_raw:
+        namespaces = [n.strip() for n in namespaces_raw.split(",") if n.strip()]
         if not namespaces:
             err("--namespaces produced an empty list"); sys.exit(1)
         namespace = namespaces[0]

--- a/pipeline/setup.py
+++ b/pipeline/setup.py
@@ -14,6 +14,7 @@ from pathlib import Path
 @dataclass
 class SetupConfig:
     namespace: str
+    namespaces: list[str]
     registry: str
     repo_name: str
     run_name: str
@@ -63,6 +64,8 @@ Examples:
 """,
     )
     p.add_argument("--namespace",      metavar="NS",    help="Kubernetes namespace")
+    p.add_argument("--namespaces",     metavar="NS1,NS2,...",
+                                       help="Comma-separated list of namespaces to provision (overrides --namespace)")
     p.add_argument("--hf-token",       metavar="TOKEN", help="HuggingFace API token")
     p.add_argument("--registry",       metavar="REG",   help="Container registry host (e.g. quay.io/username)")
     p.add_argument("--repo-name",      metavar="NAME",  default=None,
@@ -239,12 +242,19 @@ def collect_config(args: argparse.Namespace) -> tuple[SetupConfig, Path, str]:
     if defaults:
         info("Loading defaults from previous setup_config.json")
 
-    # Namespace
-    ns_default = defaults.get("namespace", "sim2real-" + os.environ.get("USER", "dev"))
-    namespace = args.namespace or prompt("namespace", "Kubernetes namespace",
-                                        default=ns_default, env_var="NAMESPACE")
-    if not namespace:
-        err("NAMESPACE is required"); sys.exit(1)
+    # Resolve namespace list
+    if getattr(args, "namespaces", None):
+        namespaces = [n.strip() for n in args.namespaces.split(",") if n.strip()]
+        if not namespaces:
+            err("--namespaces produced an empty list"); sys.exit(1)
+        namespace = namespaces[0]
+    else:
+        ns_default = defaults.get("namespace", "sim2real-" + os.environ.get("USER", "dev"))
+        namespace = args.namespace or prompt("namespace", "Kubernetes namespace",
+                                            default=ns_default, env_var="NAMESPACE")
+        if not namespace:
+            err("NAMESPACE is required"); sys.exit(1)
+        namespaces = [namespace]
 
     # Registry
     reg_default = defaults.get("registry", "")
@@ -290,7 +300,7 @@ def collect_config(args: argparse.Namespace) -> tuple[SetupConfig, Path, str]:
     container_rt = _detect_container_runtime()
 
     cfg = SetupConfig(
-        namespace=namespace, registry=registry, repo_name=repo_name,
+        namespace=namespace, namespaces=namespaces, registry=registry, repo_name=repo_name,
         run_name=run_name, hf_token=hf_token,
         registry_user=reg_user, registry_token=reg_token,
         storage_class=storage_class, is_openshift=is_openshift,
@@ -597,6 +607,7 @@ def step_config_output(cfg: SetupConfig, run_dir: Path, container_rt: str) -> No
     # setup_config.json
     setup_config = {
         "namespace": cfg.namespace,
+        "namespaces": cfg.namespaces,
         "registry": cfg.registry,
         "repo_name": cfg.repo_name,
         "storage_class": cfg.storage_class,
@@ -709,12 +720,28 @@ def main() -> int:
     # 8-step flow
     cfg, run_dir, container_rt = collect_config(args)
 
-    step_namespace(cfg)
-    step_rbac(cfg)
-    step_secrets(cfg, container_rt)
     step_test_push(cfg, container_rt, args.test_push_tag, args.test_push)
-    step_pvcs(cfg)
-    step_tekton(cfg)
+    for ns in cfg.namespaces:
+        ns_cfg = SetupConfig(
+            namespace=ns,
+            namespaces=cfg.namespaces,
+            registry=cfg.registry,
+            repo_name=cfg.repo_name,
+            run_name=cfg.run_name,
+            hf_token=cfg.hf_token,
+            registry_user=cfg.registry_user,
+            registry_token=cfg.registry_token,
+            storage_class=cfg.storage_class,
+            is_openshift=cfg.is_openshift,
+            no_cluster=cfg.no_cluster,
+        )
+        if len(cfg.namespaces) > 1:
+            print(_c("36", f"\n  ── Provisioning namespace: {ns} ──"))
+        step_namespace(ns_cfg)
+        step_rbac(ns_cfg)
+        step_secrets(ns_cfg, container_rt)
+        step_pvcs(ns_cfg)
+        step_tekton(ns_cfg)
     step_config_output(cfg, run_dir, container_rt)
 
     # Completion

--- a/pipeline/templates/pipeline.yaml.j2
+++ b/pipeline/templates/pipeline.yaml.j2
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: sim2real-{{ phase }}
+  name: sim2real-{{ run_name }}
 spec:
   params:
     - name: experimentId
@@ -12,6 +12,12 @@ spec:
       type: string
       default: "30s"
     - name: runName
+      type: string
+    - name: phase
+      type: string
+    - name: gaieConfig
+      type: string
+    - name: inferenceObjectives
       type: string
     - name: workloadName
       type: string
@@ -52,7 +58,7 @@ spec:
         - name: modelLabel
           value: "sim2real-$(params.experimentId)"
         - name: config
-          value: {{ gaie_config | tojson }}
+          value: "$(params.gaieConfig)"
         - name: namespace
           value: "$(params.namespace)"
 
@@ -105,7 +111,7 @@ spec:
         - name: inferencepool
           value: "$(tasks.deploy-gaie.results.inferencepool)"
         - name: objectives
-          value: {{ inference_objectives | tojson }}
+          value: "$(params.inferenceObjectives)"
 
     - name: run-workload
       runAfter: ["pause-after-model-deploy", "deploy-httproute", "deploy-inference-objectives"]
@@ -124,7 +130,7 @@ spec:
         - name: blisImage
           value: "{{ observe.image }}"
         - name: resultsDir
-          value: "$(params.runName)/{{ phase }}/$(params.workloadName)"
+          value: "$(params.runName)/$(params.phase)/$(params.workloadName)"
 
     - name: collect-results
       runAfter: ["run-workload"]
@@ -139,7 +145,7 @@ spec:
         - name: modelLabel
           value: "sim2real-$(params.experimentId)"
         - name: resultsDir
-          value: "$(params.runName)/{{ phase }}/$(params.workloadName)"
+          value: "$(params.runName)/$(params.phase)/$(params.workloadName)"
         - name: containerName
           value: "$(tasks.deploy-gaie.results.epp-container)"
 
@@ -149,7 +155,7 @@ spec:
         name: delete-inference-objectives
       params:
         - name: objectives
-          value: {{ inference_objectives | tojson }}
+          value: "$(params.inferenceObjectives)"
         - name: namespace
           value: "$(params.namespace)"
     - name: delete-httproute

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -101,7 +101,7 @@ def test_load_pairs_discovers_all_pairs(tmp_path):
             "apiVersion": "tekton.dev/v1", "kind": "PipelineRun",
             "metadata": {"name": f"{pkg}-{wl}-run1", "namespace": "sim2real-0"},
             "spec": {"params": [
-                {"name": "workloadName", "value": wl},
+                {"name": "workloadName", "value": f"wl-{wl}"},
                 {"name": "phase", "value": pkg},
             ]},
         }

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -1,0 +1,92 @@
+"""Tests for deploy.py run orchestrator and status subcommand."""
+import json
+
+
+_PROGRESS = {
+    "wl-smoke-baseline":   {"workload": "wl-smoke",  "package": "baseline",   "status": "done",      "namespace": "sim2real-0", "retries": 0},
+    "wl-smoke-treatment":  {"workload": "wl-smoke",  "package": "treatment",  "status": "running",   "namespace": "sim2real-1", "retries": 0},
+    "wl-load-baseline":    {"workload": "wl-load",   "package": "baseline",   "status": "pending",   "namespace": None,         "retries": 0},
+    "wl-load-treatment":   {"workload": "wl-load",   "package": "treatment",  "status": "timed-out", "namespace": "sim2real-2", "retries": 1},
+    "wl-heavy-baseline":   {"workload": "wl-heavy",  "package": "baseline",   "status": "failed",    "namespace": "sim2real-0", "retries": 0},
+}
+
+
+def test_status_output_contains_all_pairs(tmp_path, capsys):
+    from pipeline.deploy import _cmd_status
+    progress_path = tmp_path / "progress.json"
+    progress_path.write_text(json.dumps(_PROGRESS))
+
+    class _Args:
+        workload = None
+        package = None
+        live = False
+
+    _cmd_status(_Args(), progress_path)
+    out = capsys.readouterr().out
+    for key in _PROGRESS:
+        assert key in out
+
+
+def test_status_filter_by_workload(tmp_path, capsys):
+    from pipeline.deploy import _cmd_status
+    progress_path = tmp_path / "progress.json"
+    progress_path.write_text(json.dumps(_PROGRESS))
+
+    class _Args:
+        workload = "wl-smoke"
+        package = None
+        live = False
+
+    _cmd_status(_Args(), progress_path)
+    out = capsys.readouterr().out
+    assert "wl-smoke-baseline" in out
+    assert "wl-smoke-treatment" in out
+    assert "wl-load-baseline" not in out
+
+
+def test_status_filter_by_package(tmp_path, capsys):
+    from pipeline.deploy import _cmd_status
+    progress_path = tmp_path / "progress.json"
+    progress_path.write_text(json.dumps(_PROGRESS))
+
+    class _Args:
+        workload = None
+        package = "treatment"
+        live = False
+
+    _cmd_status(_Args(), progress_path)
+    out = capsys.readouterr().out
+    assert "wl-smoke-treatment" in out
+    assert "wl-load-treatment" in out
+    assert "wl-smoke-baseline" not in out
+
+
+def test_status_summary_line(tmp_path, capsys):
+    from pipeline.deploy import _cmd_status
+    progress_path = tmp_path / "progress.json"
+    progress_path.write_text(json.dumps(_PROGRESS))
+
+    class _Args:
+        workload = None
+        package = None
+        live = False
+
+    _cmd_status(_Args(), progress_path)
+    out = capsys.readouterr().out
+    assert "5 pairs" in out
+    assert "1 done" in out
+    assert "1 running" in out
+    assert "1 pending" in out
+
+
+def test_status_missing_progress_file(tmp_path, capsys):
+    from pipeline.deploy import _cmd_status
+
+    class _Args:
+        workload = None
+        package = None
+        live = False
+
+    _cmd_status(_Args(), tmp_path / "missing.json")
+    out = capsys.readouterr().out
+    assert "0 pairs" in out

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -90,3 +90,66 @@ def test_status_missing_progress_file(tmp_path, capsys):
     _cmd_status(_Args(), tmp_path / "missing.json")
     out = capsys.readouterr().out
     assert "0 pairs" in out
+
+
+def test_load_pairs_discovers_all_pairs(tmp_path):
+    from pipeline.deploy import _load_pairs
+    for wl, pkg in [("smoke", "baseline"), ("smoke", "treatment"), ("load", "baseline")]:
+        d = tmp_path / f"wl-{wl}-{pkg}"
+        d.mkdir()
+        pr = {
+            "apiVersion": "tekton.dev/v1", "kind": "PipelineRun",
+            "metadata": {"name": f"{pkg}-{wl}-run1", "namespace": "sim2real-0"},
+            "spec": {"params": [
+                {"name": "workloadName", "value": wl},
+                {"name": "phase", "value": pkg},
+            ]},
+        }
+        import yaml as _yaml
+        (d / f"pipelinerun-{wl}-{pkg}.yaml").write_text(_yaml.dump(pr))
+
+    pairs = _load_pairs(tmp_path)
+    assert "wl-smoke-baseline" in pairs
+    assert "wl-smoke-treatment" in pairs
+    assert "wl-load-baseline" in pairs
+    assert len(pairs) == 3
+
+
+def test_apply_run_filters_by_status():
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = None; workload = None; package = None; status = "failed"
+
+    result = _apply_run_filters(dict(_PROGRESS), _Args())
+    assert result == {"wl-heavy-baseline"}
+
+
+def test_apply_run_filters_compose():
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = None; workload = None; package = "treatment"; status = "timed-out"
+
+    result = _apply_run_filters(dict(_PROGRESS), _Args())
+    assert result == {"wl-load-treatment"}
+
+
+def test_apply_run_filters_only_flag():
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = "wl-smoke-baseline"; workload = None; package = None; status = None
+
+    result = _apply_run_filters(dict(_PROGRESS), _Args())
+    assert result == {"wl-smoke-baseline"}
+
+
+def test_apply_run_filters_no_flags_returns_empty():
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = None; workload = None; package = None; status = None
+
+    result = _apply_run_filters(dict(_PROGRESS), _Args())
+    assert result == set()

--- a/pipeline/tests/test_prepare.py
+++ b/pipeline/tests/test_prepare.py
@@ -1055,7 +1055,7 @@ class TestCompileClusterPackages:
             },
         }
 
-        def _fake_compile(template_dir, values_path, phase, out_dir):
+        def _fake_compile(template_dir, values_path, phase, out_dir, **kwargs):
             out_dir.mkdir(parents=True, exist_ok=True)
             (out_dir / f"{phase}-pipeline.yaml").write_text(
                 yaml.dump(_MINIMAL_PIPELINE, default_flow_style=False)
@@ -1099,7 +1099,7 @@ class TestCompileClusterPackages:
             },
         }
 
-        def _fake_compile(template_dir, values_path, phase, out_dir):
+        def _fake_compile(template_dir, values_path, phase, out_dir, **kwargs):
             out_dir.mkdir(parents=True, exist_ok=True)
             (out_dir / f"{phase}-pipeline.yaml").write_text(
                 yaml.dump(_MINIMAL_PIPELINE, default_flow_style=False)
@@ -1147,7 +1147,7 @@ def test_compile_cluster_packages_parallel_creates_per_pair_pipelineruns(tmp_pat
         "workspaces": {"model-cache": {"persistentVolumeClaim": {"claimName": "model-pvc"}}},
     }
 
-    def _fake_compile(template_dir, values_path, phase, out_dir, run_name=""):
+    def _fake_compile(template_dir, values_path, phase, out_dir, run_name="", **kwargs):
         stub = out_dir / f"sim2real-{run_name}.yaml"
         stub.write_text("# stub\n")
         return True

--- a/pipeline/tests/test_prepare.py
+++ b/pipeline/tests/test_prepare.py
@@ -1122,6 +1122,61 @@ class TestCompileClusterPackages:
         assert params["namespace"] == "myns"
 
 
+def test_compile_cluster_packages_parallel_creates_per_pair_pipelineruns(tmp_path, monkeypatch):
+    """Parallel mode generates one PipelineRun per (workload, package) pair."""
+    import yaml as _yaml
+    from unittest.mock import patch
+    from pipeline.prepare import _compile_cluster_packages_parallel
+
+    run_dir = tmp_path / "runs" / "sim2real-test"
+    run_dir.mkdir(parents=True)
+    values_path = run_dir / "values.yaml"
+    values_path.write_text(_yaml.dump({
+        "observe": {"workloads": [{"name": "wl-smoke"}, {"name": "wl-load"}]},
+        "stack": {
+            "gaie": {
+                "baseline":  {"helmValues": {}},
+                "treatment": {"helmValues": {}},
+                "inferenceObjectives": [],
+            }
+        },
+    }))
+    setup_config = {
+        "namespace": "sim2real-0",
+        "namespaces": ["sim2real-0", "sim2real-1"],
+        "workspaces": {"model-cache": {"persistentVolumeClaim": {"claimName": "model-pvc"}}},
+    }
+
+    def _fake_compile(template_dir, values_path, phase, out_dir, run_name=""):
+        stub = out_dir / f"sim2real-{run_name}.yaml"
+        stub.write_text("# stub\n")
+        return True
+
+    with patch("pipeline.prepare.compile_pipeline", side_effect=_fake_compile):
+        _compile_cluster_packages_parallel(
+            run_dir=run_dir,
+            resolved={},
+            values_path=values_path,
+            setup_config=setup_config,
+            run_name="sim2real-test",
+            template_dir=tmp_path,
+        )
+
+    cluster_dir = run_dir / "cluster"
+    # Shared pipeline stub
+    assert (cluster_dir / "sim2real-sim2real-test.yaml").exists()
+
+    # One PipelineRun per pair
+    for wl in ["wl-smoke", "wl-load"]:
+        for pkg in ["baseline", "treatment"]:
+            pr_path = cluster_dir / f"wl-{wl}-{pkg}" / f"pipelinerun-{wl}-{pkg}.yaml"
+            assert pr_path.exists(), f"Missing: {pr_path}"
+            pr_data = _yaml.safe_load(pr_path.read_text())
+            params = {p["name"]: p["value"] for p in pr_data["spec"]["params"]}
+            assert params["phase"] == pkg
+            assert params["workloadName"] == wl
+
+
 class TestExperimentRootSeparation:
     """Verify --experiment-root correctly separates experiment paths from framework paths."""
 

--- a/pipeline/tests/test_progress.py
+++ b/pipeline/tests/test_progress.py
@@ -1,4 +1,5 @@
-import pytest  # noqa: F401
+import json
+import pytest
 from pipeline.lib.progress import LocalProgressStore
 
 def test_load_missing_returns_empty(tmp_path):
@@ -28,3 +29,10 @@ def test_save_overwrites_existing(tmp_path):
     store.save({"x": {"workload": "x", "package": "baseline", "status": "pending", "namespace": None, "retries": 0}})
     store.save({"y": {"workload": "y", "package": "treatment", "status": "done", "namespace": "ns", "retries": 0}})
     assert list(store.load().keys()) == ["y"]
+
+def test_load_corrupt_file_raises(tmp_path):
+    path = tmp_path / "progress.json"
+    path.write_text("{truncated")
+    store = LocalProgressStore(path)
+    with pytest.raises((json.JSONDecodeError, ValueError)):
+        store.load()

--- a/pipeline/tests/test_progress.py
+++ b/pipeline/tests/test_progress.py
@@ -1,0 +1,30 @@
+import pytest  # noqa: F401
+from pipeline.lib.progress import LocalProgressStore
+
+def test_load_missing_returns_empty(tmp_path):
+    store = LocalProgressStore(tmp_path / "progress.json")
+    assert store.load() == {}
+
+def test_save_and_load_roundtrip(tmp_path):
+    store = LocalProgressStore(tmp_path / "progress.json")
+    data = {
+        "wl-smoke-baseline": {
+            "workload": "wl-smoke", "package": "baseline",
+            "status": "done", "namespace": "sim2real-0", "retries": 0,
+        }
+    }
+    store.save(data)
+    assert store.load() == data
+
+def test_save_is_atomic(tmp_path):
+    path = tmp_path / "progress.json"
+    store = LocalProgressStore(path)
+    store.save({"a": {"workload": "a", "package": "baseline", "status": "done", "namespace": "ns", "retries": 0}})
+    assert not (tmp_path / "progress.json.tmp").exists()
+    assert path.exists()
+
+def test_save_overwrites_existing(tmp_path):
+    store = LocalProgressStore(tmp_path / "progress.json")
+    store.save({"x": {"workload": "x", "package": "baseline", "status": "pending", "namespace": None, "retries": 0}})
+    store.save({"y": {"workload": "y", "package": "treatment", "status": "done", "namespace": "ns", "retries": 0}})
+    assert list(store.load().keys()) == ["y"]

--- a/pipeline/tests/test_tekton.py
+++ b/pipeline/tests/test_tekton.py
@@ -304,3 +304,53 @@ def test_standby_pipeline_compiled_pipeline_unchanged():
     original = copy.deepcopy(_COMPILED_PIPELINE)
     make_standby_pipeline("baseline", _COMPILED_PIPELINE, "run-1", "test-ns")
     assert _COMPILED_PIPELINE == original
+
+
+# ── Tests for make_pipelinerun_parallel ──────────────────────────────────────
+
+_WORKSPACE_BINDINGS_PARALLEL = {
+    "model-cache":    {"persistentVolumeClaim": {"claimName": "model-pvc"}},
+    "data-storage":   {"persistentVolumeClaim": {"claimName": "data-pvc"}},
+    "hf-credentials": {"secret": {"secretName": "hf-secret"}},
+}
+
+
+def test_make_pipelinerun_parallel_name():
+    from pipeline.lib.tekton import make_pipelinerun_parallel
+    pr = make_pipelinerun_parallel(
+        phase="baseline", workload={"name": "wl-smoke"}, run_name="sim2real-2026-04-23",
+        namespace="sim2real-0", pipeline_name="sim2real-2026-04-23",
+        gaie_config="{}", inference_objectives="[]",
+        workspace_bindings=_WORKSPACE_BINDINGS_PARALLEL,
+    )
+    assert pr["metadata"]["name"] == "baseline-wl-smoke-sim2real-2026-04-23"
+    assert pr["metadata"]["namespace"] == "sim2real-0"
+
+
+def test_make_pipelinerun_parallel_params_include_phase_and_config():
+    from pipeline.lib.tekton import make_pipelinerun_parallel
+    pr = make_pipelinerun_parallel(
+        phase="treatment", workload={"name": "wl-load"}, run_name="run1",
+        namespace="ns", pipeline_name="sim2real-run1",
+        gaie_config='{"key":"val"}', inference_objectives='[{"name":"obj"}]',
+        workspace_bindings=_WORKSPACE_BINDINGS_PARALLEL,
+    )
+    params = {p["name"]: p["value"] for p in pr["spec"]["params"]}
+    assert params["phase"] == "treatment"
+    assert params["gaieConfig"] == '{"key":"val"}'
+    assert params["inferenceObjectives"] == '[{"name":"obj"}]'
+    assert params["workloadName"] == "wl-load"
+
+
+def test_make_pipelinerun_parallel_workspace_bindings():
+    from pipeline.lib.tekton import make_pipelinerun_parallel
+    pr = make_pipelinerun_parallel(
+        phase="baseline", workload={"name": "wl-smoke"}, run_name="r",
+        namespace="ns", pipeline_name="sim2real-r",
+        gaie_config="{}", inference_objectives="[]",
+        workspace_bindings=_WORKSPACE_BINDINGS_PARALLEL,
+    )
+    ws_names = {ws["name"] for ws in pr["spec"]["workspaces"]}
+    assert "model-cache" in ws_names
+    assert "data-storage" in ws_names
+    assert "hf-credentials" in ws_names


### PR DESCRIPTION
## Summary

Fixes https://github.com/inference-sim/sim2real/issues/10

- `setup.py --namespaces NS1,NS2,...` provisions multiple namespace slots, each bootstrapped identically to a single `--namespace`
- `prepare.py --mode parallel` (default) generates one shared Tekton Pipeline + one PipelineRun per `(workload, package)` pair instead of one experiment-level PipelineRun
- `deploy.py run` orchestrates execution across namespace slots: assigns pairs to free slots, polls for completion, collects results inline, retries timed-out pairs, and resumes from `progress.json` after interruption
- `deploy.py status` prints a snapshot table of all pair statuses from `progress.json`
- `pipeline/lib/progress.py` — new `LocalProgressStore` with atomic JSON persistence

## Test plan

- [ ] `python -m pytest pipeline/ -v` passes (215 tests)
- [ ] `ruff check pipeline/ --select F` passes
- [ ] `setup.py --namespaces sim2real-0,sim2real-1` provisions two slots
- [ ] `prepare.py` generates `cluster/sim2real-{run}.yaml` + `cluster/wl-*/pipelinerun-*.yaml`
- [ ] `deploy.py run` assigns pairs to slots and advances through `pending → running → done`
- [ ] `deploy.py status` shows correct pair table
- [ ] `deploy.py` (no subcommand) still works for sequential layout