### PR TITLE
feat(deploy): show valid values on filter mismatch

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -651,7 +651,8 @@ def _apply_run_filters(progress: dict, args) -> set:
 def _resolve_scope(progress: dict, args) -> set:
     """Apply filter args and return the set of pair keys in scope.
 
-    No flags → all pairs. Flags + match → narrowed set. Flags + no match → abort.
+    No flags → all pairs. Flags + match → narrowed set. Flags + no match → abort
+    with valid values printed.
     """
     filters_given = any([
         getattr(args, "only", None) is not None,
@@ -661,9 +662,42 @@ def _resolve_scope(progress: dict, args) -> set:
     ])
     filtered = _apply_run_filters(progress, args)
     if filters_given and not filtered:
-        err("No pairs matched the specified filter — aborting")
+        _report_filter_mismatch(progress, args)
         sys.exit(1)
     return filtered or set(progress.keys())
+
+
+def _report_filter_mismatch(progress: dict, args) -> None:
+    """Print valid values for each active filter flag."""
+    only = getattr(args, "only", None)
+    workload = getattr(args, "workload", None)
+    package = getattr(args, "package", None)
+    status_filter = getattr(args, "status", None)
+
+    parts = []
+    if only:
+        parts.append(f"--only '{only}'")
+    if workload:
+        parts.append(f"--workload '{workload}'")
+    if package:
+        parts.append(f"--package '{package}'")
+    if status_filter:
+        parts.append(f"--status '{status_filter}'")
+
+    print(f"No pairs matched {', '.join(parts)}.\n")
+
+    keys = sorted(progress.keys())
+    print(f"  Valid pair keys ({len(keys)}):")
+    for k in keys:
+        print(f"    {k}")
+
+    valid_workloads = sorted({v.get("workload", "") for v in progress.values()} - {""})
+    valid_packages = sorted({v.get("package", "") for v in progress.values()} - {""})
+    valid_statuses = sorted({v.get("status", "") for v in progress.values()} - {""})
+
+    print(f"\n  Valid --workload values: {', '.join(valid_workloads)}")
+    print(f"  Valid --package values:  {', '.join(valid_packages)}")
+    print(f"  Valid --status values:   {', '.join(valid_statuses)}")
 
 
 def _check_slot_ready(namespace: str) -> tuple[bool, list[str]]:

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -156,16 +156,11 @@ def _cmd_status(args, progress_path: Path) -> None:
     store = LocalProgressStore(progress_path)
     progress = store.load()
 
-    # Apply filters
-    pairs = dict(progress)
-    if getattr(args, "workload", None):
-        pairs = {k: v for k, v in pairs.items() if v.get("workload") == args.workload}
-    if getattr(args, "package", None):
-        pairs = {k: v for k, v in pairs.items() if v.get("package") == args.package}
-
-    if not pairs:
+    if not progress:
         print("  0 pairs" + (" (no progress file)" if not progress_path.exists() else ""))
         return
+
+    pairs = {k: progress[k] for k in _resolve_scope(progress, args)}
 
     pair_w = max(len(k) for k in pairs) + 2
     col_status = 12
@@ -1132,8 +1127,10 @@ Examples:
                            help="Skip vLLM and EPP log files, collect only traces")
 
     status_p = sub.add_parser("status", help="Show progress of all (workload, package) pairs")
