### PR TITLE
Remove config.helm_path and round-trip validation

### DIFF
--- a/.claude/skills/sim2real-translate/SKILL.md
+++ b/.claude/skills/sim2real-translate/SKILL.md
@@ -617,7 +617,7 @@ import json, sys
 from pathlib import Path
 o = json.load(open('$RUN_DIR/translation_output.json'))
 required = ['plugin_type', 'files_created', 'files_modified', 'package',
-            'register_file', 'test_commands', 'config_kind', 'helm_path',
+            'register_file', 'test_commands', 'config_kind',
             'treatment_config_generated', 'description']
 missing = [f for f in required if f not in o]
 if missing:

--- a/.claude/skills/sim2real-translate/tests/test_copy_generated.py
+++ b/.claude/skills/sim2real-translate/tests/test_copy_generated.py
@@ -46,7 +46,6 @@ def run_dir(tmp_path):
         "register_file": "register.go",
         "test_commands": ["go test ./..."],
         "config_kind": "ScorerConfig",
-        "helm_path": "epp.scorerConfig",
         "treatment_config_generated": True,
         "description": "test plugin",
     }))

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -274,7 +274,6 @@ target:
   repo: <path>              # llm-d-inference-scheduler repo path
 config:
   kind: <string>            # config kind (e.g. "gaie")
-  helm_path: <path>         # Helm chart path within target repo
 observe:                    # optional — defaults applied if absent
   request_multiplier: 1     # scales workload num_requests for real-cluster benchmarks (default: 1)
 build:                      # optional — defaults applied if absent

--- a/pipeline/lib/manifest.py
+++ b/pipeline/lib/manifest.py
@@ -208,8 +208,6 @@ def _validate_v3_fields(data: dict) -> None:
         raise ManifestError("config must be a mapping")
     if "kind" not in config:
         raise ManifestError("Missing required field: config.kind")
-    if "helm_path" not in config:
-        raise ManifestError("Missing required field: config.helm_path")
 
     # observe (optional, defaults applied)
     observe = data.get("observe")

