### PR TITLE
feat: add zsh/bash tab completion for deploy.py

### DIFF
--- a/pipeline/completions.bash
+++ b/pipeline/completions.bash
@@ -1,0 +1,84 @@
+# Tab completion for sim2real deploy.py (bash)
+# Usage: source $SIM2REAL/pipeline/completions.bash
+
+_sim2real_deploy() {
+    local cur prev subcmd
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    local subcommands="run status collect cleanup pairs"
+    local status_values="pending running done failed timed-out"
+
+    # Find the subcommand (first positional argument)
+    subcmd=""
+    local i
+    for ((i=1; i < COMP_CWORD; i++)); do
+        case "${COMP_WORDS[i]}" in
+            -*) ;;
+            run|status|collect|cleanup|pairs)
+                subcmd="${COMP_WORDS[i]}"
+                break
+                ;;
+        esac
+    done
+
+    # If no subcommand yet, complete subcommands and global flags
+    if [[ -z "$subcmd" ]]; then
+        if [[ "$cur" == -* ]]; then
+            COMPREPLY=($(compgen -W "--run --experiment-root" -- "$cur"))
+        else
+            COMPREPLY=($(compgen -W "$subcommands" -- "$cur"))
+        fi
+        return
+    fi
+
+    # Complete flag values based on prev
+    case "$prev" in
+        --only)
+            local keys
+            keys="$(python pipeline/deploy.py pairs --keys-only 2>/dev/null)"
+            COMPREPLY=($(compgen -W "$keys" -- "$cur"))
+            return
+            ;;
+        --workload)
+            local workloads
+            workloads="$(python pipeline/deploy.py pairs --workloads-only 2>/dev/null)"
+            COMPREPLY=($(compgen -W "$workloads" -- "$cur"))
+            return
+            ;;
+        --package)
+            local packages
+            packages="$(python pipeline/deploy.py pairs --packages-only 2>/dev/null)"
+            COMPREPLY=($(compgen -W "$packages" -- "$cur"))
+            return
+            ;;
+        --status)
+            COMPREPLY=($(compgen -W "$status_values" -- "$cur"))
+            return
+            ;;
+    esac
+
+    # Complete flags for the active subcommand
+    if [[ "$cur" == -* ]]; then
+        case "$subcmd" in
+            run)
+                COMPREPLY=($(compgen -W "--only --workload --package --status --force --skip-build-epp --max-retries --poll-interval --gpu-resource-type --default-gpu-cost --pending-threshold --max-pending-stalls" -- "$cur"))
+                ;;
+            status)
+                COMPREPLY=($(compgen -W "--only --workload --package --status" -- "$cur"))
+                ;;
+            cleanup)
+                COMPREPLY=($(compgen -W "--only --workload --package --status --dry-run" -- "$cur"))
+                ;;
+            collect)
+                COMPREPLY=($(compgen -W "--package --skip-logs" -- "$cur"))
+                ;;
+            pairs)
+                COMPREPLY=($(compgen -W "--keys-only --workloads-only --packages-only" -- "$cur"))
+                ;;
+        esac
+    fi
+}
+
+complete -F _sim2real_deploy deploy.py

--- a/pipeline/completions.bash
+++ b/pipeline/completions.bash
@@ -1,5 +1,10 @@
 # Tab completion for sim2real deploy.py (bash)
-# Usage: source $SIM2REAL/pipeline/completions.bash
+#
+# Usage — add to your .bashrc:
+#   source /path/to/sim2real/pipeline/completions.bash
+#
+# Also registers completion for "python pipeline/deploy.py" via a wrapper.
+# For aliases, register manually:  complete -F _sim2real_deploy my-alias
 
 _sim2real_deploy() {
     local cur prev subcmd
@@ -8,13 +13,15 @@ _sim2real_deploy() {
     prev="${COMP_WORDS[COMP_CWORD-1]}"
 
     local subcommands="run status collect cleanup pairs"
-    local status_values="pending running done failed timed-out"
+    local status_values="pending running done failed timed-out stalled collect-failed collecting"
 
-    # Find the subcommand (first positional argument)
     subcmd=""
     local i
     for ((i=1; i < COMP_CWORD; i++)); do
         case "${COMP_WORDS[i]}" in
+            # These flags take a value argument — skip it to avoid misidentifying
+            # the value as a subcommand (e.g. --experiment-root run)
+            --experiment-root|--run) ((i++)) ;;
             -*) ;;
             run|status|collect|cleanup|pairs)
                 subcmd="${COMP_WORDS[i]}"
