### PR TITLE
Remove v1 and v2 manifest support — v3 only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ python pipeline/run.py     --experiment-root ../admission-control switch <run-na
 
 | Module | Purpose |
 |--------|---------|
-| `manifest.py` | Loads and validates `transfer.yaml` (v2/v3 schema) |
+| `manifest.py` | Loads and validates `transfer.yaml` (v3 schema) |
 | `state_machine.py` | Phase tracking with atomic JSON persistence (`.state.json`) |
 | `context_builder.py` | Assembles context document, caches by SHA-256 hash |
 | `values.py` | Deep-merge utility (`deep_merge`) used by `assemble.py` |

--- a/pipeline/lib/manifest.py
+++ b/pipeline/lib/manifest.py
@@ -1,4 +1,4 @@
-"""Manifest loader for sim2real pipeline (v2/v3 schema)."""
+"""Manifest loader for sim2real pipeline (v3 schema)."""
 import re
 import warnings
 import yaml
@@ -25,7 +25,7 @@ _REQUIRED_ALGORITHM = ["source"]
 
 
 def load_manifest(path: "Path | str") -> dict:
-    """Load and validate a sim2real transfer manifest (v2 or v3)."""
+    """Load and validate a sim2real transfer manifest."""
     path = Path(path)
     if not path.exists():
         raise ManifestError(f"Manifest not found: {path}")
@@ -41,12 +41,7 @@ def load_manifest(path: "Path | str") -> dict:
     version = data.get("version")
     if version is None:
         raise ManifestError("Missing required field: version")
-    if version == 1:
-        raise ManifestError(
-            "v1 manifests are no longer supported. "
-            "Use version 2 or 3 (see pipeline/README.md for field reference)."
-        )
-    if version not in (2, 3):
+    if version != 3:
         raise ManifestError(f"Unsupported manifest version: {version}")
 
     for field in _REQUIRED_TOP:
@@ -68,32 +63,21 @@ def load_manifest(path: "Path | str") -> dict:
         if not isinstance(bl, dict):
             raise ManifestError("baseline must be a mapping")
 
-        if version == 2:
-            # v2: flat baseline.config — normalize to v3 shape for uniform downstream access
-            if "config" not in bl:
-                raise ManifestError("Missing required field: baseline.config")
-            data["baseline"] = {
-                "sim": {"config": bl["config"]},
-                "real": {"config": None, "notes": ""},
-            }
+        sim_section = bl.get("sim")
+        if sim_section is None:
+            data["baseline"]["sim"] = {"config": None}
+        elif not isinstance(sim_section, dict):
+            raise ManifestError("baseline.sim must be a mapping")
         else:
-            # v3: baseline.sim.config optional (None when scenario has no sim baseline);
-            # baseline.real.* optional with defaults
-            sim_section = bl.get("sim")
-            if sim_section is None:
-                data["baseline"]["sim"] = {"config": None}
-            elif not isinstance(sim_section, dict):
-                raise ManifestError("baseline.sim must be a mapping")
-            else:
-                sim_section.setdefault("config", None)
-            real_section = bl.get("real")
-            if real_section is None:
-                data["baseline"]["real"] = {"config": None, "notes": ""}
-            elif not isinstance(real_section, dict):
-                raise ManifestError("baseline.real must be a mapping")
-            else:
-                data["baseline"]["real"].setdefault("config", None)
-                data["baseline"]["real"].setdefault("notes", "")
+            sim_section.setdefault("config", None)
+        real_section = bl.get("real")
+        if real_section is None:
+            data["baseline"]["real"] = {"config": None, "notes": ""}
+        elif not isinstance(real_section, dict):
+            raise ManifestError("baseline.real must be a mapping")
+        else:
+            data["baseline"]["real"].setdefault("config", None)
+            data["baseline"]["real"].setdefault("notes", "")
 
     # Normalize workloads: absent/null → [] (standby mode — stack up, no benchmarks)
     wl = data.get("workloads")
@@ -190,9 +174,7 @@ def load_manifest(path: "Path | str") -> dict:
         hints_files.append({"path": str(fp), "content": fp.read_text()})
     data["hints"] = {"text": hints_text, "files": hints_files}
 
-    # ── v3 fields ─────────────────────────────────────────────────────────────
-    if version >= 3:
-        _validate_v3_fields(data)
+    _validate_v3_fields(data)
 
     # Deprecation warning for context.notes
     if data.get("context", {}).get("notes"):

