### PR TITLE
feat(deploy): add cleanup subcommand to tear down pipeline executions

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -112,7 +112,7 @@ Phase state is tracked per-run in `workspace/runs/<run>/.state.json`. Delete it 
 Builds the EPP image, applies Tekton resources, and orchestrates PipelineRun execution across namespace slots.
 
 ```bash
-python pipeline/deploy.py {run|status|collect} [flags]
+python pipeline/deploy.py {run|status|collect|cleanup} [flags]
 ```
 
 Common flags (all subcommands):
@@ -135,6 +135,7 @@ Common flags (all subcommands):
 python pipeline/deploy.py run     [flags]   # orchestrate parallel pool execution across namespace slots
 python pipeline/deploy.py status            # show progress snapshot of all (workload, package) pairs
 python pipeline/deploy.py collect [--package NAME…]
+python pipeline/deploy.py cleanup [flags]   # tear down cluster resources for failed/stalled pairs
 ```
 
 **`deploy.py run`** — assigns `(workload, package)` pairs to free namespace slots, polls for completion, collects results inline, and retries pairs that time out. Reads `progress.json` to resume interrupted runs.
@@ -145,7 +146,7 @@ python pipeline/deploy.py collect [--package NAME…]
 | `--workload NAME` | — | Scope execution to pairs matching this workload |
 | `--package NAME` | — | Scope execution to pairs matching this package |
 | `--status STATE` | — | Scope execution to pairs with this status (e.g. `failed`, `timed-out`) |
-| `--force` | — | Reset all non-pending pairs in scope back to `pending` (clears retries) |
+| `--force` | — | Reset non-pending pairs to `pending`, cleaning cluster resources (PipelineRuns + Helm) for pairs with assigned namespaces |
 | `--max-retries N` | 2 | Max retries for timed-out pairs |
 | `--poll-interval N` | 30 | Seconds between status polls |
 
@@ -157,6 +158,18 @@ python pipeline/deploy.py collect [--package NAME…]
 | `--package NAME` | Filter by package name |
 
 **`deploy.py collect`** — extracts results from the cluster PVC and writes to `workspace/runs/<run>/results/{phase}/<workload>/`.
+
+**`deploy.py cleanup`** — deletes PipelineRuns and uninstalls Helm releases for pairs that are not `done` or `pending`. Resets cleaned pairs to `pending` so they can be re-run.
+
+| Flag | Description |
+|------|-------------|
+| `--only PAIR` | Scope cleanup to one specific pair key |
+| `--workload NAME` | Scope cleanup to pairs matching this workload |
+| `--package NAME` | Scope cleanup to pairs matching this package |
+| `--status STATE` | Scope cleanup to pairs with this status |
+| `--dry-run` | Print what would be cleaned up without acting |
+
+**Safety:** Cleanup never touches `done` or `pending` pairs. Results in `workspace/runs/<run>/results/` are preserved — only cluster resources are removed.
 
 ---
 

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -159,7 +159,7 @@ python pipeline/deploy.py cleanup [flags]   # tear down cluster resources for fa
 
 **`deploy.py collect`** — extracts results from the cluster PVC and writes to `workspace/runs/<run>/results/{phase}/<workload>/`.
 
-**`deploy.py cleanup`** — deletes PipelineRuns and uninstalls Helm releases for pairs that are not `done` or `pending`. Resets cleaned pairs to `pending` so they can be re-run.
+**`deploy.py cleanup`** — removes cluster resources (PipelineRuns, Helm releases) for all non-pending pairs. Failed/running/timed-out pairs are reset to `pending` so they can be re-dispatched. Done pairs stay `done` — only their PipelineRun is deleted to free cluster resources.
 
 | Flag | Description |
 |------|-------------|
@@ -169,7 +169,7 @@ python pipeline/deploy.py cleanup [flags]   # tear down cluster resources for fa
 | `--status STATE` | Scope cleanup to pairs with this status |
 | `--dry-run` | Print what would be cleaned up without acting |
 
-**Safety:** Cleanup never touches `done` or `pending` pairs. Results in `workspace/runs/<run>/results/` are preserved — only cluster resources are removed.
+**Safety:** Results in `workspace/runs/<run>/results/` are preserved — only cluster resources are removed. For `done` pairs, only the PipelineRun is deleted (Tekton already tore down Helm releases).
 
 ---
 

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -511,25 +511,39 @@ def _cleanup_pair(key: str, entry: dict, discovered: dict, *,
         return True
 
     # Delete PipelineRun
+    pr_deleted = False
     if not pr_name:
         warn(f"{key}: no PipelineRun name found — skipping PR deletion (manual check needed)")
     elif ns:
         if entry.get("status") == "running":
             _cancel_and_delete_pipelinerun(pr_name, ns)
+            pr_deleted = True
         else:
-            run(["kubectl", "delete", "pipelinerun", pr_name, "-n", ns,
-                 "--ignore-not-found"], check=False, capture=True)
+            result = run(["kubectl", "delete", "pipelinerun", pr_name, "-n", ns,
+                         "--ignore-not-found"], check=False, capture=True)
+            if result.returncode == 0:
+                pr_deleted = True
+            else:
+                warn(f"{key}: kubectl delete pipelinerun failed in {ns}")
     elif namespaces:
         # Namespace already freed (done/collect-failed) — search all slots
         for slot_ns in namespaces:
-            run(["kubectl", "delete", "pipelinerun", pr_name, "-n", slot_ns,
-                 "--ignore-not-found"], check=False, capture=True)
+            result = run(["kubectl", "delete", "pipelinerun", pr_name, "-n", slot_ns,
+                         "--ignore-not-found"], check=False, capture=True)
+            if result.returncode == 0:
+                pr_deleted = True
+        if not pr_deleted:
+            warn(f"{key}: kubectl delete pipelinerun failed across all namespace slots")
     else:
         warn(f"{key}: no namespace and no namespace slots — cannot delete pipelinerun {pr_name}")
 
     # For done pairs, Tekton finally task already tore down Helm releases
     if is_done:
         return True
+
+    if ns and not pr_deleted and pr_name:
+        warn(f"{key}: PipelineRun not deleted — state NOT reset")
+        return False
 
     # Discover and uninstall all Helm releases in the namespace
     if ns:

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -486,16 +486,22 @@ def _load_pairs(cluster_dir: Path) -> dict:
 def _cleanup_pair(key: str, entry: dict, discovered: dict, *, dry_run: bool = False) -> bool:
     """Delete PipelineRun and Helm releases for a pair, reset to pending.
 
-    Returns True if cleanup was performed, False if skipped (no namespace).
+    Returns True if cleanup was performed (or no cluster teardown needed),
+    False if cluster teardown failed and state was NOT reset.
     """
     ns = entry.get("namespace")
     if not ns:
-        return False
+        # No namespace — no cluster resources to clean (e.g. collect-failed).
+        # Still reset state so the pair can be re-dispatched.
+        if not dry_run:
+            entry["status"] = "pending"
+            entry["retries"] = 0
+        return True
 
     pr_name = discovered.get(key, {}).get("pr_name", "")
 
     if dry_run:
-        info(f"[DRY-RUN] {key}: would delete pipelinerun {pr_name} in {ns}")
+        info(f"[DRY-RUN] {key}: would delete pipelinerun {pr_name or '(unknown)'} in {ns}")
         info(f"[DRY-RUN] {key}: would uninstall all helm releases in {ns}")
         return True
 
@@ -505,13 +511,21 @@ def _cleanup_pair(key: str, entry: dict, discovered: dict, *, dry_run: bool = Fa
     elif pr_name:
         run(["kubectl", "delete", "pipelinerun", pr_name, "-n", ns,
              "--ignore-not-found"], check=False, capture=True)
+    else:
+        warn(f"{key}: no PipelineRun name found — skipping PR deletion (manual check needed)")
 
     # Discover and uninstall all Helm releases in the namespace
     result = run(["helm", "list", "-n", ns, "-q"], check=False, capture=True)
-    if result.returncode == 0 and result.stdout.strip():
+    if result.returncode != 0:
+        warn(f"{key}: helm list failed in {ns} — skipping cleanup (manual intervention needed)")
+        return False
+    if result.stdout.strip():
         for release in result.stdout.strip().splitlines():
-            run(["helm", "uninstall", release, "-n", ns], check=False, capture=True)
-            ok(f"Uninstalled: {release} (ns: {ns})")
+            ur = run(["helm", "uninstall", release, "-n", ns], check=False, capture=True)
+            if ur.returncode == 0:
+                ok(f"Uninstalled: {release} (ns: {ns})")
+            else:
+                warn(f"Failed to uninstall {release} in {ns}")
 
     # Reset state
     entry["status"] = "pending"
@@ -928,15 +942,25 @@ def _cmd_cleanup(args, progress_path: Path, discovered: dict) -> None:
          + (" [DRY-RUN]" if dry_run else ""))
 
     cleaned = 0
+    errors = 0
     for key in sorted(actionable):
         entry = progress[key]
-        if _cleanup_pair(key, entry, discovered, dry_run=dry_run):
-            cleaned += 1
+        try:
+            if _cleanup_pair(key, entry, discovered, dry_run=dry_run):
+                cleaned += 1
+            else:
+                errors += 1
+        except Exception as e:
+            err(f"{key}: cleanup failed — {e}")
+            errors += 1
 
     if not dry_run:
         store.save(progress)
 
-    ok(f"{cleaned} pair(s) cleaned up" + (" and reset to pending" if not dry_run else ""))
+    msg = f"{cleaned} pair(s) cleaned up" + (" and reset to pending" if not dry_run else "")
+    if errors:
+        msg += f" ({errors} failed — manual intervention needed)"
+    ok(msg)
 
 
 # ── CLI ──────────────────────────────────────────────────────────────────────
@@ -983,7 +1007,7 @@ Examples:
     run_p.add_argument("--package",      metavar="NAME",  help="Scope execution to pairs matching this package")
     run_p.add_argument("--status",       metavar="STATE", help="Scope execution to pairs with this status (e.g. failed, timed-out)")
     run_p.add_argument("--force",        action="store_true",
-                       help="Reset non-pending pairs in scope to pending (clears retries)")
+                       help="Reset non-pending pairs to pending, cleaning cluster resources for pairs with assigned namespaces")
     run_p.add_argument("--max-retries",  type=int, default=2, dest="max_retries",
                        help="Max retries for timed-out pairs [2]")
     run_p.add_argument("--poll-interval", type=int, default=30, dest="poll_interval",

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -953,6 +953,8 @@ Examples:
   python pipeline/deploy.py status                     # Show progress snapshot
   python pipeline/deploy.py collect                    # Pull results for completed phases
   python pipeline/deploy.py collect --skip-logs        # Collect traces only (skip large logs)
+  python pipeline/deploy.py cleanup                    # Tear down stalled/failed pairs
+  python pipeline/deploy.py cleanup --dry-run          # Preview what would be cleaned
 """,
     )
     p.add_argument("--run", metavar="NAME",

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -536,12 +536,17 @@ def _cleanup_pair(key: str, entry: dict, discovered: dict, *,
             warn(f"{key}: helm list failed in {ns} — skipping cleanup (manual intervention needed)")
             return False
         if result.stdout.strip():
+            helm_failed = False
             for release in result.stdout.strip().splitlines():
                 ur = run(["helm", "uninstall", release, "-n", ns], check=False, capture=True)
                 if ur.returncode == 0:
                     ok(f"Uninstalled: {release} (ns: {ns})")
                 else:
                     warn(f"Failed to uninstall {release} in {ns}")
+                    helm_failed = True
+            if helm_failed:
+                warn(f"{key}: some releases failed to uninstall — state NOT reset")
+                return False
 
     # Reset state
     entry["status"] = "pending"
@@ -558,12 +563,16 @@ def _force_reset(progress: dict, scope: set, discovered: dict | None = None) -> 
         entry = progress.get(key, {})
         if entry.get("status") not in (None, "pending"):
             if entry.get("namespace") and discovered:
-                _cleanup_pair(key, entry, discovered)
+                try:
+                    if _cleanup_pair(key, entry, discovered):
+                        reset += 1
+                except Exception as e:
+                    warn(f"{key}: cleanup failed during --force: {e}")
             else:
                 entry["status"] = "pending"
                 entry["namespace"] = None
                 entry["retries"] = 0
-            reset += 1
+                reset += 1
     return reset
 
 

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -5,7 +5,7 @@ Subcommands:
   run      Build EPP image, apply Pipeline, submit PipelineRuns
   status   Show progress of all (workload, package) pairs
   collect  Pull results from cluster for completed phases
-  cleanup  Tear down cluster resources for failed/stalled pairs
+  cleanup  Tear down cluster resources for all non-pending pairs
 """
 
 import argparse
@@ -524,6 +524,8 @@ def _cleanup_pair(key: str, entry: dict, discovered: dict, *,
         for slot_ns in namespaces:
             run(["kubectl", "delete", "pipelinerun", pr_name, "-n", slot_ns,
                  "--ignore-not-found"], check=False, capture=True)
+    else:
+        warn(f"{key}: no namespace and no namespace slots — cannot delete pipelinerun {pr_name}")
 
     # For done pairs, Tekton finally task already tore down Helm releases
     if is_done:
@@ -555,24 +557,23 @@ def _cleanup_pair(key: str, entry: dict, discovered: dict, *,
     return True
 
 
-def _force_reset(progress: dict, scope: set, discovered: dict | None = None) -> int:
-    """Reset non-pending pairs in scope to pending. Cleans cluster resources
-    for pairs that have a namespace assigned. Returns count of pairs reset."""
+def _force_reset(progress: dict, scope: set, discovered: dict | None = None,
+                 namespaces: list[str] | None = None) -> int:
+    """Reset non-pending, non-done pairs in scope to pending.
+
+    Calls _cleanup_pair for cluster teardown when possible. Pairs where
+    cleanup fails are skipped (not counted, state preserved).
+    """
     reset = 0
     for key in scope:
         entry = progress.get(key, {})
-        if entry.get("status") not in (None, "pending"):
-            if entry.get("namespace") and discovered:
-                try:
-                    if _cleanup_pair(key, entry, discovered):
-                        reset += 1
-                except Exception as e:
-                    warn(f"{key}: cleanup failed during --force: {e}")
-            else:
-                entry["status"] = "pending"
-                entry["namespace"] = None
-                entry["retries"] = 0
-                reset += 1
+        if entry.get("status") not in (None, "pending", "done"):
+            try:
+                if _cleanup_pair(key, entry, discovered or {},
+                                 namespaces=namespaces):
+                    reset += 1
+            except Exception as e:
+                warn(f"{key}: cleanup failed during --force: {e}")
     return reset
 
 
@@ -740,7 +741,7 @@ def _cmd_run(args, manifest: dict, run_dir: Path, setup_config: dict) -> None:
         info(f"Scope: {len(_scope)}/{len(progress)} pairs")
 
     if getattr(args, "force", False):
-        n = _force_reset(progress, _scope, discovered)
+        n = _force_reset(progress, _scope, discovered, namespaces=namespaces)
         if n:
             info(f"--force: reset {n} non-pending pair(s) to pending")
         else:
@@ -1040,7 +1041,7 @@ Examples:
     run_p.add_argument("--poll-interval", type=int, default=30, dest="poll_interval",
                        help="Seconds between status polls [30]")
 
-    cleanup_p = sub.add_parser("cleanup", help="Tear down cluster resources for failed/stalled pairs")
+    cleanup_p = sub.add_parser("cleanup", help="Tear down cluster resources for all non-pending pairs")
     cleanup_p.add_argument("--only",     metavar="PAIR",  help="Scope to one specific pair key")
     cleanup_p.add_argument("--workload", metavar="NAME",  help="Scope to pairs matching this workload")
     cleanup_p.add_argument("--package",  metavar="NAME",  help="Scope to pairs matching this package")
@@ -1089,8 +1090,11 @@ def main():
         progress_path = run_dir / "progress.json"
         cluster_dir = run_dir / "cluster"
         discovered = _load_pairs(cluster_dir)
-        namespaces = setup_config.get("namespaces") or [setup_config.get("namespace", "")]
-        _cmd_cleanup(args, progress_path, discovered, namespaces=namespaces)
+        namespaces = [ns for ns in (setup_config.get("namespaces") or
+                      [setup_config.get("namespace", "")]) if ns]
+        if not namespaces:
+            warn("No namespaces in setup_config — PipelineRun deletion for done pairs may be incomplete")
+        _cmd_cleanup(args, progress_path, discovered, namespaces=namespaces or None)
     else:
         err("No subcommand specified. Use: deploy.py run | status | collect | cleanup")
         sys.exit(1)

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -482,6 +482,43 @@ def _load_pairs(cluster_dir: Path) -> dict:
     return pairs
 
 
+def _cleanup_pair(key: str, entry: dict, discovered: dict, *, dry_run: bool = False) -> bool:
+    """Delete PipelineRun and Helm releases for a pair, reset to pending.
+
+    Returns True if cleanup was performed, False if skipped (no namespace).
+    """
+    ns = entry.get("namespace")
+    if not ns:
+        return False
+
+    pr_name = discovered.get(key, {}).get("pr_name", "")
+
+    if dry_run:
+        info(f"[DRY-RUN] {key}: would delete pipelinerun {pr_name} in {ns}")
+        info(f"[DRY-RUN] {key}: would uninstall all helm releases in {ns}")
+        return True
+
+    # Cancel running PipelineRuns; delete non-running ones directly
+    if entry.get("status") == "running" and pr_name:
+        _cancel_and_delete_pipelinerun(pr_name, ns)
+    elif pr_name:
+        run(["kubectl", "delete", "pipelinerun", pr_name, "-n", ns,
+             "--ignore-not-found"], check=False, capture=True)
+
+    # Discover and uninstall all Helm releases in the namespace
+    result = run(["helm", "list", "-n", ns, "-q"], check=False, capture=True)
+    if result.returncode == 0 and result.stdout.strip():
+        for release in result.stdout.strip().splitlines():
+            run(["helm", "uninstall", release, "-n", ns], check=False, capture=True)
+            ok(f"Uninstalled: {release} (ns: {ns})")
+
+    # Reset state
+    entry["status"] = "pending"
+    entry["namespace"] = None
+    entry["retries"] = 0
+    return True
+
+
 def _force_reset(progress: dict, scope: set) -> int:
     """Reset non-pending pairs in scope to pending. Returns count of pairs reset."""
     reset = 0

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -520,15 +520,19 @@ def _cleanup_pair(key: str, entry: dict, discovered: dict, *, dry_run: bool = Fa
     return True
 
 
-def _force_reset(progress: dict, scope: set) -> int:
-    """Reset non-pending pairs in scope to pending. Returns count of pairs reset."""
+def _force_reset(progress: dict, scope: set, discovered: dict | None = None) -> int:
+    """Reset non-pending pairs in scope to pending. Cleans cluster resources
+    for pairs that have a namespace assigned. Returns count of pairs reset."""
     reset = 0
     for key in scope:
         entry = progress.get(key, {})
         if entry.get("status") not in (None, "pending"):
-            entry["status"] = "pending"
-            entry["namespace"] = None
-            entry["retries"] = 0
+            if entry.get("namespace") and discovered:
+                _cleanup_pair(key, entry, discovered)
+            else:
+                entry["status"] = "pending"
+                entry["namespace"] = None
+                entry["retries"] = 0
             reset += 1
     return reset
 
@@ -697,7 +701,7 @@ def _cmd_run(args, manifest: dict, run_dir: Path, setup_config: dict) -> None:
         info(f"Scope: {len(_scope)}/{len(progress)} pairs")
 
     if getattr(args, "force", False):
-        n = _force_reset(progress, _scope)
+        n = _force_reset(progress, _scope, discovered)
         if n:
             info(f"--force: reset {n} non-pending pair(s) to pending")
         else:

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -5,6 +5,7 @@ Subcommands:
   run      Build EPP image, apply Pipeline, submit PipelineRuns
   status   Show progress of all (workload, package) pairs
   collect  Pull results from cluster for completed phases
+  cleanup  Tear down cluster resources for failed/stalled pairs
 """
 
 import argparse
@@ -896,6 +897,44 @@ def _cmd_run(args, manifest: dict, run_dir: Path, setup_config: dict) -> None:
     print()
 
 
+def _cmd_cleanup(args, progress_path: Path, discovered: dict) -> None:
+    """Tear down cluster resources for non-terminal pairs and reset to pending."""
+    from pipeline.lib.progress import LocalProgressStore
+    store = LocalProgressStore(progress_path)
+    progress = store.load()
+
+    if not progress:
+        info("No progress data found — nothing to clean up")
+        return
+
+    # Determine scope
+    _filtered = _apply_run_filters(progress, args)
+    _scope = _filtered or set(progress.keys())
+
+    # Exclude done and pending
+    actionable = {k for k in _scope
+                  if progress[k].get("status") not in ("done", "pending")}
+
+    if not actionable:
+        info("No pairs need cleanup (all are done or pending)")
+        return
+
+    dry_run = getattr(args, "dry_run", False)
+    info(f"Scope: {len(actionable)}/{len(progress)} pairs"
+         + (" [DRY-RUN]" if dry_run else ""))
+
+    cleaned = 0
+    for key in sorted(actionable):
+        entry = progress[key]
+        if _cleanup_pair(key, entry, discovered, dry_run=dry_run):
+            cleaned += 1
+
+    if not dry_run:
+        store.save(progress)
+
+    ok(f"{cleaned} pair(s) cleaned up" + (" and reset to pending" if not dry_run else ""))
+
+
 # ── CLI ──────────────────────────────────────────────────────────────────────
 
 def build_parser() -> argparse.ArgumentParser:
@@ -944,6 +983,14 @@ Examples:
     run_p.add_argument("--poll-interval", type=int, default=30, dest="poll_interval",
                        help="Seconds between status polls [30]")
 
+    cleanup_p = sub.add_parser("cleanup", help="Tear down cluster resources for failed/stalled pairs")
+    cleanup_p.add_argument("--only",     metavar="PAIR",  help="Scope to one specific pair key")
+    cleanup_p.add_argument("--workload", metavar="NAME",  help="Scope to pairs matching this workload")
+    cleanup_p.add_argument("--package",  metavar="NAME",  help="Scope to pairs matching this package")
+    cleanup_p.add_argument("--status",   metavar="STATE", help="Scope to pairs with this status")
+    cleanup_p.add_argument("--dry-run",  action="store_true", dest="dry_run",
+                           help="Print what would be cleaned up without doing it")
+
     return p
 
 
@@ -981,8 +1028,13 @@ def main():
         _cmd_status(args, progress_path)
     elif cmd == "collect":
         _cmd_collect(args, manifest, run_dir, setup_config)
+    elif cmd == "cleanup":
+        progress_path = run_dir / "progress.json"
+        cluster_dir = run_dir / "cluster"
+        discovered = _load_pairs(cluster_dir)
+        _cmd_cleanup(args, progress_path, discovered)
     else:
-        err("No subcommand specified. Use: deploy.py run | status | collect")
+        err("No subcommand specified. Use: deploy.py run | status | collect | cleanup")
         sys.exit(1)
 
 

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -483,49 +483,65 @@ def _load_pairs(cluster_dir: Path) -> dict:
     return pairs
 
 
-def _cleanup_pair(key: str, entry: dict, discovered: dict, *, dry_run: bool = False) -> bool:
-    """Delete PipelineRun and Helm releases for a pair, reset to pending.
+def _cleanup_pair(key: str, entry: dict, discovered: dict, *,
+                  dry_run: bool = False, namespaces: list[str] | None = None) -> bool:
+    """Delete PipelineRun and Helm releases for a pair.
 
-    Returns True if cleanup was performed (or no cluster teardown needed),
-    False if cluster teardown failed and state was NOT reset.
+    For non-done pairs: also resets state to pending.
+    For done pairs: deletes PipelineRun only (Helm already torn down by Tekton).
+
+    Returns True if cleanup was performed, False if it failed and state was NOT reset.
     """
     ns = entry.get("namespace")
-    if not ns:
-        # No namespace — no cluster resources to clean (e.g. collect-failed).
-        # Still reset state so the pair can be re-dispatched.
-        if not dry_run:
+    pr_name = discovered.get(key, {}).get("pr_name", "")
+    is_done = entry.get("status") == "done"
+
+    # No namespace and no pr_name — just reset state (e.g. collect-failed)
+    if not ns and not pr_name:
+        if not dry_run and not is_done:
             entry["status"] = "pending"
             entry["retries"] = 0
         return True
 
-    pr_name = discovered.get(key, {}).get("pr_name", "")
-
     if dry_run:
-        info(f"[DRY-RUN] {key}: would delete pipelinerun {pr_name or '(unknown)'} in {ns}")
-        info(f"[DRY-RUN] {key}: would uninstall all helm releases in {ns}")
+        target = ns or "all namespace slots"
+        info(f"[DRY-RUN] {key}: would delete pipelinerun {pr_name or '(unknown)'} in {target}")
+        if not is_done:
+            info(f"[DRY-RUN] {key}: would uninstall all helm releases in {target}")
         return True
 
-    # Cancel running PipelineRuns; delete non-running ones directly
-    if entry.get("status") == "running" and pr_name:
-        _cancel_and_delete_pipelinerun(pr_name, ns)
-    elif pr_name:
-        run(["kubectl", "delete", "pipelinerun", pr_name, "-n", ns,
-             "--ignore-not-found"], check=False, capture=True)
-    else:
+    # Delete PipelineRun
+    if not pr_name:
         warn(f"{key}: no PipelineRun name found — skipping PR deletion (manual check needed)")
+    elif ns:
+        if entry.get("status") == "running":
+            _cancel_and_delete_pipelinerun(pr_name, ns)
+        else:
+            run(["kubectl", "delete", "pipelinerun", pr_name, "-n", ns,
+                 "--ignore-not-found"], check=False, capture=True)
+    elif namespaces:
+        # Namespace already freed (done/collect-failed) — search all slots
+        for slot_ns in namespaces:
+            run(["kubectl", "delete", "pipelinerun", pr_name, "-n", slot_ns,
+                 "--ignore-not-found"], check=False, capture=True)
+
+    # For done pairs, Tekton finally task already tore down Helm releases
+    if is_done:
+        return True
 
     # Discover and uninstall all Helm releases in the namespace
-    result = run(["helm", "list", "-n", ns, "-q"], check=False, capture=True)
-    if result.returncode != 0:
-        warn(f"{key}: helm list failed in {ns} — skipping cleanup (manual intervention needed)")
-        return False
-    if result.stdout.strip():
-        for release in result.stdout.strip().splitlines():
-            ur = run(["helm", "uninstall", release, "-n", ns], check=False, capture=True)
-            if ur.returncode == 0:
-                ok(f"Uninstalled: {release} (ns: {ns})")
-            else:
-                warn(f"Failed to uninstall {release} in {ns}")
+    if ns:
+        result = run(["helm", "list", "-n", ns, "-q"], check=False, capture=True)
+        if result.returncode != 0:
+            warn(f"{key}: helm list failed in {ns} — skipping cleanup (manual intervention needed)")
+            return False
+        if result.stdout.strip():
+            for release in result.stdout.strip().splitlines():
+                ur = run(["helm", "uninstall", release, "-n", ns], check=False, capture=True)
+                if ur.returncode == 0:
+                    ok(f"Uninstalled: {release} (ns: {ns})")
+                else:
+                    warn(f"Failed to uninstall {release} in {ns}")
 
     # Reset state
     entry["status"] = "pending"
@@ -915,8 +931,9 @@ def _cmd_run(args, manifest: dict, run_dir: Path, setup_config: dict) -> None:
     print()
 
 
-def _cmd_cleanup(args, progress_path: Path, discovered: dict) -> None:
-    """Tear down cluster resources for non-terminal pairs and reset to pending."""
+def _cmd_cleanup(args, progress_path: Path, discovered: dict,
+                 namespaces: list[str] | None = None) -> None:
+    """Tear down cluster resources for all non-pending pairs."""
     from pipeline.lib.progress import LocalProgressStore
     store = LocalProgressStore(progress_path)
     progress = store.load()
@@ -929,12 +946,12 @@ def _cmd_cleanup(args, progress_path: Path, discovered: dict) -> None:
     _filtered = _apply_run_filters(progress, args)
     _scope = _filtered or set(progress.keys())
 
-    # Exclude done and pending
+    # Exclude pending (nothing to clean)
     actionable = {k for k in _scope
-                  if progress[k].get("status") not in ("done", "pending")}
+                  if progress[k].get("status") not in (None, "pending")}
 
     if not actionable:
-        info("No pairs need cleanup (all are done or pending)")
+        info("No pairs need cleanup (all pending)")
         return
 
     dry_run = getattr(args, "dry_run", False)
@@ -946,7 +963,8 @@ def _cmd_cleanup(args, progress_path: Path, discovered: dict) -> None:
     for key in sorted(actionable):
         entry = progress[key]
         try:
-            if _cleanup_pair(key, entry, discovered, dry_run=dry_run):
+            if _cleanup_pair(key, entry, discovered, dry_run=dry_run,
+                             namespaces=namespaces):
                 cleaned += 1
             else:
                 errors += 1
@@ -957,7 +975,7 @@ def _cmd_cleanup(args, progress_path: Path, discovered: dict) -> None:
     if not dry_run:
         store.save(progress)
 
-    msg = f"{cleaned} pair(s) cleaned up" + (" and reset to pending" if not dry_run else "")
+    msg = f"{cleaned} pair(s) cleaned up"
     if errors:
         msg += f" ({errors} failed — manual intervention needed)"
     ok(msg)
@@ -1062,7 +1080,8 @@ def main():
         progress_path = run_dir / "progress.json"
         cluster_dir = run_dir / "cluster"
         discovered = _load_pairs(cluster_dir)
-        _cmd_cleanup(args, progress_path, discovered)
+        namespaces = setup_config.get("namespaces") or [setup_config.get("namespace", "")]
+        _cmd_cleanup(args, progress_path, discovered, namespaces=namespaces)
     else:
         err("No subcommand specified. Use: deploy.py run | status | collect | cleanup")
         sys.exit(1)

--- a/pipeline/tests/test_deploy_cleanup.py
+++ b/pipeline/tests/test_deploy_cleanup.py
@@ -116,6 +116,27 @@ def test_cleanup_pair_helm_list_failure_does_not_reset(monkeypatch):
     assert entry["namespace"] == "sim2real-0"
 
 
+def test_cleanup_pair_helm_uninstall_failure_does_not_reset(monkeypatch):
+    """When helm uninstall fails, state is NOT reset."""
+    import pipeline.deploy as mod
+
+    entry = {"workload": "wl-heavy", "package": "baseline", "status": "failed",
+             "namespace": "sim2real-0", "retries": 0}
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 1 if cmd[:2] == ["helm", "uninstall"] else 0
+            stdout = "stuck-release\n" if cmd[:2] == ["helm", "list"] else ""
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    result = mod._cleanup_pair("wl-heavy-baseline", entry, _DISCOVERED)
+    assert result is False
+    assert entry["status"] == "failed"
+    assert entry["namespace"] == "sim2real-0"
+
+
 def test_cleanup_pair_missing_pr_name_warns(monkeypatch, capsys):
     """When pr_name is not in discovered, a warning is emitted."""
     import pipeline.deploy as mod
@@ -353,3 +374,56 @@ def test_force_reset_calls_cleanup_for_pairs_with_namespace(monkeypatch):
     assert progress["wl-a-baseline"]["status"] == "pending"
     assert progress["wl-b-baseline"]["status"] == "pending"
     assert progress["wl-a-treatment"]["status"] == "pending"
+
+
+def test_force_reset_skips_count_on_cleanup_failure(monkeypatch):
+    """_force_reset does not count pairs where _cleanup_pair returned False."""
+    import pipeline.deploy as mod
+
+    progress = {
+        "wl-a-baseline": {"workload": "wl-a", "package": "baseline", "status": "failed",
+                          "namespace": "sim2real-0", "retries": 0},
+    }
+    discovered = {"wl-a-baseline": {"pr_name": "pr1", "workload": "wl-a", "package": "baseline"}}
+
+    monkeypatch.setattr(mod, "_cleanup_pair", lambda *a, **kw: False)
+
+    n = mod._force_reset(progress, {"wl-a-baseline"}, discovered)
+    assert n == 0
+    assert progress["wl-a-baseline"]["status"] == "failed"
+
+
+def test_force_reset_continues_on_exception(monkeypatch):
+    """_force_reset handles exceptions without aborting remaining pairs."""
+    import pipeline.deploy as mod
+
+    progress = {
+        "wl-a-baseline": {"workload": "wl-a", "package": "baseline", "status": "failed",
+                          "namespace": "sim2real-0", "retries": 0},
+        "wl-b-baseline": {"workload": "wl-b", "package": "baseline", "status": "failed",
+                          "namespace": "sim2real-1", "retries": 0},
+    }
+    discovered = {
+        "wl-a-baseline": {"pr_name": "pr1", "workload": "wl-a", "package": "baseline"},
+        "wl-b-baseline": {"pr_name": "pr2", "workload": "wl-b", "package": "baseline"},
+    }
+
+    call_count = []
+
+    def sometimes_fails(key, entry, disc, dry_run=False):
+        call_count.append(key)
+        if key == "wl-a-baseline":
+            raise RuntimeError("network error")
+        entry["status"] = "pending"
+        entry["namespace"] = None
+        entry["retries"] = 0
+        return True
+
+    monkeypatch.setattr(mod, "_cleanup_pair", sometimes_fails)
+
+    n = mod._force_reset(progress, set(progress.keys()), discovered)
+
+    assert len(call_count) == 2
+    assert n == 1  # only wl-b succeeded
+    assert progress["wl-a-baseline"]["status"] == "failed"  # unchanged
+    assert progress["wl-b-baseline"]["status"] == "pending"

--- a/pipeline/tests/test_deploy_cleanup.py
+++ b/pipeline/tests/test_deploy_cleanup.py
@@ -82,16 +82,99 @@ def test_cleanup_pair_running_cancels_first(monkeypatch):
     assert entry["namespace"] is None
 
 
-def test_cleanup_pair_skips_none_namespace(monkeypatch):
-    """Pairs with no namespace are no-ops (returns False)."""
+def test_cleanup_pair_none_namespace_resets_state(monkeypatch):
+    """Pairs with no namespace still get reset (e.g. collect-failed)."""
     import pipeline.deploy as mod
 
-    entry = {"workload": "wl-load", "package": "baseline", "status": "pending",
-             "namespace": None, "retries": 0}
+    entry = {"workload": "wl-load", "package": "baseline", "status": "collect-failed",
+             "namespace": None, "retries": 2}
 
     result = mod._cleanup_pair("wl-load-baseline", entry, _DISCOVERED)
-    assert result is False
+    assert result is True
     assert entry["status"] == "pending"
+    assert entry["retries"] == 0
+
+
+def test_cleanup_pair_helm_list_failure_does_not_reset(monkeypatch):
+    """When helm list fails, state is NOT reset — operator needs manual intervention."""
+    import pipeline.deploy as mod
+
+    entry = {"workload": "wl-heavy", "package": "baseline", "status": "failed",
+             "namespace": "sim2real-0", "retries": 0}
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 1 if cmd[:2] == ["helm", "list"] else 0
+            stdout = ""
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    result = mod._cleanup_pair("wl-heavy-baseline", entry, _DISCOVERED)
+    assert result is False
+    assert entry["status"] == "failed"
+    assert entry["namespace"] == "sim2real-0"
+
+
+def test_cleanup_pair_missing_pr_name_warns(monkeypatch, capsys):
+    """When pr_name is not in discovered, a warning is emitted."""
+    import pipeline.deploy as mod
+
+    entry = {"workload": "wl-unknown", "package": "baseline", "status": "failed",
+             "namespace": "sim2real-0", "retries": 0}
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = ""
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    result = mod._cleanup_pair("wl-unknown-baseline", entry, {})
+    assert result is True
+    assert entry["status"] == "pending"
+    out = capsys.readouterr().out
+    assert "no PipelineRun name found" in out
+
+
+def test_cmd_cleanup_continues_on_exception(tmp_path, monkeypatch, capsys):
+    """One pair raising an exception does not abort cleanup of remaining pairs."""
+    import pipeline.deploy as mod
+
+    progress = {
+        "wl-a-baseline": {"workload": "wl-a", "package": "baseline", "status": "failed",
+                          "namespace": "sim2real-0", "retries": 0},
+        "wl-b-baseline": {"workload": "wl-b", "package": "baseline", "status": "failed",
+                          "namespace": "sim2real-1", "retries": 0},
+    }
+    progress_path = tmp_path / "progress.json"
+    progress_path.write_text(json.dumps(progress))
+
+    call_count = []
+
+    def exploding_cleanup(key, entry, disc, dry_run=False):
+        call_count.append(key)
+        if key == "wl-a-baseline":
+            raise RuntimeError("kubectl not found")
+        entry["status"] = "pending"
+        entry["namespace"] = None
+        entry["retries"] = 0
+        return True
+
+    monkeypatch.setattr(mod, "_cleanup_pair", exploding_cleanup)
+
+    class _Args:
+        only = None; workload = None; package = None; status = None; dry_run = False
+
+    mod._cmd_cleanup(_Args(), progress_path, _DISCOVERED)
+
+    # Both pairs should have been attempted
+    assert "wl-a-baseline" in call_count
+    assert "wl-b-baseline" in call_count
+    # Progress should still be saved (wl-b was cleaned)
+    saved = json.loads(progress_path.read_text())
+    assert saved["wl-b-baseline"]["status"] == "pending"
 
 
 def test_cmd_cleanup_skips_done_and_pending(tmp_path, monkeypatch, capsys):

--- a/pipeline/tests/test_deploy_cleanup.py
+++ b/pipeline/tests/test_deploy_cleanup.py
@@ -190,3 +190,47 @@ def test_cmd_cleanup_saves_progress_on_success(tmp_path, monkeypatch, capsys):
     # done and pending unchanged
     assert saved["wl-smoke-baseline"]["status"] == "done"
     assert saved["wl-load-baseline"]["status"] == "pending"
+
+
+def test_force_reset_calls_cleanup_for_pairs_with_namespace(monkeypatch):
+    """_force_reset should clean cluster resources for pairs that had a namespace."""
+    import pipeline.deploy as mod
+
+    progress = {
+        "wl-a-baseline": {"workload": "wl-a", "package": "baseline", "status": "failed",
+                          "namespace": "sim2real-0", "retries": 0},
+        "wl-a-treatment": {"workload": "wl-a", "package": "treatment", "status": "pending",
+                           "namespace": None, "retries": 0},
+        "wl-b-baseline": {"workload": "wl-b", "package": "baseline", "status": "timed-out",
+                          "namespace": "sim2real-1", "retries": 2},
+    }
+    discovered = {
+        "wl-a-baseline": {"pr_name": "baseline-a-run1", "workload": "wl-a", "package": "baseline"},
+        "wl-a-treatment": {"pr_name": "treatment-a-run1", "workload": "wl-a", "package": "treatment"},
+        "wl-b-baseline": {"pr_name": "baseline-b-run1", "workload": "wl-b", "package": "baseline"},
+    }
+
+    cleaned = []
+
+    def fake_cleanup(key, entry, disc, dry_run=False):
+        cleaned.append(key)
+        entry["status"] = "pending"
+        entry["namespace"] = None
+        entry["retries"] = 0
+        return True
+
+    monkeypatch.setattr(mod, "_cleanup_pair", fake_cleanup)
+
+    scope = set(progress.keys())
+    n = mod._force_reset(progress, scope, discovered)
+
+    # Only pairs with a namespace AND non-pending status should have been cleaned
+    assert "wl-a-baseline" in cleaned
+    assert "wl-b-baseline" in cleaned
+    assert "wl-a-treatment" not in cleaned
+    # Count should reflect pairs that were actually reset
+    assert n == 2
+    # All non-pending should now be pending
+    assert progress["wl-a-baseline"]["status"] == "pending"
+    assert progress["wl-b-baseline"]["status"] == "pending"
+    assert progress["wl-a-treatment"]["status"] == "pending"

--- a/pipeline/tests/test_deploy_cleanup.py
+++ b/pipeline/tests/test_deploy_cleanup.py
@@ -1,0 +1,92 @@
+"""Tests for deploy.py cleanup subcommand and _cleanup_pair helper."""
+
+
+_PROGRESS = {
+    "wl-smoke-baseline":   {"workload": "wl-smoke",  "package": "baseline",  "status": "done",      "namespace": "sim2real-0", "retries": 0},
+    "wl-smoke-treatment":  {"workload": "wl-smoke",  "package": "treatment", "status": "running",   "namespace": "sim2real-1", "retries": 0},
+    "wl-load-baseline":    {"workload": "wl-load",   "package": "baseline",  "status": "pending",   "namespace": None,         "retries": 0},
+    "wl-load-treatment":   {"workload": "wl-load",   "package": "treatment", "status": "timed-out", "namespace": "sim2real-2", "retries": 1},
+    "wl-heavy-baseline":   {"workload": "wl-heavy",  "package": "baseline",  "status": "failed",    "namespace": "sim2real-0", "retries": 0},
+}
+
+_DISCOVERED = {
+    "wl-smoke-baseline":  {"pr_name": "baseline-smoke-run1",  "workload": "wl-smoke", "package": "baseline"},
+    "wl-smoke-treatment": {"pr_name": "treatment-smoke-run1", "workload": "wl-smoke", "package": "treatment"},
+    "wl-load-baseline":   {"pr_name": "baseline-load-run1",   "workload": "wl-load",  "package": "baseline"},
+    "wl-load-treatment":  {"pr_name": "treatment-load-run1",  "workload": "wl-load",  "package": "treatment"},
+    "wl-heavy-baseline":  {"pr_name": "baseline-heavy-run1",  "workload": "wl-heavy", "package": "baseline"},
+}
+
+
+def test_cleanup_pair_failed_deletes_pr_and_helm(monkeypatch):
+    """A failed pair gets its PipelineRun deleted and Helm releases uninstalled."""
+    import pipeline.deploy as mod
+
+    entry = {"workload": "wl-heavy", "package": "baseline", "status": "failed",
+             "namespace": "sim2real-0", "retries": 0}
+    calls = []
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        calls.append(cmd)
+        class _R:
+            returncode = 0
+            stdout = "release-a\nrelease-b\n"
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    mod._cleanup_pair("wl-heavy-baseline", entry, _DISCOVERED)
+
+    assert entry["status"] == "pending"
+    assert entry["namespace"] is None
+    assert entry["retries"] == 0
+
+    # Should have: kubectl delete pipelinerun, helm list, helm uninstall x2
+    kubectl_deletes = [c for c in calls if c[:2] == ["kubectl", "delete"]]
+    assert len(kubectl_deletes) == 1
+    assert "baseline-heavy-run1" in kubectl_deletes[0]
+
+    helm_lists = [c for c in calls if c[:2] == ["helm", "list"]]
+    assert len(helm_lists) == 1
+
+    helm_uninstalls = [c for c in calls if c[:2] == ["helm", "uninstall"]]
+    assert len(helm_uninstalls) == 2
+
+
+def test_cleanup_pair_running_cancels_first(monkeypatch):
+    """A running pair gets cancelled before deletion."""
+    import pipeline.deploy as mod
+
+    entry = {"workload": "wl-smoke", "package": "treatment", "status": "running",
+             "namespace": "sim2real-1", "retries": 0}
+    cancelled = []
+
+    def fake_cancel(pr_name, ns):
+        cancelled.append((pr_name, ns))
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = ""
+        return _R()
+
+    monkeypatch.setattr(mod, "_cancel_and_delete_pipelinerun", fake_cancel)
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    mod._cleanup_pair("wl-smoke-treatment", entry, _DISCOVERED)
+
+    assert cancelled == [("treatment-smoke-run1", "sim2real-1")]
+    assert entry["status"] == "pending"
+    assert entry["namespace"] is None
+
+
+def test_cleanup_pair_skips_none_namespace(monkeypatch):
+    """Pairs with no namespace are no-ops (returns False)."""
+    import pipeline.deploy as mod
+
+    entry = {"workload": "wl-load", "package": "baseline", "status": "pending",
+             "namespace": None, "retries": 0}
+
+    result = mod._cleanup_pair("wl-load-baseline", entry, _DISCOVERED)
+    assert result is False
+    assert entry["status"] == "pending"

--- a/pipeline/tests/test_deploy_cleanup.py
+++ b/pipeline/tests/test_deploy_cleanup.py
@@ -1,5 +1,7 @@
 """Tests for deploy.py cleanup subcommand and _cleanup_pair helper."""
 
+import json
+
 
 _PROGRESS = {
     "wl-smoke-baseline":   {"workload": "wl-smoke",  "package": "baseline",  "status": "done",      "namespace": "sim2real-0", "retries": 0},
@@ -90,3 +92,101 @@ def test_cleanup_pair_skips_none_namespace(monkeypatch):
     result = mod._cleanup_pair("wl-load-baseline", entry, _DISCOVERED)
     assert result is False
     assert entry["status"] == "pending"
+
+
+def test_cmd_cleanup_skips_done_and_pending(tmp_path, monkeypatch, capsys):
+    """cleanup only acts on non-done, non-pending pairs."""
+    import pipeline.deploy as mod
+
+    progress_path = tmp_path / "progress.json"
+    progress_path.write_text(json.dumps(_PROGRESS))
+
+    cleaned = []
+    monkeypatch.setattr(mod, "_cleanup_pair",
+                        lambda k, e, d, dry_run=False: cleaned.append(k) or True)
+
+    class _Args:
+        only = None; workload = None; package = None; status = None; dry_run = False
+
+    mod._cmd_cleanup(_Args(), progress_path, _DISCOVERED)
+
+    # done (wl-smoke-baseline) and pending (wl-load-baseline) should be skipped
+    assert "wl-smoke-baseline" not in cleaned
+    assert "wl-load-baseline" not in cleaned
+    # running, timed-out, failed should be cleaned
+    assert "wl-smoke-treatment" in cleaned
+    assert "wl-load-treatment" in cleaned
+    assert "wl-heavy-baseline" in cleaned
+
+
+def test_cmd_cleanup_respects_only_filter(tmp_path, monkeypatch, capsys):
+    """--only scopes cleanup to a single pair."""
+    import pipeline.deploy as mod
+
+    progress_path = tmp_path / "progress.json"
+    progress_path.write_text(json.dumps(_PROGRESS))
+
+    cleaned = []
+    monkeypatch.setattr(mod, "_cleanup_pair",
+                        lambda k, e, d, dry_run=False: cleaned.append(k) or True)
+
+    class _Args:
+        only = "wl-heavy-baseline"; workload = None; package = None; status = None; dry_run = False
+
+    mod._cmd_cleanup(_Args(), progress_path, _DISCOVERED)
+
+    assert cleaned == ["wl-heavy-baseline"]
+
+
+def test_cmd_cleanup_dry_run_does_not_save(tmp_path, monkeypatch, capsys):
+    """--dry-run does not mutate progress.json."""
+    import pipeline.deploy as mod
+
+    progress_path = tmp_path / "progress.json"
+    progress_path.write_text(json.dumps(_PROGRESS))
+
+    monkeypatch.setattr(mod, "_cleanup_pair",
+                        lambda k, e, d, dry_run=False: True)
+
+    class _Args:
+        only = None; workload = None; package = None; status = None; dry_run = True
+
+    mod._cmd_cleanup(_Args(), progress_path, _DISCOVERED)
+
+    # Progress should not be modified
+    saved = json.loads(progress_path.read_text())
+    assert saved == _PROGRESS
+
+
+def test_cmd_cleanup_saves_progress_on_success(tmp_path, monkeypatch, capsys):
+    """After cleanup, progress.json is updated with reset entries."""
+    import pipeline.deploy as mod
+
+    progress_path = tmp_path / "progress.json"
+    progress_path.write_text(json.dumps(_PROGRESS))
+
+    # Use real _cleanup_pair logic but mock subprocess calls
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = ""
+        return _R()
+
+    def fake_cancel(pr_name, ns):
+        pass
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    monkeypatch.setattr(mod, "_cancel_and_delete_pipelinerun", fake_cancel)
+
+    class _Args:
+        only = None; workload = None; package = None; status = None; dry_run = False
+
+    mod._cmd_cleanup(_Args(), progress_path, _DISCOVERED)
+
+    saved = json.loads(progress_path.read_text())
+    assert saved["wl-smoke-treatment"]["status"] == "pending"
+    assert saved["wl-load-treatment"]["status"] == "pending"
+    assert saved["wl-heavy-baseline"]["status"] == "pending"
+    # done and pending unchanged
+    assert saved["wl-smoke-baseline"]["status"] == "done"
+    assert saved["wl-load-baseline"]["status"] == "pending"

--- a/pipeline/tests/test_deploy_cleanup.py
+++ b/pipeline/tests/test_deploy_cleanup.py
@@ -95,6 +95,27 @@ def test_cleanup_pair_none_namespace_resets_state(monkeypatch):
     assert entry["retries"] == 0
 
 
+def test_cleanup_pair_kubectl_delete_failure_does_not_reset(monkeypatch):
+    """When kubectl delete pipelinerun fails, state is NOT reset."""
+    import pipeline.deploy as mod
+
+    entry = {"workload": "wl-heavy", "package": "baseline", "status": "failed",
+             "namespace": "sim2real-0", "retries": 0}
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 1 if "pipelinerun" in cmd else 0
+            stdout = ""
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    result = mod._cleanup_pair("wl-heavy-baseline", entry, _DISCOVERED)
+    assert result is False
+    assert entry["status"] == "failed"
+    assert entry["namespace"] == "sim2real-0"
+
+
 def test_cleanup_pair_helm_list_failure_does_not_reset(monkeypatch):
     """When helm list fails, state is NOT reset — operator needs manual intervention."""
     import pipeline.deploy as mod

--- a/pipeline/tests/test_deploy_cleanup.py
+++ b/pipeline/tests/test_deploy_cleanup.py
@@ -153,7 +153,7 @@ def test_cmd_cleanup_continues_on_exception(tmp_path, monkeypatch, capsys):
 
     call_count = []
 
-    def exploding_cleanup(key, entry, disc, dry_run=False):
+    def exploding_cleanup(key, entry, disc, dry_run=False, namespaces=None):
         call_count.append(key)
         if key == "wl-a-baseline":
             raise RuntimeError("kubectl not found")
@@ -177,8 +177,41 @@ def test_cmd_cleanup_continues_on_exception(tmp_path, monkeypatch, capsys):
     assert saved["wl-b-baseline"]["status"] == "pending"
 
 
-def test_cmd_cleanup_skips_done_and_pending(tmp_path, monkeypatch, capsys):
-    """cleanup only acts on non-done, non-pending pairs."""
+def test_cleanup_pair_done_deletes_pr_without_state_reset(monkeypatch):
+    """Done pairs get PipelineRun deleted but stay in done state."""
+    import pipeline.deploy as mod
+
+    entry = {"workload": "wl-smoke", "package": "baseline", "status": "done",
+             "namespace": None, "retries": 0}
+    calls = []
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        calls.append(cmd)
+        class _R:
+            returncode = 0
+            stdout = ""
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    result = mod._cleanup_pair("wl-smoke-baseline", entry, _DISCOVERED,
+                               namespaces=["sim2real-0", "sim2real-1"])
+
+    assert result is True
+    # State stays done
+    assert entry["status"] == "done"
+    # PipelineRun deleted across all namespace slots
+    kubectl_deletes = [c for c in calls if "delete" in c and "pipelinerun" in c]
+    assert len(kubectl_deletes) == 2
+    assert "sim2real-0" in kubectl_deletes[0]
+    assert "sim2real-1" in kubectl_deletes[1]
+    # No helm operations for done pairs
+    helm_calls = [c for c in calls if c[0] == "helm"]
+    assert helm_calls == []
+
+
+def test_cmd_cleanup_skips_pending_only(tmp_path, monkeypatch, capsys):
+    """cleanup acts on all non-pending pairs, including done."""
     import pipeline.deploy as mod
 
     progress_path = tmp_path / "progress.json"
@@ -186,17 +219,17 @@ def test_cmd_cleanup_skips_done_and_pending(tmp_path, monkeypatch, capsys):
 
     cleaned = []
     monkeypatch.setattr(mod, "_cleanup_pair",
-                        lambda k, e, d, dry_run=False: cleaned.append(k) or True)
+                        lambda k, e, d, dry_run=False, namespaces=None: cleaned.append(k) or True)
 
     class _Args:
         only = None; workload = None; package = None; status = None; dry_run = False
 
     mod._cmd_cleanup(_Args(), progress_path, _DISCOVERED)
 
-    # done (wl-smoke-baseline) and pending (wl-load-baseline) should be skipped
-    assert "wl-smoke-baseline" not in cleaned
+    # pending (wl-load-baseline) should be skipped
     assert "wl-load-baseline" not in cleaned
-    # running, timed-out, failed should be cleaned
+    # done, running, timed-out, failed should all be cleaned
+    assert "wl-smoke-baseline" in cleaned
     assert "wl-smoke-treatment" in cleaned
     assert "wl-load-treatment" in cleaned
     assert "wl-heavy-baseline" in cleaned
@@ -211,7 +244,7 @@ def test_cmd_cleanup_respects_only_filter(tmp_path, monkeypatch, capsys):
 
     cleaned = []
     monkeypatch.setattr(mod, "_cleanup_pair",
-                        lambda k, e, d, dry_run=False: cleaned.append(k) or True)
+                        lambda k, e, d, dry_run=False, namespaces=None: cleaned.append(k) or True)
 
     class _Args:
         only = "wl-heavy-baseline"; workload = None; package = None; status = None; dry_run = False
@@ -229,7 +262,7 @@ def test_cmd_cleanup_dry_run_does_not_save(tmp_path, monkeypatch, capsys):
     progress_path.write_text(json.dumps(_PROGRESS))
 
     monkeypatch.setattr(mod, "_cleanup_pair",
-                        lambda k, e, d, dry_run=False: True)
+                        lambda k, e, d, dry_run=False, namespaces=None: True)
 
     class _Args:
         only = None; workload = None; package = None; status = None; dry_run = True
@@ -264,14 +297,17 @@ def test_cmd_cleanup_saves_progress_on_success(tmp_path, monkeypatch, capsys):
     class _Args:
         only = None; workload = None; package = None; status = None; dry_run = False
 
-    mod._cmd_cleanup(_Args(), progress_path, _DISCOVERED)
+    mod._cmd_cleanup(_Args(), progress_path, _DISCOVERED,
+                     namespaces=["sim2real-0", "sim2real-1", "sim2real-2"])
 
     saved = json.loads(progress_path.read_text())
+    # Non-done pairs reset to pending
     assert saved["wl-smoke-treatment"]["status"] == "pending"
     assert saved["wl-load-treatment"]["status"] == "pending"
     assert saved["wl-heavy-baseline"]["status"] == "pending"
-    # done and pending unchanged
+    # Done pair stays done (PipelineRun deleted but state preserved)
     assert saved["wl-smoke-baseline"]["status"] == "done"
+    # Pending pair unchanged
     assert saved["wl-load-baseline"]["status"] == "pending"
 
 

--- a/pipeline/tests/test_deploy_cleanup.py
+++ b/pipeline/tests/test_deploy_cleanup.py
@@ -332,8 +332,8 @@ def test_cmd_cleanup_saves_progress_on_success(tmp_path, monkeypatch, capsys):
     assert saved["wl-load-baseline"]["status"] == "pending"
 
 
-def test_force_reset_calls_cleanup_for_pairs_with_namespace(monkeypatch):
-    """_force_reset should clean cluster resources for pairs that had a namespace."""
+def test_force_reset_calls_cleanup_for_non_pending_non_done(monkeypatch):
+    """_force_reset cleans non-pending, non-done pairs via _cleanup_pair."""
     import pipeline.deploy as mod
 
     progress = {
@@ -343,16 +343,19 @@ def test_force_reset_calls_cleanup_for_pairs_with_namespace(monkeypatch):
                            "namespace": None, "retries": 0},
         "wl-b-baseline": {"workload": "wl-b", "package": "baseline", "status": "timed-out",
                           "namespace": "sim2real-1", "retries": 2},
+        "wl-c-baseline": {"workload": "wl-c", "package": "baseline", "status": "done",
+                          "namespace": None, "retries": 0},
     }
     discovered = {
         "wl-a-baseline": {"pr_name": "baseline-a-run1", "workload": "wl-a", "package": "baseline"},
         "wl-a-treatment": {"pr_name": "treatment-a-run1", "workload": "wl-a", "package": "treatment"},
         "wl-b-baseline": {"pr_name": "baseline-b-run1", "workload": "wl-b", "package": "baseline"},
+        "wl-c-baseline": {"pr_name": "baseline-c-run1", "workload": "wl-c", "package": "baseline"},
     }
 
     cleaned = []
 
-    def fake_cleanup(key, entry, disc, dry_run=False):
+    def fake_cleanup(key, entry, disc, dry_run=False, namespaces=None):
         cleaned.append(key)
         entry["status"] = "pending"
         entry["namespace"] = None
@@ -362,18 +365,17 @@ def test_force_reset_calls_cleanup_for_pairs_with_namespace(monkeypatch):
     monkeypatch.setattr(mod, "_cleanup_pair", fake_cleanup)
 
     scope = set(progress.keys())
-    n = mod._force_reset(progress, scope, discovered)
+    n = mod._force_reset(progress, scope, discovered,
+                         namespaces=["sim2real-0", "sim2real-1"])
 
-    # Only pairs with a namespace AND non-pending status should have been cleaned
+    # Pending and done should be skipped
+    assert "wl-a-treatment" not in cleaned
+    assert "wl-c-baseline" not in cleaned
+    # Failed and timed-out should be cleaned
     assert "wl-a-baseline" in cleaned
     assert "wl-b-baseline" in cleaned
-    assert "wl-a-treatment" not in cleaned
-    # Count should reflect pairs that were actually reset
     assert n == 2
-    # All non-pending should now be pending
-    assert progress["wl-a-baseline"]["status"] == "pending"
-    assert progress["wl-b-baseline"]["status"] == "pending"
-    assert progress["wl-a-treatment"]["status"] == "pending"
+    assert progress["wl-c-baseline"]["status"] == "done"
 
 
 def test_force_reset_skips_count_on_cleanup_failure(monkeypatch):
@@ -410,7 +412,7 @@ def test_force_reset_continues_on_exception(monkeypatch):
 
     call_count = []
 
-    def sometimes_fails(key, entry, disc, dry_run=False):
+    def sometimes_fails(key, entry, disc, dry_run=False, namespaces=None):
         call_count.append(key)
         if key == "wl-a-baseline":
             raise RuntimeError("network error")

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -289,8 +289,22 @@ def test_do_collect_interrupt_saves_collect_failed(tmp_path, monkeypatch):
 
 # ── _force_reset ──────────────────────────────────────────────────────────────
 
-def test_force_reset_resets_non_pending_non_done_pairs():
+def _mock_run(monkeypatch):
+    """Mock subprocess.run for _force_reset tests (no real kubectl/helm)."""
+    import pipeline.deploy as mod
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = ""
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+
+def test_force_reset_resets_non_pending_non_done_pairs(monkeypatch):
     from pipeline.deploy import _force_reset
+    _mock_run(monkeypatch)
     progress = dict(_PROGRESS)
     scope = set(progress.keys())
     n = _force_reset(progress, scope)
@@ -303,16 +317,18 @@ def test_force_reset_resets_non_pending_non_done_pairs():
     assert progress["wl-smoke-baseline"]["status"] == "done"
 
 
-def test_force_reset_leaves_pending_pairs_unchanged():
+def test_force_reset_leaves_pending_pairs_unchanged(monkeypatch):
     from pipeline.deploy import _force_reset
+    _mock_run(monkeypatch)
     progress = dict(_PROGRESS)
     scope = set(progress.keys())
     _force_reset(progress, scope)
     assert progress["wl-load-baseline"]["status"] == "pending"
 
 
-def test_force_reset_scoped_to_package():
+def test_force_reset_scoped_to_package(monkeypatch):
     from pipeline.deploy import _force_reset
+    _mock_run(monkeypatch)
     progress = {
         "wl-a-baseline":  {"workload": "wl-a", "package": "baseline",  "status": "failed", "namespace": "ns-0", "retries": 2},
         "wl-a-treatment": {"workload": "wl-a", "package": "treatment", "status": "failed", "namespace": "ns-1", "retries": 1},
@@ -335,8 +351,9 @@ def test_force_reset_returns_zero_when_nothing_to_reset():
     assert progress["wl-a-baseline"]["status"] == "pending"
 
 
-def test_force_reset_clears_retries():
+def test_force_reset_clears_retries(monkeypatch):
     from pipeline.deploy import _force_reset
+    _mock_run(monkeypatch)
     progress = {
         "wl-a-baseline": {"workload": "wl-a", "package": "baseline", "status": "timed-out", "namespace": "ns-0", "retries": 3},
     }

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -289,17 +289,18 @@ def test_do_collect_interrupt_saves_collect_failed(tmp_path, monkeypatch):
 
 # ── _force_reset ──────────────────────────────────────────────────────────────
 
-def test_force_reset_resets_non_pending_pairs():
+def test_force_reset_resets_non_pending_non_done_pairs():
     from pipeline.deploy import _force_reset
     progress = dict(_PROGRESS)
     scope = set(progress.keys())
     n = _force_reset(progress, scope)
-    # All non-pending pairs reset (done, running, timed-out, failed)
-    assert n == 4
-    for key in ("wl-smoke-baseline", "wl-smoke-treatment", "wl-load-treatment", "wl-heavy-baseline"):
+    # running, timed-out, failed are reset; done and pending are skipped
+    assert n == 3
+    for key in ("wl-smoke-treatment", "wl-load-treatment", "wl-heavy-baseline"):
         assert progress[key]["status"] == "pending"
         assert progress[key]["namespace"] is None
         assert progress[key]["retries"] == 0
+    assert progress["wl-smoke-baseline"]["status"] == "done"
 
 
 def test_force_reset_leaves_pending_pairs_unchanged():
@@ -313,15 +314,15 @@ def test_force_reset_leaves_pending_pairs_unchanged():
 def test_force_reset_scoped_to_package():
     from pipeline.deploy import _force_reset
     progress = {
-        "wl-a-baseline":  {"workload": "wl-a", "package": "baseline",  "status": "done", "namespace": "ns-0", "retries": 2},
-        "wl-a-treatment": {"workload": "wl-a", "package": "treatment", "status": "done", "namespace": "ns-1", "retries": 1},
+        "wl-a-baseline":  {"workload": "wl-a", "package": "baseline",  "status": "failed", "namespace": "ns-0", "retries": 2},
+        "wl-a-treatment": {"workload": "wl-a", "package": "treatment", "status": "failed", "namespace": "ns-1", "retries": 1},
     }
     scope = {"wl-a-baseline"}
     n = _force_reset(progress, scope)
     assert n == 1
     assert progress["wl-a-baseline"]["status"] == "pending"
     assert progress["wl-a-baseline"]["retries"] == 0
-    assert progress["wl-a-treatment"]["status"] == "done"
+    assert progress["wl-a-treatment"]["status"] == "failed"
 
 
 def test_force_reset_returns_zero_when_nothing_to_reset():
@@ -337,7 +338,7 @@ def test_force_reset_returns_zero_when_nothing_to_reset():
 def test_force_reset_clears_retries():
     from pipeline.deploy import _force_reset
     progress = {
-        "wl-a-baseline": {"workload": "wl-a", "package": "baseline", "status": "done", "namespace": "ns-0", "retries": 3},
+        "wl-a-baseline": {"workload": "wl-a", "package": "baseline", "status": "timed-out", "namespace": "ns-0", "retries": 3},
     }
     _force_reset(progress, {"wl-a-baseline"})
     assert progress["wl-a-baseline"]["retries"] == 0


### PR DESCRIPTION
## Summary

Closes #6

- Extract shared `_cleanup_pair()` helper that handles PipelineRun deletion and Helm release uninstallation for a single pair
- Add `deploy.py cleanup` subcommand with `--only`, `--workload`, `--package`, `--status`, and `--dry-run` flags — cleans all non-pending pairs including `done` (removes PipelineRuns from cluster)
- Fix `--force` path in `deploy.py run` to clean cluster resources before resetting state (skips `done` pairs to prevent re-dispatch of completed work)
- Robust error handling: helm list/uninstall failures preserve state, exceptions in one pair don't abort cleanup of remaining pairs

### Behavior by state

| State | Cluster action | State after |
|---|---|---|
| `pending` | No-op (excluded) | `pending` |
| `running` | Cancel + delete PR + Helm uninstall | → `pending` |
| `failed` / `timed-out` | Delete PR + Helm uninstall | → `pending` |
| `collect-failed` | Reset only (ns already freed) | → `pending` |
| `done` | Delete PipelineRun across namespace slots | stays `done` |

**Note:** The original issue listed `done` as no-op, but this contradicts the stated motivation of freeing cluster resources after successful runs. See [issue comment](https://github.com/inference-sim/sim2real/issues/6#issuecomment-4400624345) for scope clarification.

## Test Plan

- [x] 15 unit tests covering `_cleanup_pair`, `_cmd_cleanup`, and `_force_reset`
- [x] Full CI suite passes (367 tests, lint clean)
- [x] `deploy.py --help` shows `cleanup` subcommand with examples
- [ ] Manual: `deploy.py cleanup --dry-run` lists actionable pairs without acting
- [ ] Manual: `deploy.py cleanup` deletes PipelineRuns and Helm releases, resets progress
- [ ] Manual: `deploy.py run --force` cleans cluster resources before re-submitting