### PR TITLE
feat(deploy): add --force to re-run completed pairs

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -136,10 +136,11 @@ python pipeline/deploy.py collect [--package NAME…]
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--only PAIR` | — | Reset and run one specific pair key |
-| `--workload NAME` | — | Reset pairs matching this workload |
-| `--package NAME` | — | Reset pairs matching this package |
-| `--status STATE` | — | Reset pairs with this status (e.g. `failed`, `timed-out`) |
+| `--only PAIR` | — | Scope execution to one specific pair key |
+| `--workload NAME` | — | Scope execution to pairs matching this workload |
+| `--package NAME` | — | Scope execution to pairs matching this package |
+| `--status STATE` | — | Scope execution to pairs with this status (e.g. `failed`, `timed-out`) |
+| `--force` | — | Reset `done` pairs in scope back to `pending` (clears retries) |
 | `--max-retries N` | 2 | Max retries for timed-out pairs |
 | `--poll-interval N` | 30 | Seconds between status polls |
 

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -694,6 +694,18 @@ def _load_pairs(cluster_dir: Path) -> dict:
     return pairs
 
 
+def _force_reset(progress: dict, scope: set) -> int:
+    """Reset done pairs in scope to pending. Returns count of pairs reset."""
+    reset = 0
+    for key in scope:
+        if progress.get(key, {}).get("status") == "done":
+            progress[key]["status"] = "pending"
+            progress[key]["namespace"] = None
+            progress[key]["retries"] = 0
+            reset += 1
+    return reset
+
+
 def _apply_run_filters(progress: dict, args) -> set:
     """Return the set of pair keys in scope for this invocation.
 
@@ -865,6 +877,12 @@ def _cmd_run(args, manifest: dict, run_dir: Path, setup_config: dict) -> None:
     _scope = _filtered or set(progress.keys())
     if len(_scope) < len(progress):
         info(f"Scope: {len(_scope)}/{len(progress)} pairs")
+
+    if getattr(args, "force", False):
+        n = _force_reset(progress, _scope)
+        if n:
+            info(f"--force: reset {n} done pair(s) to pending")
+        store.save(progress)
 
     # Reconcile 'running' entries against actual cluster state on resume
     for key, entry in progress.items():
@@ -1085,6 +1103,8 @@ Examples:
     run_p.add_argument("--workload",     metavar="NAME",  help="Scope execution to pairs matching this workload")
     run_p.add_argument("--package",      metavar="NAME",  help="Scope execution to pairs matching this package")
     run_p.add_argument("--status",       metavar="STATE", help="Scope execution to pairs with this status (e.g. failed, timed-out)")
+    run_p.add_argument("--force",        action="store_true",
+                       help="Re-run completed pairs in scope (resets done → pending, clears retries)")
     run_p.add_argument("--max-retries",  type=int, default=2, dest="max_retries",
                        help="Max retries for timed-out pairs [2]")
     run_p.add_argument("--poll-interval", type=int, default=30, dest="poll_interval",

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -235,3 +235,61 @@ def test_do_collect_interrupt_saves_collect_failed(tmp_path, monkeypatch):
     saved = store.load()
     assert saved["wl-x-baseline"]["status"] == "collect-failed"
     assert saved["wl-x-baseline"]["namespace"] is None
+
+
+# ── _force_reset ──────────────────────────────────────────────────────────────
+
+def test_force_reset_resets_done_pairs():
+    from pipeline.deploy import _force_reset
+    progress = dict(_PROGRESS)
+    scope = set(progress.keys())
+    n = _force_reset(progress, scope)
+    assert n == 1
+    entry = progress["wl-smoke-baseline"]
+    assert entry["status"] == "pending"
+    assert entry["namespace"] is None
+    assert entry["retries"] == 0
+
+
+def test_force_reset_leaves_non_done_pairs_unchanged():
+    from pipeline.deploy import _force_reset
+    progress = dict(_PROGRESS)
+    scope = set(progress.keys())
+    _force_reset(progress, scope)
+    assert progress["wl-smoke-treatment"]["status"] == "running"
+    assert progress["wl-load-baseline"]["status"] == "pending"
+    assert progress["wl-load-treatment"]["status"] == "timed-out"
+    assert progress["wl-heavy-baseline"]["status"] == "failed"
+
+
+def test_force_reset_scoped_to_package():
+    from pipeline.deploy import _force_reset
+    progress = {
+        "wl-a-baseline":  {"workload": "wl-a", "package": "baseline",  "status": "done", "namespace": "ns-0", "retries": 2},
+        "wl-a-treatment": {"workload": "wl-a", "package": "treatment", "status": "done", "namespace": "ns-1", "retries": 1},
+    }
+    scope = {"wl-a-baseline"}
+    n = _force_reset(progress, scope)
+    assert n == 1
+    assert progress["wl-a-baseline"]["status"] == "pending"
+    assert progress["wl-a-baseline"]["retries"] == 0
+    assert progress["wl-a-treatment"]["status"] == "done"
+
+
+def test_force_reset_returns_zero_when_nothing_to_reset():
+    from pipeline.deploy import _force_reset
+    progress = {
+        "wl-a-baseline": {"workload": "wl-a", "package": "baseline", "status": "pending", "namespace": None, "retries": 0},
+    }
+    n = _force_reset(progress, {"wl-a-baseline"})
+    assert n == 0
+    assert progress["wl-a-baseline"]["status"] == "pending"
+
+
+def test_force_reset_clears_retries():
+    from pipeline.deploy import _force_reset
+    progress = {
+        "wl-a-baseline": {"workload": "wl-a", "package": "baseline", "status": "done", "namespace": "ns-0", "retries": 3},
+    }
+    _force_reset(progress, {"wl-a-baseline"})
+    assert progress["wl-a-baseline"]["retries"] == 0


### PR DESCRIPTION
## Summary

- Adds `--force` flag to `deploy.py run` that resets `done` pairs in scope back to `pending` before the execution loop starts
- Clears `namespace` and resets `retries` to 0 so re-run pairs get a fresh retry budget
- Composable with existing scope flags: `--only`, `--workload`, `--package`
- Extracted reset logic into `_force_reset(progress, scope)` for testability

## Test Plan

- [x] 5 new unit tests covering: full reset, non-done pairs unchanged, scoped reset, zero-reset case, retries cleared
- [x] All 226 pipeline tests passing

Closes #12