--- a/pipeline/tests/test_manifest.py
+++ b/pipeline/tests/test_manifest.py
@@ -1,22 +1,9 @@
-"""Tests for v2 manifest loader."""
+"""Tests for manifest loader."""
 import pytest
 import yaml
 from pathlib import Path
 
 from pipeline.lib.manifest import load_manifest, ManifestError
-
-MINIMAL_V2 = {
-    "kind": "sim2real-transfer",
-    "version": 2,
-    "scenario": "routing",
-    "algorithm": {
-        "source": "sim2real_golden/routers/router_adaptive_v2.go",
-        "config": "sim2real_golden/routers/policy_adaptive_v2.yaml",
-    },
-    "baseline": {"config": "sim2real_golden/routers/policy_baseline_211.yaml"},
-    "workloads": ["sim2real_golden/workloads/wl1.yaml"],
-}
-
 
 def _write_manifest(tmp_path, data):
     p = tmp_path / "transfer.yaml"
@@ -24,22 +11,8 @@ def _write_manifest(tmp_path, data):
     return p
 
 
-def test_load_valid_v2(tmp_path):
-    path = _write_manifest(tmp_path, MINIMAL_V2)
-    m = load_manifest(path)
-    assert m["scenario"] == "routing"
-    assert m["algorithm"]["source"].endswith(".go")
-
-
-def test_v1_raises_migration_error(tmp_path):
-    v1 = {"kind": "sim2real-transfer", "version": 1, "algorithm": {"experiment_dir": "x"}}
-    path = _write_manifest(tmp_path, v1)
-    with pytest.raises(ManifestError, match="v1 manifests are no longer supported"):
-        load_manifest(path)
-
-
 def test_missing_version_raises(tmp_path):
-    data = {k: v for k, v in MINIMAL_V2.items() if k != "version"}
+    data = {k: v for k, v in MINIMAL_V3.items() if k != "version"}
     path = _write_manifest(tmp_path, data)
     with pytest.raises(ManifestError, match="version"):
         load_manifest(path)
@@ -47,7 +20,7 @@ def test_missing_version_raises(tmp_path):
 
 def test_missing_required_field(tmp_path):
     for field in ["scenario", "baseline"]:
-        data = {k: v for k, v in MINIMAL_V2.items() if k != field}
+        data = {k: v for k, v in MINIMAL_V3.items() if k != field}
         path = _write_manifest(tmp_path, data)
         with pytest.raises(ManifestError, match=field):
             load_manifest(path)
@@ -55,7 +28,7 @@ def test_missing_required_field(tmp_path):
 
 def test_algorithm_section_entirely_optional(tmp_path):
     """Manifest without algorithm field is valid (baseline-only mode)."""
-    data = {k: v for k, v in MINIMAL_V2.items() if k != "algorithm"}
+    data = {k: v for k, v in MINIMAL_V3.items() if k != "algorithm"}
     path = _write_manifest(tmp_path, data)
     m = load_manifest(path)
     assert "algorithm" not in m
@@ -63,14 +36,14 @@ def test_algorithm_section_entirely_optional(tmp_path):
 
 def test_algorithm_null_normalized_to_absent(tmp_path):
     """algorithm: null in YAML is normalized to key-absent (baseline-only)."""
-    data = {**MINIMAL_V2, "algorithm": None}
+    data = {**MINIMAL_V3, "algorithm": None}
     path = _write_manifest(tmp_path, data)
     m = load_manifest(path)
     assert "algorithm" not in m
 
 
 def test_missing_algorithm_source(tmp_path):
-    data = {**MINIMAL_V2, "algorithm": {"config": "x.yaml"}}
+    data = {**MINIMAL_V3, "algorithm": {"config": "x.yaml"}}
     path = _write_manifest(tmp_path, data)
     with pytest.raises(ManifestError, match="algorithm.source"):
         load_manifest(path)
@@ -78,21 +51,14 @@ def test_missing_algorithm_source(tmp_path):
 
 def test_missing_algorithm_config_is_valid(tmp_path):
     """algorithm.config is optional — manifests without it load cleanly."""
-    data = {**MINIMAL_V2, "algorithm": {"source": "x.go"}}
+    data = {**MINIMAL_V3, "algorithm": {"source": "x.go"}}
     path = _write_manifest(tmp_path, data)
     m = load_manifest(path)
     assert "config" not in m["algorithm"]
 
 
-def test_missing_baseline_config(tmp_path):
-    data = {**MINIMAL_V2, "baseline": {}}
-    path = _write_manifest(tmp_path, data)
-    with pytest.raises(ManifestError, match="baseline.config"):
-        load_manifest(path)
-
-
 def test_optional_context_fields(tmp_path):
