### PR TITLE
feat(capacity): add GPU capacity probe for deploy.py run

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -147,7 +147,7 @@ python pipeline/deploy.py cleanup [flags]   # tear down cluster resources for fa
 | `--force` | — | Reset non-pending pairs to `pending`, cleaning cluster resources (PipelineRuns + Helm) for pairs with assigned namespaces |
 | `--max-retries N` | 2 | Max retries for timed-out pairs |
 | `--poll-interval N` | 30 | Seconds between status polls |
-| `--gpu-resource-type` | `nvidia.com/gpu` | Kubernetes resource name for GPU counting (auto-derived from scenario if available) |
+| `--gpu-resource-type` | auto-derived | Override GPU resource name (derived from scenario's `accelerator.resource`, else `nvidia.com/gpu`) |
 | `--default-gpu-cost N` | 1 | Fallback GPU cost per pair when not derivable from scenario |
 
 **`deploy.py status`** — prints the current state of all pairs from `workspace/runs/<run>/progress.json`.

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -147,6 +147,8 @@ python pipeline/deploy.py cleanup [flags]   # tear down cluster resources for fa
 | `--force` | — | Reset non-pending pairs to `pending`, cleaning cluster resources (PipelineRuns + Helm) for pairs with assigned namespaces |
 | `--max-retries N` | 2 | Max retries for timed-out pairs |
 | `--poll-interval N` | 30 | Seconds between status polls |
+| `--gpu-resource-type` | `nvidia.com/gpu` | Kubernetes resource name for GPU counting (auto-derived from scenario if available) |
+| `--default-gpu-cost N` | 1 | Fallback GPU cost per pair when not derivable from scenario |
 
 **`deploy.py status`** — prints the current state of all pairs from `workspace/runs/<run>/progress.json`.
 

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -725,30 +725,37 @@ def _cmd_run(args, manifest: dict, run_dir: Path, setup_config: dict) -> None:
     store = LocalProgressStore(progress_path)
 
     # Derive GPU resource type and cost from scenario + defaults
-    gpu_resource_type = args.gpu_resource_type
+    # CLI --gpu-resource-type overrides auto-derivation when explicitly set
+    gpu_resource_type = args.gpu_resource_type  # None means auto-derive
     pair_gpu_cost = args.default_gpu_cost
-    defaults = load_defaults(REPO_ROOT)
+    defaults_result = load_defaults(REPO_ROOT)
+    if isinstance(defaults_result, str):
+        warn(defaults_result)
+        defaults_result = None
     baseline_scenario_path = cluster_dir / "baseline.yaml"
-    if defaults and baseline_scenario_path.exists():
+    if defaults_result and baseline_scenario_path.exists():
         try:
             resolved = yaml.safe_load(baseline_scenario_path.read_text()) or {}
         except yaml.YAMLError as e:
             warn(f"Could not parse {baseline_scenario_path.name}: {e}")
             resolved = None
         if resolved:
-            gpu_resource_type = derive_gpu_resource_type(resolved, defaults)
-            derived_cost = gpu_cost_per_pair(resolved, defaults)
-            if derived_cost is not None:
+            if gpu_resource_type is None:
+                gpu_resource_type = derive_gpu_resource_type(resolved, defaults_result)
+            derived_cost = gpu_cost_per_pair(resolved, defaults_result)
+            if isinstance(derived_cost, int):
                 pair_gpu_cost = derived_cost
             else:
-                warn(f"Could not derive GPU cost from scenario — using fallback ({pair_gpu_cost})")
-    else:
-        warn(f"Defaults or baseline.yaml unavailable — using CLI defaults "
-             f"(resource={gpu_resource_type}, cost={pair_gpu_cost})")
+                warn(f"GPU cost derivation failed: {derived_cost} — using fallback ({pair_gpu_cost})")
+    elif defaults_result is None and not baseline_scenario_path.exists():
+        info("Defaults or baseline.yaml not found — using CLI defaults")
+    if gpu_resource_type is None:
+        gpu_resource_type = "nvidia.com/gpu"
     if gpu_resource_type != "nvidia.com/gpu":
         info(f"GPU resource type: {gpu_resource_type}")
     info(f"GPU cost per pair: {pair_gpu_cost}")
     _probe_fail_count = 0
+    _last_probe_error = ""
 
     # Load or initialize progress
     progress = store.load()
@@ -975,11 +982,15 @@ def _cmd_run(args, manifest: dict, run_dir: Path, setup_config: dict) -> None:
         if isinstance(capacity, tuple):
             free, allocatable, requested = capacity
             info(f"Capacity: {free} free GPUs ({allocatable} allocatable − {requested} requested)")
+            if _probe_fail_count > 0:
+                info(f"Capacity probe recovered after {_probe_fail_count} failure(s)")
             _probe_fail_count = 0
+            _last_probe_error = ""
         else:
             _probe_fail_count += 1
-            if _probe_fail_count == 1 or _probe_fail_count % 10 == 0:
+            if capacity != _last_probe_error or _probe_fail_count % 10 == 0:
                 warn(f"Capacity probe failed: {capacity}")
+            _last_probe_error = capacity
 
         if _work_remaining() or slots_busy:
             time.sleep(poll_interval)
@@ -1094,8 +1105,8 @@ Examples:
                        help="Max retries for timed-out pairs [2]")
     run_p.add_argument("--poll-interval", type=int, default=30, dest="poll_interval",
                        help="Seconds between status polls [30]")
-    run_p.add_argument("--gpu-resource-type", default="nvidia.com/gpu", dest="gpu_resource_type",
-                       help="Kubernetes resource name for GPU counting [nvidia.com/gpu]")
+    run_p.add_argument("--gpu-resource-type", default=None, dest="gpu_resource_type",
+                       help="Override GPU resource name (default: derived from scenario, else nvidia.com/gpu)")
     run_p.add_argument("--default-gpu-cost", type=int, default=1, dest="default_gpu_cost",
                        help="Fallback GPU cost per pair when not derivable from scenario [1]")
 

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -704,7 +704,7 @@ def _cmd_run(args, manifest: dict, run_dir: Path, setup_config: dict) -> None:
     import tempfile as _tmp
     from pipeline.lib.progress import LocalProgressStore
     from pipeline.lib.capacity import (
-        probe_free_gpus, gpu_cost_per_pair, derive_gpu_resource_type, load_defaults,
+        probe_free_gpus, gpu_cost_per_pair, derive_gpu_resource_type, load_defaults
     )
 
     namespaces = setup_config.get("namespaces") or [setup_config.get("namespace", "")]
@@ -730,13 +730,25 @@ def _cmd_run(args, manifest: dict, run_dir: Path, setup_config: dict) -> None:
     defaults = load_defaults(REPO_ROOT)
     baseline_scenario_path = cluster_dir / "baseline.yaml"
     if defaults and baseline_scenario_path.exists():