--- a/pipeline/prepare.py
+++ b/pipeline/prepare.py
@@ -300,7 +300,7 @@ def _phase_translate(args, state: StateMachine, manifest: dict, run_dir: Path,
         output = json.loads(output_path.read_text())
         # Validate required fields
         for f in ["plugin_type", "files_created", "files_modified",
-                  "package", "test_commands", "config_kind", "helm_path",
+                  "package", "test_commands", "config_kind",
                   "treatment_config_generated", "description"]:
             if f not in output:
                 err(f"translation_output.json missing required field: {f}")

--- a/pipeline/tests/test_manifest.py
+++ b/pipeline/tests/test_manifest.py
@@ -194,7 +194,6 @@ MINIMAL_V3 = {
     "target": {"repo": "llm-d-inference-scheduler"},
     "config": {
         "kind": "EndpointPickerConfig",
-        "helm_path": "gaie.treatment.helmValues.inferenceExtension.pluginsCustomConfig.custom-plugins.yaml",
     },
     "epp_image": {
         "upstream": {
@@ -282,7 +281,6 @@ def test_v3_target_and_config_loaded(tmp_path):
     m = load_manifest(path)
     assert m["target"]["repo"] == "llm-d-inference-scheduler"
     assert m["config"]["kind"] == "EndpointPickerConfig"
-    assert "helm_path" in m["config"]
 
 
 def test_v3_observe_defaults(tmp_path):
@@ -405,18 +403,11 @@ def test_v3_config_absent_raises(tmp_path):
 
 def test_v3_config_missing_kind_raises(tmp_path):
     """config without kind raises."""
-    data = {**MINIMAL_V3, "config": {"helm_path": "x"}}
+    data = {**MINIMAL_V3, "config": {}}
     path = _write_manifest(tmp_path, data)
     with pytest.raises(ManifestError, match="config.kind"):
         load_manifest(path)
 
-
-def test_v3_config_missing_helm_path_raises(tmp_path):
-    """config without helm_path raises."""
-    data = {**MINIMAL_V3, "config": {"kind": "EndpointPickerConfig"}}
-    path = _write_manifest(tmp_path, data)
-    with pytest.raises(ManifestError, match="config.helm_path"):
-        load_manifest(path)
 
 
 def test_v3_target_missing_repo_raises(tmp_path):
@@ -487,7 +478,6 @@ MULTI_BASELINE_V3 = {
     "target": {"repo": "llm-d-inference-scheduler"},
     "config": {
         "kind": "EndpointPickerConfig",
-        "helm_path": "gaie.treatment.helmValues.inferenceExtension.pluginsCustomConfig.custom-plugins.yaml",
     },
 }
 

--- a/pipeline/tests/test_prepare.py
+++ b/pipeline/tests/test_prepare.py
@@ -37,7 +37,6 @@ MINIMAL_MANIFEST = {
     "target": {"repo": "llm-d-inference-scheduler"},
     "config": {
         "kind": "EndpointPickerConfig",
-        "helm_path": "gaie.treatment.helmValues.inferenceExtension.pluginsCustomConfig.custom-plugins.yaml",
     },
     "observe": {"request_multiplier": 10},
     "build": {"commands": [["go", "build", "./..."]]},
@@ -296,7 +295,6 @@ class TestPhaseTranslate:
             "package": "scorer",
             "test_commands": [["go", "test", "./..."]],
             "config_kind": "EndpointPickerConfig",
-            "helm_path": "gaie.treatment.helmValues.config",
             "treatment_config_generated": True,
             "description": "Adaptive v2 scorer",
             "register_file": "pkg/plugins/register.go",
@@ -449,7 +447,6 @@ class TestPhaseTranslate:
             "files_modified": [],
             "package": "scorer",
             "config_kind": "EndpointPickerConfig",
-            "helm_path": "some.path",
             "treatment_config_generated": True,
             "description": "A test scorer",
             "register_file": None,
@@ -486,7 +483,6 @@ class TestPhaseTranslate:
             "package": "scorer",
             "test_commands": [["go", "test", "./..."]],
             "config_kind": "EndpointPickerConfig",
-            "helm_path": "some.path",
             "treatment_config_generated": True,
             "description": "A test scorer",
             # missing register_file
@@ -522,7 +518,6 @@ class TestPhaseTranslate:
             "package": "scorer",
             "test_commands": [["go", "test", "./..."]],
             "config_kind": "EndpointPickerConfig",
-            "helm_path": "some.path",
             "treatment_config_generated": True,
             "description": "A test scorer",
             "register_file": "pkg/plugins/register.go",
@@ -617,7 +612,6 @@ class TestPhaseTranslate:
             "target": {"repo": "llm-d-inference-scheduler"},
             "config": {
                 "kind": "EndpointPickerConfig",
-                "helm_path": "gaie.treatment.helmValues.inferenceExtension.pluginsCustomConfig.custom-plugins.yaml",
             },
         }
         _write_yaml(repo / "config" / "transfer.yaml", v3_data)
@@ -928,7 +922,7 @@ class TestExperimentRootSeparation:
             "baseline": {"sim": {"config": None}, "real": {"config": None, "notes": ""}},
             "workloads": ["workloads/w1.yaml"],
             "target": {"repo": "llm-d-inference-scheduler"},
-            "config": {"kind": "AdmissionConfig", "helm_path": "x"},
+            "config": {"kind": "AdmissionConfig"},
         }
         _write_yaml(exp / "transfer.yaml", manifest_data)
         _write_text(exp / "algorithm" / "admission.go", "package main\n")
@@ -1142,7 +1136,6 @@ class TestBaselineOnlyAssembly:
             "package": "scorer",
             "test_commands": [["go", "test", "./..."]],
             "config_kind": "EndpointPickerConfig",
-            "helm_path": "gaie.treatment.helmValues.config",
             "treatment_config_generated": True,
             "description": "Test scorer plugin",
             "register_file": "pkg/plugins/register.go",

--- a/prompts/prepare/agent-reviewer.md
+++ b/prompts/prepare/agent-reviewer.md
@@ -165,8 +165,6 @@ Verify:
 - `treatment_config_generated: true` is set in `translation_output.json`
 - Every key in the treatment overlay also appears in the baseline structure, or is explicitly
   justified (no invented keys that would silently be ignored by the EPP)
-- `helm_path` in `translation_output.json` matches `config.helm_path` from the manifest
-
 Raise any problem as `[assembly]` NEEDS_CHANGES. Assembly failures only manifest at
 Phase 4 and are silent — catch them here.
 
@@ -208,7 +206,7 @@ Verification summary (required — one line per criterion):
 - Code quality: [confirm interfaces correct, no dead code, patterns followed]
 - Registration: TypeConst=<exact value>, Factory=<name>, register.go line ~<N>
 - Config: kind=<value>, all plugin types registered, keys match baseline
-- Assembly: baseline bundle shape matches, overlay YAML valid, helm_path correct,
+- Assembly: baseline bundle shape matches, overlay YAML valid,
   treatment_config_generated=true
 ```
 

--- a/prompts/prepare/agent-writer.md
+++ b/prompts/prepare/agent-writer.md
@@ -190,7 +190,7 @@ Follow `prompts/prepare/translate.md`. Specifically:
 ## Phase 4.5: Write Preliminary translation_output.json
 
 After writing all plugin code (but before running the build), write `{RUN_DIR}/translation_output.json`
-with all 10 required fields you now know. This must exist before the first snapshot.
+with all 9 required fields you now know. This must exist before the first snapshot.
 
 If the file list changes in a later round (e.g., you add or remove files), update it.
 
@@ -322,7 +322,7 @@ Then exit.
 
 ### `{RUN_DIR}/translation_output.json`
 
-Write this file with ALL 10 required fields:
+Write this file with ALL 9 required fields:
 
 ```json
 {

--- a/prompts/prepare/agent-writer.md
+++ b/prompts/prepare/agent-writer.md
@@ -337,7 +337,6 @@ Write this file with ALL 10 required fields:
     ["go", "test", "-timeout", "10m", "./pkg/plugins/<pkg>/...", "-v"]
   ],
   "config_kind": "{CONFIG_KIND}",
-  "helm_path": "gaie.treatment.helmValues.inferenceExtension.pluginsCustomConfig.custom-plugins.yaml",
   "treatment_config_generated": true,
   "description": "<one-line summary of what was built>"
 }


### PR DESCRIPTION
Closes #96

## Summary
- Remove `config.helm_path` required-field validation from `manifest.py`
- Remove `helm_path` from `translation_output.json` required fields in `prepare.py`
- Remove all `helm_path` references from test fixtures, prompts, translate skill, and README

## Context
`helm_path` was never consumed by pipeline logic — it followed a pure round-trip: manifest validates it, passes it to the skill via `skill_input.json`, skill echoes it back in `translation_output.json`, prepare validates the echo. No downstream code (deploy, assemble, tekton) ever reads the value.

## Test Plan
- [x] All 523 tests pass (`pytest pipeline/ .claude/skills/sim2real-translate/tests/`)
- [x] Lint clean (`ruff check pipeline/ .claude/skills/ --select F`)
- [x] `grep -rn helm_path pipeline/ prompts/ .claude/skills/` returns zero matches