### PR TITLE
feat(prepare): baseline-only assembly without translation

### DIFF
--- a/pipeline/prepare.py
+++ b/pipeline/prepare.py
@@ -338,39 +338,43 @@ def _phase_assembly(args, state: StateMachine, manifest: dict, run_dir: Path,
         err(str(e))
         sys.exit(1)
 
-    # 4b.5: Inject deterministic EPP image into treatment scenario
-    # The image tag is deterministic: {registry}/{repo_name}:{run_name} — same as
-    # what build-epp.sh pushes. Read from run_metadata.json (written by setup.py).
-    meta_path = run_dir / "run_metadata.json"
-    if not meta_path.exists():
-        err("run_metadata.json absent — cannot inject EPP image. Re-run setup.py.")
-        sys.exit(1)
-    try:
-        meta = json.loads(meta_path.read_text())
-    except json.JSONDecodeError as e:
-        err(f"run_metadata.json is not valid JSON: {e}. Re-run setup.py.")
-        sys.exit(1)
-    registry = meta.get("registry", "")
-    repo_name = meta.get("repo_name", "llm-d-inference-scheduler")
-    run_name_tag = run_dir.name
-    if not registry:
-        err("run_metadata.json has no registry — cannot determine EPP image. Re-run setup.py.")
-        sys.exit(1)
-    injected = inject_epp_image(treatment_resolved, registry, repo_name, run_name_tag)
-    if injected:
-        ok(f"EPP image injected: {registry}/{repo_name}:{run_name_tag}")
-    else:
-        err("treatment has no 'scenario' entries — EPP image cannot be injected.")
-        sys.exit(1)
+    # 4b.5: Inject EPP image into treatment (only when translation occurred)
+    translation_happened = translation_output_path.exists()
+
+    if translation_happened:
+        meta_path = run_dir / "run_metadata.json"
+        if not meta_path.exists():
+            err("run_metadata.json absent — cannot inject EPP image. Re-run setup.py.")
+            sys.exit(1)
+        try:
+            meta = json.loads(meta_path.read_text())
+        except json.JSONDecodeError as e:
+            err(f"run_metadata.json is not valid JSON: {e}. Re-run setup.py.")
+            sys.exit(1)
+        registry = meta.get("registry", "")
+        repo_name = meta.get("repo_name", "llm-d-inference-scheduler")
+        run_name_tag = run_dir.name
+        if not registry:
+            err("run_metadata.json has no registry — cannot determine EPP image. Re-run setup.py.")
+            sys.exit(1)
+        injected = inject_epp_image(treatment_resolved, registry, repo_name, run_name_tag)
+        if injected:
+            ok(f"EPP image injected: {registry}/{repo_name}:{run_name_tag}")
+        else:
+            err("treatment has no 'scenario' entries — EPP image cannot be injected.")
+            sys.exit(1)
 
     # 4c: Write resolved scenarios
     cluster_dir = run_dir / "cluster"
     cluster_dir.mkdir(parents=True, exist_ok=True)
 
     baseline_out = cluster_dir / "baseline.yaml"
-    treatment_out = cluster_dir / "treatment.yaml"
     baseline_out.write_text(yaml.dump(baseline_resolved, default_flow_style=False, allow_unicode=True))
-    treatment_out.write_text(yaml.dump(treatment_resolved, default_flow_style=False, allow_unicode=True))
+
+    if translation_happened:
+        treatment_out = cluster_dir / "treatment.yaml"
+        treatment_out.write_text(yaml.dump(treatment_resolved, default_flow_style=False, allow_unicode=True))
+
     ok(f"Resolved scenarios: {_display_path(cluster_dir)}")
 
     # 4d: Load and scale workloads
@@ -401,7 +405,8 @@ def _phase_assembly(args, state: StateMachine, manifest: dict, run_dir: Path,
 
     if not workloads:
         warn("No workloads defined — cannot generate PipelineRuns")
-        state.mark_done("assembly", packages=["baseline", "treatment"])
+        done_packages = ["baseline", "treatment"] if translation_happened else ["baseline"]
+        state.mark_done("assembly", packages=done_packages)
         return
 
     # 4e: Pipeline resource
@@ -421,13 +426,19 @@ def _phase_assembly(args, state: StateMachine, manifest: dict, run_dir: Path,
     benchmark_sub = REPO_ROOT / "llm-d-benchmark"
     benchmark_repo_url = ""
     if benchmark_sub.exists() and (benchmark_sub / ".git").exists():
-        result = run(["git", "remote", "get-url", "origin"], capture=True, cwd=benchmark_sub)
-        benchmark_repo_url = result.stdout.strip()
+        try:
+            result = run(["git", "remote", "get-url", "origin"], capture=True, cwd=benchmark_sub)
+            benchmark_repo_url = result.stdout.strip()
+        except subprocess.CalledProcessError:
+            pass
     blis_sub = REPO_ROOT / "inference-sim"
     blis_repo_url = ""
     if blis_sub.exists() and (blis_sub / ".git").exists():
-        result = run(["git", "remote", "get-url", "origin"], capture=True, cwd=blis_sub)
-        blis_repo_url = result.stdout.strip()
+        try:
+            result = run(["git", "remote", "get-url", "origin"], capture=True, cwd=blis_sub)
+            blis_repo_url = result.stdout.strip()
+        except subprocess.CalledProcessError:
+            pass
 
     missing_params = []
     if not benchmark_repo_url:
@@ -435,13 +446,21 @@ def _phase_assembly(args, state: StateMachine, manifest: dict, run_dir: Path,
     if not blis_repo_url:
         missing_params.append("blis_repo_url (inference-sim submodule)")
     if missing_params:
-        err(f"Critical PipelineRun params resolved to empty: {', '.join(missing_params)}. "
-            "Initialize submodules with: git submodule update --init")
-        sys.exit(1)
+        if translation_happened:
+            err(f"Critical PipelineRun params resolved to empty: {', '.join(missing_params)}. "
+                "Initialize submodules with: git submodule update --init")
+            sys.exit(1)
+        else:
+            warn(f"Submodule params not available: {', '.join(missing_params)}. "
+                 "Baseline-only mode — continuing with empty values.")
     scenarios = baseline_resolved.get("scenario", [])
     model_name = scenarios[0].get("model", {}).get("name", "") if scenarios else ""
 
-    for pkg, scenario in [("baseline", baseline_resolved), ("treatment", treatment_resolved)]:
+    packages = [("baseline", baseline_resolved)]
+    if translation_happened:
+        packages.append(("treatment", treatment_resolved))
+
+    for pkg, scenario in packages:
         scenario_content = yaml.dump(scenario, default_flow_style=False, allow_unicode=True)
         for wl in workloads:
             wl_name = wl.get("name", wl.get("workload_name", "unknown"))
@@ -464,15 +483,17 @@ def _phase_assembly(args, state: StateMachine, manifest: dict, run_dir: Path,
             pr_path = cluster_dir / f"pipelinerun-{safe_wl}-{pkg}.yaml"
             pr_path.write_text(yaml.dump(pr, default_flow_style=False, allow_unicode=True))
 
-    ok(f"PipelineRuns: {len(workloads) * 2} generated")
+    ok(f"PipelineRuns: {len(workloads) * len(packages)} generated")
 
-    # 4g: Verify generated dir
-    _verify_generated_dir(run_dir)
+    # 4g: Verify generated dir (only when translation produced files)
+    if translation_happened:
+        _verify_generated_dir(run_dir)
 
     # 4h: validate-assembly
     _validate_assembly(run_dir, resolved)
 
-    state.mark_done("assembly", packages=["baseline", "treatment"])
+    done_packages = ["baseline", "treatment"] if translation_happened else ["baseline"]
+    state.mark_done("assembly", packages=done_packages)
     ok("Assembly complete")
 
 
@@ -581,26 +602,36 @@ def _phase_summary(state: StateMachine, manifest: dict, run_dir: Path, resolved:
         info("[skip] Summary already complete")
         return
 
-    output = json.loads((run_dir / "translation_output.json").read_text())
-    translate_meta = state.get_phase("translate")
+    translation_output_path = run_dir / "translation_output.json"
 
-    lines = [
-        f"**Run Summary: `{state.run_name}`**",
-        f"Generated: {datetime.now(timezone.utc).isoformat()} | Scenario: {manifest['scenario']}",
-        "",
-        "**Algorithm**",
-        f"- Source: `{manifest['algorithm']['source']}`",
-        f"- Description: {output.get('description', 'N/A')}",
-        "",
-        "**Translation**",
-        f"- Plugin type: `{output['plugin_type']}`",
-        f"- Files created: {', '.join(f'`{f}`' for f in output.get('files_created', []))}",
-        f"- Files modified: {', '.join(f'`{f}`' for f in output.get('files_modified', []))}",
-    ]
+    if translation_output_path.exists():
+        output = json.loads(translation_output_path.read_text())
+        translate_meta = state.get_phase("translate")
 
-    if translate_meta.get("review_rounds"):
-        lines.append(f"- Review: {translate_meta.get('consensus', 'N/A')} "
-                     f"after {translate_meta['review_rounds']} rounds")
+        lines = [
+            f"**Run Summary: `{state.run_name}`**",
+            f"Generated: {datetime.now(timezone.utc).isoformat()} | Scenario: {manifest['scenario']}",
+            "",
+            "**Algorithm**",
+            f"- Source: `{manifest['algorithm']['source']}`",
+            f"- Description: {output.get('description', 'N/A')}",
+            "",
+            "**Translation**",
+            f"- Plugin type: `{output['plugin_type']}`",
+            f"- Files created: {', '.join(f'`{f}`' for f in output.get('files_created', []))}",
+            f"- Files modified: {', '.join(f'`{f}`' for f in output.get('files_modified', []))}",
+        ]
+
+        if translate_meta.get("review_rounds"):
+            lines.append(f"- Review: {translate_meta.get('consensus', 'N/A')} "
+                         f"after {translate_meta['review_rounds']} rounds")
+    else:
+        lines = [
+            f"**Run Summary: `{state.run_name}`**",
+            f"Generated: {datetime.now(timezone.utc).isoformat()} | Scenario: {manifest['scenario']}",
+            "",
+            "**Mode:** Baseline-only (no translation)",
+        ]
 
     # Baseline vs Treatment config comparison
     lines.extend(["", "**Packages**", ""])
@@ -617,13 +648,21 @@ def _phase_summary(state: StateMachine, manifest: dict, run_dir: Path, resolved:
         lines.append(f"- {wl_name} (x{multiplier})")
 
     # Checklist
-    lines.extend([
-        "", "**Checklist**",
-        "- [x] Translation complete",
-        "- [x] Assembly complete",
-        "- [x] validate-assembly passed",
-        "",
-    ])
+    if translation_output_path.exists():
+        lines.extend([
+            "", "**Checklist**",
+            "- [x] Translation complete",
+            "- [x] Assembly complete",
+            "- [x] validate-assembly passed",
+            "",
+        ])
+    else:
+        lines.extend([
+            "", "**Checklist**",
+            "- [-] Translation skipped (baseline-only)",
+            "- [x] Assembly complete",
+            "",
+        ])
 
     summary_path = run_dir / "run_summary.md"
     summary_path.write_text("\n".join(lines))
@@ -693,9 +732,9 @@ def _cmd_assemble(args, manifest, run_dir):
         err("No state file. Run prepare.py first.")
         sys.exit(1)
 
-    if not state.is_done("translate"):
-        err("Cannot assemble: translation not complete. Run /sim2real-translate first.")
-        sys.exit(1)
+    baseline_only = not (run_dir / "translation_output.json").exists()
+    if baseline_only:
+        warn("No translation output — producing baseline-only PipelineRuns")
 
     resolved = _load_resolved_config(manifest)
     state.reset("assembly")
@@ -703,16 +742,15 @@ def _cmd_assemble(args, manifest, run_dir):
     state.reset("gate")
     _phase_assembly(args, state, manifest, run_dir, resolved)
     _phase_summary(state, manifest, run_dir, resolved)
-    _phase_gate(state, run_dir)
+    if not baseline_only:
+        _phase_gate(state, run_dir)
 
 
 def _cmd_validate_assembly(args, manifest, run_dir):
     """Run validate-assembly checks standalone."""
-    required = ["translation_output.json"]
-    for name in required:
-        if not (run_dir / name).exists():
-            err(f"Required file missing: {name}. Run translation skill first.")
-            sys.exit(1)
+    if not (run_dir / "translation_output.json").exists():
+        info("Baseline-only run — no treatment validation needed")
+        return
     resolved = _load_resolved_config(manifest)
     _validate_assembly(run_dir, resolved)
 

--- a/pipeline/prepare.py
+++ b/pipeline/prepare.py
@@ -339,6 +339,8 @@ def _phase_assembly(args, state: StateMachine, manifest: dict, run_dir: Path,
         sys.exit(1)
 
     # 4b.5: Inject EPP image into treatment (only when translation occurred)
+    # The image tag is deterministic: {registry}/{repo_name}:{run_name} — same as
+    # what build-epp.sh pushes. Read from run_metadata.json (written by setup.py).
     translation_happened = translation_output_path.exists()
 
     if translation_happened:
@@ -429,16 +431,16 @@ def _phase_assembly(args, state: StateMachine, manifest: dict, run_dir: Path,
         try:
             result = run(["git", "remote", "get-url", "origin"], capture=True, cwd=benchmark_sub)
             benchmark_repo_url = result.stdout.strip()
-        except subprocess.CalledProcessError:
-            pass
+        except subprocess.CalledProcessError as e:
+            warn(f"git remote get-url origin failed in {benchmark_sub}: {e}")
     blis_sub = REPO_ROOT / "inference-sim"
     blis_repo_url = ""
     if blis_sub.exists() and (blis_sub / ".git").exists():
         try:
             result = run(["git", "remote", "get-url", "origin"], capture=True, cwd=blis_sub)
             blis_repo_url = result.stdout.strip()
-        except subprocess.CalledProcessError:
-            pass
+        except subprocess.CalledProcessError as e:
+            warn(f"git remote get-url origin failed in {blis_sub}: {e}")
 
     missing_params = []
     if not benchmark_repo_url:
@@ -452,7 +454,8 @@ def _phase_assembly(args, state: StateMachine, manifest: dict, run_dir: Path,
             sys.exit(1)
         else:
             warn(f"Submodule params not available: {', '.join(missing_params)}. "
-                 "Baseline-only mode — continuing with empty values.")
+                 "Generated PipelineRuns will FAIL on cluster until submodules are initialized: "
+                 "git submodule update --init")
     scenarios = baseline_resolved.get("scenario", [])
     model_name = scenarios[0].get("model", {}).get("name", "") if scenarios else ""
 
@@ -725,7 +728,7 @@ def _cmd_context(args, manifest, run_dir):
 
 
 def _cmd_assemble(args, manifest, run_dir):
-    """Re-run assembly from existing translation output."""
+    """Re-run assembly (baseline-only if no translation output exists)."""
     try:
         state = StateMachine.load(run_dir)
     except FileNotFoundError:
@@ -734,6 +737,12 @@ def _cmd_assemble(args, manifest, run_dir):
 
     baseline_only = not (run_dir / "translation_output.json").exists()
     if baseline_only:
+        translate_phase = state.get_phase("translate")
+        if translate_phase.get("checkpoint_hits"):
+            err("Translation was attempted but translation_output.json is missing. "
+                "Re-run /sim2real-translate or remove the translate phase from state "
+                "to proceed in baseline-only mode.")
+            sys.exit(1)
         warn("No translation output — producing baseline-only PipelineRuns")
 
     resolved = _load_resolved_config(manifest)

--- a/pipeline/tests/test_prepare.py
+++ b/pipeline/tests/test_prepare.py
@@ -993,3 +993,190 @@ class TestExperimentRootSeparation:
         # State file should exist in experiment root, not framework root
         assert (exp / "workspace" / "runs" / "test-run" / ".state.json").exists()
         assert not (fw / "workspace").exists()
+
+
+# ── Baseline-only assembly ─────────────────────────────────────────────────
+
+class TestBaselineOnlyAssembly:
+    """Tests for baseline-only mode: no translation_output.json present.
+
+    These tests document the expected behavior when prepare.py assemble is
+    invoked without a prior translation step — producing only baseline
+    PipelineRuns and skipping treatment-specific logic.
+    """
+
+    def _setup_baseline_only_repo(self, repo):
+        """Set up repo with everything needed for assembly EXCEPT translation_output.json."""
+        run_dir = repo / "workspace" / "runs" / "test-run"
+        run_dir.mkdir(parents=True, exist_ok=True)
+
+        # setup_config.json (written by setup.py)
+        setup_config = {"namespace": "sim2real-test", "workspaces": {}}
+        (repo / "workspace" / "setup_config.json").write_text(json.dumps(setup_config))
+
+        # baseline.yaml bundle (experiment root)
+        baseline_bundle = {
+            "scenario": [{"name": "baseline-scenario", "model": {"name": "test-model"}}]
+        }
+        _write_yaml(repo / "baseline.yaml", baseline_bundle)
+
+        # llm-d-benchmark submodule (git repo — needed for SHA detection)
+        benchmark = repo / "llm-d-benchmark"
+        benchmark.mkdir(parents=True, exist_ok=True)
+        _init_git_repo(benchmark)
+
+        return run_dir
+
+    def test_assembly_baseline_only_produces_only_baseline_pipelineruns(self, repo):
+        """When no translation_output.json exists, _phase_assembly should produce
+        only pipelinerun-*-baseline.yaml files, no cluster/treatment.yaml, and
+        mark_done('assembly', packages=['baseline']).
+        """
+        mod = _import_prepare_with_root(repo)
+        run_dir = self._setup_baseline_only_repo(repo)
+
+        manifest = dict(MINIMAL_MANIFEST)
+        resolved = mod._load_resolved_config(manifest)
+        state = StateMachine("test-run", "routing", run_dir)
+        state.mark_done("init")
+
+        class Args:
+            force = False
+
+        mod._phase_assembly(Args(), state, manifest, run_dir, resolved)
+
+        # Should mark done with baseline-only packages
+        assert state.is_done("assembly")
+        assert state.get_phase("assembly")["packages"] == ["baseline"]
+
+        # Should produce only baseline PipelineRuns
+        cluster_dir = run_dir / "cluster"
+        pr_files = list(cluster_dir.glob("pipelinerun-*.yaml"))
+        assert all("-baseline.yaml" in f.name for f in pr_files)
+        assert not any("-treatment.yaml" in f.name for f in pr_files)
+
+        # Should NOT produce cluster/treatment.yaml
+        assert not (cluster_dir / "treatment.yaml").exists()
+
+    def test_assembly_baseline_only_skips_epp_validation(self, repo):
+        """When run_metadata.json has NO registry key but no translation_output.json
+        exists, _phase_assembly should still succeed (EPP validation skipped).
+        """
+        mod = _import_prepare_with_root(repo)
+        run_dir = self._setup_baseline_only_repo(repo)
+
+        # Write run_metadata.json WITHOUT registry (would fail in full mode)
+        meta = {"repo_name": "llm-d-inference-scheduler"}
+        (run_dir / "run_metadata.json").write_text(json.dumps(meta))
+
+        manifest = dict(MINIMAL_MANIFEST)
+        resolved = mod._load_resolved_config(manifest)
+        state = StateMachine("test-run", "routing", run_dir)
+        state.mark_done("init")
+
+        class Args:
+            force = False
+
+        # Should succeed — EPP injection should be skipped in baseline-only mode
+        mod._phase_assembly(Args(), state, manifest, run_dir, resolved)
+        assert state.is_done("assembly")
+
+    def test_summary_baseline_only_does_not_crash(self, repo):
+        """_phase_summary should produce a reduced summary with 'Baseline-only'
+        and 'Translation skipped' text when translation_output.json is absent.
+        """
+        mod = _import_prepare_with_root(repo)
+        run_dir = self._setup_baseline_only_repo(repo)
+
+        manifest = dict(MINIMAL_MANIFEST)
+        resolved = mod._load_resolved_config(manifest)
+        state = StateMachine("test-run", "routing", run_dir)
+        state.mark_done("init")
+        state.mark_done("assembly", packages=["baseline"])
+
+        # Do NOT create translation_output.json
+
+        # Should NOT crash with FileNotFoundError
+        mod._phase_summary(state, manifest, run_dir, resolved)
+
+        assert state.is_done("summary")
+        summary_path = run_dir / "run_summary.md"
+        assert summary_path.exists()
+        content = summary_path.read_text()
+        assert "Baseline-only" in content or "baseline-only" in content.lower()
+        assert "Translation skipped" in content or "translation skipped" in content.lower()
+
+    def test_summary_full_mode_unchanged(self, repo):
+        """_phase_summary still works normally when translation_output.json IS present."""
+        mod = _import_prepare_with_root(repo)
+        run_dir = self._setup_baseline_only_repo(repo)
+
+        manifest = dict(MINIMAL_MANIFEST)
+        resolved = mod._load_resolved_config(manifest)
+        state = StateMachine("test-run", "routing", run_dir)
+        state.mark_done("init")
+        state.mark_done("translate", plugin_type="test-scorer", files_created=[])
+        state.mark_done("assembly", packages=["baseline", "treatment"])
+
+        # Write translation_output.json (full mode)
+        output = {
+            "plugin_type": "test-scorer",
+            "files_created": ["pkg/plugins/scorer/test.go"],
+            "files_modified": ["pkg/plugins/register.go"],
+            "package": "scorer",
+            "test_commands": [["go", "test", "./..."]],
+            "config_kind": "EndpointPickerConfig",
+            "helm_path": "gaie.treatment.helmValues.config",
+            "treatment_config_generated": True,
+            "description": "Test scorer plugin",
+            "register_file": "pkg/plugins/register.go",
+        }
+        (run_dir / "translation_output.json").write_text(json.dumps(output))
+
+        # Should work normally
+        mod._phase_summary(state, manifest, run_dir, resolved)
+
+        assert state.is_done("summary")
+        summary_path = run_dir / "run_summary.md"
+        assert summary_path.exists()
+        content = summary_path.read_text()
+        assert "test-scorer" in content
+        assert "Test scorer plugin" in content
+
+    def test_validate_assembly_baseline_only_exits_cleanly(self, repo):
+        """_validate_assembly should return cleanly (not raise/exit) when
+        translation_output.json is absent.
+        """
+        mod = _import_prepare_with_root(repo)
+        run_dir = repo / "workspace" / "runs" / "test-run"
+        run_dir.mkdir(parents=True, exist_ok=True)
+
+        resolved = {"target": {"repo": "llm-d-inference-scheduler"}, "config": {"kind": "EndpointPickerConfig"}}
+
+        # Do NOT create translation_output.json
+        # Should return without raising or sys.exit
+        mod._validate_assembly(run_dir, resolved)
+
+    def test_cmd_assemble_no_translation_proceeds(self, repo):
+        """_cmd_assemble should NOT sys.exit(1) when translation_output.json is
+        missing; should proceed and produce baseline-only output.
+        """
+        mod = _import_prepare_with_root(repo)
+        run_dir = self._setup_baseline_only_repo(repo)
+
+        manifest = dict(MINIMAL_MANIFEST)
+
+        # Create state with init done (cmd_assemble loads from disk)
+        state = StateMachine("test-run", "routing", run_dir)
+        state.mark_done("init")
+        # Do NOT mark translate as done — that's the point of this test
+
+        class Args:
+            force = False
+
+        # _cmd_assemble currently requires translate to be done; in baseline-only
+        # mode it should proceed without translation.
+        # Patch input() to avoid interactive gate prompt
+        import unittest.mock as mock
+        with mock.patch("builtins.input", side_effect=["q"]):
+            mod._cmd_assemble(Args(), manifest, run_dir)

--- a/pipeline/tests/test_prepare.py
+++ b/pipeline/tests/test_prepare.py
@@ -1174,9 +1174,30 @@ class TestBaselineOnlyAssembly:
         class Args:
             force = False
 
-        # _cmd_assemble currently requires translate to be done; in baseline-only
-        # mode it should proceed without translation.
-        # Patch input() to avoid interactive gate prompt
-        import unittest.mock as mock
-        with mock.patch("builtins.input", side_effect=["q"]):
+        # _cmd_assemble proceeds in baseline-only mode without translation.
+        mod._cmd_assemble(Args(), manifest, run_dir)
+
+        # Verify baseline-only output
+        cluster_dir = run_dir / "cluster"
+        prs = list(cluster_dir.glob("pipelinerun-*.yaml"))
+        assert all("-baseline.yaml" in f.name for f in prs)
+
+    def test_cmd_assemble_errors_when_translation_attempted_but_missing(self, repo):
+        """_cmd_assemble should sys.exit(1) when translate phase was attempted
+        (checkpoint_hits > 0) but translation_output.json is absent.
+        """
+        mod = _import_prepare_with_root(repo)
+        run_dir = self._setup_baseline_only_repo(repo)
+
+        manifest = dict(MINIMAL_MANIFEST)
+
+        # State with translate checkpoint_hits (translation was attempted)
+        state = StateMachine("test-run", "routing", run_dir)
+        state.mark_done("init")
+        state.increment("translate", "checkpoint_hits")
+
+        class Args:
+            force = False
+
+        with pytest.raises(SystemExit):
             mod._cmd_assemble(Args(), manifest, run_dir)


### PR DESCRIPTION
## Summary

Closes #68

- `_phase_assembly` now skips EPP injection, treatment.yaml write, and treatment PipelineRun generation when `translation_output.json` is absent
- `_phase_summary` produces a reduced summary ("Baseline-only") instead of crashing on missing file
- `_cmd_assemble` gate changed from `state.is_done("translate")` to file-existence check — warns and proceeds
- `_cmd_validate_assembly` early-exits gracefully in baseline-only mode
- Submodule URL resolution made resilient (warns instead of hard-exiting in baseline-only)

## Test plan

- [x] 6 new tests in `TestBaselineOnlyAssembly` covering all baseline-only paths
- [x] All 328 existing tests pass (no regressions)
- [x] `ruff check pipeline/ --select F` clean

## Reviewer notes

- The `_cmd_assemble` baseline-only path skips `_phase_gate` (the interactive deploy/edit/quit prompt) since there's no treatment to review — this is intentional
- `subprocess.CalledProcessError` wrapping around `git remote get-url` was needed for test environments where submodule repos have no remote configured; also improves real-world resilience