### PR TITLE
Consolidate hints + context into unified context section

### DIFF
--- a/.claude/skills/sim2real-translate/SKILL.md
+++ b/.claude/skills/sim2real-translate/SKILL.md
@@ -139,7 +139,7 @@ import json, sys
 si = json.load(open('$RUN_DIR/skill_input.json'))
 required = ['run_name', 'run_dir', 'scenario', 'context_path', 'manifest_path',
             'algorithm_source', 'baseline_sim_config',
-            'target', 'build_commands', 'config_kind', 'hints']
+            'target', 'build_commands', 'config_kind', 'context']
 missing = [f for f in required if f not in si]
 if missing:
     print(f'HALT: skill_input.json missing fields: {missing}')
@@ -163,15 +163,7 @@ ALGO_SOURCE=$EXPERIMENT_ROOT/$(python3 -c "import json; print(json.load(open('$R
 ALGO_CONFIG=$(python3 -c "import json; v=json.load(open('$RUN_DIR/skill_input.json')).get('algorithm_config'); print('$EXPERIMENT_ROOT/' + v if v else '')")
 TARGET_REPO=$EXPERIMENT_ROOT/$(python3 -c "import json; print(json.load(open('$RUN_DIR/skill_input.json'))['target']['repo'])")
 CONFIG_KIND=$(python3 -c "import json; print(json.load(open('$RUN_DIR/skill_input.json'))['config_kind'])")
-HINTS_TEXT=$(python3 -c "import json; print(json.load(open('$RUN_DIR/skill_input.json')).get('hints', {}).get('text', ''))")
-HINTS_FILES_CONTENT=$(python3 -c "
-import json
-hints = json.load(open('$RUN_DIR/skill_input.json')).get('hints', {}).get('files', [])
-for f in hints:
-    print(f'### {f[\"path\"]}')
-    print(f['content'])
-    print()
-")
+CONTEXT_TEXT=$(python3 -c "import json; print(json.load(open('$RUN_DIR/skill_input.json')).get('context', {}).get('text', ''))")
 BASELINE_SIM_CONFIG=$(python3 -c "import json; v=json.load(open('$RUN_DIR/skill_input.json'))['baseline_sim_config']; print('$EXPERIMENT_ROOT/' + v if v else '')")
 BASELINE_REAL_CONFIG=$(python3 -c "import json; v=json.load(open('$RUN_DIR/skill_input.json')).get('baseline_real_config'); print('$EXPERIMENT_ROOT/' + v if v else 'null')")
 BASELINE_REAL_NOTES=$(python3 -c "import json; print(json.load(open('$RUN_DIR/skill_input.json')).get('baseline_real_notes', ''))")
@@ -310,7 +302,7 @@ Scenario: $SCENARIO | inference-sim@<sha> | llm-d@<sha>
 [full contents]
 ```
 
-Do NOT include hints in the context file — hints are held in session memory via $HINTS_TEXT and $HINTS_FILES_CONTENT.
+Do NOT include context.text in the context file — it is held in session memory via $CONTEXT_TEXT.
 
 Verify the file was written:
 
@@ -363,8 +355,8 @@ all `{PLACEHOLDER}` values with the corresponding shell variables
 `{EXPERT_AGENT_NAME}` → `"expert"`,
 `{TARGET_REPO}` → `$TARGET_REPO`, `{CONFIG_KIND}` →
 `$CONFIG_KIND`, `{REVIEW_ROUNDS}` → `$REVIEW_ROUNDS`, `{SCENARIO}` →
-`$SCENARIO`, `{BUILD_COMMANDS}` → `$BUILD_COMMANDS`, `{HINTS_TEXT}` →
-`$HINTS_TEXT`, `{HINTS_FILES_CONTENT}` → `$HINTS_FILES_CONTENT`,
+`$SCENARIO`, `{BUILD_COMMANDS}` → `$BUILD_COMMANDS`, `{CONTEXT_TEXT}` →
+`$CONTEXT_TEXT`,
 `{MAIN_SESSION_NAME}` → `"main-session"`).
 
 Use TeamCreate to create the team:

--- a/.claude/skills/sim2real-translate/scripts/review.py
+++ b/.claude/skills/sim2real-translate/scripts/review.py
@@ -91,7 +91,7 @@ def build_user_message(
     context_doc: str,
     treatment_config: str,
     round_num: int,
-    hints_json: "str | None" = None,
+    context_json: "str | None" = None,
 ) -> str:
     base = (
         f"## Review Round {round_num}\n\n"
@@ -104,20 +104,14 @@ def build_user_message(
         f"## Translation Context\n{context_doc}\n\n"
         f"## Treatment Config\n```yaml\n{treatment_config}\n```\n"
     )
-    if hints_json:
+    if context_json:
         try:
-            hints = json.loads(hints_json)
-            hints_text = hints.get("text", "")
-            hints_files = hints.get("files", [])
-            if hints_text or hints_files:
-                parts = ["\n## Transfer Hints (user's mandate for this run)\n"]
-                if hints_text:
-                    parts.append(hints_text)
-                for f in hints_files:
-                    parts.append(f"\n### {f.get('path', 'hint')}\n{f.get('content', '')}")
-                base = base + "\n".join(parts)
+            ctx = json.loads(context_json)
+            ctx_text = ctx.get("text", "")
+            if ctx_text:
+                base += f"\n## Transfer Context (operator's mandate for this run)\n{ctx_text}\n"
         except (json.JSONDecodeError, AttributeError):
-            pass  # hints are optional; don't fail review if malformed
+            pass
     return base
 
 
@@ -300,7 +294,7 @@ def run_review_round(
     models: list,
     api_key: str,
     base_url: str,
-    hints_json: "str | None" = None,
+    context_json: "str | None" = None,
 ) -> list:
     """Run one review round across all models in parallel."""
     plugin_parts = []
@@ -318,7 +312,7 @@ def run_review_round(
             Path(context).read_text(),
             Path(treatment_config).read_text(),
             round_num,
-            hints_json=hints_json,
+            context_json=context_json,
         )},
     ]
 
@@ -373,9 +367,9 @@ def main():
         "--dev", action="store_true", help="Dev mode: only aws/claude-opus-4-6"
     )
     parser.add_argument(
-        "--hints-json", dest="hints_json", default=None,
-        help="Optional JSON string with hints {text, files:[{path, content}]}. "
-             "Used to evaluate whether translation honored the user's mandate."
+        "--context-json", dest="context_json", default=None,
+        help="Optional JSON string with context {text}. "
+             "Used to evaluate whether translation honored the operator's instructions."
     )
     args = parser.parse_args()
 
@@ -409,7 +403,7 @@ def main():
         models,
         api_key,
         base_url,
-        hints_json=getattr(args, "hints_json", None),
+        context_json=args.context_json,
     )
     has_consensus, approve_count, total_successful = check_consensus(reviews)
 

--- a/.claude/skills/sim2real-translate/tests/test_review.py
+++ b/.claude/skills/sim2real-translate/tests/test_review.py
@@ -189,3 +189,22 @@ def test_collect_issues_string_coercion():
 def test_collect_issues_ignores_errors():
     reviews = [{"verdict": "ERROR", "issues": []}]
     assert rv.collect_issues(reviews) == []
+
+
+def test_build_user_message_with_context_json():
+    """context_json with text is included in the user message."""
+    import json
+    ctx = json.dumps({"text": "Modify scorer X"})
+    msg = rv.build_user_message("package p", "func algo(){}", None,
+                                 "# Context", "kind: Scorer", 1,
+                                 context_json=ctx)
+    assert "Modify scorer X" in msg
+    assert "Transfer Context" in msg
+
+
+def test_build_user_message_context_json_none():
+    """context_json=None produces no extra section."""
+    msg = rv.build_user_message("package p", "func algo(){}", None,
+                                 "# Context", "kind: Scorer", 1,
+                                 context_json=None)
+    assert "operator" not in msg

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -262,11 +262,8 @@ baseline:
 workloads:
   - <path>                  # one or more workload YAMLs
 
-hints:
-  files: [<path>, ...]      # hint files passed to translation skill
-  text: |                   # freeform hint text
-
 context:
+  text: |                   # freeform instructions for translation skill
   files: [<path>, ...]      # files assembled into context document (Phase 2)
 
 # v3 fields (required unless noted)

--- a/pipeline/lib/manifest.py
+++ b/pipeline/lib/manifest.py
@@ -1,6 +1,5 @@
 """Manifest loader for sim2real pipeline (v3 schema)."""
 import re
-import warnings
 import yaml
 from pathlib import Path
 
@@ -162,28 +161,22 @@ def load_manifest(path: "Path | str") -> dict:
             f"duplicates: {sorted(set(dupes))}"
         )
 
-    # Hints section (optional)
-    hints_raw = data.get("hints", {}) or {}
-    hints_text = hints_raw.get("text", "") or ""
-    hints_files_raw = hints_raw.get("files", []) or []
-    hints_files = []
-    for fpath in hints_files_raw:
-        fp = Path(fpath)
-        if not fp.exists():
-            raise ManifestError(f"hints.files entry not found: {fpath}")
-        hints_files.append({"path": str(fp), "content": fp.read_text()})
-    data["hints"] = {"text": hints_text, "files": hints_files}
+    # Context section (optional): only 'text' and 'files' are valid keys
+    ctx_raw = data.get("context", {}) or {}
+    _valid_context_keys = {"text", "files"}
+    unknown = set(ctx_raw.keys()) - _valid_context_keys
+    if unknown:
+        raise ManifestError(
+            f"context contains unknown keys: {sorted(unknown)}. "
+            f"Valid keys: text, files"
+        )
+    ctx_text = ctx_raw.get("text", "") or ""
+    ctx_files = ctx_raw.get("files", []) or []
+    if not isinstance(ctx_files, list):
+        raise ManifestError("context.files must be a list")
+    data["context"] = {"text": ctx_text, "files": ctx_files}
 
     _validate_v3_fields(data)
-
-    # Deprecation warning for context.notes
-    if data.get("context", {}).get("notes"):
-        warnings.warn(
-            "context.notes is deprecated; use hints.text instead. "
-            "The value is currently ignored.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
 
     return data
 

--- a/pipeline/prepare.py
+++ b/pipeline/prepare.py
@@ -289,7 +289,7 @@ def _phase_translate(args, state: StateMachine, manifest: dict, run_dir: Path,
         "target": {"repo": target.get("repo", "")},
         "build_commands": commands,
         "config_kind": config_cfg.get("kind", ""),
-        "hints": manifest.get("hints", {"text": "", "files": []}),
+        "context": {"text": manifest.get("context", {}).get("text", "")},
     }
     skill_input_path = run_dir / "skill_input.json"
     skill_input_path.write_text(json.dumps(skill_input, indent=2))

--- a/pipeline/setup.py
+++ b/pipeline/setup.py
@@ -779,7 +779,7 @@ def main() -> int:
     print(f"Run directory: {run_dir}")
     print()
     print("Next steps:")
-    print("  1. Edit <experiment-root>/transfer.yaml (algorithm source, workloads, context hints)")
+    print("  1. Edit <experiment-root>/transfer.yaml (algorithm source, workloads, context)")
     print("  2. Run: python <repo-root>/pipeline/prepare.py")
     return 0
 

--- a/pipeline/tests/test_manifest.py
+++ b/pipeline/tests/test_manifest.py
@@ -60,12 +60,10 @@ def test_missing_algorithm_config_is_valid(tmp_path):
 def test_optional_context_fields(tmp_path):
     data = {**MINIMAL_V3, "context": {
         "files": ["docs/mapping.md"],
-        "notes": "Use regime detection pattern",
     }}
     path = _write_manifest(tmp_path, data)
     m = load_manifest(path)
-    assert m["context"]["notes"] == "Use regime detection pattern"
-    assert len(m["context"]["files"]) == 1
+    assert m["context"]["files"] == ["docs/mapping.md"]
 
 
 def test_workloads_must_be_list(tmp_path):
@@ -126,55 +124,43 @@ def test_file_not_found():
         load_manifest(Path("/nonexistent/transfer.yaml"))
 
 
-# ── Hints section ─────────────────────────────────────────────────────────────
+# ── Context section ──────────────────────────────────────────────────────────
 
-def test_hints_section_optional(tmp_path):
-    """Manifest without hints loads cleanly; hints defaults to empty."""
+def test_context_section_optional(tmp_path):
+    """Manifest without context loads cleanly; context defaults to empty."""
     path = _write_manifest(tmp_path, MINIMAL_V3)
     m = load_manifest(path)
-    hints = m.get("hints", {})
-    assert hints.get("text", "") == ""
-    assert hints.get("files", []) == []
+    ctx = m.get("context", {})
+    assert ctx.get("text", "") == ""
+    assert ctx.get("files", []) == []
 
 
-def test_hints_text_loaded(tmp_path):
-    data = {**MINIMAL_V3, "hints": {"text": "Modify precise_prefix_cache.go"}}
+def test_context_text_loaded(tmp_path):
+    data = {**MINIMAL_V3, "context": {"text": "Modify precise_prefix_cache.go"}}
     path = _write_manifest(tmp_path, data)
     m = load_manifest(path)
-    assert m["hints"]["text"] == "Modify precise_prefix_cache.go"
+    assert m["context"]["text"] == "Modify precise_prefix_cache.go"
 
 
-def test_hints_files_contents_embedded(tmp_path):
-    hint_file = tmp_path / "hint.md"
-    hint_file.write_text("# Transfer hint\nRewrite scorer")
-    data = {**MINIMAL_V3, "hints": {"files": [str(hint_file)]}}
+def test_context_files_loaded(tmp_path):
+    data = {**MINIMAL_V3, "context": {"files": ["docs/mapping.md"]}}
     path = _write_manifest(tmp_path, data)
     m = load_manifest(path)
-    assert len(m["hints"]["files"]) == 1
-    assert m["hints"]["files"][0]["path"] == str(hint_file)
-    assert "Rewrite scorer" in m["hints"]["files"][0]["content"]
+    assert m["context"]["files"] == ["docs/mapping.md"]
 
 
-def test_hints_file_not_found_raises(tmp_path):
-    data = {**MINIMAL_V3, "hints": {"files": ["/nonexistent/hint.md"]}}
+def test_context_rejects_unknown_keys(tmp_path):
+    data = {**MINIMAL_V3, "context": {"text": "ok", "notes": "bad"}}
     path = _write_manifest(tmp_path, data)
-    with pytest.raises(ManifestError, match="hints.files"):
+    with pytest.raises(ManifestError, match="context.*unknown.*notes"):
         load_manifest(path)
 
 
-def test_context_notes_deprecated_warns(tmp_path):
-    data = {**MINIMAL_V3, "context": {"notes": "old style note", "files": []}}
+def test_context_files_must_be_list(tmp_path):
+    data = {**MINIMAL_V3, "context": {"files": "not_a_list"}}
     path = _write_manifest(tmp_path, data)
-    import warnings
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        m = load_manifest(path)
-    dep_warnings = [warning for warning in w if issubclass(warning.category, DeprecationWarning)]
-    assert dep_warnings, "No DeprecationWarning emitted"
-    texts = [str(warning.message) for warning in dep_warnings]
-    assert any("context.notes" in t and "deprecated" in t for t in texts)
-    # Value is ignored (not migrated to hints.text)
-    assert m.get("hints", {}).get("text", "") == ""
+    with pytest.raises(ManifestError, match="context.files.*list"):
+        load_manifest(path)
 
 
 # ── v3 manifest fixtures ───────────────────────────────────────────────────

--- a/pipeline/tests/test_prepare.py
+++ b/pipeline/tests/test_prepare.py
@@ -363,11 +363,10 @@ class TestPhaseTranslate:
             mod._phase_translate(Args(), state, manifest, run_dir, resolved, context_path)
         assert state.get_phase("translate").get("checkpoint_hits") == 2
 
-    def test_skill_input_contains_hints_empty(self, repo):
-        """When manifest has no hints, skill_input.json has hints={text:'', files:[]}."""
+    def test_skill_input_contains_context_empty(self, repo):
+        """When manifest has no context.text, skill_input.json has context={text:''}."""
         mod = _import_prepare_with_root(repo)
         manifest = dict(MINIMAL_MANIFEST)
-        # no 'hints' key in manifest
         run_dir = repo / "workspace" / "runs" / "test-run"
         run_dir.mkdir(parents=True, exist_ok=True)
 
@@ -386,24 +385,17 @@ class TestPhaseTranslate:
             mod._phase_translate(Args(), state, manifest, run_dir, resolved, context_path)
 
         si = json.loads((run_dir / "skill_input.json").read_text())
-        assert "hints" in si
-        assert si["hints"]["text"] == ""
-        assert si["hints"]["files"] == []
+        assert "context" in si
+        assert si["context"]["text"] == ""
+        assert "hints" not in si
         # target has only repo
         assert set(si["target"].keys()) == {"repo"}
-        # old fields removed
-        assert "context_notes" not in si
-        assert "plugin_dir" not in si.get("target", {})
-        assert "register_file" not in si.get("target", {})
 
-    def test_skill_input_contains_hints_from_manifest(self, repo):
-        """When manifest has hints, they are written to skill_input.json."""
+    def test_skill_input_contains_context_text_from_manifest(self, repo):
+        """When manifest has context.text, it is written to skill_input.json."""
         mod = _import_prepare_with_root(repo)
         manifest = dict(MINIMAL_MANIFEST)
-        manifest["hints"] = {
-            "text": "Modify scorer X",
-            "files": [{"path": "hint.md", "content": "# Hint content"}],
-        }
+        manifest["context"] = {"text": "Modify scorer X", "files": []}
         run_dir = repo / "workspace" / "runs" / "test-run2"
         run_dir.mkdir(parents=True, exist_ok=True)
 
@@ -422,8 +414,8 @@ class TestPhaseTranslate:
             mod._phase_translate(Args(), state, manifest, run_dir, resolved, context_path)
 
         si = json.loads((run_dir / "skill_input.json").read_text())
-        assert si["hints"]["text"] == "Modify scorer X"
-        assert si["hints"]["files"][0]["content"] == "# Hint content"
+        assert si["context"]["text"] == "Modify scorer X"
+        assert "hints" not in si
 
     def test_translation_output_validates_all_required_fields(self, repo):
         """translation_output.json must have all required fields."""

--- a/prompts/prepare/agent-expert.md
+++ b/prompts/prepare/agent-expert.md
@@ -27,7 +27,7 @@ Target repo: {TARGET_REPO}
 Read the following to build your foundation. These tell you what this run is translating and
 what the mapping context is.
 
-1. Read `{EXPERIMENT_ROOT}/transfer.yaml` — understand scenario, algorithm, baseline (sim + real), hints
+1. Read `{EXPERIMENT_ROOT}/transfer.yaml` — understand scenario, algorithm, baseline (sim + real), context
 2. Read the full content of `{ALGO_SOURCE}` — the simulation algorithm being translated
 3. If `{ALGO_CONFIG}` is non-empty: read it — algorithm weights and thresholds (ground truth)
 4. Read `{BASELINE_SIM_CONFIG}` — the simulation baseline policy

--- a/prompts/prepare/agent-reviewer.md
+++ b/prompts/prepare/agent-reviewer.md
@@ -31,11 +31,9 @@ Read and hold in context:
 
 You will read the generated plugin files and treatment config fresh on each review request.
 
-Hints from the operator (held in mind, not written to disk):
+Context from the operator (held in mind, not written to disk):
 
-{HINTS_TEXT}
-
-{HINTS_FILES_CONTENT}
+{CONTEXT_TEXT}
 
 ## Tool Discipline
 

--- a/prompts/prepare/agent-writer.md
+++ b/prompts/prepare/agent-writer.md
@@ -31,11 +31,9 @@ test -f pipeline/pipeline.yaml || { echo "ERROR: not in sim2real root"; exit 1; 
 | `{ALGO_CONFIG}` | Algorithm policy config (weights, thresholds) — empty when scenario has no custom config |
 | `prompts/prepare/translate.md` | Translation guidance — follow this |
 
-Hints from the operator (held in mind, not written to disk):
+Context from the operator (held in mind, not written to disk):
 
-{HINTS_TEXT}
-
-{HINTS_FILES_CONTENT}
+{CONTEXT_TEXT}
 
 Expert agent name (for queries): {EXPERT_AGENT_NAME}
 

--- a/prompts/prepare/translate.md
+++ b/prompts/prepare/translate.md
@@ -20,7 +20,7 @@ Read `skill_input.json` from the run directory. It contains:
 | `run_dir`          | Path to the run directory (relative to repo root)    |
 | `scenario`         | Transfer scenario (e.g., `routing`, `admission_control`) |
 | `context_path`     | Path to the cached context.md document               |
-| `context_notes`    | Free-text notes from the manifest author             |
+| `context.text`     | Free-text instructions from the manifest author (in `context` object) |
 | `algorithm_source` | Path to the source algorithm file                    |
 | `algorithm_config` | Path to the algorithm's policy config                |
 | `target`           | Target repo info (repo, plugin_dir, register_file, package) |
@@ -33,8 +33,8 @@ Read the context document at `context_path`. It contains:
 - Mapping documents (sim signals to production equivalents)
 - Submodule commit SHAs for traceability
 
-Also read `context_notes` for scenario-specific translation hints from the
-manifest author.
+Also read `context.text` from the `context` object in `skill_input.json` for
+scenario-specific instructions from the manifest author.
 
 ## Translation Loop
 


### PR DESCRIPTION
Closes #103

## Summary

- Merges the `hints` and `context` top-level sections in `transfer.yaml` into a single `context` section with two valid keys: `text` and `files`
- Removes the eager-embed code path for `hints.files` — all files now go through Phase 2's `build_context()` cache
- `skill_input.json` writes `context: {text: ...}` instead of `hints: {text, files}`
- Removes the deprecated `context.notes` field (unknown keys are now rejected)
- Updates the translate skill, review script, and all four prompt templates to use the new naming

## Changes by area

**Pipeline core** (`manifest.py`, `prepare.py`):
- `manifest.py`: replaced hints parsing + context.notes deprecation with unified context validation that rejects unknown keys
- `prepare.py` Phase 3: writes `context: {text}` instead of `hints: {text, files}` to `skill_input.json`

**Translate skill** (`SKILL.md`, `review.py`):
- `SKILL.md`: validates `context` instead of `hints`, extracts `CONTEXT_TEXT` instead of `HINTS_TEXT`/`HINTS_FILES_CONTENT`
- `review.py`: renamed `--hints-json` CLI flag to `--context-json`, simplified to read only `text` (no `files`)

**Prompt templates** (`translate.md`, `agent-expert.md`, `agent-writer.md`, `agent-reviewer.md`):
- All references to `hints`, `HINTS_TEXT`, `HINTS_FILES_CONTENT`, `context_notes` updated to `context.text` / `CONTEXT_TEXT`

**Docs** (`README.md`, `setup.py`):
- Removed stale `hints:` section from schema example, updated setup.py next-steps message

## Test plan

- [x] 521 tests pass (`python -m pytest pipeline/ .claude/skills/sim2real-translate/tests/ -v`)
- [x] Lint clean (`ruff check pipeline/ .claude/skills/ --select F`)
- [x] No stale `hints` field references remain (only negative test assertions `assert "hints" not in si`)