-        resolved = yaml.safe_load(baseline_scenario_path.read_text()) or {}
-        gpu_resource_type = derive_gpu_resource_type(resolved, defaults)
-        pair_gpu_cost = gpu_cost_per_pair(resolved, defaults)
+        try:
+            resolved = yaml.safe_load(baseline_scenario_path.read_text()) or {}
+        except yaml.YAMLError as e:
+            warn(f"Could not parse {baseline_scenario_path.name}: {e}")
+            resolved = None
+        if resolved:
+            gpu_resource_type = derive_gpu_resource_type(resolved, defaults)
+            derived_cost = gpu_cost_per_pair(resolved, defaults)
+            if derived_cost is not None:
+                pair_gpu_cost = derived_cost
+            else:
+                warn(f"Could not derive GPU cost from scenario — using fallback ({pair_gpu_cost})")
+    else:
+        warn(f"Defaults or baseline.yaml unavailable — using CLI defaults "
+             f"(resource={gpu_resource_type}, cost={pair_gpu_cost})")
     if gpu_resource_type != "nvidia.com/gpu":
         info(f"GPU resource type: {gpu_resource_type}")
     info(f"GPU cost per pair: {pair_gpu_cost}")
-    _probe_warn_emitted = False
+    _probe_fail_count = 0
 
     # Load or initialize progress
     progress = store.load()
@@ -960,15 +972,14 @@ def _cmd_run(args, manifest: dict, run_dir: Path, setup_config: dict) -> None:
 
         # ── Capacity probe ───────────────────────────────────────────────
         capacity = probe_free_gpus(gpu_resource_type=gpu_resource_type)
-        if capacity is not None:
+        if isinstance(capacity, tuple):
             free, allocatable, requested = capacity
             info(f"Capacity: {free} free GPUs ({allocatable} allocatable − {requested} requested)")
-            _probe_warn_emitted = False
-        elif not _probe_warn_emitted:
-            from pipeline.lib.capacity import probe_stderr
-            stderr_msg = probe_stderr(gpu_resource_type=gpu_resource_type) or "unknown error"
-            warn(f"Capacity probe failed: {stderr_msg}")
-            _probe_warn_emitted = True
+            _probe_fail_count = 0
+        else:
+            _probe_fail_count += 1
+            if _probe_fail_count == 1 or _probe_fail_count % 10 == 0:
+                warn(f"Capacity probe failed: {capacity}")
 
         if _work_remaining() or slots_busy:
             time.sleep(poll_interval)

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -703,7 +703,9 @@ def _cmd_run(args, manifest: dict, run_dir: Path, setup_config: dict) -> None:
     import datetime as _dt
     import tempfile as _tmp
     from pipeline.lib.progress import LocalProgressStore
-    from pipeline.lib.capacity import probe_free_gpus
+    from pipeline.lib.capacity import (
+        probe_free_gpus, gpu_cost_per_pair, derive_gpu_resource_type, load_defaults,
+    )
 
     namespaces = setup_config.get("namespaces") or [setup_config.get("namespace", "")]
     if not namespaces or not namespaces[0]:
@@ -721,6 +723,20 @@ def _cmd_run(args, manifest: dict, run_dir: Path, setup_config: dict) -> None:
     cluster_dir = run_dir / "cluster"
     progress_path = run_dir / "progress.json"
     store = LocalProgressStore(progress_path)
+
+    # Derive GPU resource type and cost from scenario + defaults
+    gpu_resource_type = args.gpu_resource_type
+    pair_gpu_cost = args.default_gpu_cost
+    defaults = load_defaults(REPO_ROOT)
+    baseline_scenario_path = cluster_dir / "baseline.yaml"
+    if defaults and baseline_scenario_path.exists():
+        resolved = yaml.safe_load(baseline_scenario_path.read_text()) or {}
+        gpu_resource_type = derive_gpu_resource_type(resolved, defaults)
+        pair_gpu_cost = gpu_cost_per_pair(resolved, defaults)
+    if gpu_resource_type != "nvidia.com/gpu":
+        info(f"GPU resource type: {gpu_resource_type}")
+    info(f"GPU cost per pair: {pair_gpu_cost}")
+    _probe_warn_emitted = False
 
     # Load or initialize progress
     progress = store.load()
@@ -943,13 +959,16 @@ def _cmd_run(args, manifest: dict, run_dir: Path, setup_config: dict) -> None:
             ok(f"[{pair_key}] → {ns} ({pr_name})")
 
         # ── Capacity probe ───────────────────────────────────────────────
-        gpu_resource_type = getattr(args, "gpu_resource_type", "nvidia.com/gpu")
         capacity = probe_free_gpus(gpu_resource_type=gpu_resource_type)
         if capacity is not None:
             free, allocatable, requested = capacity
             info(f"Capacity: {free} free GPUs ({allocatable} allocatable − {requested} requested)")
-        else:
-            warn("Capacity probe failed — kubectl unavailable or returned error")
+            _probe_warn_emitted = False
+        elif not _probe_warn_emitted:
+            from pipeline.lib.capacity import probe_stderr
+            stderr_msg = probe_stderr(gpu_resource_type=gpu_resource_type) or "unknown error"
+            warn(f"Capacity probe failed: {stderr_msg}")
+            _probe_warn_emitted = True
 
         if _work_remaining() or slots_busy:
             time.sleep(poll_interval)

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -703,6 +703,7 @@ def _cmd_run(args, manifest: dict, run_dir: Path, setup_config: dict) -> None:
     import datetime as _dt
     import tempfile as _tmp
     from pipeline.lib.progress import LocalProgressStore
+    from pipeline.lib.capacity import probe_free_gpus
 
     namespaces = setup_config.get("namespaces") or [setup_config.get("namespace", "")]
     if not namespaces or not namespaces[0]:
@@ -941,6 +942,15 @@ def _cmd_run(args, manifest: dict, run_dir: Path, setup_config: dict) -> None:
             store.save(progress)
             ok(f"[{pair_key}] → {ns} ({pr_name})")
 
+        # ── Capacity probe ───────────────────────────────────────────────
+        gpu_resource_type = getattr(args, "gpu_resource_type", "nvidia.com/gpu")
+        capacity = probe_free_gpus(gpu_resource_type=gpu_resource_type)
+        if capacity is not None:
+            free, allocatable, requested = capacity
+            info(f"Capacity: {free} free GPUs ({allocatable} allocatable − {requested} requested)")
+        else:
+            warn("Capacity probe failed — kubectl unavailable or returned error")
+
         if _work_remaining() or slots_busy:
             time.sleep(poll_interval)
 
