### PR TITLE
feat(deploy): add pairs subcommand to list available keys

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -113,7 +113,7 @@ Phase state is tracked per-run in `workspace/runs/<run>/.state.json`. Delete it 
 Builds the EPP image and orchestrates PipelineRun execution across namespace slots. Operates independently of `transfer.yaml` — driven by workspace files and `setup_config.json`.
 
 ```bash
-python pipeline/deploy.py {run|status|collect|cleanup} [flags]
+python pipeline/deploy.py {run|status|collect|cleanup|pairs} [flags]
 ```
 
 Common flags (all subcommands):
@@ -137,6 +137,7 @@ python pipeline/deploy.py run     [flags]   # orchestrate parallel pool executio
 python pipeline/deploy.py status            # show progress snapshot of all (workload, package) pairs
 python pipeline/deploy.py collect [--package NAME…]
 python pipeline/deploy.py cleanup [flags]   # tear down cluster resources for failed/stalled pairs
+python pipeline/deploy.py pairs   [flags]   # list available pair keys, workloads, and packages
 ```
 
 **`deploy.py run`** — assigns `(workload, package)` pairs to free namespace slots, polls for completion, collects results inline, and retries pairs that time out. Reads `progress.json` to resume interrupted runs.
@@ -173,6 +174,16 @@ python pipeline/deploy.py cleanup [flags]   # tear down cluster resources for fa
 | `--dry-run` | Print what would be cleaned up without acting |
 
 **Safety:** Results in `workspace/runs/<run>/results/` are preserved — only cluster resources are removed. For `done` pairs, only the PipelineRun is deleted (Tekton already tore down Helm releases).
+
+**`deploy.py pairs`** — lists available pair keys, workloads, and packages by scanning `cluster/pipelinerun-*.yaml`. Works without `progress.json`.
+
+| Flag | Description |
+|------|-------------|
+| `--keys-only` | Print pair keys only (one per line, for scripting) |
+| `--workloads-only` | Print distinct workload names only (one per line) |
+| `--packages-only` | Print distinct package names only (one per line) |
+
+Flags are mutually exclusive. Default (no flag) prints a human-readable table with PAIR, WORKLOAD, and PACKAGE columns.
 
 ---
 

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -6,6 +6,7 @@ Subcommands:
   status   Show progress of all (workload, package) pairs
   collect  Pull results from cluster for completed phases
   cleanup  Tear down cluster resources for all non-pending pairs
+  pairs    List available pair keys, workloads, and packages
 """
 
 import argparse
@@ -203,7 +204,11 @@ def _cmd_pairs(cluster_dir: Path, *, keys_only: bool = False,
     pairs = _load_pairs(cluster_dir)
 
     if not pairs:
-        print("  0 pairs (no pipelinerun-*.yaml files found)")
+        n = len(list(cluster_dir.glob("pipelinerun-*.yaml"))) if cluster_dir.exists() else 0
+        if n == 0:
+            print("  0 pairs (no pipelinerun-*.yaml files found)")
+        else:
+            print(f"  0 pairs ({n} files found but failed to parse — see warnings above)")
         return
 
     if keys_only:
@@ -1208,7 +1213,7 @@ Examples:
   python pipeline/deploy.py collect --skip-logs        # Collect traces only (skip large logs)
   python pipeline/deploy.py cleanup                    # Tear down stalled/failed pairs
   python pipeline/deploy.py cleanup --dry-run          # Preview what would be cleaned
-  python pipeline/deploy.py pairs                       # List all pair keys
+  python pipeline/deploy.py pairs                       # List pairs with workloads and packages
   python pipeline/deploy.py pairs --keys-only           # Machine-readable: keys only
 """,
     )

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1208,6 +1208,8 @@ Examples:
   python pipeline/deploy.py collect --skip-logs        # Collect traces only (skip large logs)
   python pipeline/deploy.py cleanup                    # Tear down stalled/failed pairs
   python pipeline/deploy.py cleanup --dry-run          # Preview what would be cleaned
+  python pipeline/deploy.py pairs                       # List all pair keys
+  python pipeline/deploy.py pairs --keys-only           # Machine-readable: keys only
 """,
     )
     p.add_argument("--run", metavar="NAME",
@@ -1254,6 +1256,15 @@ Examples:
     cleanup_p.add_argument("--dry-run",  action="store_true", dest="dry_run",
                            help="Print what would be cleaned up without doing it")
 
+    pairs_p = sub.add_parser("pairs", help="List available pair keys, workloads, and packages")
+    pairs_group = pairs_p.add_mutually_exclusive_group()
+    pairs_group.add_argument("--keys-only", action="store_true", dest="keys_only",
+                             help="Print pair keys only (one per line)")
+    pairs_group.add_argument("--workloads-only", action="store_true", dest="workloads_only",
+                             help="Print distinct workload names only (one per line)")
+    pairs_group.add_argument("--packages-only", action="store_true", dest="packages_only",
+                             help="Print distinct package names only (one per line)")
+
     return p
 
 
@@ -1293,8 +1304,13 @@ def main():
         if not namespaces:
             warn("No namespaces in setup_config — PipelineRun deletion for done pairs may be incomplete")
         _cmd_cleanup(args, progress_path, discovered, namespaces=namespaces or None)
+    elif cmd == "pairs":
+        cluster_dir = run_dir / "cluster"
+        _cmd_pairs(cluster_dir, keys_only=args.keys_only,
+                   workloads_only=args.workloads_only,
+                   packages_only=args.packages_only)
     else:
-        err("No subcommand specified. Use: deploy.py run | status | collect | cleanup")
+        err("No subcommand specified. Use: deploy.py run | status | collect | cleanup | pairs")
         sys.exit(1)
 
 

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -195,6 +195,50 @@ def _cmd_status(args, progress_path: Path) -> None:
     print()
 
 
+# ── Pairs command ────────────────────────────────────────────────────────────
+
+def _cmd_pairs(cluster_dir: Path, *, keys_only: bool = False,
+               workloads_only: bool = False, packages_only: bool = False) -> None:
+    """List available pair keys, workloads, and packages from cluster/ YAML files."""
+    pairs = _load_pairs(cluster_dir)
+
+    if not pairs:
+        print("  0 pairs (no pipelinerun-*.yaml files found)")
+        return
+
+    if keys_only:
+        for key in sorted(pairs):
+            print(key)
+        return
+
+    if workloads_only:
+        workloads = sorted({v["workload"] for v in pairs.values() if v["workload"]})
+        for w in workloads:
+            print(w)
+        return
+
+    if packages_only:
+        packages = sorted({v["package"] for v in pairs.values() if v["package"]})
+        for p in packages:
+            print(p)
+        return
+
+    # Default: human-readable table
+    pair_w = max(len(k) for k in pairs) + 2
+    col_wl = max(len(v["workload"]) for v in pairs.values()) + 2
+    col_wl = max(col_wl, 10)
+
+    header = f"{'PAIR':<{pair_w}} {'WORKLOAD':<{col_wl}} PACKAGE"
+    print()
+    print(header)
+    print("-" * len(header))
+    for key in sorted(pairs):
+        entry = pairs[key]
+        print(f"{key:<{pair_w}} {entry['workload']:<{col_wl}} {entry['package']}")
+    print()
+    print(f"  {len(pairs)} pairs")
+
+
 # ── Collect command ──────────────────────────────────────────────────────────
 
 def _check_pipelinerun_status(pr_name: str, namespace: str) -> str:

--- a/pipeline/tests/test_deploy_pairs.py
+++ b/pipeline/tests/test_deploy_pairs.py
@@ -31,6 +31,7 @@ def test_pairs_table_lists_all(tmp_path, capsys):
     assert "PAIR" in out
     assert "WORKLOAD" in out
     assert "PACKAGE" in out
+    assert "3 pairs" in out
 
 
 def test_pairs_keys_only(tmp_path, capsys):
@@ -42,7 +43,7 @@ def test_pairs_keys_only(tmp_path, capsys):
     out = capsys.readouterr().out
 
     lines = out.strip().splitlines()
-    assert set(lines) == {"wl-smoke-baseline", "wl-load-treatment"}
+    assert lines == ["wl-load-treatment", "wl-smoke-baseline"]
     assert "PAIR" not in out
 
 
@@ -90,14 +91,37 @@ def test_pairs_missing_cluster(tmp_path, capsys):
     assert "0 pairs" in out
 
 
+def test_pairs_single_pair(tmp_path, capsys):
+    """Single pair works (boundary for column-width calculation)."""
+    from pipeline.deploy import _cmd_pairs
+    _make_cluster(tmp_path, [("a", "b")])
+
+    _cmd_pairs(tmp_path)
+    out = capsys.readouterr().out
+
+    assert "wl-a-b" in out
+    assert "1 pairs" in out
+
+
+def test_pairs_all_files_corrupt(tmp_path, capsys):
+    """When files exist but all fail to parse, message distinguishes from empty dir."""
+    from pipeline.deploy import _cmd_pairs
+    (tmp_path / "pipelinerun-bad1.yaml").write_text("{{invalid")
+    (tmp_path / "pipelinerun-bad2.yaml").write_text("[[broken")
+
+    _cmd_pairs(tmp_path)
+    out = capsys.readouterr().out
+
+    assert "0 pairs" in out
+    assert "failed to parse" in out
+
+
 def test_pairs_cli_mutually_exclusive_flags():
     """--keys-only, --workloads-only, --packages-only are mutually exclusive."""
-    import subprocess
-    result = subprocess.run(
-        [".venv/bin/python", "-m", "pipeline.deploy", "pairs",
-         "--keys-only", "--workloads-only"],
-        capture_output=True, text=True,
-        cwd="/Users/kalantar/projects/go.workspace/src/github.com/inference-sim/sim2real/.claude/worktrees/issue-59-pairs-subcommand",
-    )
-    assert result.returncode != 0
-    assert "not allowed with argument" in result.stderr
+    import pytest
+    from pipeline.deploy import build_parser
+
+    parser = build_parser()
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["pairs", "--keys-only", "--workloads-only"])
+    assert exc_info.value.code != 0

--- a/pipeline/tests/test_deploy_pairs.py
+++ b/pipeline/tests/test_deploy_pairs.py
@@ -1,0 +1,92 @@
+"""Tests for deploy.py pairs subcommand."""
+import yaml as _yaml
+
+import pytest
+
+
+def _make_cluster(tmp_path, pairs):
+    """Write pipelinerun-*.yaml files into tmp_path for each (workload, package) tuple."""
+    for wl, pkg in pairs:
+        pr = {
+            "apiVersion": "tekton.dev/v1",
+            "kind": "PipelineRun",
+            "metadata": {"name": f"{pkg}-{wl}-run1", "namespace": "sim2real-0"},
+            "spec": {"params": [
+                {"name": "workloadName", "value": f"wl-{wl}"},
+                {"name": "phase", "value": pkg},
+            ]},
+        }
+        (tmp_path / f"pipelinerun-{wl}-{pkg}.yaml").write_text(_yaml.dump(pr))
+
+
+def test_pairs_table_lists_all(tmp_path, capsys):
+    """Default mode prints a table with all pair keys, workloads, and packages."""
+    from pipeline.deploy import _cmd_pairs
+    _make_cluster(tmp_path, [("smoke", "baseline"), ("smoke", "treatment"), ("load", "baseline")])
+
+    _cmd_pairs(tmp_path)
+    out = capsys.readouterr().out
+
+    assert "wl-smoke-baseline" in out
+    assert "wl-smoke-treatment" in out
+    assert "wl-load-baseline" in out
+    assert "PAIR" in out
+    assert "WORKLOAD" in out
+    assert "PACKAGE" in out
+
+
+def test_pairs_keys_only(tmp_path, capsys):
+    """--keys-only prints one pair key per line, no header."""
+    from pipeline.deploy import _cmd_pairs
+    _make_cluster(tmp_path, [("smoke", "baseline"), ("load", "treatment")])
+
+    _cmd_pairs(tmp_path, keys_only=True)
+    out = capsys.readouterr().out
+
+    lines = out.strip().splitlines()
+    assert set(lines) == {"wl-smoke-baseline", "wl-load-treatment"}
+    assert "PAIR" not in out
+
+
+def test_pairs_workloads_only(tmp_path, capsys):
+    """--workloads-only prints distinct workload names, one per line."""
+    from pipeline.deploy import _cmd_pairs
+    _make_cluster(tmp_path, [("smoke", "baseline"), ("smoke", "treatment"), ("load", "baseline")])
+
+    _cmd_pairs(tmp_path, workloads_only=True)
+    out = capsys.readouterr().out
+
+    lines = out.strip().splitlines()
+    assert set(lines) == {"wl-smoke", "wl-load"}
+
+
+def test_pairs_packages_only(tmp_path, capsys):
+    """--packages-only prints distinct package names, one per line."""
+    from pipeline.deploy import _cmd_pairs
+    _make_cluster(tmp_path, [("smoke", "baseline"), ("smoke", "treatment"), ("load", "baseline")])
+
+    _cmd_pairs(tmp_path, packages_only=True)
+    out = capsys.readouterr().out
+
+    lines = out.strip().splitlines()
+    assert set(lines) == {"baseline", "treatment"}
+
+
+def test_pairs_empty_cluster(tmp_path, capsys):
+    """Empty cluster directory prints a zero-pairs message."""
+    from pipeline.deploy import _cmd_pairs
+
+    _cmd_pairs(tmp_path)
+    out = capsys.readouterr().out
+
+    assert "0 pairs" in out
+
+
+def test_pairs_missing_cluster(tmp_path, capsys):
+    """Non-existent cluster directory prints a zero-pairs message."""
+    from pipeline.deploy import _cmd_pairs
+
+    _cmd_pairs(tmp_path / "nonexistent")
+    out = capsys.readouterr().out
+
+    assert "0 pairs" in out

--- a/pipeline/tests/test_deploy_pairs.py
+++ b/pipeline/tests/test_deploy_pairs.py
@@ -1,8 +1,6 @@
 """Tests for deploy.py pairs subcommand."""
 import yaml as _yaml
 
-import pytest
-
 
 def _make_cluster(tmp_path, pairs):
     """Write pipelinerun-*.yaml files into tmp_path for each (workload, package) tuple."""

--- a/pipeline/tests/test_deploy_pairs.py
+++ b/pipeline/tests/test_deploy_pairs.py
@@ -90,3 +90,16 @@ def test_pairs_missing_cluster(tmp_path, capsys):
     out = capsys.readouterr().out
 
     assert "0 pairs" in out
+
+
+def test_pairs_cli_mutually_exclusive_flags():
+    """--keys-only, --workloads-only, --packages-only are mutually exclusive."""
+    import subprocess
+    result = subprocess.run(
+        [".venv/bin/python", "-m", "pipeline.deploy", "pairs",
+         "--keys-only", "--workloads-only"],
+        capture_output=True, text=True,
+        cwd="/Users/kalantar/projects/go.workspace/src/github.com/inference-sim/sim2real/.claude/worktrees/issue-59-pairs-subcommand",
+    )
+    assert result.returncode != 0
+    assert "not allowed with argument" in result.stderr


### PR DESCRIPTION
Closes #59

## Summary

- Adds `deploy.py pairs` subcommand that lists available pair keys, workloads, and packages by scanning `cluster/pipelinerun-*.yaml` — works without `progress.json`
- Supports machine-readable output via mutually exclusive flags: `--keys-only`, `--workloads-only`, `--packages-only`
- Default mode prints a human-readable table with PAIR, WORKLOAD, PACKAGE columns

## Test Plan

- [x] 7 new tests in `test_deploy_pairs.py` (table output, each flag mode, empty/missing cluster, CLI mutual exclusivity)
- [x] Full suite passes (385 tests)
- [x] `ruff check --select F` clean
- [x] `deploy.py pairs --help` shows correct usage