### PR TITLE
Drop singular baseline:/algorithm: support, require list forms

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -248,16 +248,19 @@ kind: sim2real-transfer
 version: 3
 scenario: <name>            # scenario name used in generated PipelineRun labels
 
-algorithm:                    # optional — omit for baseline-only benchmarks
-  source: <path>            # sim algorithm implementation
-  config: <path>            # sim algorithm config (optional)
+baselines:                  # required — list of baseline specs
+  - name: <pkg-name>       # unique package name (lowercase alphanumeric, 1-20 chars)
+    scenario: <path>        # baseline scenario YAML (null if none)
+    sim:
+      config: <path>        # baseline policy for sim
+    real:
+      config: <path>        # optional: baseline EPP config template
+      notes: |              # optional: notes embedded in skill_input.json
 
-baseline:
-  sim:
-    config: <path>          # baseline policy for sim
-  real:
-    config: <path>          # optional: baseline EPP config template
-    notes: |                # optional: notes embedded in skill_input.json
+algorithms:                 # optional — omit for baseline-only benchmarks
+  - name: <pkg-name>       # unique package name
+    source: <path>          # sim algorithm implementation
+    defaults: <baseline>    # name of baseline this algorithm inherits from
 
 workloads:
   - <path>                  # one or more workload YAMLs

--- a/pipeline/lib/manifest.py
+++ b/pipeline/lib/manifest.py
@@ -21,7 +21,6 @@ def _validate_package_name(name: str, context: str) -> None:
 
 
 _REQUIRED_TOP = ["kind", "version", "scenario"]
-_REQUIRED_ALGORITHM = ["source"]
 
 
 def load_manifest(path: "Path | str") -> dict:
@@ -48,37 +47,6 @@ def load_manifest(path: "Path | str") -> dict:
         if field not in data:
             raise ManifestError(f"Missing required field: {field}")
 
-    algo = data.get("algorithm")
-    if algo is None and "algorithm" in data:
-        del data["algorithm"]
-    elif algo is not None:
-        if not isinstance(algo, dict):
-            raise ManifestError("algorithm must be a mapping")
-        for f in _REQUIRED_ALGORITHM:
-            if f not in algo:
-                raise ManifestError(f"Missing required field: algorithm.{f}")
-
-    if "baseline" in data:
-        bl = data["baseline"]
-        if not isinstance(bl, dict):
-            raise ManifestError("baseline must be a mapping")
-
-        sim_section = bl.get("sim")
-        if sim_section is None:
-            data["baseline"]["sim"] = {"config": None}
-        elif not isinstance(sim_section, dict):
-            raise ManifestError("baseline.sim must be a mapping")
-        else:
-            sim_section.setdefault("config", None)
-        real_section = bl.get("real")
-        if real_section is None:
-            data["baseline"]["real"] = {"config": None, "notes": ""}
-        elif not isinstance(real_section, dict):
-            raise ManifestError("baseline.real must be a mapping")
-        else:
-            data["baseline"]["real"].setdefault("config", None)
-            data["baseline"]["real"].setdefault("notes", "")
-
     # Normalize workloads: absent/null → [] (standby mode — stack up, no benchmarks)
     wl = data.get("workloads")
     if wl is None:
@@ -86,47 +54,26 @@ def load_manifest(path: "Path | str") -> dict:
     elif not isinstance(wl, list):
         raise ManifestError("workloads must be a list")
 
