### PR TITLE
Remove observe.request_multiplier

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,5 +166,3 @@ If a fix only exists in `workspace/`, it will be silently lost the next time tha
 - `treatment_resolved = deep_merge(deep_merge(baseline_resolved, treatment_diffs), treatment_overlay)`
 - EPP image injected into treatment scenarios from `run_metadata.json`
 - PipelineRuns generated per workload × {baseline, treatment}
-
-**Manifest config** — `observe.request_multiplier` (number, default `1`): multiplies each workload's `num_requests` for real-cluster benchmarks. Set in `transfer.yaml` under `observe:`.

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -22,7 +22,7 @@ python pipeline/deploy.py  --experiment-root ../admission-control
 ```
 
 The experiment repo must contain:
-- `transfer.yaml` (or `config/transfer.yaml` for backward compat) — v3 schema with `target`, `config`, `observe`, `build`, `epp_image` fields
+- `transfer.yaml` (or `config/transfer.yaml` for backward compat) — v3 schema with `target`, `config`, `build`, `epp_image` fields
 - `baseline.yaml` — llmdbenchmark-style scenario file (required for Phase 4 assembly)
 - `treatment.yaml` (optional) — merged into `baseline.yaml` for the treatment scenario
 - `algorithm/` and `workloads/` directories as referenced in `transfer.yaml`
@@ -87,7 +87,7 @@ python pipeline/prepare.py [--force] [--rebuild-context] [--manifest PATH] [--ru
 
 **Phase 3 checkpoint**: writes `skill_input.json` and exits cleanly (exit 0). Run `/sim2real-translate` in Claude Code, then re-run `prepare.py` to continue from Phase 4. When no `algorithm` is present in the manifest, Phase 3 is skipped entirely (baseline-only mode).
 
-**Phase 4 assembly** reads `baseline.yaml` and `treatment.yaml` from the experiment root, merges them with skill-generated overlay files (`generated/baseline_config.yaml`, `generated/treatment_config.yaml`), and writes resolved scenario files to `cluster/`. PipelineRuns are generated with a `scenarioContent` param containing the fully resolved scenario YAML. Workloads are loaded from the manifest and scaled by `observe.request_multiplier`.
+**Phase 4 assembly** reads `baseline.yaml` and `treatment.yaml` from the experiment root, merges them with skill-generated overlay files (`generated/baseline_config.yaml`, `generated/treatment_config.yaml`), and writes resolved scenario files to `cluster/`. PipelineRuns are generated with a `scenarioContent` param containing the fully resolved scenario YAML. Workloads are loaded from the manifest.
 
 **Phase 6 gate**: `d` marks the run `READY TO DEPLOY` (required by `deploy.py`). `e` drops you back to edit files, then re-displays the summary. `q` marks `abandoned` and exits.
 
@@ -275,8 +275,6 @@ target:
 config:
   kind: <string>            # config kind (e.g. "gaie")
   helm_path: <path>         # Helm chart path within target repo
-observe:                    # optional — defaults applied if absent
-  request_multiplier: 1     # scales workload num_requests for real-cluster benchmarks (default: 1)
 build:                      # optional — defaults applied if absent
   commands: []              # EPP build commands
 epp_image:                  # optional

--- a/pipeline/lib/manifest.py
+++ b/pipeline/lib/manifest.py
@@ -211,15 +211,6 @@ def _validate_v3_fields(data: dict) -> None:
     if "helm_path" not in config:
         raise ManifestError("Missing required field: config.helm_path")
 
-    # observe (optional, defaults applied)
-    observe = data.get("observe")
-    if observe is None:
-        data["observe"] = {"request_multiplier": 1}
-    elif not isinstance(observe, dict):
-        raise ManifestError("observe must be a mapping")
-    else:
-        observe.setdefault("request_multiplier", 1)
-
     # build (optional, defaults applied)
     build = data.get("build")
     if build is None:

--- a/pipeline/prepare.py
+++ b/pipeline/prepare.py
@@ -104,9 +104,9 @@ def _load_setup_config() -> dict:
 
 
 def _load_resolved_config(manifest: dict) -> dict:
-    """Build resolved config from manifest v3 fields (target, config, observe, build, epp_image)."""
+    """Build resolved config from manifest v3 fields (target, config, build, epp_image)."""
     resolved = {}
-    for key in ("target", "config", "observe", "build", "epp_image"):
+    for key in ("target", "config", "build", "epp_image"):
         if key in manifest:
             resolved[key] = manifest[key]
     return resolved
@@ -430,12 +430,7 @@ def _phase_assembly(args, state: StateMachine, manifest: dict, run_dir: Path,
 
     ok(f"Resolved scenarios: {_display_path(cluster_dir)}")
 
-    # 4d: Load and scale workloads
-    try:
-        multiplier = int(manifest.get("observe", {}).get("request_multiplier", 1))
-    except (TypeError, ValueError):
-        err("observe.request_multiplier must be a number")
-        sys.exit(1)
+    # 4d: Load workloads
     workloads = []
     for wl_path_str in manifest.get("workloads", []):
         wl_path = EXPERIMENT_ROOT / wl_path_str
@@ -452,8 +447,6 @@ def _phase_assembly(args, state: StateMachine, manifest: dict, run_dir: Path,
             sys.exit(1)
         if "name" not in wl_data and "workload_name" not in wl_data:
             wl_data["workload_name"] = Path(wl_path_str).stem
-        if multiplier > 1 and "num_requests" in wl_data:
-            wl_data["num_requests"] = int(wl_data["num_requests"] * multiplier)
         workloads.append(wl_data)
 
     if not workloads:
@@ -701,10 +694,9 @@ def _phase_summary(state: StateMachine, manifest: dict, run_dir: Path, resolved:
 
     # Workloads
     lines.extend(["", "**Workloads**", ""])
-    multiplier = resolved.get("observe", {}).get("request_multiplier", 1)
     for wl in manifest["workloads"]:
         wl_name = Path(wl).stem
-        lines.append(f"- {wl_name} (x{multiplier})")
+        lines.append(f"- {wl_name}")
 
     # Checklist
     if translation_output_path.exists():

--- a/pipeline/tests/test_manifest.py
+++ b/pipeline/tests/test_manifest.py
@@ -285,22 +285,6 @@ def test_v3_target_and_config_loaded(tmp_path):
     assert "helm_path" in m["config"]
 
 
-def test_v3_observe_defaults(tmp_path):
-    """v3 without observe section gets default request_multiplier=1."""
-    data = {k: v for k, v in MINIMAL_V3.items() if k != "observe"}
-    path = _write_manifest(tmp_path, data)
-    m = load_manifest(path)
-    assert m["observe"]["request_multiplier"] == 1
-
-
-def test_v3_observe_explicit(tmp_path):
-    """v3 with explicit observe.request_multiplier preserves value."""
-    data = {**MINIMAL_V3, "observe": {"request_multiplier": 10}}
-    path = _write_manifest(tmp_path, data)
-    m = load_manifest(path)
-    assert m["observe"]["request_multiplier"] == 10
-
-
 def test_v3_build_defaults(tmp_path):
     """v3 without build section gets default commands=[]."""
     data = {k: v for k, v in MINIMAL_V3.items() if k != "build"}

--- a/pipeline/tests/test_prepare.py
+++ b/pipeline/tests/test_prepare.py
@@ -39,7 +39,6 @@ MINIMAL_MANIFEST = {
         "kind": "EndpointPickerConfig",
         "helm_path": "gaie.treatment.helmValues.inferenceExtension.pluginsCustomConfig.custom-plugins.yaml",
     },
-    "observe": {"request_multiplier": 10},
     "build": {"commands": [["go", "build", "./..."]]},
 }
 
@@ -896,7 +895,6 @@ class TestConfigResolution:
         manifest = dict(MINIMAL_MANIFEST)
         resolved = mod._load_resolved_config(manifest)
         # Should have merged common + routing scenario
-        assert resolved["observe"]["request_multiplier"] == 10
         assert resolved["target"]["repo"] == "llm-d-inference-scheduler"
         assert resolved["config"]["kind"] == "EndpointPickerConfig"
 
@@ -1321,7 +1319,7 @@ class TestBaselineOnlyNoAlgorithm:
         state.mark_done("translate", mode="baseline-only")
         state.mark_done("assembly", packages=["baseline"])
 
-        resolved = {"observe": {"request_multiplier": 1}}
+        resolved = {}
 
         # Should not crash even with stale translation_output.json
         mod._phase_summary(state, manifest, run_dir, resolved)


### PR DESCRIPTION
Closes #95

## Summary

- Remove `observe` section validation and defaults from `pipeline/lib/manifest.py`
- Remove multiplier scaling logic (Phase 4) and multiplier display (Phase 5) from `pipeline/prepare.py`
- Remove `"observe"` from `_load_resolved_config` key set
- Clean up all test fixtures referencing `observe.request_multiplier` in `test_manifest.py` and `test_prepare.py`
- Remove `observe.request_multiplier` documentation from `CLAUDE.md`

## Reviewer Notes

The vet review identified 3 additional locations beyond the issue's change list (`prepare.py:107-109`, `test_prepare.py:42`, `test_prepare.py:899`, `test_prepare.py:1324`). All have been addressed — `grep -rn request_multiplier pipeline/` returns zero hits.

## Test Plan

- [x] `ruff check pipeline/ --select F` — all checks passed
- [x] `python -m pytest pipeline/ -v` — 490 passed, 0 failed
- [x] Zero remaining references to `request_multiplier` in pipeline code