@@ -23,7 +30,6 @@ _sim2real_deploy() {
         esac
     done
 
-    # If no subcommand yet, complete subcommands and global flags
     if [[ -z "$subcmd" ]]; then
         if [[ "$cur" == -* ]]; then
             COMPREPLY=($(compgen -W "--run --experiment-root" -- "$cur"))
@@ -33,7 +39,6 @@ _sim2real_deploy() {
         return
     fi
 
-    # Complete flag values based on prev
     case "$prev" in
         --only)
             local keys
@@ -59,7 +64,6 @@ _sim2real_deploy() {
             ;;
     esac
 
-    # Complete flags for the active subcommand
     if [[ "$cur" == -* ]]; then
         case "$subcmd" in
             run)
@@ -82,3 +86,18 @@ _sim2real_deploy() {
 }
 
 complete -F _sim2real_deploy deploy.py
+
+# Handle "python pipeline/deploy.py ..." — bash sees "python" as the command,
+# so we intercept and delegate when the first arg ends in deploy.py.
+_python_deploy_py() {
+    if [[ "${COMP_WORDS[1]}" == */deploy.py || "${COMP_WORDS[1]}" == deploy.py ]]; then
+        local orig_words=("${COMP_WORDS[@]}")
+        COMP_WORDS=("deploy.py" "${COMP_WORDS[@]:2}")
+        (( COMP_CWORD -= 1 ))
+        _sim2real_deploy
+        COMP_WORDS=("${orig_words[@]}")
+    fi
+}
+
+complete -F _python_deploy_py python
+complete -F _python_deploy_py python3

--- a/pipeline/completions.zsh
+++ b/pipeline/completions.zsh
@@ -1,143 +1,113 @@
 #compdef deploy.py
 
-# Zsh tab-completion for pipeline/deploy.py
+# Tab completion for sim2real deploy.py (zsh)
 #
-# Usage — add one of these to your .zshrc:
+# Usage — add to your .zshrc:
 #   source /path/to/sim2real/pipeline/completions.zsh
 #
-# The script registers completion for both "deploy.py" (when on $PATH or run
-# as ./deploy.py) and "python pipeline/deploy.py" (via a wrapper).
-
-# ── helpers ─────────────────────────────────────────────────────────────────
-
-# Resolve the deploy.py invocation.  Prefer an --experiment-root that the user
-# already typed on the current line; fall back to bare "python pipeline/deploy.py".
-_deploy_py_cmd() {
-    local root=""
-    # Scan existing words for --experiment-root VALUE
-    local i
-    for (( i=1; i < ${#words[@]}; i++ )); do
-        if [[ "${words[$i]}" == --experiment-root && -n "${words[$i+1]}" ]]; then
-            root="${words[$i+1]}"
-            break
-        elif [[ "${words[$i]}" == --experiment-root=* ]]; then
-            root="${words[$i]#--experiment-root=}"
-            break
-        fi
-    done
-
-    local cmd=(python pipeline/deploy.py)
-    [[ -n "$root" ]] && cmd+=(--experiment-root "$root")
-    printf '%s\n' "${cmd[@]}"
-}
+# Also registers completion for "python pipeline/deploy.py" via a wrapper.
+# For aliases, register manually:  compdef _sim2real_deploy my-alias
 
 _deploy_py_pair_keys() {
     local -a keys
-    keys=( ${(f)"$(python pipeline/deploy.py pairs --keys-only 2>/dev/null)"} )
-    compadd -a keys
+    keys=(${(f)"$(python pipeline/deploy.py pairs --keys-only 2>/dev/null)"})
+    (( ${#keys} )) && compadd -a keys
 }
 
 _deploy_py_workloads() {
-    local -a wl
-    wl=( ${(f)"$(python pipeline/deploy.py pairs --workloads-only 2>/dev/null)"} )
-    compadd -a wl
+    local -a workloads
+    workloads=(${(f)"$(python pipeline/deploy.py pairs --workloads-only 2>/dev/null)"})
+    (( ${#workloads} )) && compadd -a workloads
 }
 
 _deploy_py_packages() {
-    local -a pkg
-    pkg=( ${(f)"$(python pipeline/deploy.py pairs --packages-only 2>/dev/null)"} )
-    compadd -a pkg
+    local -a packages
+    packages=(${(f)"$(python pipeline/deploy.py pairs --packages-only 2>/dev/null)"})
+    (( ${#packages} )) && compadd -a packages
 }
 
 _deploy_py_statuses() {
-    compadd pending running done failed timed-out
+    compadd pending running done failed timed-out stalled collect-failed collecting
 }
 
-# ── main completion function ────────────────────────────────────────────────
-
-_deploy_py() {
+_sim2real_deploy() {
     local curcontext="$curcontext" state line
     typeset -A opt_args
 
-    # Top-level: global flags + subcommand
     _arguments -C \
         '--run[Run name]:run name:' \
-        '--experiment-root[Experiment repo path]:path:_directories' \
+        '--experiment-root[Experiment repo root]:directory:_directories' \
         '1:subcommand:->subcmd' \
-        '*::arg:->args' \
-        && return
+        '*::arg:->args'
 
     case "$state" in
-    subcmd)
-        local -a subcmds=(
-            'run:Orchestrate parallel pool execution'
-            'status:Show progress of all (workload, package) pairs'
-            'collect:Pull results for completed packages'
-            'cleanup:Tear down cluster resources for all non-pending pairs'
-            'pairs:List available pair keys, workloads, and packages'
-        )
-        _describe 'subcommand' subcmds
-        ;;
-    args)
-        case "${line[1]}" in
-        run)
-            _arguments \
-                '--only[Scope to one pair key]:pair key:_deploy_py_pair_keys' \
-                '--workload[Scope to workload]:workload:_deploy_py_workloads' \
-                '--package[Scope to package]:package:_deploy_py_packages' \
-                '--status[Scope to status]:status:_deploy_py_statuses' \
-                '--force[Reset non-pending pairs to pending]' \
-                '--skip-build-epp[Skip EPP image build]' \
-                '--max-retries[Max retries per pair]:count:' \
-                '--poll-interval[Seconds between polls]:seconds:' \
-                '--gpu-resource-type[GPU resource type]:type:' \
-                '--default-gpu-cost[GPU cost per pod]:cost:' \
-                '--pending-threshold[Pending timeout in seconds]:seconds:' \
-                '--max-pending-stalls[Max stall cycles]:count:'
+        subcmd)
+            local -a subcommands=(
+                'run:Orchestrate parallel pool execution'
+                'status:Show progress of all (workload, package) pairs'
+                'collect:Pull results for completed packages'
+                'cleanup:Tear down cluster resources for all non-pending pairs'
+                'pairs:List available pair keys, workloads, and packages'
+            )
+            _describe 'subcommand' subcommands
             ;;
-        status)
-            _arguments \
-                '--only[Scope to one pair key]:pair key:_deploy_py_pair_keys' \
-                '--workload[Scope to workload]:workload:_deploy_py_workloads' \
-                '--package[Scope to package]:package:_deploy_py_packages' \
-                '--status[Scope to status]:status:_deploy_py_statuses'
+        args)
+            case "${line[1]}" in
+                run)
+                    _arguments \
+                        '--only[Scope to one pair key]:pair key:_deploy_py_pair_keys' \
+                        '--workload[Scope to workload]:workload:_deploy_py_workloads' \
+                        '--package[Scope to package]:package:_deploy_py_packages' \
+                        '--status[Scope to status]:status:_deploy_py_statuses' \
+                        '--force[Reset non-pending pairs to pending]' \
+                        '--skip-build-epp[Skip EPP image build]' \
+                        '--max-retries[Max retries per pair]:count:' \
+                        '--poll-interval[Seconds between polls]:seconds:' \
+                        '--gpu-resource-type[GPU resource type]:type:' \
+                        '--default-gpu-cost[GPU cost per pod]:cost:' \
+                        '--pending-threshold[Pending timeout in seconds]:seconds:' \
+                        '--max-pending-stalls[Max stall cycles]:count:'
+                    ;;
+                status)
+                    _arguments \
+                        '--only[Scope to one pair key]:pair key:_deploy_py_pair_keys' \
+                        '--workload[Scope to workload]:workload:_deploy_py_workloads' \
+                        '--package[Scope to package]:package:_deploy_py_packages' \
+                        '--status[Scope to status]:status:_deploy_py_statuses'
+                    ;;
+                collect)
+                    _arguments \
+                        '*--package[Collect only these packages]:package:_deploy_py_packages' \
+                        '--skip-logs[Skip vLLM and EPP log files]'
+                    ;;
+                cleanup)
+                    _arguments \
+                        '--only[Scope to one pair key]:pair key:_deploy_py_pair_keys' \
+                        '--workload[Scope to workload]:workload:_deploy_py_workloads' \
+                        '--package[Scope to package]:package:_deploy_py_packages' \
+                        '--status[Scope to status]:status:_deploy_py_statuses' \
+                        '--dry-run[Print what would be cleaned up]'
+                    ;;
+                pairs)
+                    _arguments \
+                        '(--workloads-only --packages-only)--keys-only[Print pair keys only]' \
+                        '(--keys-only --packages-only)--workloads-only[Print workload names only]' \
+                        '(--keys-only --workloads-only)--packages-only[Print package names only]'
+                    ;;
+            esac
             ;;
-        collect)
-            _arguments \
-                '--package[Scope to package]:package:_deploy_py_packages' \
-                '--skip-logs[Collect traces only, skip large logs]'
-            ;;
-        cleanup)
-            _arguments \
-                '--only[Scope to one pair key]:pair key:_deploy_py_pair_keys' \
-                '--workload[Scope to workload]:workload:_deploy_py_workloads' \
-                '--package[Scope to package]:package:_deploy_py_packages' \
-                '--status[Scope to status]:status:_deploy_py_statuses' \
-                '--dry-run[Preview what would be cleaned up]'
-            ;;
-        pairs)
-            _arguments \
-                '(--workloads-only --packages-only)--keys-only[Print pair keys only]' \
-                '(--keys-only --packages-only)--workloads-only[Print workload names only]' \
-                '(--keys-only --workloads-only)--packages-only[Print package names only]'
-            ;;
-        esac
-        ;;
     esac
 }
 
