### PR TITLE
Remove config.kind assembly validation check

### DIFF
--- a/pipeline/prepare.py
+++ b/pipeline/prepare.py
@@ -585,7 +585,6 @@ def _validate_assembly(run_dir: Path, resolved: dict, algorithm_packages: list[s
         warn("translation_output.json is not valid JSON — skipping validation")
         return
     plugin_type = output["plugin_type"]
-    config_cfg = resolved.get("config", {})
     target = resolved.get("target", {})
     treatment_config_generated = output.get("treatment_config_generated", True)
 
@@ -622,21 +621,7 @@ def _validate_assembly(run_dir: Path, resolved: dict, algorithm_packages: list[s
                     errors.append(
                         f"plugin_type '{plugin_type}' not found in {pkg_name}.yaml")
 
-    # Check 3: algorithm config contains expected kind (may be nested in scenario overlay)
-    if treatment_config_generated and config_cfg.get("kind"):
-        check_names = algorithm_packages or ["treatment"]
-        for pkg_name in check_names:
-            tc_path = run_dir / "generated" / f"{pkg_name}_config.yaml"
-            if not tc_path.exists():
-                tc_path = run_dir / "generated" / "treatment_config.yaml"
-            if tc_path.exists():
-                tc_text = tc_path.read_text()
-                expected_kind = config_cfg["kind"]
-                if f"kind: {expected_kind}" not in tc_text:
-                    errors.append(
-                        f"{pkg_name} config does not contain 'kind: {expected_kind}'")
-
-    # Check 4: all files_created exist in target repo
+    # Check 3: all files_created exist in target repo
     target_repo = target.get("repo", "")
     for f in output.get("files_created", []):
         if target_repo and not (EXPERIMENT_ROOT / target_repo / f).exists():

--- a/pipeline/tests/test_prepare.py
+++ b/pipeline/tests/test_prepare.py
@@ -746,38 +746,6 @@ class TestValidateAssembly:
         with pytest.raises(SystemExit):
             mod._validate_assembly(run_dir, resolved)
 
-    def test_fails_kind_mismatch(self, repo):
-        mod = _import_prepare_with_root(repo)
-        run_dir = repo / "workspace" / "runs" / "test-run"
-        run_dir.mkdir(parents=True, exist_ok=True)
-
-        resolved = {"target": {"repo": "llm-d-inference-scheduler"}, "config": {"kind": "EndpointPickerConfig"}}
-
-        output = {
-            "plugin_type": "test-scorer",
-            "files_created": [],
-            "files_modified": [],
-            "register_file": "pkg/plugins/register.go",
-            "treatment_config_generated": True,
-        }
-        (run_dir / "translation_output.json").write_text(json.dumps(output))
-
-        # register.go contains the plugin type
-        register_path = repo / "llm-d-inference-scheduler" / "pkg" / "plugins" / "register.go"
-        register_path.write_text('Register("test-scorer", NewTestScorer)')
-
-        # treatment.yaml contains the plugin type
-        cluster_dir = run_dir / "cluster"
-        cluster_dir.mkdir(parents=True, exist_ok=True)
-        (cluster_dir / "treatment.yaml").write_text("- type: test-scorer\n")
-
-        # treatment_config has wrong kind
-        (run_dir / "generated").mkdir(parents=True, exist_ok=True)
-        _write_yaml(run_dir / "generated" / "treatment_config.yaml", {"kind": "WrongKind"})
-
-        with pytest.raises(SystemExit):
-            mod._validate_assembly(run_dir, resolved)
-
     def test_fails_files_created_missing(self, repo):
         mod = _import_prepare_with_root(repo)
         run_dir = repo / "workspace" / "runs" / "test-run"
@@ -861,31 +829,6 @@ class TestValidateAssembly:
 
         mod._validate_assembly(run_dir, resolved)  # should not raise
 
-    def test_check3_skipped_when_not_generated(self, repo):
-        """treatment_config_generated=False — Check 3 (kind match) skipped."""
-        mod = _import_prepare_with_root(repo)
-        run_dir = repo / "workspace" / "runs" / "test-run"
-        run_dir.mkdir(parents=True, exist_ok=True)
-
-        resolved = {"target": {"repo": "llm-d-inference-scheduler"}, "config": {"kind": "EndpointPickerConfig"}}
-        output = {
-            "plugin_type": "test-scorer",
-            "files_created": [],
-            "files_modified": ["pkg/plugins/scorer/precise_prefix_cache.go"],
-            "register_file": "pkg/plugins/register.go",
-            "treatment_config_generated": False,
-        }
-        (run_dir / "translation_output.json").write_text(json.dumps(output))
-
-        register = repo / "llm-d-inference-scheduler" / "pkg" / "plugins" / "register.go"
-        register.write_text('Register("test-scorer", NewTestScorer)')
-
-        cluster_dir = run_dir / "cluster"
-        cluster_dir.mkdir(parents=True, exist_ok=True)
-        (cluster_dir / "treatment.yaml").write_text("type: test-scorer\n")
-        # No treatment_config.yaml — but treatment_config_generated=False, so Check 3 is skipped
-
-        mod._validate_assembly(run_dir, resolved)  # should not raise
 
 
 # ── Config resolution ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Removes the redundant Check 3 block from `_validate_assembly()` in `prepare.py` — a raw substring check (`kind: X` in generated YAML text) that only verified the translate skill echoed back a value it was given as input
- Removes the dead `config_cfg` variable (only consumer was Check 3)
- Deletes two test methods: `test_fails_kind_mismatch` and `test_check3_skipped_when_not_generated`
- Renumbers old Check 4 → Check 3

Net: **-73 lines**, 555 tests pass, lint clean.

Closes #94

## Reviewer notes

The passing-path tests (`test_register_null_skips_check1`, `test_check2_uses_treatment_yaml`) still set up `kind` in their `resolved` dict and write `treatment_config.yaml` — this fixture data is now inert (not consumed by any check) but doesn't harm the tests and removing it would be a separate cleanup scope.

## Test plan

- [x] `ruff check pipeline/ .claude/skills/ --select F` — clean
- [x] `python -m pytest pipeline/ .claude/skills/sim2real-analyze/tests/ .claude/skills/sim2real-translate/tests/ -v` — 555 passed