### PR TITLE
feat: early reclaim of Pending pod slots

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ python pipeline/run.py     --experiment-root ../admission-control switch <run-na
 | `values.py` | Deep-merge utility (`deep_merge`) used by `assemble.py` |
 | `assemble.py` | Scenario assembly: deep-merges bundles + overlays into resolved scenarios |
 | `tekton.py` | Generates PipelineRun YAMLs for scenario-based benchmarks |
+| `pod_pending.py` | Classifies pod scheduling failures as recoverable or non-recoverable |
 | `run_manager.py` | `list_runs`, `inspect_run`, `switch_run` logic |
 
 ## Workspace Artifacts

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -157,7 +157,7 @@ python pipeline/deploy.py cleanup [flags]   # tear down cluster resources for fa
 
 **Early reclaim** — on each poll cycle, pods in `Running`/`Started` PipelineRuns are checked for scheduling failures. Recoverable reasons (e.g. `Insufficient nvidia.com/gpu`) trigger early reclaim after `--pending-threshold` seconds. Non-recoverable reasons (e.g. node affinity mismatch, PVC not found) fail the pair immediately. Each early reclaim increments `pending_stalls`; at `--max-pending-stalls` the pair transitions to `stalled` (terminal).
 
-**Pair statuses:** `pending` → `running` → `done` | `failed` | `timed-out` | `stalled`
+**Pair statuses:** `pending` → `running` → `collecting` → `done` | `collect-failed`. Failure paths: `running` → `failed` (hard failure or non-recoverable pending), `running` → `timed-out` (4h timeout exceeded), `running` → `pending` (recoverable early reclaim, repeats up to `--max-pending-stalls` times) → `stalled`.
 
 **`deploy.py status`** — prints the current state of all pairs from `workspace/runs/<run>/progress.json`.
 

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -152,6 +152,12 @@ python pipeline/deploy.py cleanup [flags]   # tear down cluster resources for fa
 | `--poll-interval N` | 30 | Seconds between status polls |
 | `--gpu-resource-type` | auto-derived | Override GPU resource name (derived from scenario's `accelerator.resource`, else `nvidia.com/gpu`) |
 | `--default-gpu-cost N` | 1 | Fallback GPU cost per pair when not derivable from scenario |
+| `--pending-threshold N` | 600 | Seconds a pod may remain Pending (recoverable reason) before early reclaim |
+| `--max-pending-stalls N` | 10 | Max early reclaims before marking pair `stalled` |
+
+**Early reclaim** — on each poll cycle, pods in `Running`/`Started` PipelineRuns are checked for scheduling failures. Recoverable reasons (e.g. `Insufficient nvidia.com/gpu`) trigger early reclaim after `--pending-threshold` seconds. Non-recoverable reasons (e.g. node affinity mismatch, PVC not found) fail the pair immediately. Each early reclaim increments `pending_stalls`; at `--max-pending-stalls` the pair transitions to `stalled` (terminal).
+
+**Pair statuses:** `pending` → `running` → `done` | `failed` | `timed-out` | `stalled`
 
 **`deploy.py status`** — prints the current state of all pairs from `workspace/runs/<run>/progress.json`.
 

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -228,11 +228,13 @@ def _handle_pending_pods(*, pr_name: str, namespace: str, entry: dict,
         check=False, capture=True,
     )
     if result.returncode != 0:
+        warn(f"[{entry.get('workload', '?')}] pod query failed: {(result.stdout or result.stderr or '')[:120]}")
         return False
 
     try:
         pods_json = _json.loads(result.stdout)
     except _json.JSONDecodeError:
+        warn(f"[{entry.get('workload', '?')}] pod query returned invalid JSON: {result.stdout[:120]}")
         return False
 
     category, detail = parse_pod_conditions(pods_json)

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -210,6 +210,71 @@ def _check_pipelinerun_status(pr_name: str, namespace: str) -> str:
 
 
 
+def _handle_pending_pods(*, pr_name: str, namespace: str, entry: dict,
+                         pending_threshold: int, max_pending_stalls: int) -> bool:
+    """Check for pods stuck in Pending and take action.
+
+    Returns True if the slot was reclaimed (caller should free slot).
+    Returns False if no action taken (caller should proceed to timeout check).
+    """
+    import datetime as _dt
+    import json as _json
+    from pipeline.lib.pod_pending import parse_pod_conditions
+
+    result = run(
+        ["kubectl", "get", "pods", f"-n={namespace}",
+         "-l", f"tekton.dev/pipelineRun={pr_name}",
+         "-o", "json"],
+        check=False, capture=True,
+    )
+    if result.returncode != 0:
+        return False
+
+    try:
+        pods_json = _json.loads(result.stdout)
+    except _json.JSONDecodeError:
+        return False
+
+    category, detail = parse_pod_conditions(pods_json)
+
+    if category is None:
+        if entry.get("pending_since") is not None:
+            entry["pending_since"] = None
+        return False
+
+    if category == "non_recoverable":
+        warn(f"[{entry.get('workload', '?')}] non-recoverable pending: {detail}")
+        _cancel_and_delete_pipelinerun(pr_name, namespace)
+        entry["status"] = "failed"
+        entry["namespace"] = None
+        return True
+
+    # category == "recoverable"
+    now = _dt.datetime.now(_dt.timezone.utc)
+    if entry.get("pending_since") is None:
+        entry["pending_since"] = now.isoformat()
+        info(f"[{entry.get('workload', '?')}] pending (recoverable): {detail}")
+        return False
+
+    pending_since = _dt.datetime.fromisoformat(entry["pending_since"])
+    elapsed = (now - pending_since).total_seconds()
+    if elapsed <= pending_threshold:
+        return False
+
+    warn(f"[{entry.get('workload', '?')}] pending {int(elapsed)}s > {pending_threshold}s threshold → reclaim")
+    _cancel_and_delete_pipelinerun(pr_name, namespace)
+    stalls = entry.get("pending_stalls", 0) + 1
+    entry["pending_stalls"] = stalls
+    entry["pending_since"] = None
+    entry["namespace"] = None
+    if stalls >= max_pending_stalls:
+        entry["status"] = "stalled"
+        warn(f"[{entry.get('workload', '?')}] reached max pending stalls ({max_pending_stalls}) → stalled")
+    else:
+        entry["status"] = "pending"
+    return True
+
+
 def _probe_phase_sizes(pod_name: str, run_name: str, phases: list[str],
                        namespace: str) -> dict[str, int]:
     """Return byte sizes for each phase directory on the PVC."""
@@ -830,6 +895,8 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
 
     max_retries = getattr(args, "max_retries", 2)
     poll_interval = getattr(args, "poll_interval", 30)
+    pending_threshold = getattr(args, "pending_threshold", 600)
+    max_pending_stalls = getattr(args, "max_pending_stalls", 10)
 
     cluster_dir = run_dir / "cluster"
     progress_path = run_dir / "progress.json"
@@ -909,16 +976,20 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                 actual = _check_pipelinerun_status(pr_name, ns)
                 if actual == "Succeeded":
                     entry["status"] = "collecting"
+                    entry["pending_since"] = None
                 elif actual in ("Failed", "PipelineRunCancelled"):
                     entry["status"] = "failed"
+                    entry["pending_since"] = None
                 elif actual == "Unknown":
                     warn(f"[{key}] PipelineRun not found on cluster → resetting to pending")
                     entry["status"] = "pending"
                     entry["namespace"] = None
+                    entry["pending_since"] = None
                 # If still "Running"/"Started", leave as "running" — will be monitored
             else:
                 entry["status"] = "pending"
                 entry["namespace"] = None
+                entry["pending_since"] = None
         elif entry["status"] == "collecting":
             _reconcile_collecting(key, entry, run_dir)
     store.save(progress)
@@ -979,6 +1050,16 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                 del slots_busy[ns]
 
             elif status in ("Running", "Started"):
+                # Check for pending pods (before timeout)
+                if _handle_pending_pods(
+                    pr_name=pr_name, namespace=ns, entry=entry,
+                    pending_threshold=pending_threshold,
+                    max_pending_stalls=max_pending_stalls,
+                ):
+                    del slots_busy[ns]
+                    store.save(progress)
+                    continue
+
                 # Check for timeout
                 ts_result = run(
                     ["kubectl", "get", "pipelinerun", pr_name, f"-n={ns}",

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -216,6 +216,12 @@ def _handle_pending_pods(*, pr_name: str, namespace: str, entry: dict,
 
     Returns True if the slot was reclaimed (caller should free slot).
     Returns False if no action taken (caller should proceed to timeout check).
+
+    Side effects on *entry* (caller must persist):
+      - pending_since: set/cleared as pending state changes
+      - pending_stalls: incremented on each reclaim
+      - status: set to "pending", "failed", or "stalled" on reclaim
+      - namespace: set to None on reclaim
     """
     import datetime as _dt
     import json as _json

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -884,6 +884,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                 "namespace": None,
                 "retries":  0,
                 "gpu_cost": pair_gpu_cost,
+                "pending_stalls": 0,
             }
 
     _scope = _resolve_scope(progress, args)
@@ -1201,6 +1202,10 @@ Examples:
                        help="Override GPU resource name (default: derived from scenario, else nvidia.com/gpu)")
     run_p.add_argument("--default-gpu-cost", type=int, default=1, dest="default_gpu_cost",
                        help="Fallback GPU cost per pair when not derivable from scenario [1]")
+    run_p.add_argument("--pending-threshold", type=int, default=600, dest="pending_threshold",
+                       help="Seconds a pod may remain Pending (recoverable) before early reclaim [600]")
+    run_p.add_argument("--max-pending-stalls", type=int, default=10, dest="max_pending_stalls",
+                       help="Max early reclaims before marking pair stalled [10]")
 
     cleanup_p = sub.add_parser("cleanup", help="Tear down cluster resources for all non-pending pairs")
     cleanup_p.add_argument("--only",     metavar="PAIR",  help="Scope to one specific pair key (wl- prefix optional)")

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -258,7 +258,12 @@ def _handle_pending_pods(*, pr_name: str, namespace: str, entry: dict,
         info(f"[{entry.get('workload', '?')}] pending (recoverable): {detail}")
         return False
 
-    pending_since = _dt.datetime.fromisoformat(entry["pending_since"])
+    try:
+        pending_since = _dt.datetime.fromisoformat(entry["pending_since"])
+    except (ValueError, TypeError):
+        warn(f"[{entry.get('workload', '?')}] malformed pending_since — resetting timer")
+        entry["pending_since"] = now.isoformat()
+        return False
     elapsed = (now - pending_since).total_seconds()
     if elapsed <= pending_threshold:
         return False
@@ -595,6 +600,8 @@ def _cleanup_pair(key: str, entry: dict, discovered: dict, *,
         if not dry_run and not is_done:
             entry["status"] = "pending"
             entry["retries"] = 0
+            entry["pending_stalls"] = 0
+            entry["pending_since"] = None
         return True
 
     if dry_run:
@@ -662,6 +669,8 @@ def _cleanup_pair(key: str, entry: dict, discovered: dict, *,
     entry["status"] = "pending"
     entry["namespace"] = None
     entry["retries"] = 0
+    entry["pending_stalls"] = 0
+    entry["pending_since"] = None
     return True
 
 
@@ -954,6 +963,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                 "retries":  0,
                 "gpu_cost": pair_gpu_cost,
                 "pending_stalls": 0,
+                "pending_since": None,
             }
 
     _scope = _resolve_scope(progress, args)

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -218,10 +218,14 @@ def _handle_pending_pods(*, pr_name: str, namespace: str, entry: dict,
     Returns False if no action taken (caller should proceed to timeout check).
 
     Side effects on *entry* (caller must persist):
-      - pending_since: set/cleared as pending state changes
-      - pending_stalls: incremented on each reclaim
-      - status: set to "pending", "failed", or "stalled" on reclaim
-      - namespace: set to None on reclaim
+      On True (slot reclaimed):
+        - status: "pending", "failed", or "stalled"
+        - namespace: None
+        - pending_stalls: incremented
+        - pending_since: None
+      On False (no action):
+        - pending_since: set on first recoverable detection, cleared when
+          pods start running, reset on malformed timestamp
     """
     import datetime as _dt
     import json as _json
@@ -243,7 +247,11 @@ def _handle_pending_pods(*, pr_name: str, namespace: str, entry: dict,
         warn(f"[{entry.get('workload', '?')}] pod query returned invalid JSON: {result.stdout[:120]}")
         return False
 
-    category, detail = parse_pod_conditions(pods_json)
+    try:
+        category, detail = parse_pod_conditions(pods_json)
+    except (KeyError, TypeError, AttributeError) as exc:
+        warn(f"[{entry.get('workload', '?')}] unexpected pod JSON shape: {exc}")
+        return False
 
     if category is None:
         if entry.get("pending_since") is not None:

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1077,11 +1077,16 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
 
             elif status in ("Running", "Started"):
                 # Check for pending pods (before timeout)
-                if _handle_pending_pods(
-                    pr_name=pr_name, namespace=ns, entry=entry,
-                    pending_threshold=pending_threshold,
-                    max_pending_stalls=max_pending_stalls,
-                ):
+                try:
+                    reclaimed = _handle_pending_pods(
+                        pr_name=pr_name, namespace=ns, entry=entry,
+                        pending_threshold=pending_threshold,
+                        max_pending_stalls=max_pending_stalls,
+                    )
+                except Exception as exc:
+                    warn(f"[{pair_key}] pending check failed: {exc}")
+                    reclaimed = False
+                if reclaimed:
                     del slots_busy[ns]
                     store.save(progress)
                     continue

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -218,11 +218,11 @@ def _handle_pending_pods(*, pr_name: str, namespace: str, entry: dict,
     Returns False if no action taken (caller should proceed to timeout check).
 
     Side effects on *entry* (caller must persist):
-      On True (slot reclaimed):
-        - status: "pending", "failed", or "stalled"
-        - namespace: None
-        - pending_stalls: incremented
-        - pending_since: None
+      On True (non-recoverable):
+        - status: "failed", namespace: None, pending_since: None
+      On True (recoverable threshold exceeded):
+        - status: "pending" or "stalled", namespace: None
+        - pending_stalls: incremented, pending_since: None
       On False (no action):
         - pending_since: set on first recoverable detection, cleared when
           pods start running, reset on malformed timestamp
@@ -263,6 +263,7 @@ def _handle_pending_pods(*, pr_name: str, namespace: str, entry: dict,
         _cancel_and_delete_pipelinerun(pr_name, namespace)
         entry["status"] = "failed"
         entry["namespace"] = None
+        entry["pending_since"] = None
         return True
 
     # category == "recoverable"
@@ -1084,7 +1085,9 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                         max_pending_stalls=max_pending_stalls,
                     )
                 except Exception as exc:
-                    warn(f"[{pair_key}] pending check failed: {exc}")
+                    import traceback as _tb
+                    err(f"[{pair_key}] pending check failed: {exc}")
+                    _tb.print_exc(file=sys.stderr)
                     reclaimed = False
                 if reclaimed:
                     del slots_busy[ns]
@@ -1113,6 +1116,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                                 warn(f"[{pair_key}] timed out, max retries → timed-out")
                                 entry["status"] = "timed-out"
                             entry["namespace"] = None
+                            entry["pending_since"] = None
                             del slots_busy[ns]
                             store.save(progress)
                     except ValueError:
@@ -1195,6 +1199,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
 
             entry["status"] = "running"
             entry["namespace"] = ns
+            entry["pending_since"] = None
             slots_busy[ns] = pair_key
             store.save(progress)
             ok(f"[{pair_key}] → {ns} ({pr_name})")

--- a/pipeline/lib/pod_pending.py
+++ b/pipeline/lib/pod_pending.py
@@ -1,7 +1,10 @@
 """Pod pending detection and reason classification."""
 from __future__ import annotations
 
+import logging
 import re
+
+_log = logging.getLogger(__name__)
 
 _RECOVERABLE_PATTERNS = [
     re.compile(r"Insufficient\s+\S+", re.IGNORECASE),
@@ -20,8 +23,8 @@ def classify_pending_reason(message: str) -> str:
 
     Returns "recoverable" (resource scarcity) or "non_recoverable" (config error).
     Empty messages → non_recoverable (missing data = config problem).
-    Unrecognized non-empty messages → recoverable (10-min wait is cheaper
-    than irreversible cancellation of hours of GPU work).
+    Unrecognized non-empty messages → recoverable (waiting up to the
+    configured threshold is cheaper than irreversible cancellation).
     """
     if not message:
         return "non_recoverable"
@@ -34,6 +37,8 @@ def classify_pending_reason(message: str) -> str:
         if pat.search(message):
             return "non_recoverable"
 
+    _log.warning("unrecognized scheduling message (defaulting to recoverable): %s",
+                 message[:200])
     return "recoverable"
 
 

--- a/pipeline/lib/pod_pending.py
+++ b/pipeline/lib/pod_pending.py
@@ -1,10 +1,8 @@
 """Pod pending detection and reason classification."""
 from __future__ import annotations
 
-import logging
 import re
-
-_log = logging.getLogger(__name__)
+import sys
 
 _RECOVERABLE_PATTERNS = [
     re.compile(r"Insufficient\s+\S+", re.IGNORECASE),
@@ -37,8 +35,8 @@ def classify_pending_reason(message: str) -> str:
         if pat.search(message):
             return "non_recoverable"
 
-    _log.warning("unrecognized scheduling message (defaulting to recoverable): %s",
-                 message[:200])
+    print(f"[WARN]  unrecognized scheduling message (defaulting to recoverable): "
+          f"{message[:200]}", file=sys.stderr)
     return "recoverable"
 
 

--- a/pipeline/lib/pod_pending.py
+++ b/pipeline/lib/pod_pending.py
@@ -19,8 +19,9 @@ def classify_pending_reason(message: str) -> str:
     """Classify a pod scheduling failure message.
 
     Returns "recoverable" (resource scarcity) or "non_recoverable" (config error).
-    Unrecognized messages default to "recoverable" — a 10-min wait is cheaper
-    than irreversible cancellation of hours of GPU work.
+    Empty messages → non_recoverable (missing data = config problem).
+    Unrecognized non-empty messages → recoverable (10-min wait is cheaper
+    than irreversible cancellation of hours of GPU work).
     """
     if not message:
         return "non_recoverable"
@@ -39,9 +40,12 @@ def classify_pending_reason(message: str) -> str:
 def parse_pod_conditions(pods_json: dict) -> tuple[str | None, str]:
     """Parse kubectl get pods JSON output for pending scheduling failures.
 
-    Returns (category, detail) where category is "recoverable",
-    "non_recoverable", or None if no pods are stuck pending.
+    Scans all pods and returns the worst severity found
+    (non_recoverable > recoverable). Returns (None, "") if no pods are
+    stuck pending with Unschedulable condition.
     """
+    worst_category: str | None = None
+    worst_detail = ""
     for item in pods_json.get("items", []):
         status = item.get("status", {})
         if status.get("phase") != "Pending":
@@ -52,5 +56,9 @@ def parse_pod_conditions(pods_json: dict) -> tuple[str | None, str]:
                     and cond.get("reason") == "Unschedulable"):
                 message = cond.get("message", "")
                 category = classify_pending_reason(message)
-                return category, message
-    return None, ""
+                if category == "non_recoverable":
+                    return category, message
+                if worst_category is None:
+                    worst_category = category
+                    worst_detail = message
+    return worst_category, worst_detail

--- a/pipeline/lib/pod_pending.py
+++ b/pipeline/lib/pod_pending.py
@@ -19,6 +19,8 @@ def classify_pending_reason(message: str) -> str:
     """Classify a pod scheduling failure message.
 
     Returns "recoverable" (resource scarcity) or "non_recoverable" (config error).
+    Unrecognized messages default to "recoverable" — a 10-min wait is cheaper
+    than irreversible cancellation of hours of GPU work.
     """
     if not message:
         return "non_recoverable"
@@ -27,7 +29,11 @@ def classify_pending_reason(message: str) -> str:
         if pat.search(message):
             return "recoverable"
 
-    return "non_recoverable"
+    for pat in _NON_RECOVERABLE_PATTERNS:
+        if pat.search(message):
+            return "non_recoverable"
+
+    return "recoverable"
 
 
 def parse_pod_conditions(pods_json: dict) -> tuple[str | None, str]:

--- a/pipeline/lib/pod_pending.py
+++ b/pipeline/lib/pod_pending.py
@@ -1,0 +1,50 @@
+"""Pod pending detection and reason classification."""
+from __future__ import annotations
+
+import re
+
+_RECOVERABLE_PATTERNS = [
+    re.compile(r"Insufficient\s+\S+", re.IGNORECASE),
+    re.compile(r"\d+/\d+ nodes are available:.*Insufficient", re.IGNORECASE),
+]
+
+_NON_RECOVERABLE_PATTERNS = [
+    re.compile(r"node\(s\) didn't match Pod's node affinity/selector", re.IGNORECASE),
+    re.compile(r"persistentvolumeclaim\s+.*not found", re.IGNORECASE),
+    re.compile(r"node\(s\) had untolerated taint", re.IGNORECASE),
+]
+
+
+def classify_pending_reason(message: str) -> str:
+    """Classify a pod scheduling failure message.
+
+    Returns "recoverable" (resource scarcity) or "non_recoverable" (config error).
+    """
+    if not message:
+        return "non_recoverable"
+
+    for pat in _RECOVERABLE_PATTERNS:
+        if pat.search(message):
+            return "recoverable"
+
+    return "non_recoverable"
+
+
+def parse_pod_conditions(pods_json: dict) -> tuple[str | None, str]:
+    """Parse kubectl get pods JSON output for pending scheduling failures.
+
+    Returns (category, detail) where category is "recoverable",
+    "non_recoverable", or None if no pods are stuck pending.
+    """
+    for item in pods_json.get("items", []):
+        status = item.get("status", {})
+        if status.get("phase") != "Pending":
+            continue
+        for cond in status.get("conditions", []):
+            if (cond.get("type") == "PodScheduled"
+                    and cond.get("status") == "False"
+                    and cond.get("reason") == "Unschedulable"):
+                message = cond.get("message", "")
+                category = classify_pending_reason(message)
+                return category, message
+    return None, ""

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -776,3 +776,36 @@ def test_slot_limited_dispatch(capsys):
     out = capsys.readouterr().out
     assert "slot-limited" in out
     assert "1/3" in out
+
+
+def test_init_progress_includes_pending_stalls():
+    """New progress entries include pending_stalls field initialized to 0."""
+    progress_entry = {
+        "workload": "wl-smoke",
+        "package": "baseline",
+        "status": "pending",
+        "namespace": None,
+        "retries": 0,
+        "gpu_cost": 1,
+        "pending_stalls": 0,
+    }
+    assert "pending_stalls" in progress_entry
+    assert progress_entry["pending_stalls"] == 0
+
+
+def test_run_parser_has_pending_flags():
+    """run subcommand exposes --pending-threshold and --max-pending-stalls."""
+    from pipeline.deploy import build_parser
+    parser = build_parser()
+    args = parser.parse_args(["run", "--pending-threshold", "300", "--max-pending-stalls", "5"])
+    assert args.pending_threshold == 300
+    assert args.max_pending_stalls == 5
+
+
+def test_run_parser_pending_flag_defaults():
+    """--pending-threshold defaults to 600, --max-pending-stalls to 10."""
+    from pipeline.deploy import build_parser
+    parser = build_parser()
+    args = parser.parse_args(["run"])
+    assert args.pending_threshold == 600
+    assert args.max_pending_stalls == 10

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -960,6 +960,7 @@ def test_early_reclaim_non_recoverable_fails_immediately(monkeypatch):
     assert reclaimed is True
     assert entry["status"] == "failed"
     assert entry["namespace"] is None
+    assert entry["pending_stalls"] == 0
     assert cancelled == [("baseline-smoke-run1", "sim2real-0")]
 
 
@@ -1157,3 +1158,36 @@ def test_force_reset_clears_pending_stalls(monkeypatch):
     _force_reset(progress, {"wl-a-baseline"})
     assert progress["wl-a-baseline"]["pending_stalls"] == 0
     assert progress["wl-a-baseline"]["pending_since"] is None
+
+
+def test_early_reclaim_json_decode_error_warns(monkeypatch, capsys):
+    """kubectl returns garbage JSON with rc=0: warn and don't reclaim."""
+    import pipeline.deploy as mod
+
+    entry = {
+        "workload": "wl-smoke", "package": "baseline", "status": "running",
+        "namespace": "sim2real-0", "retries": 0, "gpu_cost": 1,
+        "pending_stalls": 0, "pending_since": None,
+    }
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = "<html>auth proxy page</html>"
+            stderr = ""
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    reclaimed = mod._handle_pending_pods(
+        pr_name="baseline-smoke-run1",
+        namespace="sim2real-0",
+        entry=entry,
+        pending_threshold=600,
+        max_pending_stalls=10,
+    )
+
+    assert reclaimed is False
+    assert entry["status"] == "running"
+    out = capsys.readouterr().out
+    assert "invalid JSON" in out

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -809,3 +809,275 @@ def test_run_parser_pending_flag_defaults():
     args = parser.parse_args(["run"])
     assert args.pending_threshold == 600
     assert args.max_pending_stalls == 10
+
+
+def test_early_reclaim_recoverable_threshold_exceeded(monkeypatch):
+    """Recoverable pending pod past threshold: cancel PR, free slot, return to pending."""
+    import datetime as _dt
+    import json
+    import pipeline.deploy as mod
+
+    pods_json_recoverable = {
+        "items": [{
+            "status": {
+                "phase": "Pending",
+                "conditions": [{
+                    "type": "PodScheduled",
+                    "status": "False",
+                    "reason": "Unschedulable",
+                    "message": "0/8 nodes are available: 8 Insufficient nvidia.com/gpu.",
+                }],
+            },
+        }],
+    }
+
+    entry = {
+        "workload": "wl-smoke", "package": "baseline", "status": "running",
+        "namespace": "sim2real-0", "retries": 0, "gpu_cost": 1,
+        "pending_stalls": 0,
+        "pending_since": (_dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(seconds=700)).isoformat(),
+    }
+
+    cancelled = []
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = json.dumps(pods_json_recoverable)
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    monkeypatch.setattr(mod, "_cancel_and_delete_pipelinerun",
+                        lambda pr, ns: cancelled.append((pr, ns)))
+
+    reclaimed = mod._handle_pending_pods(
+        pr_name="baseline-smoke-run1",
+        namespace="sim2real-0",
+        entry=entry,
+        pending_threshold=600,
+        max_pending_stalls=10,
+    )
+
+    assert reclaimed is True
+    assert entry["status"] == "pending"
+    assert entry["namespace"] is None
+    assert entry["pending_stalls"] == 1
+    assert entry["pending_since"] is None
+    assert cancelled == [("baseline-smoke-run1", "sim2real-0")]
+
+
+def test_early_reclaim_recoverable_under_threshold(monkeypatch):
+    """Recoverable pending pod under threshold: set pending_since, do NOT reclaim."""
+    import json
+    import pipeline.deploy as mod
+
+    pods_json_recoverable = {
+        "items": [{
+            "status": {
+                "phase": "Pending",
+                "conditions": [{
+                    "type": "PodScheduled",
+                    "status": "False",
+                    "reason": "Unschedulable",
+                    "message": "0/8 nodes are available: 8 Insufficient nvidia.com/gpu.",
+                }],
+            },
+        }],
+    }
+
+    entry = {
+        "workload": "wl-smoke", "package": "baseline", "status": "running",
+        "namespace": "sim2real-0", "retries": 0, "gpu_cost": 1,
+        "pending_stalls": 0, "pending_since": None,
+    }
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = json.dumps(pods_json_recoverable)
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    reclaimed = mod._handle_pending_pods(
+        pr_name="baseline-smoke-run1",
+        namespace="sim2real-0",
+        entry=entry,
+        pending_threshold=600,
+        max_pending_stalls=10,
+    )
+
+    assert reclaimed is False
+    assert entry["status"] == "running"
+    assert entry["pending_since"] is not None
+
+
+def test_early_reclaim_non_recoverable_fails_immediately(monkeypatch):
+    """Non-recoverable pending: fail immediately, no waiting."""
+    import json
+    import pipeline.deploy as mod
+
+    pods_json_non_recoverable = {
+        "items": [{
+            "status": {
+                "phase": "Pending",
+                "conditions": [{
+                    "type": "PodScheduled",
+                    "status": "False",
+                    "reason": "Unschedulable",
+                    "message": "0/8 nodes are available: 8 node(s) didn't match Pod's node affinity/selector.",
+                }],
+            },
+        }],
+    }
+
+    entry = {
+        "workload": "wl-smoke", "package": "baseline", "status": "running",
+        "namespace": "sim2real-0", "retries": 0, "gpu_cost": 1,
+        "pending_stalls": 0, "pending_since": None,
+    }
+
+    cancelled = []
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = json.dumps(pods_json_non_recoverable)
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    monkeypatch.setattr(mod, "_cancel_and_delete_pipelinerun",
+                        lambda pr, ns: cancelled.append((pr, ns)))
+
+    reclaimed = mod._handle_pending_pods(
+        pr_name="baseline-smoke-run1",
+        namespace="sim2real-0",
+        entry=entry,
+        pending_threshold=600,
+        max_pending_stalls=10,
+    )
+
+    assert reclaimed is True
+    assert entry["status"] == "failed"
+    assert entry["namespace"] is None
+    assert cancelled == [("baseline-smoke-run1", "sim2real-0")]
+
+
+def test_early_reclaim_stalled_at_max_pending_stalls(monkeypatch):
+    """When pending_stalls reaches max, pair transitions to stalled."""
+    import datetime as _dt
+    import json
+    import pipeline.deploy as mod
+
+    pods_json_recoverable = {
+        "items": [{
+            "status": {
+                "phase": "Pending",
+                "conditions": [{
+                    "type": "PodScheduled",
+                    "status": "False",
+                    "reason": "Unschedulable",
+                    "message": "0/8 nodes are available: 8 Insufficient nvidia.com/gpu.",
+                }],
+            },
+        }],
+    }
+
+    entry = {
+        "workload": "wl-smoke", "package": "baseline", "status": "running",
+        "namespace": "sim2real-0", "retries": 0, "gpu_cost": 1,
+        "pending_stalls": 9,
+        "pending_since": (_dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(seconds=700)).isoformat(),
+    }
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = json.dumps(pods_json_recoverable)
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    monkeypatch.setattr(mod, "_cancel_and_delete_pipelinerun", lambda pr, ns: None)
+
+    reclaimed = mod._handle_pending_pods(
+        pr_name="baseline-smoke-run1",
+        namespace="sim2real-0",
+        entry=entry,
+        pending_threshold=600,
+        max_pending_stalls=10,
+    )
+
+    assert reclaimed is True
+    assert entry["status"] == "stalled"
+    assert entry["pending_stalls"] == 10
+
+
+def test_early_reclaim_kubectl_failure_returns_false(monkeypatch):
+    """kubectl get pods failure: don't reclaim, let timeout handle it."""
+    import pipeline.deploy as mod
+
+    entry = {
+        "workload": "wl-smoke", "package": "baseline", "status": "running",
+        "namespace": "sim2real-0", "retries": 0, "gpu_cost": 1,
+        "pending_stalls": 0, "pending_since": None,
+    }
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 1
+            stdout = ""
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    reclaimed = mod._handle_pending_pods(
+        pr_name="baseline-smoke-run1",
+        namespace="sim2real-0",
+        entry=entry,
+        pending_threshold=600,
+        max_pending_stalls=10,
+    )
+
+    assert reclaimed is False
+    assert entry["status"] == "running"
+
+
+def test_early_reclaim_pods_running_clears_pending_since(monkeypatch):
+    """When pods transition from Pending to Running, clear pending_since."""
+    import json
+    import pipeline.deploy as mod
+
+    pods_json_running = {
+        "items": [{
+            "status": {
+                "phase": "Running",
+                "conditions": [{"type": "Ready", "status": "True"}],
+            },
+        }],
+    }
+
+    entry = {
+        "workload": "wl-smoke", "package": "baseline", "status": "running",
+        "namespace": "sim2real-0", "retries": 0, "gpu_cost": 1,
+        "pending_stalls": 0,
+        "pending_since": "2026-05-09T12:00:00+00:00",
+    }
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = json.dumps(pods_json_running)
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    reclaimed = mod._handle_pending_pods(
+        pr_name="baseline-smoke-run1",
+        namespace="sim2real-0",
+        entry=entry,
+        pending_threshold=600,
+        max_pending_stalls=10,
+    )
+
+    assert reclaimed is False
+    assert entry["pending_since"] is None

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -1012,8 +1012,8 @@ def test_early_reclaim_stalled_at_max_pending_stalls(monkeypatch):
     assert entry["pending_stalls"] == 10
 
 
-def test_early_reclaim_kubectl_failure_returns_false(monkeypatch):
-    """kubectl get pods failure: don't reclaim, let timeout handle it."""
+def test_early_reclaim_kubectl_failure_returns_false(monkeypatch, capsys):
+    """kubectl get pods failure: warn and don't reclaim, let timeout handle it."""
     import pipeline.deploy as mod
 
     entry = {
@@ -1026,6 +1026,7 @@ def test_early_reclaim_kubectl_failure_returns_false(monkeypatch):
         class _R:
             returncode = 1
             stdout = ""
+            stderr = "connection refused"
         return _R()
 
     monkeypatch.setattr(mod, "run", fake_run)
@@ -1040,6 +1041,8 @@ def test_early_reclaim_kubectl_failure_returns_false(monkeypatch):
 
     assert reclaimed is False
     assert entry["status"] == "running"
+    out = capsys.readouterr().out
+    assert "pod query failed" in out
 
 
 def test_early_reclaim_pods_running_clears_pending_since(monkeypatch):

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -1084,3 +1084,76 @@ def test_early_reclaim_pods_running_clears_pending_since(monkeypatch):
 
     assert reclaimed is False
     assert entry["pending_since"] is None
+
+
+def test_early_reclaim_malformed_pending_since_resets_timer(monkeypatch, capsys):
+    """Malformed pending_since resets timer instead of crashing."""
+    import json
+    import pipeline.deploy as mod
+
+    pods_json_recoverable = {
+        "items": [{
+            "status": {
+                "phase": "Pending",
+                "conditions": [{
+                    "type": "PodScheduled",
+                    "status": "False",
+                    "reason": "Unschedulable",
+                    "message": "0/8 nodes are available: 8 Insufficient nvidia.com/gpu.",
+                }],
+            },
+        }],
+    }
+
+    entry = {
+        "workload": "wl-smoke", "package": "baseline", "status": "running",
+        "namespace": "sim2real-0", "retries": 0, "gpu_cost": 1,
+        "pending_stalls": 0,
+        "pending_since": "not-a-valid-timestamp",
+    }
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = json.dumps(pods_json_recoverable)
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    reclaimed = mod._handle_pending_pods(
+        pr_name="baseline-smoke-run1",
+        namespace="sim2real-0",
+        entry=entry,
+        pending_threshold=600,
+        max_pending_stalls=10,
+    )
+
+    assert reclaimed is False
+    assert entry["pending_since"] != "not-a-valid-timestamp"
+    out = capsys.readouterr().out
+    assert "malformed pending_since" in out
+
+
+def test_force_reset_clears_pending_stalls(monkeypatch):
+    """--force resets pending_stalls along with retries."""
+    from pipeline.deploy import _force_reset
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = ""
+        return _R()
+
+    import pipeline.deploy as mod
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    progress = {
+        "wl-a-baseline": {
+            "workload": "wl-a", "package": "baseline", "status": "stalled",
+            "namespace": None, "retries": 2, "pending_stalls": 10,
+            "pending_since": "2026-05-09T12:00:00+00:00",
+        },
+    }
+    _force_reset(progress, {"wl-a-baseline"})
+    assert progress["wl-a-baseline"]["pending_stalls"] == 0
+    assert progress["wl-a-baseline"]["pending_since"] is None

--- a/pipeline/tests/test_pod_pending.py
+++ b/pipeline/tests/test_pod_pending.py
@@ -67,6 +67,15 @@ def test_classify_empty_message():
     assert result == "non_recoverable"
 
 
+def test_classify_unknown_message_defaults_recoverable():
+    """Unrecognized messages default to recoverable (safer: wait vs cancel)."""
+    from pipeline.lib.pod_pending import classify_pending_reason
+    result = classify_pending_reason(
+        "0/3 nodes are available: 3 custom-scheduler-reason."
+    )
+    assert result == "recoverable"
+
+
 def test_parse_pending_pod_recoverable():
     from pipeline.lib.pod_pending import parse_pod_conditions
     pods_json = {

--- a/pipeline/tests/test_pod_pending.py
+++ b/pipeline/tests/test_pod_pending.py
@@ -1,0 +1,192 @@
+# pipeline/tests/test_pod_pending.py
+"""Tests for pod pending reason classification."""
+
+
+def test_classify_insufficient_gpu():
+    from pipeline.lib.pod_pending import classify_pending_reason
+    result = classify_pending_reason(
+        "0/8 nodes are available: 8 Insufficient nvidia.com/gpu. "
+        "preemption: 0/8 nodes are available: 8 No preemption victims found."
+    )
+    assert result == "recoverable"
+
+
+def test_classify_insufficient_memory():
+    from pipeline.lib.pod_pending import classify_pending_reason
+    result = classify_pending_reason(
+        "0/8 nodes are available: 8 Insufficient memory."
+    )
+    assert result == "recoverable"
+
+
+def test_classify_insufficient_cpu():
+    from pipeline.lib.pod_pending import classify_pending_reason
+    result = classify_pending_reason(
+        "0/4 nodes are available: 4 Insufficient cpu."
+    )
+    assert result == "recoverable"
+
+
+def test_classify_nodes_unavailable_capacity():
+    from pipeline.lib.pod_pending import classify_pending_reason
+    result = classify_pending_reason(
+        "0/6 nodes are available: 2 Insufficient nvidia.com/gpu, "
+        "4 node(s) had untolerated taint {nvidia.com/gpu.deploy.container-toolkit=true}."
+    )
+    assert result == "recoverable"
+
+
+def test_classify_node_affinity_mismatch():
+    from pipeline.lib.pod_pending import classify_pending_reason
+    result = classify_pending_reason(
+        "0/8 nodes are available: 8 node(s) didn't match Pod's node affinity/selector."
+    )
+    assert result == "non_recoverable"
+
+
+def test_classify_pvc_not_found():
+    from pipeline.lib.pod_pending import classify_pending_reason
+    result = classify_pending_reason(
+        'persistentvolumeclaim "data-pvc" not found'
+    )
+    assert result == "non_recoverable"
+
+
+def test_classify_taint_toleration_only():
+    from pipeline.lib.pod_pending import classify_pending_reason
+    result = classify_pending_reason(
+        "0/4 nodes are available: 4 node(s) had untolerated taint "
+        "{node.kubernetes.io/unschedulable: }."
+    )
+    assert result == "non_recoverable"
+
+
+def test_classify_empty_message():
+    from pipeline.lib.pod_pending import classify_pending_reason
+    result = classify_pending_reason("")
+    assert result == "non_recoverable"
+
+
+def test_parse_pending_pod_recoverable():
+    from pipeline.lib.pod_pending import parse_pod_conditions
+    pods_json = {
+        "items": [{
+            "status": {
+                "phase": "Pending",
+                "conditions": [{
+                    "type": "PodScheduled",
+                    "status": "False",
+                    "reason": "Unschedulable",
+                    "message": "0/8 nodes are available: 8 Insufficient nvidia.com/gpu.",
+                }],
+            },
+        }],
+    }
+    category, detail = parse_pod_conditions(pods_json)
+    assert category == "recoverable"
+    assert "Insufficient nvidia.com/gpu" in detail
+
+
+def test_parse_pending_pod_non_recoverable():
+    from pipeline.lib.pod_pending import parse_pod_conditions
+    pods_json = {
+        "items": [{
+            "status": {
+                "phase": "Pending",
+                "conditions": [{
+                    "type": "PodScheduled",
+                    "status": "False",
+                    "reason": "Unschedulable",
+                    "message": "0/8 nodes are available: 8 node(s) didn't match Pod's node affinity/selector.",
+                }],
+            },
+        }],
+    }
+    category, detail = parse_pod_conditions(pods_json)
+    assert category == "non_recoverable"
+    assert "node affinity" in detail
+
+
+def test_parse_running_pod_returns_none():
+    from pipeline.lib.pod_pending import parse_pod_conditions
+    pods_json = {
+        "items": [{
+            "status": {
+                "phase": "Running",
+                "conditions": [{
+                    "type": "Ready",
+                    "status": "True",
+                }],
+            },
+        }],
+    }
+    category, detail = parse_pod_conditions(pods_json)
+    assert category is None
+    assert detail == ""
+
+
+def test_parse_no_pods_returns_none():
+    from pipeline.lib.pod_pending import parse_pod_conditions
+    category, detail = parse_pod_conditions({"items": []})
+    assert category is None
+    assert detail == ""
+
+
+def test_parse_mixed_pods_pending_wins():
+    """If any pod is Pending+Unschedulable, report it even if others are Running."""
+    from pipeline.lib.pod_pending import parse_pod_conditions
+    pods_json = {
+        "items": [
+            {
+                "status": {
+                    "phase": "Running",
+                    "conditions": [{"type": "Ready", "status": "True"}],
+                },
+            },
+            {
+                "status": {
+                    "phase": "Pending",
+                    "conditions": [{
+                        "type": "PodScheduled",
+                        "status": "False",
+                        "reason": "Unschedulable",
+                        "message": "0/4 nodes are available: 4 Insufficient memory.",
+                    }],
+                },
+            },
+        ],
+    }
+    category, detail = parse_pod_conditions(pods_json)
+    assert category == "recoverable"
+
+
+def test_parse_pending_without_conditions_returns_none():
+    """Pending pod with no conditions (e.g. image pull) is not flagged."""
+    from pipeline.lib.pod_pending import parse_pod_conditions
+    pods_json = {
+        "items": [{
+            "status": {
+                "phase": "Pending",
+            },
+        }],
+    }
+    category, detail = parse_pod_conditions(pods_json)
+    assert category is None
+
+
+def test_parse_pending_scheduled_true_returns_none():
+    """Pending pod that IS scheduled (e.g. pulling image) is not flagged."""
+    from pipeline.lib.pod_pending import parse_pod_conditions
+    pods_json = {
+        "items": [{
+            "status": {
+                "phase": "Pending",
+                "conditions": [{
+                    "type": "PodScheduled",
+                    "status": "True",
+                }],
+            },
+        }],
+    }
+    category, detail = parse_pod_conditions(pods_json)
+    assert category is None

--- a/pipeline/tests/test_pod_pending.py
+++ b/pipeline/tests/test_pod_pending.py
@@ -199,3 +199,37 @@ def test_parse_pending_scheduled_true_returns_none():
     }
     category, detail = parse_pod_conditions(pods_json)
     assert category is None
+
+
+def test_parse_multi_pod_worst_severity_wins():
+    """Non-recoverable on a later pod overrides recoverable on earlier pod."""
+    from pipeline.lib.pod_pending import parse_pod_conditions
+    pods_json = {
+        "items": [
+            {
+                "status": {
+                    "phase": "Pending",
+                    "conditions": [{
+                        "type": "PodScheduled",
+                        "status": "False",
+                        "reason": "Unschedulable",
+                        "message": "0/8 nodes are available: 8 Insufficient nvidia.com/gpu.",
+                    }],
+                },
+            },
+            {
+                "status": {
+                    "phase": "Pending",
+                    "conditions": [{
+                        "type": "PodScheduled",
+                        "status": "False",
+                        "reason": "Unschedulable",
+                        "message": "0/8 nodes are available: 8 node(s) didn't match Pod's node affinity/selector.",
+                    }],
+                },
+            },
+        ],
+    }
+    category, detail = parse_pod_conditions(pods_json)
+    assert category == "non_recoverable"
+    assert "node affinity" in detail


### PR DESCRIPTION
Closes #62

## Summary

- Add `pipeline/lib/pod_pending.py` — pure classification of pod scheduling failure messages into "recoverable" (resource scarcity) vs "non_recoverable" (config errors)
- Add `_handle_pending_pods` to `deploy.py` poll loop — queries pod conditions for Running/Started PipelineRuns, detects Pending+Unschedulable, and acts on the classification
- Add `--pending-threshold` (default 600s) and `--max-pending-stalls` (default 10) CLI flags to control early reclaim behavior
- Add `pending_stalls` counter and `stalled` terminal status to progress schema

## Behavior

| Scenario | Action |
|----------|--------|
| Recoverable pending (e.g. Insufficient GPU) under threshold | Record `pending_since`, wait |
| Recoverable pending exceeding threshold | Cancel PipelineRun, free slot, return pair to `pending`, increment `pending_stalls` |
| Recoverable pending at max stalls | Transition to `stalled` terminal status |
| Non-recoverable pending (e.g. node affinity mismatch) | Fail immediately on next poll |
| Pods transition from Pending to Running | Clear `pending_since` timer |
| kubectl failure | Graceful degradation — skip check, let 4h timeout handle it |

## Test plan

- [x] 15 unit tests for classification (`test_pod_pending.py`)
- [x] 6 integration tests for `_handle_pending_pods` (`test_deploy_run.py`)
- [x] 3 CLI flag tests (parser + defaults)
- [x] Full suite: 452 tests pass
- [x] Lint: `ruff check pipeline/ --select F` clean