-    # ── Normalize to list forms ──────────────────────────────────────────────
-    has_baseline = "baseline" in data
-    has_baselines = "baselines" in data
+    # ── Validate list-form sections ─────────────────────────────────────────
+    if "baselines" not in data:
+        raise ManifestError("Missing required field: baselines")
+    bls = data["baselines"]
+    if not isinstance(bls, list):
+        raise ManifestError("baselines must be a list")
+    seen_names: set[str] = set()
+    for i, entry in enumerate(bls):
+        if not isinstance(entry, dict):
+            raise ManifestError(f"baselines[{i}] must be a mapping")
+        if "name" not in entry:
+            raise ManifestError(f"baselines[{i}] missing required field: name")
+        if "scenario" not in entry:
+            raise ManifestError(f"baselines[{i}] missing required field: scenario")
+        _validate_package_name(entry["name"], f"baselines[{i}]")
+        if entry["name"] in seen_names:
+            raise ManifestError(f"baselines: duplicate name '{entry['name']}'")
+        seen_names.add(entry["name"])
 
-    if has_baseline and has_baselines:
-        raise ManifestError("Cannot have both 'baseline' and 'baselines' — use one or the other")
-
-    if has_baselines:
-        bls = data["baselines"]
-        if not isinstance(bls, list):
-            raise ManifestError("baselines must be a list")
-        seen_names: set[str] = set()
-        for i, entry in enumerate(bls):
-            if not isinstance(entry, dict):
-                raise ManifestError(f"baselines[{i}] must be a mapping")
-            if "name" not in entry:
-                raise ManifestError(f"baselines[{i}] missing required field: name")
-            if "scenario" not in entry:
-                raise ManifestError(f"baselines[{i}] missing required field: scenario")
-            _validate_package_name(entry["name"], f"baselines[{i}]")
-            if entry["name"] in seen_names:
-                raise ManifestError(f"baselines: duplicate name '{entry['name']}'")
-            seen_names.add(entry["name"])
-    elif has_baseline:
-        bl = data["baseline"]
-        data["baselines"] = [{
-            "name": "baseline",
-            "scenario": None,
-            "sim": bl.get("sim", {"config": None}),
-            "real": bl.get("real", {"config": None, "notes": ""}),
-        }]
-    else:
-        raise ManifestError("Missing required field: baseline or baselines")
-
-    has_algorithm = "algorithm" in data
-    has_algorithms = "algorithms" in data
-
-    if has_algorithm and has_algorithms:
-        raise ManifestError("Cannot have both 'algorithm' and 'algorithms' — use one or the other")
-
-    if has_algorithms:
+    if "algorithms" in data:
         algos = data["algorithms"]
         if not isinstance(algos, list):
             raise ManifestError("algorithms must be a list")
@@ -141,15 +88,6 @@ def load_manifest(path: "Path | str") -> dict:
             if entry["name"] in seen_algo_names:
                 raise ManifestError(f"algorithms: duplicate name '{entry['name']}'")
             seen_algo_names.add(entry["name"])
-    elif has_algorithm:
-        algo = data["algorithm"]
-        data["algorithms"] = [{
-            "name": "treatment",
-            "source": algo["source"],
-            "config": algo.get("config"),
-            "scenario": None,
-            "defaults": data["baselines"][0]["name"],
-        }]
     else:
         data["algorithms"] = []
 

--- a/pipeline/tests/test_manifest.py
+++ b/pipeline/tests/test_manifest.py
@@ -19,42 +19,19 @@ def test_missing_version_raises(tmp_path):
 
 
 def test_missing_required_field(tmp_path):
-    for field in ["scenario", "baseline"]:
+    for field in ["scenario", "baselines"]:
         data = {k: v for k, v in MINIMAL_V3.items() if k != field}
         path = _write_manifest(tmp_path, data)
         with pytest.raises(ManifestError, match=field):
             load_manifest(path)
 
 
-def test_algorithm_section_entirely_optional(tmp_path):
-    """Manifest without algorithm field is valid (baseline-only mode)."""
-    data = {k: v for k, v in MINIMAL_V3.items() if k != "algorithm"}
+def test_algorithms_section_entirely_optional(tmp_path):
+    """Manifest without algorithms is valid (baseline-only mode)."""
+    data = {k: v for k, v in MINIMAL_V3.items() if k != "algorithms"}
     path = _write_manifest(tmp_path, data)
     m = load_manifest(path)