@@ -1054,6 +1064,10 @@ Examples:
                        help="Max retries for timed-out pairs [2]")
     run_p.add_argument("--poll-interval", type=int, default=30, dest="poll_interval",
                        help="Seconds between status polls [30]")
+    run_p.add_argument("--gpu-resource-type", default="nvidia.com/gpu", dest="gpu_resource_type",
+                       help="Kubernetes resource name for GPU counting [nvidia.com/gpu]")
+    run_p.add_argument("--default-gpu-cost", type=int, default=1, dest="default_gpu_cost",
+                       help="Fallback GPU cost per pair when not derivable from scenario [1]")
 
     cleanup_p = sub.add_parser("cleanup", help="Tear down cluster resources for all non-pending pairs")
     cleanup_p.add_argument("--only",     metavar="PAIR",  help="Scope to one specific pair key")

--- a/pipeline/lib/capacity.py
+++ b/pipeline/lib/capacity.py
@@ -52,3 +52,58 @@ def probe_free_gpus(
 
     free = max(0, total_allocatable - total_requested)
     return (free, total_allocatable, total_requested)
+
+
+# ── GPU cost derivation ────────────────────────────────────────────────────────
+
+from pipeline.lib.values import deep_merge
+
+
+def gpu_cost_per_pair(resolved_scenario: dict, defaults: dict) -> int:
+    """Compute total GPU cost for one baseline/treatment pair.
+
+    Merges the first scenario entry over defaults, then sums GPU cost
+    across enabled roles using the 3-level precedence:
+      role.accelerator.count > accelerator.count > tensor * dataLocal
+
+    Args:
+        resolved_scenario: The resolved scenario dict (has "scenario" list).
+        defaults: The full defaults.yaml dict from llm-d-benchmark.
+
+    Returns:
+        Total GPU count needed for one pair (one arm of baseline or treatment).
+    """
+    scenario_entry = {}
+    scenarios = resolved_scenario.get("scenario", [])
+    if scenarios:
+        scenario_entry = scenarios[0]
+
+    merged = deep_merge(defaults, scenario_entry)
+
+    top_accel = merged.get("accelerator", {})
+    if top_accel.get("count") is not None and int(top_accel["count"]) == 0:
+        return 0
+
+    gpu_cost = 0
+    for role_name, default_enabled, default_replicas in [
+        ("decode", True, 1),
+        ("prefill", False, 0),
+    ]:
+        role_cfg = merged.get(role_name, {})
+        if not role_cfg.get("enabled", default_enabled):
+            continue
+
+        replicas = role_cfg.get("replicas", default_replicas)
+        parallelism = role_cfg.get("parallelism", {})
+
+        role_accel = role_cfg.get("accelerator", {})
+        if "count" in role_accel:
+            gpus_per_pod = int(role_accel["count"])
+        elif "count" in top_accel:
+            gpus_per_pod = int(top_accel["count"])
+        else:
+            gpus_per_pod = parallelism.get("tensor", 1) * parallelism.get("dataLocal", 1)
+
+        gpu_cost += replicas * gpus_per_pod
+
+    return gpu_cost

--- a/pipeline/lib/capacity.py
+++ b/pipeline/lib/capacity.py
@@ -1,0 +1,54 @@
+"""GPU capacity probe for deploy.py orchestrator."""
+
+import json
+import subprocess
+from typing import Optional
+
+
+def probe_free_gpus(
+    gpu_resource_type: str = "nvidia.com/gpu",
+) -> Optional[tuple[int, int, int]]:
+    """Return (free_gpus, total_allocatable, total_requested) or None on failure.
+
+    Queries kubectl for node allocatable resources and pod requests,
+    computes the delta clamped to zero.
+    """
+    try:
+        nodes_result = subprocess.run(
+            ["kubectl", "get", "nodes", "-o", "json"],
+            check=False, text=True, capture_output=True,
+        )
+        if nodes_result.returncode != 0:
+            return None
+
+        pods_result = subprocess.run(
+            ["kubectl", "get", "pods", "--all-namespaces",
+             "--field-selector=status.phase!=Succeeded,status.phase!=Failed",
+             "-o", "json"],
+            check=False, text=True, capture_output=True,
+        )
+        if pods_result.returncode != 0:
+            return None
+
+        nodes = json.loads(nodes_result.stdout)
+        pods = json.loads(pods_result.stdout)
+    except (json.JSONDecodeError, OSError):
+        return None
+
+    total_allocatable = 0
+    for node in nodes.get("items", []):
+        alloc = node.get("status", {}).get("allocatable", {})
+        count = alloc.get(gpu_resource_type)
+        if count is not None:
+            total_allocatable += int(count)
+
+    total_requested = 0
+    for pod in pods.get("items", []):
+        for container in pod.get("spec", {}).get("containers", []):
+            requests = container.get("resources", {}).get("requests", {})
+            count = requests.get(gpu_resource_type)
+            if count is not None:
+                total_requested += int(count)
+
+    free = max(0, total_allocatable - total_requested)
+    return (free, total_allocatable, total_requested)

--- a/pipeline/lib/capacity.py
+++ b/pipeline/lib/capacity.py
@@ -3,15 +3,20 @@
 import json
 import subprocess
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
+
+import yaml
 
 from pipeline.lib.values import deep_merge
 
 
+# ── Cluster probe ──────────────────────────────────────────────────────────────
+
+
 def probe_free_gpus(
     gpu_resource_type: str = "nvidia.com/gpu",
-) -> Optional[tuple[int, int, int]]:
-    """Return (free_gpus, total_allocatable, total_requested) or None on failure.
+) -> Union[tuple[int, int, int], str]:
+    """Return (free_gpus, total_allocatable, total_requested) or error string.
 
     Queries kubectl for node allocatable resources and pod requests,
     computes the delta clamped to zero.
@@ -29,7 +34,7 @@ def probe_free_gpus(
             check=False, text=True, capture_output=True,
         )
         if nodes_result.returncode != 0:
-            return None
+            return nodes_result.stderr.strip() or "kubectl get nodes failed"
 
         pods_result = subprocess.run(
             ["kubectl", "get", "pods", "--all-namespaces",
@@ -38,54 +43,40 @@ def probe_free_gpus(
             check=False, text=True, capture_output=True,
         )
         if pods_result.returncode != 0:
-            return None
+            return pods_result.stderr.strip() or "kubectl get pods failed"
 
+    except OSError as e:
+        return str(e)
+
+    try:
         nodes = json.loads(nodes_result.stdout)
         pods = json.loads(pods_result.stdout)
+    except json.JSONDecodeError as e:
+        return f"JSON parse error: {e}"
 
-        total_allocatable = 0
-        for node in nodes.get("items", []):
-            alloc = node.get("status", {}).get("allocatable", {})
-            count = alloc.get(gpu_resource_type)
-            if count is not None:
+    total_allocatable = 0
+    for node in nodes.get("items", []):
+        alloc = node.get("status", {}).get("allocatable", {})
+        count = alloc.get(gpu_resource_type)
+        if count is not None:
+            try:
                 total_allocatable += int(count)
+            except ValueError:
+                return f"non-integer allocatable value {count!r} on node {node.get('metadata', {}).get('name', '?')}"
 
-        total_requested = 0
-        for pod in pods.get("items", []):
-            for container in pod.get("spec", {}).get("containers", []):
-                requests = container.get("resources", {}).get("requests", {})
-                count = requests.get(gpu_resource_type)
-                if count is not None:
+    total_requested = 0
+    for pod in pods.get("items", []):
+        for container in pod.get("spec", {}).get("containers", []):
+            requests = container.get("resources", {}).get("requests", {})
+            count = requests.get(gpu_resource_type)
+            if count is not None:
+                try:
                     total_requested += int(count)
-
-    except (json.JSONDecodeError, OSError, ValueError):
-        return None
+                except ValueError:
+                    return f"non-integer request value {count!r} in pod {pod.get('metadata', {}).get('name', '?')}"
 
     free = max(0, total_allocatable - total_requested)
     return (free, total_allocatable, total_requested)
-
-
-def probe_stderr(gpu_resource_type: str = "nvidia.com/gpu") -> Optional[str]:
-    """Run the same kubectl calls as probe_free_gpus but return stderr on failure."""
-    try:
-        nodes_result = subprocess.run(
-            ["kubectl", "get", "nodes", "-o", "json"],
-            check=False, text=True, capture_output=True,
-        )
-        if nodes_result.returncode != 0:
-            return nodes_result.stderr.strip()
-
-        pods_result = subprocess.run(
-            ["kubectl", "get", "pods", "--all-namespaces",
-             "--field-selector=status.phase!=Succeeded,status.phase!=Failed",
-             "-o", "json"],
-            check=False, text=True, capture_output=True,
-        )
-        if pods_result.returncode != 0:
-            return pods_result.stderr.strip()
-    except OSError as e:
-        return str(e)
-    return None
 
 
 # ── GPU cost derivation ────────────────────────────────────────────────────────
@@ -106,7 +97,7 @@ def derive_gpu_resource_type(resolved_scenario: dict, defaults: dict) -> str:
     return merged.get("accelerator", {}).get("resource", "nvidia.com/gpu")
 
 
-def gpu_cost_per_pair(resolved_scenario: dict, defaults: dict) -> int:
+def gpu_cost_per_pair(resolved_scenario: dict, defaults: dict) -> Optional[int]:
     """Compute total GPU cost for one baseline/treatment pair.
 
     Merges the first scenario entry over defaults, then sums GPU cost
@@ -117,12 +108,7 @@ def gpu_cost_per_pair(resolved_scenario: dict, defaults: dict) -> int:
     Jinja template's 2-level logic — kept intentionally so that top-level
     accelerator.count propagates to roles that don't override it.
 
-    Args:
-        resolved_scenario: The resolved scenario dict (has "scenario" list).
-        defaults: The full defaults.yaml dict from llm-d-benchmark.
-
-    Returns:
-        Total GPU count needed for one pair (one arm of baseline or treatment).
+    Returns None if cost cannot be computed (e.g., non-numeric values).
     """
     scenario_entry = {}
     scenarios = resolved_scenario.get("scenario", [])
@@ -132,8 +118,11 @@ def gpu_cost_per_pair(resolved_scenario: dict, defaults: dict) -> int:
     merged = deep_merge(defaults, scenario_entry)
 
     top_accel = merged.get("accelerator", {})
-    if top_accel.get("count") is not None and int(top_accel["count"]) == 0:
-        return 0
+    try:
+        if top_accel.get("count") is not None and int(top_accel["count"]) == 0:
+            return 0
+    except (ValueError, TypeError):
+        return None
 
     gpu_cost = 0
     for role_name, default_enabled, default_replicas in [
@@ -148,12 +137,15 @@ def gpu_cost_per_pair(resolved_scenario: dict, defaults: dict) -> int:
         parallelism = role_cfg.get("parallelism", {})
 
         role_accel = role_cfg.get("accelerator", {})
-        if "count" in role_accel:
-            gpus_per_pod = int(role_accel["count"])
-        elif "count" in top_accel:
-            gpus_per_pod = int(top_accel["count"])
-        else:
-            gpus_per_pod = parallelism.get("tensor", 1) * parallelism.get("dataLocal", 1)
+        try:
+            if "count" in role_accel:
+                gpus_per_pod = int(role_accel["count"])
+            elif "count" in top_accel:
+                gpus_per_pod = int(top_accel["count"])
+            else:
+                gpus_per_pod = parallelism.get("tensor", 1) * parallelism.get("dataLocal", 1)
+        except (ValueError, TypeError):
+            return None
 
         gpu_cost += replicas * gpus_per_pod
 
@@ -166,7 +158,6 @@ def load_defaults(repo_root: Path) -> Optional[dict]:
     if not defaults_path.exists():
         return None
     try:
-        import yaml
         return yaml.safe_load(defaults_path.read_text()) or {}
-    except Exception:
+    except (yaml.YAMLError, OSError):
         return None

--- a/pipeline/lib/capacity.py
+++ b/pipeline/lib/capacity.py
@@ -2,7 +2,10 @@
 
 import json
 import subprocess
+from pathlib import Path
 from typing import Optional
+
+from pipeline.lib.values import deep_merge
 
 
 def probe_free_gpus(
@@ -12,6 +15,13 @@ def probe_free_gpus(
 
     Queries kubectl for node allocatable resources and pod requests,
     computes the delta clamped to zero.
+
+    Assumes only spec.containers request GPUs (initContainers are excluded —
+    llm-d workloads do not use GPU-requesting init containers).
+
+    Note: the two kubectl calls are not atomic — cluster state may change
+    between them. Acceptable for logging; consumers that gate on capacity
+    (#64) should account for this.
     """
     try:
         nodes_result = subprocess.run(
@@ -32,39 +42,80 @@ def probe_free_gpus(
 
         nodes = json.loads(nodes_result.stdout)
         pods = json.loads(pods_result.stdout)
-    except (json.JSONDecodeError, OSError):
-        return None
 
-    total_allocatable = 0
-    for node in nodes.get("items", []):
-        alloc = node.get("status", {}).get("allocatable", {})
-        count = alloc.get(gpu_resource_type)
-        if count is not None:
-            total_allocatable += int(count)
-
-    total_requested = 0
-    for pod in pods.get("items", []):
-        for container in pod.get("spec", {}).get("containers", []):
-            requests = container.get("resources", {}).get("requests", {})
-            count = requests.get(gpu_resource_type)
+        total_allocatable = 0
+        for node in nodes.get("items", []):
+            alloc = node.get("status", {}).get("allocatable", {})
+            count = alloc.get(gpu_resource_type)
             if count is not None:
-                total_requested += int(count)
+                total_allocatable += int(count)
+
+        total_requested = 0
+        for pod in pods.get("items", []):
+            for container in pod.get("spec", {}).get("containers", []):
+                requests = container.get("resources", {}).get("requests", {})
+                count = requests.get(gpu_resource_type)
+                if count is not None:
+                    total_requested += int(count)
+
+    except (json.JSONDecodeError, OSError, ValueError):
+        return None
 
     free = max(0, total_allocatable - total_requested)
     return (free, total_allocatable, total_requested)
 
 
+def probe_stderr(gpu_resource_type: str = "nvidia.com/gpu") -> Optional[str]:
+    """Run the same kubectl calls as probe_free_gpus but return stderr on failure."""
+    try:
+        nodes_result = subprocess.run(
+            ["kubectl", "get", "nodes", "-o", "json"],
+            check=False, text=True, capture_output=True,
+        )
+        if nodes_result.returncode != 0:
+            return nodes_result.stderr.strip()
+
+        pods_result = subprocess.run(
+            ["kubectl", "get", "pods", "--all-namespaces",
+             "--field-selector=status.phase!=Succeeded,status.phase!=Failed",
+             "-o", "json"],
+            check=False, text=True, capture_output=True,
+        )
+        if pods_result.returncode != 0:
+            return pods_result.stderr.strip()
+    except OSError as e:
+        return str(e)
+    return None
+
+
 # ── GPU cost derivation ────────────────────────────────────────────────────────
 
-from pipeline.lib.values import deep_merge
+
+def derive_gpu_resource_type(resolved_scenario: dict, defaults: dict) -> str:
+    """Derive the Kubernetes GPU resource name from scenario + defaults.
+
+    Merges the first scenario entry over defaults, then reads
+    accelerator.resource. Falls back to "nvidia.com/gpu".
+    """
+    scenario_entry = {}
+    scenarios = resolved_scenario.get("scenario", [])
+    if scenarios:
+        scenario_entry = scenarios[0]
+
+    merged = deep_merge(defaults, scenario_entry)
+    return merged.get("accelerator", {}).get("resource", "nvidia.com/gpu")
 
 
 def gpu_cost_per_pair(resolved_scenario: dict, defaults: dict) -> int:
     """Compute total GPU cost for one baseline/treatment pair.
 
     Merges the first scenario entry over defaults, then sums GPU cost
-    across enabled roles using the 3-level precedence:
+    across enabled roles using 3-level precedence:
       role.accelerator.count > accelerator.count > tensor * dataLocal
+
+    The middle tier (accelerator.count as per-role fallback) extends the
+    Jinja template's 2-level logic — kept intentionally so that top-level
+    accelerator.count propagates to roles that don't override it.
 
     Args:
         resolved_scenario: The resolved scenario dict (has "scenario" list).
@@ -107,3 +158,15 @@ def gpu_cost_per_pair(resolved_scenario: dict, defaults: dict) -> int:
         gpu_cost += replicas * gpus_per_pod
 
     return gpu_cost
+
+
+def load_defaults(repo_root: Path) -> Optional[dict]:
+    """Load llm-d-benchmark defaults.yaml, or None if unavailable."""
+    defaults_path = repo_root / "llm-d-benchmark" / "config" / "templates" / "values" / "defaults.yaml"
+    if not defaults_path.exists():
+        return None
+    try:
+        import yaml
+        return yaml.safe_load(defaults_path.read_text()) or {}
+    except Exception:
+        return None

--- a/pipeline/lib/capacity.py
+++ b/pipeline/lib/capacity.py
@@ -3,7 +3,7 @@
 import json
 import subprocess
 from pathlib import Path
-from typing import Optional, Union
+from typing import Union
 
 import yaml
 
@@ -97,7 +97,7 @@ def derive_gpu_resource_type(resolved_scenario: dict, defaults: dict) -> str:
     return merged.get("accelerator", {}).get("resource", "nvidia.com/gpu")
 
 
-def gpu_cost_per_pair(resolved_scenario: dict, defaults: dict) -> Optional[int]:
+def gpu_cost_per_pair(resolved_scenario: dict, defaults: dict) -> Union[int, str]:
     """Compute total GPU cost for one baseline/treatment pair.
 
     Merges the first scenario entry over defaults, then sums GPU cost
@@ -108,7 +108,7 @@ def gpu_cost_per_pair(resolved_scenario: dict, defaults: dict) -> Optional[int]:
     Jinja template's 2-level logic — kept intentionally so that top-level
     accelerator.count propagates to roles that don't override it.
 
-    Returns None if cost cannot be computed (e.g., non-numeric values).
+    Returns int on success, or error string describing the problematic field.
     """
     scenario_entry = {}
     scenarios = resolved_scenario.get("scenario", [])
@@ -118,11 +118,13 @@ def gpu_cost_per_pair(resolved_scenario: dict, defaults: dict) -> Optional[int]:
     merged = deep_merge(defaults, scenario_entry)
 
     top_accel = merged.get("accelerator", {})
-    try:
-        if top_accel.get("count") is not None and int(top_accel["count"]) == 0:
-            return 0
-    except (ValueError, TypeError):
-        return None
+    top_count_raw = top_accel.get("count")
+    if top_count_raw is not None:
+        try:
+            if int(top_count_raw) == 0:
+                return 0
+        except (ValueError, TypeError):
+            return f"accelerator.count={top_count_raw!r} is not a valid integer"
 
     gpu_cost = 0
     for role_name, default_enabled, default_replicas in [
@@ -140,24 +142,34 @@ def gpu_cost_per_pair(resolved_scenario: dict, defaults: dict) -> Optional[int]:
         try:
             if "count" in role_accel:
                 gpus_per_pod = int(role_accel["count"])
-            elif "count" in top_accel:
-                gpus_per_pod = int(top_accel["count"])
+            elif top_count_raw is not None:
+                gpus_per_pod = int(top_count_raw)
             else:
                 gpus_per_pod = parallelism.get("tensor", 1) * parallelism.get("dataLocal", 1)
         except (ValueError, TypeError):
-            return None
+            field = f"{role_name}.accelerator.count" if "count" in role_accel else "accelerator.count"
+            val = role_accel.get("count") if "count" in role_accel else top_count_raw
+            return f"{field}={val!r} is not a valid integer"
 
         gpu_cost += replicas * gpus_per_pod
 
     return gpu_cost
 
 
-def load_defaults(repo_root: Path) -> Optional[dict]:
-    """Load llm-d-benchmark defaults.yaml, or None if unavailable."""
+def load_defaults(repo_root: Path) -> Union[dict, str, None]:
+    """Load llm-d-benchmark defaults.yaml.
+
+    Returns:
+        dict: parsed defaults on success.
+        None: file not found (expected when submodule not initialized).
+        str: error message when file exists but can't be parsed.
+    """
     defaults_path = repo_root / "llm-d-benchmark" / "config" / "templates" / "values" / "defaults.yaml"
     if not defaults_path.exists():
         return None
     try:
         return yaml.safe_load(defaults_path.read_text()) or {}
-    except (yaml.YAMLError, OSError):
-        return None
+    except yaml.YAMLError as e:
+        return f"defaults.yaml parse error: {e}"
+    except OSError as e:
+        return f"defaults.yaml read error: {e}"

--- a/pipeline/tests/test_capacity.py
+++ b/pipeline/tests/test_capacity.py
@@ -3,7 +3,7 @@
 import json
 from unittest.mock import patch, MagicMock
 
-from pipeline.lib.capacity import probe_free_gpus
+from pipeline.lib.capacity import probe_free_gpus, derive_gpu_resource_type
 
 
 class TestProbeFreeGpus:
@@ -99,6 +99,39 @@ class TestProbeFreeGpus:
 
         result = probe_free_gpus()
         assert result == (8, 8, 0)
+
+    @patch("pipeline.lib.capacity.subprocess.run")
+    def test_malformed_gpu_value_returns_none(self, mock_run):
+        nodes = {"items": [
+            {"metadata": {"name": "n0"}, "status": {"allocatable": {"nvidia.com/gpu": "not-a-number"}}}
+        ]}
+        pods = {"items": []}
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=json.dumps(nodes)),
+            MagicMock(returncode=0, stdout=json.dumps(pods)),
+        ]
+        result = probe_free_gpus()
+        assert result is None
+
+
+# ── derive_gpu_resource_type tests ─────────────────────────────────────────────
+
+
+class TestDeriveGpuResourceType:
+    def test_derives_from_defaults(self):
+        defaults = {"accelerator": {"resource": "nvidia.com/gpu"}}
+        scenario = {"scenario": [{"name": "test"}]}
+        assert derive_gpu_resource_type(scenario, defaults) == "nvidia.com/gpu"
+
+    def test_scenario_overrides_defaults(self):
+        defaults = {"accelerator": {"resource": "nvidia.com/gpu"}}
+        scenario = {"scenario": [{"name": "test", "accelerator": {"resource": "habana.ai/gaudi"}}]}
+        assert derive_gpu_resource_type(scenario, defaults) == "habana.ai/gaudi"
+
+    def test_missing_accelerator_falls_back(self):
+        defaults = {}
+        scenario = {"scenario": [{"name": "test"}]}
+        assert derive_gpu_resource_type(scenario, defaults) == "nvidia.com/gpu"
 
 
 # ── gpu_cost_per_pair tests ────────────────────────────────────────────────────

--- a/pipeline/tests/test_capacity.py
+++ b/pipeline/tests/test_capacity.py
@@ -3,7 +3,7 @@
 import json
 from unittest.mock import patch, MagicMock
 
-from pipeline.lib.capacity import probe_free_gpus, derive_gpu_resource_type
+from pipeline.lib.capacity import probe_free_gpus, derive_gpu_resource_type, gpu_cost_per_pair
 
 
 class TestProbeFreeGpus:
@@ -37,7 +37,6 @@ class TestProbeFreeGpus:
 
     @patch("pipeline.lib.capacity.subprocess.run")
     def test_basic_computation(self, mock_run):
-        # 14 nodes × 8 GPUs = 112 allocatable, 108 requested → 4 free
         nodes_json = self._mock_nodes([8] * 14)
         pods_json = self._mock_pods([1] * 108)
 
@@ -76,15 +75,15 @@ class TestProbeFreeGpus:
         assert result == (6, 8, 2)
 
     @patch("pipeline.lib.capacity.subprocess.run")
-    def test_kubectl_failure_returns_none(self, mock_run):
+    def test_kubectl_failure_returns_error_string(self, mock_run):
         mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="connection refused")
 
         result = probe_free_gpus()
-        assert result is None
+        assert isinstance(result, str)
+        assert "connection refused" in result
 
     @patch("pipeline.lib.capacity.subprocess.run")
     def test_nodes_without_gpu_resource_ignored(self, mock_run):
-        # Mix of GPU and non-GPU nodes
         nodes = {
             "items": [
                 {"metadata": {"name": "gpu-0"}, "status": {"allocatable": {"nvidia.com/gpu": "8", "cpu": "64"}}},
@@ -101,9 +100,9 @@ class TestProbeFreeGpus:
         assert result == (8, 8, 0)
 
     @patch("pipeline.lib.capacity.subprocess.run")
-    def test_malformed_gpu_value_returns_none(self, mock_run):
+    def test_malformed_gpu_value_returns_error(self, mock_run):
         nodes = {"items": [
-            {"metadata": {"name": "n0"}, "status": {"allocatable": {"nvidia.com/gpu": "not-a-number"}}}
+            {"metadata": {"name": "n0"}, "status": {"allocatable": {"nvidia.com/gpu": "8000m"}}}
         ]}
         pods = {"items": []}
         mock_run.side_effect = [
@@ -111,7 +110,18 @@ class TestProbeFreeGpus:
             MagicMock(returncode=0, stdout=json.dumps(pods)),
         ]
         result = probe_free_gpus()
-        assert result is None
+        assert isinstance(result, str)
+        assert "8000m" in result
+
+    @patch("pipeline.lib.capacity.subprocess.run")
+    def test_malformed_json_returns_error(self, mock_run):
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout="not json"),
+            MagicMock(returncode=0, stdout="{}"),
+        ]
+        result = probe_free_gpus()
+        assert isinstance(result, str)
+        assert "JSON parse error" in result
 
 
 # ── derive_gpu_resource_type tests ─────────────────────────────────────────────
@@ -136,12 +146,9 @@ class TestDeriveGpuResourceType:
 
 # ── gpu_cost_per_pair tests ────────────────────────────────────────────────────
 
-from pipeline.lib.capacity import gpu_cost_per_pair
-
 
 class TestGpuCostPerPair:
     def test_default_single_decode_replica(self):
-        # Minimal overlay: only decode.replicas=4, merge with defaults
         defaults = {
             "accelerator": {"resource": "nvidia.com/gpu"},
             "decode": {
@@ -155,7 +162,7 @@ class TestGpuCostPerPair:
             "scenario": [{"name": "test", "decode": {"replicas": 4}}]
         }
         cost = gpu_cost_per_pair(scenario, defaults)
-        assert cost == 4  # 4 replicas × 1 GPU per pod
+        assert cost == 4
 
     def test_tensor_parallel_derivation(self):
         defaults = {
@@ -168,7 +175,7 @@ class TestGpuCostPerPair:
         }
         scenario = {"scenario": [{"name": "test", "decode": {"replicas": 2}}]}
         cost = gpu_cost_per_pair(scenario, defaults)
-        assert cost == 8  # 2 replicas × 4 GPUs per pod
+        assert cost == 8
 
     def test_role_accelerator_count_overrides_parallelism(self):
         defaults = {
@@ -183,7 +190,7 @@ class TestGpuCostPerPair:
             "scenario": [{"name": "test", "decode": {"replicas": 2, "accelerator": {"count": 2}}}]
         }
         cost = gpu_cost_per_pair(scenario, defaults)
-        assert cost == 4  # 2 replicas × 2 (role override)
+        assert cost == 4
 
     def test_top_level_accelerator_count_zero_means_cpu_only(self):
         defaults = {
@@ -212,7 +219,7 @@ class TestGpuCostPerPair:
             "scenario": [{"name": "test", "prefill": {"enabled": True, "replicas": 1}}]
         }
         cost = gpu_cost_per_pair(scenario, defaults)
-        assert cost == 3  # decode: 2×1 + prefill: 1×1
+        assert cost == 3
 
     def test_top_level_accelerator_count_as_fallback(self):
         defaults = {
@@ -222,7 +229,6 @@ class TestGpuCostPerPair:
         }
         scenario = {"scenario": [{"name": "test"}]}
         cost = gpu_cost_per_pair(scenario, defaults)
-        # accelerator.count (8) takes precedence over tensor*dataLocal (4)
         assert cost == 8
 
     def test_empty_scenario_returns_defaults_cost(self):
@@ -233,3 +239,12 @@ class TestGpuCostPerPair:
         scenario = {"scenario": [{"name": "test"}]}
         cost = gpu_cost_per_pair(scenario, defaults)
         assert cost == 1
+
+    def test_non_numeric_accelerator_count_returns_none(self):
+        defaults = {
+            "decode": {"enabled": True, "replicas": 1, "parallelism": {"tensor": 1, "dataLocal": 1}},
+            "prefill": {"enabled": False, "replicas": 0},
+        }
+        scenario = {"scenario": [{"name": "test", "accelerator": {"count": "auto"}}]}
+        cost = gpu_cost_per_pair(scenario, defaults)
+        assert cost is None

--- a/pipeline/tests/test_capacity.py
+++ b/pipeline/tests/test_capacity.py
@@ -99,3 +99,104 @@ class TestProbeFreeGpus:
 
         result = probe_free_gpus()
         assert result == (8, 8, 0)
+
+
+# ── gpu_cost_per_pair tests ────────────────────────────────────────────────────
+
+from pipeline.lib.capacity import gpu_cost_per_pair
+
+
+class TestGpuCostPerPair:
+    def test_default_single_decode_replica(self):
+        # Minimal overlay: only decode.replicas=4, merge with defaults
+        defaults = {
+            "accelerator": {"resource": "nvidia.com/gpu"},
+            "decode": {
+                "enabled": True,
+                "replicas": 1,
+                "parallelism": {"tensor": 1, "dataLocal": 1},
+            },
+            "prefill": {"enabled": False, "replicas": 0},
+        }
+        scenario = {
+            "scenario": [{"name": "test", "decode": {"replicas": 4}}]
+        }
+        cost = gpu_cost_per_pair(scenario, defaults)
+        assert cost == 4  # 4 replicas × 1 GPU per pod
+
+    def test_tensor_parallel_derivation(self):
+        defaults = {
+            "decode": {
+                "enabled": True,
+                "replicas": 1,
+                "parallelism": {"tensor": 4, "dataLocal": 1},
+            },
+            "prefill": {"enabled": False, "replicas": 0},
+        }
+        scenario = {"scenario": [{"name": "test", "decode": {"replicas": 2}}]}
+        cost = gpu_cost_per_pair(scenario, defaults)
+        assert cost == 8  # 2 replicas × 4 GPUs per pod
+
+    def test_role_accelerator_count_overrides_parallelism(self):
+        defaults = {
+            "decode": {
+                "enabled": True,
+                "replicas": 1,
+                "parallelism": {"tensor": 4, "dataLocal": 1},
+            },
+            "prefill": {"enabled": False, "replicas": 0},
+        }
+        scenario = {
+            "scenario": [{"name": "test", "decode": {"replicas": 2, "accelerator": {"count": 2}}}]
+        }
+        cost = gpu_cost_per_pair(scenario, defaults)
+        assert cost == 4  # 2 replicas × 2 (role override)
+
+    def test_top_level_accelerator_count_zero_means_cpu_only(self):
+        defaults = {
+            "accelerator": {"count": 0},
+            "decode": {"enabled": True, "replicas": 4, "parallelism": {"tensor": 4, "dataLocal": 1}},
+            "prefill": {"enabled": False, "replicas": 0},
+        }
+        scenario = {"scenario": [{"name": "test"}]}
+        cost = gpu_cost_per_pair(scenario, defaults)
+        assert cost == 0
+
+    def test_prefill_enabled_adds_cost(self):
+        defaults = {
+            "decode": {
+                "enabled": True,
+                "replicas": 2,
+                "parallelism": {"tensor": 1, "dataLocal": 1},
+            },
+            "prefill": {
+                "enabled": False,
+                "replicas": 0,
+                "parallelism": {"tensor": 1, "dataLocal": 1},
+            },
+        }
+        scenario = {
+            "scenario": [{"name": "test", "prefill": {"enabled": True, "replicas": 1}}]
+        }
+        cost = gpu_cost_per_pair(scenario, defaults)
+        assert cost == 3  # decode: 2×1 + prefill: 1×1
+
+    def test_top_level_accelerator_count_as_fallback(self):
+        defaults = {
+            "accelerator": {"count": 8},
+            "decode": {"enabled": True, "replicas": 1, "parallelism": {"tensor": 2, "dataLocal": 2}},
+            "prefill": {"enabled": False, "replicas": 0},
+        }
+        scenario = {"scenario": [{"name": "test"}]}
+        cost = gpu_cost_per_pair(scenario, defaults)
+        # accelerator.count (8) takes precedence over tensor*dataLocal (4)
+        assert cost == 8
+
+    def test_empty_scenario_returns_defaults_cost(self):
+        defaults = {
+            "decode": {"enabled": True, "replicas": 1, "parallelism": {"tensor": 1, "dataLocal": 1}},
+            "prefill": {"enabled": False, "replicas": 0},
+        }
+        scenario = {"scenario": [{"name": "test"}]}
+        cost = gpu_cost_per_pair(scenario, defaults)
+        assert cost == 1

--- a/pipeline/tests/test_capacity.py
+++ b/pipeline/tests/test_capacity.py
@@ -240,11 +240,24 @@ class TestGpuCostPerPair:
         cost = gpu_cost_per_pair(scenario, defaults)
         assert cost == 1
 
-    def test_non_numeric_accelerator_count_returns_none(self):
+    def test_non_numeric_accelerator_count_returns_error(self):
         defaults = {
             "decode": {"enabled": True, "replicas": 1, "parallelism": {"tensor": 1, "dataLocal": 1}},
             "prefill": {"enabled": False, "replicas": 0},
         }
         scenario = {"scenario": [{"name": "test", "accelerator": {"count": "auto"}}]}
         cost = gpu_cost_per_pair(scenario, defaults)
-        assert cost is None
+        assert isinstance(cost, str)
+        assert "auto" in cost
+        assert "accelerator.count" in cost
+
+    def test_non_numeric_role_accelerator_count_returns_error(self):
+        defaults = {
+            "decode": {"enabled": True, "replicas": 1, "parallelism": {"tensor": 1, "dataLocal": 1}},
+            "prefill": {"enabled": False, "replicas": 0},
+        }
+        scenario = {"scenario": [{"name": "test", "decode": {"accelerator": {"count": "bad"}}}]}
+        cost = gpu_cost_per_pair(scenario, defaults)
+        assert isinstance(cost, str)
+        assert "bad" in cost
+        assert "decode.accelerator.count" in cost

--- a/pipeline/tests/test_capacity.py
+++ b/pipeline/tests/test_capacity.py
@@ -1,0 +1,101 @@
+"""Tests for pipeline/lib/capacity.py — GPU capacity probe."""
+
+import json
+from unittest.mock import patch, MagicMock
+
+from pipeline.lib.capacity import probe_free_gpus
+
+
+class TestProbeFreeGpus:
+    def _mock_nodes(self, allocatable_gpus: list[int], resource="nvidia.com/gpu"):
+        """Build fake kubectl nodes JSON."""
+        nodes = []
+        for gpu_count in allocatable_gpus:
+            node = {
+                "metadata": {"name": f"node-{len(nodes)}"},
+                "status": {
+                    "allocatable": {resource: str(gpu_count)} if gpu_count > 0 else {}
+                },
+            }
+            nodes.append(node)
+        return json.dumps({"items": nodes})
+
+    def _mock_pods(self, requested_gpus: list[int], resource="nvidia.com/gpu"):
+        """Build fake kubectl pods JSON."""
+        pods = []
+        for gpu_req in requested_gpus:
+            pod = {
+                "metadata": {"name": f"pod-{len(pods)}"},
+                "spec": {
+                    "containers": [
+                        {"resources": {"requests": {resource: str(gpu_req)}}}
+                    ]
+                },
+            }
+            pods.append(pod)
+        return json.dumps({"items": pods})
+
+    @patch("pipeline.lib.capacity.subprocess.run")
+    def test_basic_computation(self, mock_run):
+        # 14 nodes × 8 GPUs = 112 allocatable, 108 requested → 4 free
+        nodes_json = self._mock_nodes([8] * 14)
+        pods_json = self._mock_pods([1] * 108)
+
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=nodes_json),
+            MagicMock(returncode=0, stdout=pods_json),
+        ]
+
+        result = probe_free_gpus()
+        assert result == (4, 112, 108)
+
+    @patch("pipeline.lib.capacity.subprocess.run")
+    def test_clamps_to_zero(self, mock_run):
+        nodes_json = self._mock_nodes([2])
+        pods_json = self._mock_pods([1] * 5)
+
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=nodes_json),
+            MagicMock(returncode=0, stdout=pods_json),
+        ]
+
+        result = probe_free_gpus()
+        assert result == (0, 2, 5)
+
+    @patch("pipeline.lib.capacity.subprocess.run")
+    def test_custom_resource_type(self, mock_run):
+        nodes_json = self._mock_nodes([4, 4], resource="habana.ai/gaudi")
+        pods_json = self._mock_pods([2], resource="habana.ai/gaudi")
+
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=nodes_json),
+            MagicMock(returncode=0, stdout=pods_json),
+        ]
+
+        result = probe_free_gpus(gpu_resource_type="habana.ai/gaudi")
+        assert result == (6, 8, 2)
+
+    @patch("pipeline.lib.capacity.subprocess.run")
+    def test_kubectl_failure_returns_none(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="connection refused")
+
+        result = probe_free_gpus()
+        assert result is None
+
+    @patch("pipeline.lib.capacity.subprocess.run")
+    def test_nodes_without_gpu_resource_ignored(self, mock_run):
+        # Mix of GPU and non-GPU nodes
+        nodes = {
+            "items": [
+                {"metadata": {"name": "gpu-0"}, "status": {"allocatable": {"nvidia.com/gpu": "8", "cpu": "64"}}},
+                {"metadata": {"name": "cpu-0"}, "status": {"allocatable": {"cpu": "96"}}},
+            ]
+        }
+        pods = {"items": []}
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=json.dumps(nodes)),
+            MagicMock(returncode=0, stdout=json.dumps(pods)),
+        ]
+
+        result = probe_free_gpus()
+        assert result == (8, 8, 0)


### PR DESCRIPTION
Closes #63

## Summary

- Add `pipeline/lib/capacity.py` with `probe_free_gpus()` (queries kubectl for node allocatable and pod requests) and `gpu_cost_per_pair()` (derives GPU cost from resolved scenarios using 3-level precedence: role.accelerator.count > accelerator.count > tensor × dataLocal)
- Integrate capacity probe logging into `deploy.py run` poll loop — each cycle logs free GPU count
- Add `--gpu-resource-type` and `--default-gpu-cost` CLI flags to `run` subparser

## Test Plan

- [x] 12 unit tests for probe and cost derivation (mocked kubectl)
- [x] Full suite: 315 tests pass
- [x] Lint clean: `ruff check pipeline/ --select F`
- [ ] Manual validation on live cluster (probe returns correct free GPU count)

## Reviewer attention

- `gpu_cost_per_pair` replicates the Jinja precedence chain from `13_ms-values.yaml.j2` — verify the 3-level logic matches the template
- The probe runs every poll cycle (30s default) — consider whether this is too frequent for large clusters
- `--default-gpu-cost` is wired up but not yet consumed (foundation for #64)