### PR TITLE
refactor: rename QUAY_ROBOT_* env vars to REGISTRY_USER/TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ The pipeline has four entry points:
 | Variable | Used by | Description |
 |----------|---------|-------------|
 | `HF_TOKEN` | `setup.py` | HuggingFace API token for model image pull |
-| `REGISTRY_USER` + `REGISTRY_TOKEN` | `setup.py` | Container registry credentials (use this **or** GitHub) |
-| `GITHUB_TOKEN` | `setup.py` | GitHub PAT (`write:packages`) for ghcr.io (use this **or** Quay) |
+| `REGISTRY_USER` + `REGISTRY_TOKEN` | `setup.py` | Container registry credentials for image push |
+| `GITHUB_TOKEN` | `setup.py` | GitHub PAT for private repo cloning; also used as ghcr.io push fallback when registry credentials are not set |
 | `NAMESPACE` | `setup.py`, `deploy.py` | Kubernetes namespace (falls back to value saved by setup) |
 
 All of these can also be passed as `--flags` to `setup.py` — run `python pipeline/setup.py --help` to see all options. `deploy.py` reads `NAMESPACE` from the saved setup config if the env var is not set.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The pipeline has four entry points:
 | Variable | Used by | Description |
 |----------|---------|-------------|
 | `HF_TOKEN` | `setup.py` | HuggingFace API token for model image pull |
-| `QUAY_ROBOT_USERNAME` + `QUAY_ROBOT_TOKEN` | `setup.py` | Quay robot credentials (use this **or** GitHub) |
+| `REGISTRY_USER` + `REGISTRY_TOKEN` | `setup.py` | Container registry credentials (use this **or** GitHub) |
 | `GITHUB_TOKEN` | `setup.py` | GitHub PAT (`write:packages`) for ghcr.io (use this **or** Quay) |
 | `NAMESPACE` | `setup.py`, `deploy.py` | Kubernetes namespace (falls back to value saved by setup) |
 

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -49,8 +49,8 @@ python pipeline/setup.py [flags]
 | `--hf-token TOKEN` | `HF_TOKEN` | interactive |
 | `--github-token TOKEN` | `GITHUB_TOKEN` | — |
 | `--registry REG` | — | interactive |
-| `--registry-user USER` | `QUAY_ROBOT_USERNAME` | interactive |
-| `--registry-token TOKEN` | `QUAY_ROBOT_TOKEN` | interactive |
+| `--registry-user USER` | `REGISTRY_USER` | interactive |
+| `--registry-token TOKEN` | `REGISTRY_TOKEN` | interactive |
 | `--run NAME` | — | `sim2real-YYYY-MM-DD` |
 | `--no-cluster` | — | false |
 | `--redeploy-tasks` | — | false |

--- a/pipeline/setup.py
+++ b/pipeline/setup.py
@@ -72,8 +72,8 @@ Examples:
     p.add_argument("--registry",       metavar="REG",   help="Container registry host (e.g. quay.io/username)")
     p.add_argument("--repo-name",      metavar="NAME",  default=None,
                                                         help="Registry repository name [llm-d-inference-scheduler]")
-    p.add_argument("--registry-user",  metavar="USER",  help="Registry robot username")
-    p.add_argument("--registry-token", metavar="TOKEN", help="Registry robot token")
+    p.add_argument("--registry-user",  metavar="USER",  help="Registry username")
+    p.add_argument("--registry-token", metavar="TOKEN", help="Registry token")
     p.add_argument("--storage-class",  metavar="SC",    help="PVC storageClassName (auto-detected for OpenShift)")
     p.add_argument("--run",            metavar="NAME",  help="Run name [sim2real-YYYY-MM-DD]")
     p.add_argument("--experiment-root", metavar="PATH", dest="experiment_root",

--- a/pipeline/setup.py
+++ b/pipeline/setup.py
@@ -54,7 +54,7 @@ def build_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Environment variables (alternatives to --flags):
-  NAMESPACE, HF_TOKEN, QUAY_ROBOT_USERNAME, QUAY_ROBOT_TOKEN, GITHUB_TOKEN
+  NAMESPACE, HF_TOKEN, REGISTRY_USER, REGISTRY_TOKEN, GITHUB_TOKEN
 
 Examples:
   python pipeline/setup.py                         # fully interactive
@@ -109,7 +109,7 @@ def prompt(var_name: str, message: str, default: str = "", env_var: str = "") ->
 def prompt_secret(message: str, env_var: str = "") -> str:
     """Return env var value, or prompt with hidden input.
 
-    At the prompt the user may also type an env var name (e.g. QUAY_ROBOT_TOKEN)
+    At the prompt the user may also type an env var name (e.g. REGISTRY_TOKEN)
     instead of the secret itself — the script will resolve it from the environment.
     Character count is printed after entry so the user can confirm input was received.
     """
@@ -290,8 +290,8 @@ def collect_config(args: argparse.Namespace) -> tuple[SetupConfig, Path, str]:
 
     # Registry credentials — resolve from args > env > ghcr.io fallback > prompt
     docker_server = registry.split("/")[0] if registry else ""
-    reg_user = args.registry_user or os.environ.get("QUAY_ROBOT_USERNAME", "")
-    reg_token = args.registry_token or os.environ.get("QUAY_ROBOT_TOKEN", "")
+    reg_user = args.registry_user or os.environ.get("REGISTRY_USER", "")
+    reg_token = args.registry_token or os.environ.get("REGISTRY_TOKEN", "")
     if not reg_user and not reg_token and docker_server == "ghcr.io":
         github_token = os.environ.get("GITHUB_TOKEN", "")
         if github_token:
@@ -302,7 +302,7 @@ def collect_config(args: argparse.Namespace) -> tuple[SetupConfig, Path, str]:
         reg_user = prompt("registry_user",
             "Registry username (or press Enter to use container login)", default="")
     if registry and reg_user and not reg_token:
-        reg_token = prompt_secret("Registry token", env_var="QUAY_ROBOT_TOKEN")
+        reg_token = prompt_secret("Registry token", env_var="REGISTRY_TOKEN")
 
     # Auto-detect container runtime (not prompted)
     container_rt = _detect_container_runtime()


### PR DESCRIPTION
## Summary

- Rename `QUAY_ROBOT_USERNAME` → `REGISTRY_USER` and `QUAY_ROBOT_TOKEN` → `REGISTRY_TOKEN` in `pipeline/setup.py` (env reads, epilog, docstring, interactive prompt)
- Update env var tables in `README.md` and `pipeline/README.md`
- Hard-cut rename with no backward-compat shim — CLI flags were already generic (`--registry-user`, `--registry-token`)

Fixes #35

## Test plan

- [x] `python -m pytest pipeline/ -v` — 258 tests pass
- [x] `ruff check pipeline/ --select F` — clean
- [x] `grep -r QUAY_ROBOT` across affected files returns zero matches