### PR TITLE
completions: forward --experiment-root and --run to dynamic pair queries

### DIFF
--- a/pipeline/completions.bash
+++ b/pipeline/completions.bash
@@ -15,13 +15,14 @@ _sim2real_deploy() {
     local subcommands="run status collect cleanup pairs"
     local status_values="pending running done failed timed-out stalled collect-failed collecting"
 
+    # Extract --experiment-root and --run values while finding the subcommand.
     subcmd=""
+    local _exroot="" _run_name=""
     local i
     for ((i=1; i < COMP_CWORD; i++)); do
         case "${COMP_WORDS[i]}" in
-            # These flags take a value argument — skip it to avoid misidentifying
-            # the value as a subcommand (e.g. --experiment-root run)
-            --experiment-root|--run) ((i++)) ;;
+            --experiment-root) ((i++)); _exroot="${COMP_WORDS[i]}" ;;
+            --run)             ((i++)); _run_name="${COMP_WORDS[i]}" ;;
             -*) ;;
             run|status|collect|cleanup|pairs)
                 subcmd="${COMP_WORDS[i]}"
@@ -29,6 +30,11 @@ _sim2real_deploy() {
                 ;;
         esac
     done
+
+    # Build the base command for dynamic queries.
+    local -a _deploy_cmd=("${PYTHON:-python}" pipeline/deploy.py)
+    [[ -n "$_exroot" ]]    && _deploy_cmd+=(--experiment-root "$_exroot")
+    [[ -n "$_run_name" ]]  && _deploy_cmd+=(--run "$_run_name")
 
     if [[ -z "$subcmd" ]]; then
         if [[ "$cur" == -* ]]; then
@@ -42,19 +48,19 @@ _sim2real_deploy() {
     case "$prev" in
         --only)
             local keys
-            keys="$(python pipeline/deploy.py pairs --keys-only 2>/dev/null)"
+            keys="$("${_deploy_cmd[@]}" pairs --keys-only 2>/dev/null)"
             COMPREPLY=($(compgen -W "$keys" -- "$cur"))
             return
             ;;
         --workload)
             local workloads
-            workloads="$(python pipeline/deploy.py pairs --workloads-only 2>/dev/null)"
+            workloads="$("${_deploy_cmd[@]}" pairs --workloads-only 2>/dev/null)"
             COMPREPLY=($(compgen -W "$workloads" -- "$cur"))
             return
             ;;
         --package)
             local packages
-            packages="$(python pipeline/deploy.py pairs --packages-only 2>/dev/null)"
+            packages="$("${_deploy_cmd[@]}" pairs --packages-only 2>/dev/null)"
             COMPREPLY=($(compgen -W "$packages" -- "$cur"))
             return
             ;;