-compdef _deploy_py deploy.py
+compdef _sim2real_deploy deploy.py
 
-# Also handle "python pipeline/deploy.py ..." — zsh sees "python" as the
-# command, so we wrap with a handler that strips the script argument.
+# Handle "python pipeline/deploy.py ..." — zsh sees "python" as the command,
+# so we intercept and rewrite the word list when the first arg is deploy.py.
 _python_deploy_py() {
-    # Only activate when the first argument is pipeline/deploy.py (or a path
-    # ending in deploy.py).
     if [[ "${words[2]}" == */deploy.py || "${words[2]}" == deploy.py ]]; then
-        # Shift words so the completion logic sees "deploy.py subcmd ..."
-        words=( deploy.py "${words[@]:2}" )
+        words=(deploy.py "${words[@]:2}")
         (( CURRENT -= 1 ))
-        _deploy_py
+        _sim2real_deploy
     else
         _normal
     fi

--- a/pipeline/completions.zsh
+++ b/pipeline/completions.zsh
@@ -1,0 +1,147 @@
+#compdef deploy.py
+
+# Zsh tab-completion for pipeline/deploy.py
+#
+# Usage — add one of these to your .zshrc:
+#   source /path/to/sim2real/pipeline/completions.zsh
+#
+# The script registers completion for both "deploy.py" (when on $PATH or run
+# as ./deploy.py) and "python pipeline/deploy.py" (via a wrapper).
+
+# ── helpers ─────────────────────────────────────────────────────────────────
+
+# Resolve the deploy.py invocation.  Prefer an --experiment-root that the user
+# already typed on the current line; fall back to bare "python pipeline/deploy.py".
+_deploy_py_cmd() {
+    local root=""
+    # Scan existing words for --experiment-root VALUE
+    local i
+    for (( i=1; i < ${#words[@]}; i++ )); do
+        if [[ "${words[$i]}" == --experiment-root && -n "${words[$i+1]}" ]]; then
+            root="${words[$i+1]}"
+            break
+        elif [[ "${words[$i]}" == --experiment-root=* ]]; then
+            root="${words[$i]#--experiment-root=}"
+            break
+        fi
+    done
+
+    local cmd=(python pipeline/deploy.py)
+    [[ -n "$root" ]] && cmd+=(--experiment-root "$root")
+    printf '%s\n' "${cmd[@]}"
+}
+
+_deploy_py_pair_keys() {
+    local -a keys
+    keys=( ${(f)"$(python pipeline/deploy.py pairs --keys-only 2>/dev/null)"} )
+    compadd -a keys
+}
+
+_deploy_py_workloads() {
+    local -a wl
+    wl=( ${(f)"$(python pipeline/deploy.py pairs --workloads-only 2>/dev/null)"} )
+    compadd -a wl
+}
+
+_deploy_py_packages() {
+    local -a pkg
+    pkg=( ${(f)"$(python pipeline/deploy.py pairs --packages-only 2>/dev/null)"} )
+    compadd -a pkg
+}
+
+_deploy_py_statuses() {
+    compadd pending running done failed timed-out
+}
+
+# ── main completion function ────────────────────────────────────────────────
+
+_deploy_py() {
+    local curcontext="$curcontext" state line
+    typeset -A opt_args
+
+    # Top-level: global flags + subcommand
+    _arguments -C \
+        '--run[Run name]:run name:' \
+        '--experiment-root[Experiment repo path]:path:_directories' \
+        '1:subcommand:->subcmd' \
+        '*::arg:->args' \
+        && return
+
+    case "$state" in
+    subcmd)
+        local -a subcmds=(
+            'run:Orchestrate parallel pool execution'
+            'status:Show progress of all (workload, package) pairs'
+            'collect:Pull results for completed packages'
+            'cleanup:Tear down cluster resources for all non-pending pairs'
+            'pairs:List available pair keys, workloads, and packages'
+        )
+        _describe 'subcommand' subcmds
+        ;;
+    args)
+        case "${line[1]}" in
+        run)
+            _arguments \
+                '--only[Scope to one pair key]:pair key:_deploy_py_pair_keys' \
+                '--workload[Scope to workload]:workload:_deploy_py_workloads' \
+                '--package[Scope to package]:package:_deploy_py_packages' \
+                '--status[Scope to status]:status:_deploy_py_statuses' \
+                '--force[Reset non-pending pairs to pending]' \
+                '--skip-build-epp[Skip EPP image build]' \
+                '--max-retries[Max retries per pair]:count:' \
+                '--poll-interval[Seconds between polls]:seconds:' \
+                '--gpu-resource-type[GPU resource type]:type:' \
+                '--default-gpu-cost[GPU cost per pod]:cost:' \
+                '--pending-threshold[Pending timeout in seconds]:seconds:' \
+                '--max-pending-stalls[Max stall cycles]:count:'
+            ;;
+        status)
+            _arguments \
+                '--only[Scope to one pair key]:pair key:_deploy_py_pair_keys' \
+                '--workload[Scope to workload]:workload:_deploy_py_workloads' \
+                '--package[Scope to package]:package:_deploy_py_packages' \
+                '--status[Scope to status]:status:_deploy_py_statuses'
+            ;;
+        collect)
+            _arguments \
+                '--package[Scope to package]:package:_deploy_py_packages' \
+                '--skip-logs[Collect traces only, skip large logs]'
+            ;;
+        cleanup)
+            _arguments \
+                '--only[Scope to one pair key]:pair key:_deploy_py_pair_keys' \
+                '--workload[Scope to workload]:workload:_deploy_py_workloads' \
+                '--package[Scope to package]:package:_deploy_py_packages' \
+                '--status[Scope to status]:status:_deploy_py_statuses' \
+                '--dry-run[Preview what would be cleaned up]'
+            ;;
+        pairs)
+            _arguments \
+                '(--workloads-only --packages-only)--keys-only[Print pair keys only]' \
+                '(--keys-only --packages-only)--workloads-only[Print workload names only]' \
+                '(--keys-only --workloads-only)--packages-only[Print package names only]'
+            ;;
+        esac
+        ;;
+    esac
+}
+
+compdef _deploy_py deploy.py
+
+# Also handle "python pipeline/deploy.py ..." — zsh sees "python" as the
+# command, so we wrap with a handler that strips the script argument.
+_python_deploy_py() {
+    # Only activate when the first argument is pipeline/deploy.py (or a path
+    # ending in deploy.py).
+    if [[ "${words[2]}" == */deploy.py || "${words[2]}" == deploy.py ]]; then
+        # Shift words so the completion logic sees "deploy.py subcmd ..."
+        words=( deploy.py "${words[@]:2}" )
+        (( CURRENT -= 1 ))
+        _deploy_py
+    else
+        _normal
+    fi
+}
+
+compdef _python_deploy_py python
+compdef _python_deploy_py python3

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -42,7 +42,7 @@ def _c(code: str, text: str) -> str:
 
 def info(msg: str)  -> None: print(_c("34", "[INFO]  ") + msg)
 def ok(msg: str)    -> None: print(_c("32", "[OK]    ") + msg)
