### PR TITLE
fix(capacity): exclude Pending pods from GPU probe

### DIFF
--- a/pipeline/lib/capacity.py
+++ b/pipeline/lib/capacity.py
@@ -21,6 +21,9 @@ def probe_free_gpus(
     Queries kubectl for node allocatable resources and pod requests,
     computes the delta clamped to zero.
 
+    Skips pods without spec.nodeName — these are Pending (unscheduled) and
+    have not been allocated any node resources.
+
     Assumes only spec.containers request GPUs (initContainers are excluded —
     llm-d workloads do not use GPU-requesting init containers).
 
@@ -66,7 +69,7 @@ def probe_free_gpus(
 
     total_requested = 0
     for pod in pods.get("items", []):
-        if not pod.get("spec", {}).get("nodeName"):
+        if pod.get("spec", {}).get("nodeName") is None:
             continue
         for container in pod.get("spec", {}).get("containers", []):
             requests = container.get("resources", {}).get("requests", {})

--- a/pipeline/lib/capacity.py
+++ b/pipeline/lib/capacity.py
@@ -66,6 +66,8 @@ def probe_free_gpus(
 
     total_requested = 0
     for pod in pods.get("items", []):
+        if not pod.get("spec", {}).get("nodeName"):
+            continue
         for container in pod.get("spec", {}).get("containers", []):
             requests = container.get("resources", {}).get("requests", {})
             count = requests.get(gpu_resource_type)

--- a/pipeline/tests/test_capacity.py
+++ b/pipeline/tests/test_capacity.py
@@ -20,17 +20,27 @@ class TestProbeFreeGpus:
             nodes.append(node)
         return json.dumps({"items": nodes})
 
-    def _mock_pods(self, requested_gpus: list[int], resource="nvidia.com/gpu"):
-        """Build fake kubectl pods JSON."""
+    def _mock_pods(self, requested_gpus: list[int], resource="nvidia.com/gpu",
+                   node_names: list[str | None] | None = None):
+        """Build fake kubectl pods JSON.
+
+        node_names: per-pod nodeName (None = Pending, no nodeName).
+        Defaults to all pods having a nodeName.
+        """
+        if node_names is None:
+            node_names = [f"node-{i}" for i in range(len(requested_gpus))]
         pods = []
-        for gpu_req in requested_gpus:
+        for i, gpu_req in enumerate(requested_gpus):
+            spec: dict = {
+                "containers": [
+                    {"resources": {"requests": {resource: str(gpu_req)}}}
+                ]
+            }
+            if node_names[i] is not None:
+                spec["nodeName"] = node_names[i]
             pod = {
                 "metadata": {"name": f"pod-{len(pods)}"},
-                "spec": {
-                    "containers": [
-                        {"resources": {"requests": {resource: str(gpu_req)}}}
-                    ]
-                },
+                "spec": spec,
             }
             pods.append(pod)
         return json.dumps({"items": pods})
@@ -122,6 +132,23 @@ class TestProbeFreeGpus:
         result = probe_free_gpus()
         assert isinstance(result, str)
         assert "JSON parse error" in result
+
+    @patch("pipeline.lib.capacity.subprocess.run")
+    def test_pending_pods_excluded(self, mock_run):
+        """Pending pods (no nodeName) should not count as GPU consumers."""
+        nodes_json = self._mock_nodes([8, 8])
+        pods_json = self._mock_pods(
+            [4, 4, 4],
+            node_names=["node-0", "node-1", None],
+        )
+
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=nodes_json),
+            MagicMock(returncode=0, stdout=pods_json),
+        ]
+
+        result = probe_free_gpus()
+        assert result == (8, 16, 8)
 
 
 # ── derive_gpu_resource_type tests ─────────────────────────────────────────────

--- a/pipeline/tests/test_capacity.py
+++ b/pipeline/tests/test_capacity.py
@@ -150,6 +150,23 @@ class TestProbeFreeGpus:
         result = probe_free_gpus()
         assert result == (8, 16, 8)
 
+    @patch("pipeline.lib.capacity.subprocess.run")
+    def test_all_pods_pending_means_zero_requested(self, mock_run):
+        """When every pod is Pending, total requested should be zero."""
+        nodes_json = self._mock_nodes([8, 8])
+        pods_json = self._mock_pods(
+            [4, 4],
+            node_names=[None, None],
+        )
+
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=nodes_json),
+            MagicMock(returncode=0, stdout=pods_json),
+        ]
+
+        result = probe_free_gpus()
+        assert result == (16, 16, 0)
+
 
 # ── derive_gpu_resource_type tests ─────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Filter out pods without `spec.nodeName` in `probe_free_gpus()` — these are Pending (unscheduled) and don't consume allocatable GPU resources
- Updated test helper `_mock_pods` to include `nodeName` by default, with opt-out for Pending pod simulation
- Added `test_pending_pods_excluded` verifying the fix

Closes #89

## Reviewer Notes

The one-line change is at `pipeline/lib/capacity.py:69`. The rest is test infrastructure. The key semantic: Kubernetes sets `spec.nodeName` only after the scheduler binds a pod to a node — pods without it haven't been allocated any node resources.

## Test Plan

- [x] `test_pending_pods_excluded` — 3 pods (2 scheduled, 1 Pending), only scheduled pods counted
- [x] All 7 existing `TestProbeFreeGpus` tests pass (helper backward-compatible via default `node_names`)
- [x] Full suite: 472 passed
- [x] Lint: `ruff check pipeline/ --select F` clean