--- a/pipeline/completions.bash
+++ b/pipeline/completions.bash
@@ -31,7 +31,7 @@ _sim2real_deploy() {
         esac
     done
 
-    # Build the base command for dynamic queries.
+    # Build as an array to avoid word-splitting on paths with spaces.
     local -a _deploy_cmd=("${PYTHON:-python}" pipeline/deploy.py)
     [[ -n "$_exroot" ]]    && _deploy_cmd+=(--experiment-root "$_exroot")
     [[ -n "$_run_name" ]]  && _deploy_cmd+=(--run "$_run_name")

--- a/pipeline/completions.zsh
+++ b/pipeline/completions.zsh
@@ -9,20 +9,32 @@
 # For aliases, register manually:  compdef _sim2real_deploy my-alias
 
 _deploy_py_pair_keys() {
-    local -a keys
-    keys=(${(f)"$(python pipeline/deploy.py pairs --keys-only 2>/dev/null)"})
+    local -a keys cmd
+    cmd=("${PYTHON:-python}" pipeline/deploy.py)
+    [[ -n "${opt_args[--experiment-root]}" ]] && cmd+=(--experiment-root "${opt_args[--experiment-root]}")
+    [[ -n "${opt_args[--run]}" ]] && cmd+=(--run "${opt_args[--run]}")
+    cmd+=(pairs --keys-only)
+    keys=(${(f)"$("${cmd[@]}" 2>/dev/null)"})
     (( ${#keys} )) && compadd -a keys
 }
 
 _deploy_py_workloads() {
-    local -a workloads
-    workloads=(${(f)"$(python pipeline/deploy.py pairs --workloads-only 2>/dev/null)"})
+    local -a workloads cmd
+    cmd=("${PYTHON:-python}" pipeline/deploy.py)
+    [[ -n "${opt_args[--experiment-root]}" ]] && cmd+=(--experiment-root "${opt_args[--experiment-root]}")
+    [[ -n "${opt_args[--run]}" ]] && cmd+=(--run "${opt_args[--run]}")
+    cmd+=(pairs --workloads-only)
+    workloads=(${(f)"$("${cmd[@]}" 2>/dev/null)"})
     (( ${#workloads} )) && compadd -a workloads
 }
 
 _deploy_py_packages() {
-    local -a packages
-    packages=(${(f)"$(python pipeline/deploy.py pairs --packages-only 2>/dev/null)"})
+    local -a packages cmd
+    cmd=("${PYTHON:-python}" pipeline/deploy.py)
+    [[ -n "${opt_args[--experiment-root]}" ]] && cmd+=(--experiment-root "${opt_args[--experiment-root]}")
+    [[ -n "${opt_args[--run]}" ]] && cmd+=(--run "${opt_args[--run]}")
+    cmd+=(pairs --packages-only)
+    packages=(${(f)"$("${cmd[@]}" 2>/dev/null)"})
     (( ${#packages} )) && compadd -a packages
 }
 

--- a/pipeline/completions.zsh
+++ b/pipeline/completions.zsh
@@ -11,8 +11,8 @@
 _deploy_py_pair_keys() {
     local -a keys cmd
     cmd=("${PYTHON:-python}" pipeline/deploy.py)
-    [[ -n "${opt_args[--experiment-root]}" ]] && cmd+=(--experiment-root "${opt_args[--experiment-root]}")
-    [[ -n "${opt_args[--run]}" ]] && cmd+=(--run "${opt_args[--run]}")
+    [[ -n "$_saved_exroot" ]] && cmd+=(--experiment-root "$_saved_exroot")
+    [[ -n "$_saved_run" ]] && cmd+=(--run "$_saved_run")
     cmd+=(pairs --keys-only)
     keys=(${(f)"$("${cmd[@]}" 2>/dev/null)"})
     (( ${#keys} )) && compadd -a keys
@@ -21,8 +21,8 @@ _deploy_py_pair_keys() {
 _deploy_py_workloads() {
     local -a workloads cmd
     cmd=("${PYTHON:-python}" pipeline/deploy.py)
-    [[ -n "${opt_args[--experiment-root]}" ]] && cmd+=(--experiment-root "${opt_args[--experiment-root]}")
-    [[ -n "${opt_args[--run]}" ]] && cmd+=(--run "${opt_args[--run]}")
+    [[ -n "$_saved_exroot" ]] && cmd+=(--experiment-root "$_saved_exroot")
+    [[ -n "$_saved_run" ]] && cmd+=(--run "$_saved_run")
     cmd+=(pairs --workloads-only)
     workloads=(${(f)"$("${cmd[@]}" 2>/dev/null)"})
     (( ${#workloads} )) && compadd -a workloads
@@ -31,8 +31,8 @@ _deploy_py_workloads() {
 _deploy_py_packages() {
     local -a packages cmd
     cmd=("${PYTHON:-python}" pipeline/deploy.py)
-    [[ -n "${opt_args[--experiment-root]}" ]] && cmd+=(--experiment-root "${opt_args[--experiment-root]}")
-    [[ -n "${opt_args[--run]}" ]] && cmd+=(--run "${opt_args[--run]}")
+    [[ -n "$_saved_exroot" ]] && cmd+=(--experiment-root "$_saved_exroot")
+    [[ -n "$_saved_run" ]] && cmd+=(--run "$_saved_run")
     cmd+=(pairs --packages-only)
     packages=(${(f)"$("${cmd[@]}" 2>/dev/null)"})
     (( ${#packages} )) && compadd -a packages
@@ -64,6 +64,8 @@ _sim2real_deploy() {
             _describe 'subcommand' subcommands
             ;;
         args)
+            local _saved_exroot="${opt_args[--experiment-root]}"
+            local _saved_run="${opt_args[--run]}"
             case "${line[1]}" in
                 run)
                     _arguments \

--- a/pipeline/tests/test_completions.py
+++ b/pipeline/tests/test_completions.py
@@ -149,12 +149,16 @@ def test_cmd_pairs_silent_when_empty_and_machine_readable(tmp_path):
 
 def test_zsh_forwards_experiment_root():
     content = COMPLETIONS_ZSH.read_text()
-    assert 'opt_args[--experiment-root]' in content
+    assert '_saved_exroot' in content
+    assert content.count('_saved_exroot') >= 3, \
+        "all three helpers must reference _saved_exroot"
 
 
 def test_zsh_forwards_run():
     content = COMPLETIONS_ZSH.read_text()
-    assert 'opt_args[--run]' in content
+    assert '_saved_run' in content
+    assert content.count('_saved_run') >= 3, \
+        "all three helpers must reference _saved_run"
 
 
 def test_zsh_uses_python_variable():

--- a/pipeline/tests/test_completions.py
+++ b/pipeline/tests/test_completions.py
@@ -142,3 +142,20 @@ def test_cmd_pairs_silent_when_empty_and_machine_readable(tmp_path):
     with contextlib.redirect_stdout(buf):
         _cmd_pairs(cluster_dir, keys_only=True)
     assert buf.getvalue() == ""
+
+
+def test_zsh_forwards_experiment_root():
+    content = COMPLETIONS_ZSH.read_text()
+    assert 'opt_args[--experiment-root]' in content
+
+
+def test_zsh_forwards_run():
+    content = COMPLETIONS_ZSH.read_text()
+    assert 'opt_args[--run]' in content
+
+
+def test_zsh_uses_python_variable():
+    content = COMPLETIONS_ZSH.read_text()
+    assert '${PYTHON:-python}' in content
+    assert content.count('"$(python pipeline/') == 0, \
+        "hardcoded 'python' should be replaced with ${PYTHON:-python}"

--- a/pipeline/tests/test_completions.py
+++ b/pipeline/tests/test_completions.py
@@ -88,7 +88,10 @@ def test_bash_graceful_on_failure():
 
 def test_bash_skips_flag_values_in_subcommand_detection():
     content = COMPLETIONS_BASH.read_text()
-    assert "--experiment-root|--run) ((i++))" in content
+    assert "--experiment-root)" in content
+    assert "--run)" in content
+    assert "_exroot" in content
+    assert "_run_name" in content
 
 
 def test_zsh_has_python_wrapper():
@@ -159,3 +162,31 @@ def test_zsh_uses_python_variable():
     assert '${PYTHON:-python}' in content
     assert content.count('"$(python pipeline/') == 0, \
         "hardcoded 'python' should be replaced with ${PYTHON:-python}"
+
+
+def test_bash_forwards_experiment_root():
+    content = COMPLETIONS_BASH.read_text()
+    assert '_exroot' in content
+    assert any('_deploy_cmd' in line and 'experiment-root' in line
+               for line in content.splitlines()), \
+        "_exroot must be forwarded via _deploy_cmd"
+
+
+def test_bash_forwards_run():
+    content = COMPLETIONS_BASH.read_text()
+    assert '_run_name' in content
+    assert any('_deploy_cmd' in line and '--run' in line
+               for line in content.splitlines()), \
+        "_run_name must be forwarded via _deploy_cmd"
+
+
+def test_bash_uses_python_variable():
+    content = COMPLETIONS_BASH.read_text()
+    assert '${PYTHON:-python}' in content
+    lines_with_pairs = [l for l in content.splitlines()
+                        if 'pairs --keys-only' in l
+                        or 'pairs --workloads-only' in l
+                        or 'pairs --packages-only' in l]
+    for line in lines_with_pairs:
+        assert '_deploy_cmd' in line, \
+            f"dynamic query should use _deploy_cmd: {line}"


### PR DESCRIPTION
Closes #83

## Summary

- **Zsh**: Saves top-level `opt_args` (`--experiment-root`, `--run`) before nested `_arguments` calls overwrite them, then forwards via `_saved_exroot` / `_saved_run` in the three dynamic query helpers
- **Bash**: Extends the `COMP_WORDS` scan loop to capture `--experiment-root` and `--run` values, then forwards them via an array-based `_deploy_cmd`
- Both shells now use `${PYTHON:-python}` instead of hardcoded `python`, so completions work when the venv interpreter differs from the system one (per issue comment)

## Reviewer notes

- **Zsh scoping**: Nested `_arguments` calls reinitialize `opt_args` with their own option set, stripping the top-level flags. The fix saves values into `local` variables before the nested block — zsh's dynamic scoping makes them visible to the helpers.
- **Bash array**: Uses `local -a _deploy_cmd=(...)` + `"${_deploy_cmd[@]}"` rather than string concatenation to avoid word-splitting on paths containing spaces.
- One existing test was updated and six new tests added — all content-based (grep the script text), consistent with the existing test style in `test_completions.py`.

## Test plan

- [x] `python -m pytest pipeline/ -v` — 439 passed
- [x] `ruff check pipeline/ --select F` — all checks passed
- [x] `zsh -n pipeline/completions.zsh` — syntax valid
- [x] `bash -n pipeline/completions.bash` — syntax valid