-    status_p.add_argument("--workload", metavar="NAME", help="Filter by workload name")
-    status_p.add_argument("--package",  metavar="NAME", help="Filter by package name")
+    status_p.add_argument("--only",     metavar="PAIR",  help="Scope to one specific pair key (wl- prefix optional)")
+    status_p.add_argument("--workload", metavar="NAME",  help="Filter by workload name")
+    status_p.add_argument("--package",  metavar="NAME",  help="Filter by package name")
+    status_p.add_argument("--status",   metavar="STATE", help="Filter by status (e.g. running, done, failed)")
 
     run_p = sub.add_parser("run", help="Orchestrate parallel pool execution")
     run_p.add_argument("--skip-build-epp", action="store_true", dest="skip_build_epp",

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -157,7 +157,16 @@ def _cmd_status(args, progress_path: Path) -> None:
     progress = store.load()
 
     if not progress:
-        print("  0 pairs" + (" (no progress file)" if not progress_path.exists() else ""))
+        suffix = " (no progress file)" if not progress_path.exists() else ""
+        filters_given = any([
+            getattr(args, "only", None) is not None,
+            getattr(args, "workload", None) is not None,
+            getattr(args, "package", None) is not None,
+            getattr(args, "status", None) is not None,
+        ])
+        if filters_given:
+            suffix += " — filters ignored"
+        print(f"  0 pairs{suffix}")
         return
 
     pairs = {k: progress[k] for k in _resolve_scope(progress, args)}
@@ -663,36 +672,36 @@ def _resolve_scope(progress: dict, args) -> set:
 
 
 def _report_filter_mismatch(progress: dict, args) -> None:
-    """Print valid values for each active filter flag."""
+    """Print all valid filter values to help the user correct their filter flags."""
     only = getattr(args, "only", None)
     workload = getattr(args, "workload", None)
     package = getattr(args, "package", None)
     status_filter = getattr(args, "status", None)
 
     parts = []
-    if only:
+    if only is not None:
         parts.append(f"--only '{only}'")
-    if workload:
+    if workload is not None:
         parts.append(f"--workload '{workload}'")
-    if package:
+    if package is not None:
         parts.append(f"--package '{package}'")
-    if status_filter:
+    if status_filter is not None:
         parts.append(f"--status '{status_filter}'")
 
-    print(f"No pairs matched {', '.join(parts)}.\n")
+    err(f"No pairs matched {', '.join(parts)}.\n")
 
     keys = sorted(progress.keys())
-    print(f"  Valid pair keys ({len(keys)}):")
+    print(f"  Valid pair keys ({len(keys)}):", file=sys.stderr)
     for k in keys:
-        print(f"    {k}")
+        print(f"    {k}", file=sys.stderr)
 
     valid_workloads = sorted({v.get("workload", "") for v in progress.values()} - {""})
     valid_packages = sorted({v.get("package", "") for v in progress.values()} - {""})
     valid_statuses = sorted({v.get("status", "") for v in progress.values()} - {""})
 
-    print(f"\n  Valid --workload values: {', '.join(valid_workloads)}")
-    print(f"  Valid --package values:  {', '.join(valid_packages)}")
-    print(f"  Valid --status values:   {', '.join(valid_statuses)}")
+    print(f"\n  Valid --workload values: {', '.join(valid_workloads)}", file=sys.stderr)
+    print(f"  Valid --package values:  {', '.join(valid_packages)}", file=sys.stderr)
+    print(f"  Valid --status values:   {', '.join(valid_statuses)}", file=sys.stderr)
 
 
 def _check_slot_ready(namespace: str) -> tuple[bool, list[str]]:
@@ -1128,9 +1137,9 @@ Examples:
 
     status_p = sub.add_parser("status", help="Show progress of all (workload, package) pairs")
     status_p.add_argument("--only",     metavar="PAIR",  help="Scope to one specific pair key (wl- prefix optional)")
-    status_p.add_argument("--workload", metavar="NAME",  help="Filter by workload name")
-    status_p.add_argument("--package",  metavar="NAME",  help="Filter by package name")
-    status_p.add_argument("--status",   metavar="STATE", help="Filter by status (e.g. running, done, failed)")
+    status_p.add_argument("--workload", metavar="NAME",  help="Scope to pairs matching this workload")
+    status_p.add_argument("--package",  metavar="NAME",  help="Scope to pairs matching this package")
+    status_p.add_argument("--status",   metavar="STATE", help="Scope to pairs with this status (e.g. running, done, failed)")
 
     run_p = sub.add_parser("run", help="Orchestrate parallel pool execution")
     run_p.add_argument("--skip-build-epp", action="store_true", dest="skip_build_epp",

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -252,6 +252,78 @@ def test_apply_run_filters_only_empty_string():
     assert result == set()
 
 
+def test_resolve_scope_shows_valid_keys_on_only_mismatch(capsys):
+    """--only mismatch prints valid pair keys before aborting."""
+    from pipeline.deploy import _resolve_scope
+
+    class _Args:
+        only = "nonexistent"; workload = None; package = None; status = None
+
+    try:
+        _resolve_scope(dict(_PROGRESS), _Args())
+    except SystemExit:
+        pass
+    out = capsys.readouterr().out
+    assert "No pairs matched" in out
+    assert "wl-smoke-baseline" in out
+    assert "wl-load-treatment" in out
+
+
+def test_resolve_scope_shows_valid_workloads_on_mismatch(capsys):
+    """--workload mismatch prints valid workload values."""
+    from pipeline.deploy import _resolve_scope
+
+    class _Args:
+        only = None; workload = "nonexistent"; package = None; status = None
+
+    try:
+        _resolve_scope(dict(_PROGRESS), _Args())
+    except SystemExit:
+        pass
+    out = capsys.readouterr().out
+    assert "No pairs matched" in out
+    assert "wl-smoke" in out
+    assert "wl-load" in out
+    assert "wl-heavy" in out
+
+
+def test_resolve_scope_shows_valid_packages_on_mismatch(capsys):
+    """--package mismatch prints valid package values."""
+    from pipeline.deploy import _resolve_scope
+
+    class _Args:
+        only = None; workload = None; package = "nonexistent"; status = None
+
+    try:
+        _resolve_scope(dict(_PROGRESS), _Args())
+    except SystemExit:
+        pass
+    out = capsys.readouterr().out
+    assert "No pairs matched" in out
+    assert "baseline" in out
+    assert "treatment" in out
+
+
+def test_resolve_scope_shows_valid_statuses_on_mismatch(capsys):
+    """--status mismatch prints valid status values."""
+    from pipeline.deploy import _resolve_scope
+
+    class _Args:
+        only = None; workload = None; package = None; status = "nonexistent"
+
+    try:
+        _resolve_scope(dict(_PROGRESS), _Args())
+    except SystemExit:
+        pass
+    out = capsys.readouterr().out
+    assert "No pairs matched" in out
+    assert "done" in out
+    assert "running" in out
+    assert "pending" in out
+    assert "failed" in out
+    assert "timed-out" in out
+
+
 # ── _reconcile_collecting (bugs 1+2) ─────────────────────────────────────────
 
 def test_reconcile_collecting_trace_present_marks_done(tmp_path):

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -17,8 +17,10 @@ def test_status_output_contains_all_pairs(tmp_path, capsys):
     progress_path.write_text(json.dumps(_PROGRESS))
 
     class _Args:
+        only = None
         workload = None
         package = None
+        status = None
         live = False
 
     _cmd_status(_Args(), progress_path)
@@ -33,8 +35,10 @@ def test_status_filter_by_workload(tmp_path, capsys):
     progress_path.write_text(json.dumps(_PROGRESS))
 
     class _Args:
+        only = None
         workload = "wl-smoke"
         package = None
+        status = None
         live = False
 
     _cmd_status(_Args(), progress_path)
@@ -50,8 +54,10 @@ def test_status_filter_by_package(tmp_path, capsys):
     progress_path.write_text(json.dumps(_PROGRESS))
 
     class _Args:
+        only = None
         workload = None
         package = "treatment"
+        status = None
         live = False
 
     _cmd_status(_Args(), progress_path)
@@ -67,8 +73,10 @@ def test_status_summary_line(tmp_path, capsys):
     progress_path.write_text(json.dumps(_PROGRESS))
 
     class _Args:
+        only = None
         workload = None
         package = None
+        status = None
         live = False
 
     _cmd_status(_Args(), progress_path)
@@ -83,13 +91,63 @@ def test_status_missing_progress_file(tmp_path, capsys):
     from pipeline.deploy import _cmd_status
 
     class _Args:
+        only = None
         workload = None
         package = None
+        status = None
         live = False
 
     _cmd_status(_Args(), tmp_path / "missing.json")
     out = capsys.readouterr().out
     assert "0 pairs" in out
+
+
+def test_status_filter_by_only(tmp_path, capsys):
+    """status subcommand supports --only filter."""
+    from pipeline.deploy import _cmd_status
+    progress_path = tmp_path / "progress.json"
+    progress_path.write_text(json.dumps(_PROGRESS))
+
+    class _Args:
+        only = "wl-smoke-baseline"; workload = None; package = None; status = None; live = False
+
+    _cmd_status(_Args(), progress_path)
+    out = capsys.readouterr().out
+    assert "wl-smoke-baseline" in out
+    assert "wl-load-baseline" not in out
+
+
+def test_status_filter_by_status(tmp_path, capsys):
+    """status subcommand supports --status filter."""
+    from pipeline.deploy import _cmd_status
+    progress_path = tmp_path / "progress.json"
+    progress_path.write_text(json.dumps(_PROGRESS))
+
+    class _Args:
+        only = None; workload = None; package = None; status = "running"; live = False
+
+    _cmd_status(_Args(), progress_path)
+    out = capsys.readouterr().out
+    assert "wl-smoke-treatment" in out
+    assert "wl-load-baseline" not in out
+
+
+def test_status_mismatch_shows_valid_values(tmp_path, capsys):
+    """status subcommand shows valid values on filter mismatch."""
+    from pipeline.deploy import _cmd_status
+    progress_path = tmp_path / "progress.json"
+    progress_path.write_text(json.dumps(_PROGRESS))
+
+    class _Args:
+        only = None; workload = "nonexistent"; package = None; status = None; live = False
+
+    try:
+        _cmd_status(_Args(), progress_path)
+    except SystemExit:
+        pass
+    out = capsys.readouterr().out
+    assert "No pairs matched" in out
+    assert "wl-smoke" in out
 
 
 def test_load_pairs_discovers_all_pairs(tmp_path):

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -134,6 +134,7 @@ def test_status_filter_by_status(tmp_path, capsys):
 
 def test_status_mismatch_shows_valid_values(tmp_path, capsys):
     """status subcommand shows valid values on filter mismatch."""
+    import pytest
     from pipeline.deploy import _cmd_status
     progress_path = tmp_path / "progress.json"
     progress_path.write_text(json.dumps(_PROGRESS))
@@ -141,13 +142,27 @@ def test_status_mismatch_shows_valid_values(tmp_path, capsys):
     class _Args:
         only = None; workload = "nonexistent"; package = None; status = None; live = False
 
-    try:
+    with pytest.raises(SystemExit) as exc_info:
         _cmd_status(_Args(), progress_path)
-    except SystemExit:
-        pass
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr().err
+    assert "No pairs matched" in captured
+    assert "wl-smoke" in captured
+
+
+def test_status_empty_progress_with_filters(tmp_path, capsys):
+    """status with empty progress and active filters warns filters are ignored."""
+    from pipeline.deploy import _cmd_status
+    progress_path = tmp_path / "progress.json"
+    progress_path.write_text("{}")
+
+    class _Args:
+        only = None; workload = "foo"; package = None; status = None; live = False
+
+    _cmd_status(_Args(), progress_path)
     out = capsys.readouterr().out
-    assert "No pairs matched" in out
-    assert "wl-smoke" in out
+    assert "0 pairs" in out
+    assert "filters ignored" in out
 
 
 def test_load_pairs_discovers_all_pairs(tmp_path):
@@ -311,75 +326,91 @@ def test_apply_run_filters_only_empty_string():
 
 
 def test_resolve_scope_shows_valid_keys_on_only_mismatch(capsys):
-    """--only mismatch prints valid pair keys before aborting."""
+    """--only mismatch prints valid pair keys before aborting with exit code 1."""
+    import pytest
     from pipeline.deploy import _resolve_scope
 
     class _Args:
         only = "nonexistent"; workload = None; package = None; status = None
 
-    try:
+    with pytest.raises(SystemExit) as exc_info:
         _resolve_scope(dict(_PROGRESS), _Args())
-    except SystemExit:
-        pass
-    out = capsys.readouterr().out
-    assert "No pairs matched" in out
-    assert "wl-smoke-baseline" in out
-    assert "wl-load-treatment" in out
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr().err
+    assert "No pairs matched" in captured
+    assert "wl-smoke-baseline" in captured
+    assert "wl-load-treatment" in captured
 
 
 def test_resolve_scope_shows_valid_workloads_on_mismatch(capsys):
     """--workload mismatch prints valid workload values."""
+    import pytest
     from pipeline.deploy import _resolve_scope
 
     class _Args:
         only = None; workload = "nonexistent"; package = None; status = None
 
-    try:
+    with pytest.raises(SystemExit) as exc_info:
         _resolve_scope(dict(_PROGRESS), _Args())
-    except SystemExit:
-        pass
-    out = capsys.readouterr().out
-    assert "No pairs matched" in out
-    assert "wl-smoke" in out
-    assert "wl-load" in out
-    assert "wl-heavy" in out
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr().err
+    assert "No pairs matched" in captured
+    assert "wl-smoke" in captured
+    assert "wl-load" in captured
+    assert "wl-heavy" in captured
 
 
 def test_resolve_scope_shows_valid_packages_on_mismatch(capsys):
     """--package mismatch prints valid package values."""
+    import pytest
     from pipeline.deploy import _resolve_scope
 
     class _Args:
         only = None; workload = None; package = "nonexistent"; status = None
 
-    try:
+    with pytest.raises(SystemExit) as exc_info:
         _resolve_scope(dict(_PROGRESS), _Args())
-    except SystemExit:
-        pass
-    out = capsys.readouterr().out
-    assert "No pairs matched" in out
-    assert "baseline" in out
-    assert "treatment" in out
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr().err
+    assert "No pairs matched" in captured
+    assert "baseline" in captured
+    assert "treatment" in captured
 
 
 def test_resolve_scope_shows_valid_statuses_on_mismatch(capsys):
     """--status mismatch prints valid status values."""
+    import pytest
     from pipeline.deploy import _resolve_scope
 
     class _Args:
         only = None; workload = None; package = None; status = "nonexistent"
 
-    try:
+    with pytest.raises(SystemExit) as exc_info:
         _resolve_scope(dict(_PROGRESS), _Args())
-    except SystemExit:
-        pass
-    out = capsys.readouterr().out
-    assert "No pairs matched" in out
-    assert "done" in out
-    assert "running" in out
-    assert "pending" in out
-    assert "failed" in out
-    assert "timed-out" in out
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr().err
+    assert "No pairs matched" in captured
+    assert "done" in captured
+    assert "running" in captured
+    assert "pending" in captured
+    assert "failed" in captured
+    assert "timed-out" in captured
+
+
+def test_resolve_scope_combined_filter_mismatch(capsys):
+    """Combined filters where each value is valid but intersection is empty."""
+    import pytest
+    from pipeline.deploy import _resolve_scope
+
+    class _Args:
+        only = None; workload = "wl-smoke"; package = None; status = "timed-out"
+
+    with pytest.raises(SystemExit) as exc_info:
+        _resolve_scope(dict(_PROGRESS), _Args())
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr().err
+    assert "--workload 'wl-smoke'" in captured
+    assert "--status 'timed-out'" in captured
 
 
 # ── _reconcile_collecting (bugs 1+2) ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

- When no pairs match `--only`, `--workload`, `--package`, or `--status`, the error now lists all valid pair keys, workloads, packages, and statuses instead of a terse "No pairs matched" abort.
- Migrates the `status` subcommand to use the shared `_resolve_scope` helper, adding `--only` and `--status` flags for parity with `run` and `cleanup`.

Closes #58

## Test Plan

- [x] 7 new tests covering all filter mismatch scenarios and new `status` flags
- [x] Full suite passes (361 tests)
- [x] Lint passes (`ruff check pipeline/ --select F`)
- [ ] Manual: `deploy.py run --only bogus` shows valid pair keys
- [ ] Manual: `deploy.py status --workload bogus` shows valid workloads