-    data = {**MINIMAL_V2, "context": {
+    data = {**MINIMAL_V3, "context": {
         "files": ["docs/mapping.md"],
         "notes": "Use regime detection pattern",
     }}
@@ -103,7 +69,7 @@ def test_optional_context_fields(tmp_path):
 
 
 def test_workloads_must_be_list(tmp_path):
-    data = {**MINIMAL_V2, "workloads": "not_a_list.yaml"}
+    data = {**MINIMAL_V3, "workloads": "not_a_list.yaml"}
     path = _write_manifest(tmp_path, data)
     with pytest.raises(ManifestError, match="workloads.*list"):
         load_manifest(path)
@@ -111,7 +77,7 @@ def test_workloads_must_be_list(tmp_path):
 
 def test_empty_workloads_valid_standby_mode(tmp_path):
     """Empty workloads list is valid — standby mode: stack up, no benchmarks."""
-    data = {**MINIMAL_V2, "workloads": []}
+    data = {**MINIMAL_V3, "workloads": []}
     path = _write_manifest(tmp_path, data)
     m = load_manifest(path)
     assert m["workloads"] == []
@@ -119,7 +85,7 @@ def test_empty_workloads_valid_standby_mode(tmp_path):
 
 def test_absent_workloads_defaults_to_empty(tmp_path):
     """Missing workloads key is valid; defaults to []."""
-    data = {k: v for k, v in MINIMAL_V2.items() if k != "workloads"}
+    data = {k: v for k, v in MINIMAL_V3.items() if k != "workloads"}
     path = _write_manifest(tmp_path, data)
     m = load_manifest(path)
     assert m["workloads"] == []
@@ -127,23 +93,31 @@ def test_absent_workloads_defaults_to_empty(tmp_path):
 
 def test_null_workloads_defaults_to_empty(tmp_path):
     """workloads: null (YAML null) is valid; defaults to []."""
-    data = {**MINIMAL_V2, "workloads": None}
+    data = {**MINIMAL_V3, "workloads": None}
     path = _write_manifest(tmp_path, data)
     m = load_manifest(path)
     assert m["workloads"] == []
 
 
 def test_wrong_kind(tmp_path):
-    data = {**MINIMAL_V2, "kind": "something-else"}
+    data = {**MINIMAL_V3, "kind": "something-else"}
     path = _write_manifest(tmp_path, data)
     with pytest.raises(ManifestError, match="kind"):
         load_manifest(path)
 
 
 def test_unsupported_version(tmp_path):
-    data = {**MINIMAL_V2, "version": 99}
+    data = {**MINIMAL_V3, "version": 99}
     path = _write_manifest(tmp_path, data)
     with pytest.raises(ManifestError, match="version"):
+        load_manifest(path)
+
+
+def test_v2_rejected(tmp_path):
+    """Version 2 manifests are no longer accepted."""
+    data = {**MINIMAL_V3, "version": 2}
+    path = _write_manifest(tmp_path, data)
+    with pytest.raises(ManifestError, match="Unsupported manifest version: 2"):
         load_manifest(path)
 
 
@@ -156,7 +130,7 @@ def test_file_not_found():
 
 def test_hints_section_optional(tmp_path):
     """Manifest without hints loads cleanly; hints defaults to empty."""
-    path = _write_manifest(tmp_path, MINIMAL_V2)
+    path = _write_manifest(tmp_path, MINIMAL_V3)
     m = load_manifest(path)
     hints = m.get("hints", {})
     assert hints.get("text", "") == ""
@@ -164,7 +138,7 @@ def test_hints_section_optional(tmp_path):
 
 
 def test_hints_text_loaded(tmp_path):
-    data = {**MINIMAL_V2, "hints": {"text": "Modify precise_prefix_cache.go"}}
+    data = {**MINIMAL_V3, "hints": {"text": "Modify precise_prefix_cache.go"}}
     path = _write_manifest(tmp_path, data)
     m = load_manifest(path)
     assert m["hints"]["text"] == "Modify precise_prefix_cache.go"
@@ -173,7 +147,7 @@ def test_hints_text_loaded(tmp_path):
 def test_hints_files_contents_embedded(tmp_path):
     hint_file = tmp_path / "hint.md"
     hint_file.write_text("# Transfer hint\nRewrite scorer")
-    data = {**MINIMAL_V2, "hints": {"files": [str(hint_file)]}}
+    data = {**MINIMAL_V3, "hints": {"files": [str(hint_file)]}}
     path = _write_manifest(tmp_path, data)
     m = load_manifest(path)
     assert len(m["hints"]["files"]) == 1
@@ -182,14 +156,14 @@ def test_hints_files_contents_embedded(tmp_path):
 
 
 def test_hints_file_not_found_raises(tmp_path):
-    data = {**MINIMAL_V2, "hints": {"files": ["/nonexistent/hint.md"]}}
+    data = {**MINIMAL_V3, "hints": {"files": ["/nonexistent/hint.md"]}}
     path = _write_manifest(tmp_path, data)
     with pytest.raises(ManifestError, match="hints.files"):
         load_manifest(path)
 
 
 def test_context_notes_deprecated_warns(tmp_path):
-    data = {**MINIMAL_V2, "context": {"notes": "old style note", "files": []}}
+    data = {**MINIMAL_V3, "context": {"notes": "old style note", "files": []}}
     path = _write_manifest(tmp_path, data)
     import warnings
     with warnings.catch_warnings(record=True) as w:
@@ -298,32 +272,6 @@ def test_v3_real_partial_defaults_applied(tmp_path):
     assert m["baseline"]["real"]["notes"] == ""
 
 
-def test_v2_normalizes_to_v3_shape(tmp_path):
-    """v2 manifest: baseline.config is mapped to baseline.sim.config in output."""
-    path = _write_manifest(tmp_path, MINIMAL_V2)
-    m = load_manifest(path)
-    assert "sim" in m["baseline"]
-    assert m["baseline"]["sim"]["config"] == "sim2real_golden/routers/policy_baseline_211.yaml"
-    assert m["baseline"]["real"]["config"] is None
-    assert m["baseline"]["real"]["notes"] == ""
-
-
-def test_v2_baseline_config_missing_raises(tmp_path):
-    """v2 without baseline.config raises ManifestError."""
-    data = {**MINIMAL_V2, "baseline": {}}
-    path = _write_manifest(tmp_path, data)
-    with pytest.raises(ManifestError, match="baseline.config"):
-        load_manifest(path)
-
-
-def test_v3_accepted_alongside_v2(tmp_path):
-    """Version 3 is accepted; version 2 is still accepted."""
-    for ver, data in [(2, MINIMAL_V2), (3, MINIMAL_V3)]:
-        ver_dir = tmp_path / f"v{ver}"
-        ver_dir.mkdir()
-        path = _write_manifest(ver_dir, data)
-        m = load_manifest(path)
-        assert m["version"] == ver
 
 
 # ── v3 fields ────────────────────────────────────────────────────────────────
@@ -523,13 +471,6 @@ def test_v3_pipeline_not_mapping_raises(tmp_path):
     path = _write_manifest(tmp_path, data)
     with pytest.raises(ManifestError, match="pipeline must be a mapping"):
         load_manifest(path)
-
-
-def test_v2_does_not_get_pipeline_field(tmp_path):
-    """v2 manifests do not get the pipeline field injected."""
-    path = _write_manifest(tmp_path, MINIMAL_V2)
-    m = load_manifest(path)
-    assert "pipeline" not in m
 
 
 # ── Multi-baseline (v3 extension) ─────────────────────────────────────────


### PR DESCRIPTION
Closes #53

## Summary

- Remove v1 special-case block and v2 normalization branch from `manifest.py` — only `version: 3` is now accepted; any other version gets a generic `Unsupported manifest version` error
- Delete 7 v2-only tests, rebase 18 tests from `MINIMAL_V2` fixture onto `MINIMAL_V3`, remove the `MINIMAL_V2` fixture, add `test_v2_rejected`
- Update CLAUDE.md manifest description from "(v2/v3 schema)" to "(v3 schema)"

## Reviewer notes

- `test_missing_baseline_config` was deleted (not rebased) because `baseline: {}` is valid under v3 (defaults to `sim: {config: None}`), whereas v2 required the flat `baseline.config` key
- `test_missing_required_field` still works after rebase: removing `baseline` from a v3 manifest triggers "Missing required field: baseline or baselines" which matches the `match="baseline"` assertion

## Test plan

- [x] All 492 pipeline tests pass
- [x] `ruff check pipeline/ --select F` clean
- [x] Smoke test: version 2 manifest correctly rejected with `Unsupported manifest version: 2`
- [x] No residual v2 references in `manifest.py`, `test_manifest.py`, or `CLAUDE.md`