-def warn(msg: str)  -> None: print(_c("33", "[WARN]  ") + msg)
+def warn(msg: str)  -> None: print(_c("33", "[WARN]  ") + msg, file=sys.stderr)
 def err(msg: str)   -> None: print(_c("31", "[ERROR] ") + msg, file=sys.stderr)
 
 
@@ -204,6 +204,8 @@ def _cmd_pairs(cluster_dir: Path, *, keys_only: bool = False,
     pairs = _load_pairs(cluster_dir)
 
     if not pairs:
+        if keys_only or workloads_only or packages_only:
+            return
         n = len(list(cluster_dir.glob("pipelinerun-*.yaml"))) if cluster_dir.exists() else 0
         if n == 0:
             print("  0 pairs (no pipelinerun-*.yaml files found)")
@@ -1398,7 +1400,11 @@ Examples:
 def main():
     parser = build_parser()
     args = parser.parse_args()
-    print(_c("36", "\n━━━ sim2real-deploy ━━━\n"))
+    machine_readable = (args.command == "pairs" and
+                         any(getattr(args, f, False)
+                             for f in ("keys_only", "workloads_only", "packages_only")))
+    if not machine_readable:
+        print(_c("36", "\n━━━ sim2real-deploy ━━━\n"))
 
     global EXPERIMENT_ROOT
     EXPERIMENT_ROOT = Path(args.experiment_root).resolve() if args.experiment_root else Path.cwd()

--- a/pipeline/tests/test_completions.py
+++ b/pipeline/tests/test_completions.py
@@ -1,7 +1,10 @@
 """Tests for shell completion scripts."""
 
+import shutil
 import subprocess
 from pathlib import Path
+
+import pytest
 
 PIPELINE_DIR = Path(__file__).resolve().parent.parent
 COMPLETIONS_ZSH = PIPELINE_DIR / "completions.zsh"
@@ -16,6 +19,7 @@ def test_bash_script_exists():
     assert COMPLETIONS_BASH.exists()
 
 
+@pytest.mark.skipif(shutil.which("zsh") is None, reason="zsh not available")
 def test_zsh_syntax_valid():
     result = subprocess.run(
         ["zsh", "-n", str(COMPLETIONS_ZSH)],
@@ -46,13 +50,15 @@ def test_bash_declares_subcommands():
 
 def test_zsh_handles_status_values():
     content = COMPLETIONS_ZSH.read_text()
-    for val in ("pending", "running", "done", "failed", "timed-out"):
+    for val in ("pending", "running", "done", "failed", "timed-out",
+                "stalled", "collect-failed", "collecting"):
         assert val in content
 
 
 def test_bash_handles_status_values():
     content = COMPLETIONS_BASH.read_text()
-    for val in ("pending", "running", "done", "failed", "timed-out"):
+    for val in ("pending", "running", "done", "failed", "timed-out",
+                "stalled", "collect-failed", "collecting"):
         assert val in content
 
 
@@ -78,3 +84,61 @@ def test_zsh_graceful_on_failure():
 def test_bash_graceful_on_failure():
     content = COMPLETIONS_BASH.read_text()
     assert "2>/dev/null" in content
+
+
+def test_bash_skips_flag_values_in_subcommand_detection():
+    content = COMPLETIONS_BASH.read_text()
+    assert "--experiment-root|--run) ((i++))" in content
+
+
+def test_zsh_has_python_wrapper():
+    content = COMPLETIONS_ZSH.read_text()
+    assert "_python_deploy_py" in content
+    assert "compdef _python_deploy_py python" in content
+
+
+def test_bash_has_python_wrapper():
+    content = COMPLETIONS_BASH.read_text()
+    assert "_python_deploy_py" in content
+    assert "complete -F _python_deploy_py python" in content
+
+
+def test_banner_suppressed_for_machine_readable_pairs(tmp_path):
+    """deploy.py pairs --keys-only must not print the banner to stdout."""
+    import yaml as _yaml
+    from pipeline.deploy import _cmd_pairs
+
+    pr = {
+        "metadata": {"name": "run1", "namespace": "ns"},
+        "spec": {"params": [
+            {"name": "workloadName", "value": "wl-smoke"},
+            {"name": "phase", "value": "baseline"},
+        ]},
+    }
+    cluster_dir = tmp_path / "cluster"
+    cluster_dir.mkdir()
+    (cluster_dir / "pipelinerun-smoke-baseline.yaml").write_text(_yaml.dump(pr))
+
+    import io
+    import contextlib
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        _cmd_pairs(cluster_dir, keys_only=True)
+    output = buf.getvalue()
+    assert "sim2real-deploy" not in output
+    assert "wl-smoke-baseline" in output
+
+
+def test_cmd_pairs_silent_when_empty_and_machine_readable(tmp_path):
+    """deploy.py pairs --keys-only with no pairs produces no stdout."""
+    from pipeline.deploy import _cmd_pairs
+
+    cluster_dir = tmp_path / "cluster"
+    cluster_dir.mkdir()
+
+    import io
+    import contextlib
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        _cmd_pairs(cluster_dir, keys_only=True)
+    assert buf.getvalue() == ""

--- a/pipeline/tests/test_completions.py
+++ b/pipeline/tests/test_completions.py
@@ -1,0 +1,80 @@
+"""Tests for shell completion scripts."""
+
+import subprocess
+from pathlib import Path
+
+PIPELINE_DIR = Path(__file__).resolve().parent.parent
+COMPLETIONS_ZSH = PIPELINE_DIR / "completions.zsh"
+COMPLETIONS_BASH = PIPELINE_DIR / "completions.bash"
+
+
+def test_zsh_script_exists():
+    assert COMPLETIONS_ZSH.exists()
+
+
+def test_bash_script_exists():
+    assert COMPLETIONS_BASH.exists()
+
+
+def test_zsh_syntax_valid():
+    result = subprocess.run(
+        ["zsh", "-n", str(COMPLETIONS_ZSH)],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, f"zsh syntax error: {result.stderr}"
+
+
+def test_bash_syntax_valid():
+    result = subprocess.run(
+        ["bash", "-n", str(COMPLETIONS_BASH)],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, f"bash syntax error: {result.stderr}"
+
+
+def test_zsh_declares_subcommands():
+    content = COMPLETIONS_ZSH.read_text()
+    for subcmd in ("run", "status", "collect", "cleanup", "pairs"):
+        assert subcmd in content
+
+
+def test_bash_declares_subcommands():
+    content = COMPLETIONS_BASH.read_text()
+    for subcmd in ("run", "status", "collect", "cleanup", "pairs"):
+        assert subcmd in content
+
+
+def test_zsh_handles_status_values():
+    content = COMPLETIONS_ZSH.read_text()
+    for val in ("pending", "running", "done", "failed", "timed-out"):
+        assert val in content
+
+
+def test_bash_handles_status_values():
+    content = COMPLETIONS_BASH.read_text()
+    for val in ("pending", "running", "done", "failed", "timed-out"):
+        assert val in content
+
+
+def test_zsh_calls_pairs_subcommand():
+    content = COMPLETIONS_ZSH.read_text()
+    assert "pairs --keys-only" in content
+    assert "pairs --workloads-only" in content
+    assert "pairs --packages-only" in content
+
+
+def test_bash_calls_pairs_subcommand():
+    content = COMPLETIONS_BASH.read_text()
+    assert "pairs --keys-only" in content
+    assert "pairs --workloads-only" in content
+    assert "pairs --packages-only" in content
+
+
+def test_zsh_graceful_on_failure():
+    content = COMPLETIONS_ZSH.read_text()
+    assert "2>/dev/null" in content
+
+
+def test_bash_graceful_on_failure():
+    content = COMPLETIONS_BASH.read_text()
+    assert "2>/dev/null" in content

--- a/pipeline/tests/test_deploy_cleanup.py
+++ b/pipeline/tests/test_deploy_cleanup.py
@@ -176,8 +176,8 @@ def test_cleanup_pair_missing_pr_name_warns(monkeypatch, capsys):
     result = mod._cleanup_pair("wl-unknown-baseline", entry, {})
     assert result is True
     assert entry["status"] == "pending"
-    out = capsys.readouterr().out
-    assert "no PipelineRun name found" in out
+    err = capsys.readouterr().err
+    assert "no PipelineRun name found" in err
 
 
 def test_cmd_cleanup_continues_on_exception(tmp_path, monkeypatch, capsys):

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -205,7 +205,7 @@ def test_load_pairs_skips_corrupt_yaml(tmp_path, capsys):
 
     assert len(pairs) == 1
     assert "wl-smoke-baseline" in pairs
-    assert "pipelinerun-bad.yaml" in capsys.readouterr().out
+    assert "pipelinerun-bad.yaml" in capsys.readouterr().err
 
 
 def test_load_pairs_skips_malformed_params(tmp_path, capsys):
@@ -223,7 +223,7 @@ def test_load_pairs_skips_malformed_params(tmp_path, capsys):
     (tmp_path / "pipelinerun-test.yaml").write_text(_yaml.dump(pr))
     pairs = _load_pairs(tmp_path)
     assert len(pairs) == 0
-    assert "pipelinerun-test.yaml" in capsys.readouterr().out
+    assert "pipelinerun-test.yaml" in capsys.readouterr().err
 
 
 def test_load_pairs_warns_on_skip(tmp_path, capsys):
@@ -233,9 +233,9 @@ def test_load_pairs_warns_on_skip(tmp_path, capsys):
     (tmp_path / "pipelinerun-broken.yaml").write_text("not: valid: yaml: [[[")
     _load_pairs(tmp_path)
 
-    out = capsys.readouterr().out
-    assert "[WARN]" in out
-    assert "pipelinerun-broken.yaml" in out
+    err = capsys.readouterr().err
+    assert "[WARN]" in err
+    assert "pipelinerun-broken.yaml" in err
 
 
 def test_apply_run_filters_by_status():
@@ -1042,8 +1042,8 @@ def test_early_reclaim_kubectl_failure_returns_false(monkeypatch, capsys):
 
     assert reclaimed is False
     assert entry["status"] == "running"
-    out = capsys.readouterr().out
-    assert "pod query failed" in out
+    err = capsys.readouterr().err
+    assert "pod query failed" in err
 
 
 def test_early_reclaim_pods_running_clears_pending_since(monkeypatch):
@@ -1131,8 +1131,8 @@ def test_early_reclaim_malformed_pending_since_resets_timer(monkeypatch, capsys)
 
     assert reclaimed is False
     assert entry["pending_since"] != "not-a-valid-timestamp"
-    out = capsys.readouterr().out
-    assert "malformed pending_since" in out
+    err = capsys.readouterr().err
+    assert "malformed pending_since" in err
 
 
 def test_force_reset_clears_pending_stalls(monkeypatch):
@@ -1189,5 +1189,5 @@ def test_early_reclaim_json_decode_error_warns(monkeypatch, capsys):
 
     assert reclaimed is False
     assert entry["status"] == "running"
-    out = capsys.readouterr().out
-    assert "invalid JSON" in out
+    err = capsys.readouterr().err
+    assert "invalid JSON" in err


### PR DESCRIPTION
Closes #60

## Summary

- Adds `pipeline/completions.zsh` — zsh tab completion using `compdef`/`_arguments`/`compadd`
- Adds `pipeline/completions.bash` — bash tab completion using `complete`/`COMPREPLY`/`compgen`
- Dynamic completions for `--only`, `--workload`, `--package` by calling `deploy.py pairs`
- Static completions for `--status` (pending, running, done, failed, timed-out)
- Graceful failure when workspace is missing (no errors, just no completions)
- Tests validating syntax and content of both scripts

## Setup

```bash
# zsh
source $SIM2REAL/pipeline/completions.zsh

# bash
source $SIM2REAL/pipeline/completions.bash
```

## Test plan

- [x] `zsh -n pipeline/completions.zsh` passes
- [x] `bash -n pipeline/completions.bash` passes
- [x] 12 pytest tests pass (`pipeline/tests/test_completions.py`)
- [x] Full suite: 428 tests pass, lint clean