-    assert "algorithm" not in m
-
-
-def test_algorithm_null_normalized_to_absent(tmp_path):
-    """algorithm: null in YAML is normalized to key-absent (baseline-only)."""
-    data = {**MINIMAL_V3, "algorithm": None}
-    path = _write_manifest(tmp_path, data)
-    m = load_manifest(path)
-    assert "algorithm" not in m
-
-
-def test_missing_algorithm_source(tmp_path):
-    data = {**MINIMAL_V3, "algorithm": {"config": "x.yaml"}}
-    path = _write_manifest(tmp_path, data)
-    with pytest.raises(ManifestError, match="algorithm.source"):
-        load_manifest(path)
-
-
-def test_missing_algorithm_config_is_valid(tmp_path):
-    """algorithm.config is optional — manifests without it load cleanly."""
-    data = {**MINIMAL_V3, "algorithm": {"source": "x.go"}}
-    path = _write_manifest(tmp_path, data)
-    m = load_manifest(path)
-    assert "config" not in m["algorithm"]
+    assert m["algorithms"] == []
 
 
 def test_optional_context_fields(tmp_path):
@@ -183,13 +160,20 @@ MINIMAL_V3 = {
     "kind": "sim2real-transfer",
     "version": 3,
     "scenario": "routing",
-    "algorithm": {
-        "source": "sim2real_golden/routers/router_adaptive_v2.go",
-        "config": "sim2real_golden/routers/policy_adaptive_v2.yaml",
-    },
-    "baseline": {
-        "sim": {"config": "sim2real_golden/routers/policy_baseline_211.yaml"},
-    },
+    "algorithms": [
+        {
+            "name": "treatment",
+            "source": "sim2real_golden/routers/router_adaptive_v2.go",
+            "defaults": "baseline",
+        },
+    ],
+    "baselines": [
+        {
+            "name": "baseline",
+            "scenario": "baseline.yaml",
+            "sim": {"config": "sim2real_golden/routers/policy_baseline_211.yaml"},
+        },
+    ],
     "workloads": ["sim2real_golden/workloads/wl1.yaml"],
     "target": {"repo": "llm-d-inference-scheduler"},
     "config": {
@@ -207,68 +191,13 @@ MINIMAL_V3 = {
 
 
 def test_load_valid_v3_minimal(tmp_path):
-    """v3 with just baseline.sim.config loads cleanly."""
+    """v3 minimal manifest loads cleanly."""
     path = _write_manifest(tmp_path, MINIMAL_V3)
     m = load_manifest(path)
-    assert m["baseline"]["sim"]["config"] == "sim2real_golden/routers/policy_baseline_211.yaml"
-    assert m["baseline"]["real"]["config"] is None
-    assert m["baseline"]["real"]["notes"] == ""
-
-
-def test_v3_with_real_config_and_notes(tmp_path):
-    """v3 with baseline.real.config + notes loads and preserves both."""
-    data = {
-        **MINIMAL_V3,
-        "baseline": {
-            "sim": {"config": "sim2real_golden/routers/policy_baseline_211.yaml"},
-            "real": {
-                "config": "sim2real_golden/routers/baseline_epp_template.yaml",
-                "notes": "Use EndpointPickerConfig.Scorers[]",
-            },
-        },
-    }
-    path = _write_manifest(tmp_path, data)
-    m = load_manifest(path)
-    assert m["baseline"]["real"]["config"] == "sim2real_golden/routers/baseline_epp_template.yaml"
-    assert "EndpointPickerConfig" in m["baseline"]["real"]["notes"]
-
-
-def test_v3_missing_sim_config_defaults_to_none(tmp_path):
-    """v3 without baseline.sim.config is valid; sim.config defaults to None."""
-    data = {**MINIMAL_V3, "baseline": {"real": {"config": "x.yaml"}}}
-    path = _write_manifest(tmp_path, data)
-    m = load_manifest(path)
-    assert m["baseline"]["sim"]["config"] is None
-
-
-def test_v3_missing_sim_section_defaults_to_none(tmp_path):
-    """v3 baseline without sim key is valid; sim.config defaults to None."""
-    data = {**MINIMAL_V3, "baseline": {}}
-    path = _write_manifest(tmp_path, data)
-    m = load_manifest(path)
-    assert m["baseline"]["sim"]["config"] is None
-
-
-def test_v3_real_section_entirely_optional(tmp_path):
-    """v3 without baseline.real at all is valid; defaults applied."""
-    data = {**MINIMAL_V3}  # no baseline.real
-    path = _write_manifest(tmp_path, data)
-    m = load_manifest(path)
-    assert m["baseline"]["real"] == {"config": None, "notes": ""}
-
-
-def test_v3_real_partial_defaults_applied(tmp_path):
-    """v3 with baseline.real present but missing notes gets default."""
-    data = {
-        **MINIMAL_V3,
-        "baseline": {
-            "sim": {"config": "sim2real_golden/routers/policy_baseline_211.yaml"},
-            "real": {"config": "x.yaml"},  # no notes
-        },
-    }
-    path = _write_manifest(tmp_path, data)
-    m = load_manifest(path)
-    assert m["baseline"]["real"]["notes"] == ""
+    assert len(m["baselines"]) == 1
+    assert m["baselines"][0]["name"] == "baseline"
+    assert len(m["algorithms"]) == 1
+    assert m["algorithms"][0]["name"] == "treatment"
 
 
 
@@ -476,15 +405,6 @@ def test_baselines_list_loaded(tmp_path):
     assert m["baselines"][1]["name"] == "b2"
 
 
-def test_singular_baseline_normalized_to_baselines(tmp_path):
-    """v3 with singular baseline: normalizes to baselines: list of one."""
-    path = _write_manifest(tmp_path, MINIMAL_V3)
-    m = load_manifest(path)
-    assert "baselines" in m
-    assert len(m["baselines"]) == 1
-    assert m["baselines"][0]["name"] == "baseline"
-
-
 def test_baselines_must_be_list(tmp_path):
     data = {**MULTI_BASELINE_V3, "baselines": "not-a-list"}
     path = _write_manifest(tmp_path, data)
@@ -539,13 +459,6 @@ def test_baselines_with_defaults_field(tmp_path):
     assert m["baselines"][0]["defaults"] == "defaults.yaml"
 
 
-def test_both_baseline_and_baselines_raises(tmp_path):
-    data = {**MULTI_BASELINE_V3, "baseline": {"sim": {"config": "x.yaml"}}}
-    path = _write_manifest(tmp_path, data)
-    with pytest.raises(ManifestError, match="both.*baseline.*baselines"):
-        load_manifest(path)
-
-
 def test_algorithms_list_loaded(tmp_path):
     data = {**MULTI_BASELINE_V3, "algorithms": [
         {"name": "ac1", "source": "algo.go", "scenario": "treatment.yaml", "defaults": "b1"},
@@ -555,16 +468,6 @@ def test_algorithms_list_loaded(tmp_path):
     assert len(m["algorithms"]) == 1
     assert m["algorithms"][0]["name"] == "ac1"
     assert m["algorithms"][0]["defaults"] == "b1"
-
-
-def test_singular_algorithm_normalized_to_algorithms(tmp_path):
-    """v3 with singular algorithm: normalizes to algorithms: list of one."""
-    path = _write_manifest(tmp_path, MINIMAL_V3)
-    m = load_manifest(path)
-    assert "algorithms" in m
-    assert len(m["algorithms"]) == 1
-    assert m["algorithms"][0]["name"] == "treatment"
-    assert m["algorithms"][0]["source"] == MINIMAL_V3["algorithm"]["source"]
 
 
 def test_no_algorithm_no_algorithms_is_baseline_only(tmp_path):

--- a/pipeline/tests/test_prepare.py
+++ b/pipeline/tests/test_prepare.py
@@ -11,20 +11,10 @@ MINIMAL_MANIFEST = {
     "kind": "sim2real-transfer",
     "version": 3,
     "scenario": "routing",
-    "algorithm": {
-        "source": "sim2real_golden/routers/router_adaptive_v2.go",
-        "config": "sim2real_golden/routers/policy_adaptive_v2.yaml",
-    },
-    "baseline": {
-        "sim": {"config": "sim2real_golden/routers/policy_baseline_211.yaml"},
-        "real": {"config": None, "notes": ""},
-    },
-    # Normalized list forms (as produced by load_manifest)
     "baselines": [{
         "name": "baseline",
         "scenario": None,
         "sim": {"config": "sim2real_golden/routers/policy_baseline_211.yaml"},
-        "real": {"config": None, "notes": ""},
     }],
     "algorithms": [{
         "name": "treatment",
@@ -596,17 +586,20 @@ class TestPhaseTranslate:
             "kind": "sim2real-transfer",
             "version": 3,
             "scenario": "routing",
-            "algorithm": {
-                "source": "sim2real_golden/routers/router_adaptive_v2.go",
-                "config": "sim2real_golden/routers/policy_adaptive_v2.yaml",
-            },
-            "baseline": {
+            "baselines": [{
+                "name": "baseline",
+                "scenario": None,
                 "sim": {"config": "sim2real_golden/routers/policy_baseline_211.yaml"},
                 "real": {
                     "config": "sim2real_golden/routers/baseline_epp_template.yaml",
                     "notes": "Use EndpointPickerConfig",
                 },
-            },
+            }],
+            "algorithms": [{
+                "name": "treatment",
+                "source": "sim2real_golden/routers/router_adaptive_v2.go",
+                "defaults": "baseline",
+            }],
             "workloads": ["sim2real_golden/workloads/wl1.yaml"],
             "target": {"repo": "llm-d-inference-scheduler"},
             "config": {
@@ -859,8 +852,8 @@ class TestExperimentRootSeparation:
             "kind": "sim2real-transfer",
             "version": 3,
             "scenario": "admission_control",
-            "algorithm": {"source": "algorithm/admission.go"},
-            "baseline": {"sim": {"config": None}, "real": {"config": None, "notes": ""}},
+            "baselines": [{"name": "baseline", "scenario": None}],
+            "algorithms": [{"name": "treatment", "source": "algorithm/admission.go", "defaults": "baseline"}],
             "workloads": ["workloads/w1.yaml"],
             "target": {"repo": "llm-d-inference-scheduler"},
             "config": {"kind": "AdmissionConfig"},


### PR DESCRIPTION
Closes #97

## Summary

- Removed `baseline:` → `baselines:` and `algorithm:` → `algorithms:` normalization from `manifest.py` — only list forms accepted now
- Removed the early `algorithm` validation block (lines 51-59) — dead code once singular form is gone
- Removed the singular `baseline` validation/defaults block (lines 61-80) — only served the normalization path
- Updated `MINIMAL_V3` test fixture and all inline manifest dicts in `test_prepare.py` to use list forms
- Removed 8 tests that only exercised singular-form behavior; replaced with list-form equivalents where applicable

## Reviewer notes

Manifests using `baseline:` or `algorithm:` will now fail with "Missing required field: baselines" (no special migration error message — per issue scope). The `baselines` list validation requires `name` and `scenario` on each entry but does **not** apply the old `sim`/`real` sub-structure defaults that the singular form did. Downstream code (`prepare.py`) already uses `.get()` defensively for those fields, so this is safe.

## Test plan

- [x] `python -m pytest pipeline/ -v` — 476 passed
- [x] `ruff check pipeline/ --select F` — clean