### PR TITLE
Introduce component section (consolidate target + config + epp_image + build)

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -115,12 +115,12 @@ def _build_epp_image(run_dir: Path, run_name: str, namespace: str) -> str:
     meta_path = run_dir / "run_metadata.json"
     if meta_path.exists():
         meta = json.loads(meta_path.read_text())
-        full_image = meta.get("epp_image", "")
+        full_image = meta.get("component_image", "")
         if full_image:
             ok(f"EPP image: {full_image}")
             return full_image
 
-    err("EPP build completed but epp_image not set in run_metadata.json")
+    err("EPP build completed but component_image not set in run_metadata.json")
     sys.exit(1)
 
 

--- a/pipeline/lib/health.py
+++ b/pipeline/lib/health.py
@@ -165,7 +165,7 @@ def triage_pod(
             message=f"{pod.name}: {pod.reason}",
             suggestion=(
                 f"Image pull failed: {img_detail}\n"
-                "Check run_metadata.json → epp_image or scenario bundle → "
+                "Check run_metadata.json → component_image or scenario bundle → "
                 "model.image"
             ),
         )

--- a/pipeline/lib/manifest.py
+++ b/pipeline/lib/manifest.py
@@ -122,14 +122,6 @@ def load_manifest(path: "Path | str") -> dict:
 def _validate_v3_fields(data: dict) -> None:
     """Validate and apply defaults for v3-specific fields."""
 
-    # Reject old top-level keys that have been replaced by 'component'
-    for old_key in ("target", "config", "epp_image"):
-        if old_key in data:
-            raise ManifestError(
-                f"Top-level '{old_key}' is no longer supported; "
-                "use the 'component' section instead"
-            )
-
     # component (required)
     component = data.get("component")
     if component is None:

--- a/pipeline/lib/manifest.py
+++ b/pipeline/lib/manifest.py
@@ -122,56 +122,59 @@ def load_manifest(path: "Path | str") -> dict:
 def _validate_v3_fields(data: dict) -> None:
     """Validate and apply defaults for v3-specific fields."""
 
-    # target (required)
-    target = data.get("target")
-    if target is None:
-        raise ManifestError("Missing required field: target")
-    if not isinstance(target, dict):
-        raise ManifestError("target must be a mapping")
-    if "repo" not in target:
-        raise ManifestError("Missing required field: target.repo")
+    # Reject old top-level keys that have been replaced by 'component'
+    for old_key in ("target", "config", "epp_image"):
+        if old_key in data:
+            raise ManifestError(
+                f"Top-level '{old_key}' is no longer supported; "
+                "use the 'component' section instead"
+            )
 
-    # config (required)
-    config = data.get("config")
-    if config is None:
-        raise ManifestError("Missing required field: config")
-    if not isinstance(config, dict):
-        raise ManifestError("config must be a mapping")
-    if "kind" not in config:
-        raise ManifestError("Missing required field: config.kind")
+    # component (required)
+    component = data.get("component")
+    if component is None:
+        raise ManifestError("Missing required field: component")
+    if not isinstance(component, dict):
+        raise ManifestError("component must be a mapping")
 
-    # build (optional, defaults applied)
-    build = data.get("build")
-    if build is None:
-        data["build"] = {"commands": []}
-    elif not isinstance(build, dict):
-        raise ManifestError("build must be a mapping")
-    else:
+    # component.repo (required)
+    repo = component.get("repo")
+    if not repo or not isinstance(repo, str):
+        raise ManifestError("Missing required field: component.repo")
+
+    # component.kind (required)
+    kind = component.get("kind")
+    if not kind or not isinstance(kind, str):
+        raise ManifestError("Missing required field: component.kind")
+
+    # component.path (optional, defaults from last segment of repo)
+    if "path" not in component:
+        component["path"] = repo.rstrip("/").rsplit("/", 1)[-1]
+
+    # component.base_image (optional)
+    base_image = component.get("base_image")
+    if base_image is not None:
+        if not isinstance(base_image, dict):
+            raise ManifestError("component.base_image must be a mapping")
+        for f in ("hub", "name", "tag"):
+            if f not in base_image:
+                raise ManifestError(f"Missing required field: component.base_image.{f}")
+
+    # component.build (optional)
+    build = component.get("build")
+    if build is not None:
+        if not isinstance(build, dict):
+            raise ManifestError("component.build must be a mapping")
         build.setdefault("commands", [])
         cmds = build["commands"]
         if not isinstance(cmds, list):
-            raise ManifestError("build.commands must be a list")
-
-    # epp_image (optional)
-    epp = data.get("epp_image")
-    if epp is not None:
-        if not isinstance(epp, dict):
-            raise ManifestError("epp_image must be a mapping")
-        upstream = epp.get("upstream")
-        if upstream is None:
-            raise ManifestError("Missing required field: epp_image.upstream")
-        if not isinstance(upstream, dict):
-            raise ManifestError("epp_image.upstream must be a mapping")
-        for f in ("hub", "name", "tag"):
-            if f not in upstream:
-                raise ManifestError(f"Missing required field: epp_image.upstream.{f}")
-        build_img = epp.get("build")
-        if build_img is not None:
-            if not isinstance(build_img, dict):
-                raise ManifestError("epp_image.build must be a mapping")
-            for f in ("hub", "name", "tag"):
-                if f not in build_img:
-                    raise ManifestError(f"Missing required field: epp_image.build.{f}")
+            raise ManifestError("component.build.commands must be a list")
+        build_image = build.get("image")
+        if build_image is not None:
+            if not isinstance(build_image, dict):
+                raise ManifestError("component.build.image must be a mapping")
+            if "hub" not in build_image:
+                raise ManifestError("Missing required field: component.build.image.hub")
 
     # pipeline (optional, defaults applied)
     pipeline = data.get("pipeline")

--- a/pipeline/prepare.py
+++ b/pipeline/prepare.py
@@ -104,12 +104,8 @@ def _load_setup_config() -> dict:
 
 
 def _load_resolved_config(manifest: dict) -> dict:
-    """Build resolved config from manifest v3 fields (target, config, build, epp_image)."""
-    resolved = {}
-    for key in ("target", "config", "build", "epp_image"):
-        if key in manifest:
-            resolved[key] = manifest[key]
-    return resolved
+    """Build resolved config from manifest component section."""
+    return dict(manifest.get("component", {}))
 
 
 def _get_submodule_shas() -> dict[str, str]:
@@ -179,11 +175,10 @@ def _phase_init(args, manifest: dict, run_dir: Path) -> StateMachine:
             err(f"Workload not found: {wl}")
             sys.exit(1)
 
-    # Validate target repo exists
-    target = resolved.get("target", {})
-    target_repo = target.get("repo", "")
-    if target_repo and not (EXPERIMENT_ROOT / target_repo).exists():
-        err(f"Target repo not found: {target_repo}")
+    # Validate component repo exists
+    target_path = resolved.get("path", "")
+    if target_path and not (EXPERIMENT_ROOT / target_path).exists():
+        err(f"Component repo not found: {target_path}")
         sys.exit(1)
 
     run_name = args.run or _load_setup_config().get("current_run", _default_run_name())
@@ -245,9 +240,7 @@ def _phase_translate(args, state: StateMachine, manifest: dict, run_dir: Path,
         state.mark_done("translate", mode="baseline-only")
         return
 
-    target = resolved.get("target", {})
     build_cfg = resolved.get("build", {})
-    config_cfg = resolved.get("config", {})
 
     # Build commands: common commands (skill determines test scope)
     commands = [list(c) for c in build_cfg.get("commands", [])]
@@ -286,9 +279,9 @@ def _phase_translate(args, state: StateMachine, manifest: dict, run_dir: Path,
         "baseline_sim_config": first_bl.get("sim", {}).get("config"),
         "baseline_real_config": first_bl.get("real", {}).get("config"),
         "baseline_real_notes": first_bl.get("real", {}).get("notes", ""),
-        "target": {"repo": target.get("repo", "")},
+        "target": {"repo": resolved.get("repo", "")},
         "build_commands": commands,
-        "config_kind": config_cfg.get("kind", ""),
+        "config_kind": resolved.get("kind", ""),
         "context": {"text": manifest.get("context", {}).get("text", "")},
     }
     skill_input_path = run_dir / "skill_input.json"
@@ -578,7 +571,7 @@ def _validate_assembly(run_dir: Path, resolved: dict, algorithm_packages: list[s
         warn("translation_output.json is not valid JSON — skipping validation")
         return
     plugin_type = output["plugin_type"]
-    target = resolved.get("target", {})
+    target_path = resolved.get("path", "")
     treatment_config_generated = output.get("treatment_config_generated", True)
 
     errors = []
@@ -586,7 +579,7 @@ def _validate_assembly(run_dir: Path, resolved: dict, algorithm_packages: list[s
     # Check 1: plugin_type in register_file (skip if null — rewrite mode)
     register_file = output.get("register_file")
     if register_file is not None:
-        register_path = EXPERIMENT_ROOT / target.get("repo", "") / register_file
+        register_path = EXPERIMENT_ROOT / target_path / register_file
         if register_path.exists():
             # Search register_file's directory recursively: Go plugins use constants
             # defined in sibling files (e.g. AdaptiveV2Type = "adaptive-v2-scorer" in
@@ -615,9 +608,8 @@ def _validate_assembly(run_dir: Path, resolved: dict, algorithm_packages: list[s
                         f"plugin_type '{plugin_type}' not found in {pkg_name}.yaml")
 
     # Check 3: all files_created exist in target repo
-    target_repo = target.get("repo", "")
     for f in output.get("files_created", []):
-        if target_repo and not (EXPERIMENT_ROOT / target_repo / f).exists():
+        if target_path and not (EXPERIMENT_ROOT / target_path / f).exists():
             errors.append(f"files_created entry missing on disk: {f}")
 
     if errors:

--- a/pipeline/setup.py
+++ b/pipeline/setup.py
@@ -686,7 +686,7 @@ def step_config_output(cfg: SetupConfig, run_dir: Path, container_rt: str) -> No
         "container_runtime": container_rt,
         "created_at": now_iso,
         "pipeline_commit": commit,
-        **({"epp_image": f"{cfg.registry}/{cfg.repo_name}:{cfg.run_name}"} if cfg.registry else {}),
+        **({"component_image": f"{cfg.registry}/{cfg.repo_name}:{cfg.run_name}"} if cfg.registry else {}),
         "stages": {
             "setup":   {"status": "completed", "completed_at": now_iso,
                         "summary": f"Namespace {cfg.namespace} configured, "

--- a/pipeline/tests/test_manifest.py
+++ b/pipeline/tests/test_manifest.py
@@ -161,16 +161,13 @@ MINIMAL_V3 = {
         },
     ],
     "workloads": ["sim2real_golden/workloads/wl1.yaml"],
-    "target": {"repo": "llm-d-inference-scheduler"},
-    "config": {
+    "component": {
+        "repo": "github.com/llm-d/llm-d-inference-scheduler",
         "kind": "EndpointPickerConfig",
-    },
-    "epp_image": {
-        "upstream": {
+        "base_image": {
             "hub": "ghcr.io/llm-d",
             "name": "llm-d-inference-scheduler",
             "tag": "v0.7.1",
-            "pullPolicy": "Always",
         },
     },
 }
@@ -188,132 +185,170 @@ def test_load_valid_v3_minimal(tmp_path):
 
 
 
-# ── v3 fields ────────────────────────────────────────────────────────────────
+# ── component section ─────────────────────────────────────────────────────────
 
-def test_v3_target_and_config_loaded(tmp_path):
-    """v3 target and config fields are loaded and preserved."""
-    path = _write_manifest(tmp_path, MINIMAL_V3)
-    m = load_manifest(path)
-    assert m["target"]["repo"] == "llm-d-inference-scheduler"
-    assert m["config"]["kind"] == "EndpointPickerConfig"
-
-
-def test_v3_build_defaults(tmp_path):
-    """v3 without build section gets default commands=[]."""
-    data = {k: v for k, v in MINIMAL_V3.items() if k != "build"}
+def test_component_required(tmp_path):
+    """Missing component raises ManifestError."""
+    data = {k: v for k, v in MINIMAL_V3.items() if k != "component"}
     path = _write_manifest(tmp_path, data)
-    m = load_manifest(path)
-    assert m["build"]["commands"] == []
-
-
-def test_v3_build_commands_loaded(tmp_path):
-    """v3 with build.commands preserves the list."""
-    data = {**MINIMAL_V3, "build": {"commands": [["go", "build", "./..."]]}}
-    path = _write_manifest(tmp_path, data)
-    m = load_manifest(path)
-    assert m["build"]["commands"] == [["go", "build", "./..."]]
-
-
-def test_v3_build_commands_not_list_raises(tmp_path):
-    """build.commands must be a list."""
-    data = {**MINIMAL_V3, "build": {"commands": "go build"}}
-    path = _write_manifest(tmp_path, data)
-    with pytest.raises(ManifestError, match="build.commands.*list"):
+    with pytest.raises(ManifestError, match="component"):
         load_manifest(path)
 
 
-def test_v3_epp_image_loaded(tmp_path):
-    """v3 epp_image.upstream fields are loaded."""
+def test_component_must_be_mapping(tmp_path):
+    """component: 'string' raises."""
+    data = {**MINIMAL_V3, "component": "string"}
+    path = _write_manifest(tmp_path, data)
+    with pytest.raises(ManifestError, match="component.*mapping"):
+        load_manifest(path)
+
+
+def test_component_repo_required(tmp_path):
+    """component without repo raises."""
+    data = {**MINIMAL_V3, "component": {"kind": "EndpointPickerConfig"}}
+    path = _write_manifest(tmp_path, data)
+    with pytest.raises(ManifestError, match="component.repo"):
+        load_manifest(path)
+
+
+def test_component_kind_required(tmp_path):
+    """component without kind raises."""
+    data = {**MINIMAL_V3, "component": {"repo": "github.com/llm-d/llm-d-inference-scheduler"}}
+    path = _write_manifest(tmp_path, data)
+    with pytest.raises(ManifestError, match="component.kind"):
+        load_manifest(path)
+
+
+def test_component_path_defaults_from_repo(tmp_path):
+    """component.path defaults from last segment of repo URL."""
     path = _write_manifest(tmp_path, MINIMAL_V3)
     m = load_manifest(path)
-    assert m["epp_image"]["upstream"]["hub"] == "ghcr.io/llm-d"
-    assert m["epp_image"]["upstream"]["name"] == "llm-d-inference-scheduler"
-    assert m["epp_image"]["upstream"]["tag"] == "v0.7.1"
+    assert m["component"]["path"] == "llm-d-inference-scheduler"
 
 
-def test_v3_epp_image_with_build(tmp_path):
-    """v3 epp_image with both upstream and build loads both."""
-    data = {**MINIMAL_V3, "epp_image": {
-        "upstream": {"hub": "ghcr.io/llm-d", "name": "epp", "tag": "v1"},
-        "build": {"hub": "ghcr.io/me", "name": "epp", "tag": "dev", "platform": "linux/amd64"},
+def test_component_path_explicit(tmp_path):
+    """Explicit component.path is preserved."""
+    data = {**MINIMAL_V3, "component": {
+        "repo": "github.com/llm-d/llm-d-inference-scheduler",
+        "kind": "EndpointPickerConfig",
+        "path": "custom",
     }}
     path = _write_manifest(tmp_path, data)
     m = load_manifest(path)
-    assert m["epp_image"]["build"]["hub"] == "ghcr.io/me"
-    assert m["epp_image"]["build"]["tag"] == "dev"
+    assert m["component"]["path"] == "custom"
 
 
-def test_v3_epp_image_missing_upstream_raises(tmp_path):
-    """epp_image without upstream raises."""
-    data = {**MINIMAL_V3, "epp_image": {"build": {"hub": "x", "name": "y", "tag": "z"}}}
-    path = _write_manifest(tmp_path, data)
-    with pytest.raises(ManifestError, match="epp_image.upstream"):
-        load_manifest(path)
-
-
-def test_v3_epp_image_upstream_missing_field_raises(tmp_path):
-    """epp_image.upstream missing hub/name/tag raises."""
-    for field in ("hub", "name", "tag"):
-        upstream = {"hub": "a", "name": "b", "tag": "c"}
-        del upstream[field]
-        data = {**MINIMAL_V3, "epp_image": {"upstream": upstream}}
-        path = _write_manifest(tmp_path, data)
-        with pytest.raises(ManifestError, match=f"epp_image.upstream.{field}"):
-            load_manifest(path)
-
-
-def test_v3_epp_image_build_missing_field_raises(tmp_path):
-    """epp_image.build missing hub/name/tag raises."""
-    for field in ("hub", "name", "tag"):
-        build = {"hub": "a", "name": "b", "tag": "c"}
-        del build[field]
-        data = {**MINIMAL_V3, "epp_image": {
-            "upstream": {"hub": "x", "name": "y", "tag": "z"},
-            "build": build,
-        }}
-        path = _write_manifest(tmp_path, data)
-        with pytest.raises(ManifestError, match=f"epp_image.build.{field}"):
-            load_manifest(path)
-
-
-def test_v3_epp_image_optional(tmp_path):
-    """v3 without epp_image is valid."""
-    data = {k: v for k, v in MINIMAL_V3.items() if k != "epp_image"}
+def test_component_base_image_optional(tmp_path):
+    """MINIMAL_V3 without base_image is valid."""
+    data = {**MINIMAL_V3, "component": {
+        "repo": "github.com/llm-d/llm-d-inference-scheduler",
+        "kind": "EndpointPickerConfig",
+    }}
     path = _write_manifest(tmp_path, data)
     m = load_manifest(path)
-    assert "epp_image" not in m
+    assert "base_image" not in m["component"]
 
 
-def test_v3_target_absent_raises(tmp_path):
-    """v3 without target raises."""
-    data = {k: v for k, v in MINIMAL_V3.items() if k != "target"}
+def test_component_base_image_validates_fields(tmp_path):
+    """base_image missing hub/name/tag raises."""
+    for field in ("hub", "name", "tag"):
+        base_image = {"hub": "a", "name": "b", "tag": "c"}
+        del base_image[field]
+        data = {**MINIMAL_V3, "component": {
+            "repo": "github.com/llm-d/llm-d-inference-scheduler",
+            "kind": "EndpointPickerConfig",
+            "base_image": base_image,
+        }}
+        path = _write_manifest(tmp_path, data)
+        with pytest.raises(ManifestError, match=f"component.base_image.{field}"):
+            load_manifest(path)
+
+
+def test_component_base_image_loaded(tmp_path):
+    """Loading MINIMAL_V3 yields correct base_image fields."""
+    path = _write_manifest(tmp_path, MINIMAL_V3)
+    m = load_manifest(path)
+    assert m["component"]["base_image"]["hub"] == "ghcr.io/llm-d"
+    assert m["component"]["base_image"]["name"] == "llm-d-inference-scheduler"
+    assert m["component"]["base_image"]["tag"] == "v0.7.1"
+
+
+def test_component_build_optional(tmp_path):
+    """MINIMAL_V3 without build is valid."""
+    path = _write_manifest(tmp_path, MINIMAL_V3)
+    m = load_manifest(path)
+    assert "build" not in m["component"]
+
+
+def test_component_build_defaults_commands(tmp_path):
+    """component with build: {} gets commands=[]."""
+    data = {**MINIMAL_V3, "component": {
+        "repo": "github.com/llm-d/llm-d-inference-scheduler",
+        "kind": "EndpointPickerConfig",
+        "build": {},
+    }}
     path = _write_manifest(tmp_path, data)
-    with pytest.raises(ManifestError, match="target"):
+    m = load_manifest(path)
+    assert m["component"]["build"]["commands"] == []
+
+
+def test_component_build_commands_loaded(tmp_path):
+    """Explicit commands are preserved."""
+    data = {**MINIMAL_V3, "component": {
+        "repo": "github.com/llm-d/llm-d-inference-scheduler",
+        "kind": "EndpointPickerConfig",
+        "build": {"commands": [["go", "build", "./..."]]},
+    }}
+    path = _write_manifest(tmp_path, data)
+    m = load_manifest(path)
+    assert m["component"]["build"]["commands"] == [["go", "build", "./..."]]
+
+
+def test_component_build_commands_must_be_list(tmp_path):
+    """build.commands as string raises."""
+    data = {**MINIMAL_V3, "component": {
+        "repo": "github.com/llm-d/llm-d-inference-scheduler",
+        "kind": "EndpointPickerConfig",
+        "build": {"commands": "go build"},
+    }}
+    path = _write_manifest(tmp_path, data)
+    with pytest.raises(ManifestError, match="component.build.commands.*list"):
         load_manifest(path)
 
 
-def test_v3_config_absent_raises(tmp_path):
-    """v3 without config raises."""
-    data = {k: v for k, v in MINIMAL_V3.items() if k != "config"}
+def test_component_build_image_validates_hub(tmp_path):
+    """build.image without hub raises."""
+    data = {**MINIMAL_V3, "component": {
+        "repo": "github.com/llm-d/llm-d-inference-scheduler",
+        "kind": "EndpointPickerConfig",
+        "build": {"image": {}},
+    }}
     path = _write_manifest(tmp_path, data)
-    with pytest.raises(ManifestError, match="config"):
+    with pytest.raises(ManifestError, match="component.build.image.hub"):
         load_manifest(path)
 
 
-def test_v3_config_missing_kind_raises(tmp_path):
-    """config without kind raises."""
-    data = {**MINIMAL_V3, "config": {}}
+def test_old_target_key_rejected(tmp_path):
+    """Adding target to valid manifest raises."""
+    data = {**MINIMAL_V3, "target": {"repo": "x"}}
     path = _write_manifest(tmp_path, data)
-    with pytest.raises(ManifestError, match="config.kind"):
+    with pytest.raises(ManifestError, match="no longer supported"):
         load_manifest(path)
 
 
-
-def test_v3_target_missing_repo_raises(tmp_path):
-    """target without repo raises."""
-    data = {**MINIMAL_V3, "target": {}}
+def test_old_config_key_rejected(tmp_path):
+    """Adding config to valid manifest raises."""
+    data = {**MINIMAL_V3, "config": {"kind": "X"}}
     path = _write_manifest(tmp_path, data)
-    with pytest.raises(ManifestError, match="target.repo"):
+    with pytest.raises(ManifestError, match="no longer supported"):
+        load_manifest(path)
+
+
+def test_old_epp_image_key_rejected(tmp_path):
+    """Adding epp_image to valid manifest raises."""
+    data = {**MINIMAL_V3, "epp_image": {}}
+    path = _write_manifest(tmp_path, data)
+    with pytest.raises(ManifestError, match="no longer supported"):
         load_manifest(path)
 
 
@@ -374,8 +409,8 @@ MULTI_BASELINE_V3 = {
         {"name": "b2", "scenario": "baseline_2.yaml"},
     ],
     "workloads": ["sim2real_golden/workloads/wl1.yaml"],
-    "target": {"repo": "llm-d-inference-scheduler"},
-    "config": {
+    "component": {
+        "repo": "github.com/llm-d/llm-d-inference-scheduler",
         "kind": "EndpointPickerConfig",
     },
 }

--- a/pipeline/tests/test_manifest.py
+++ b/pipeline/tests/test_manifest.py
@@ -328,29 +328,6 @@ def test_component_build_image_validates_hub(tmp_path):
         load_manifest(path)
 
 
-def test_old_target_key_rejected(tmp_path):
-    """Adding target to valid manifest raises."""
-    data = {**MINIMAL_V3, "target": {"repo": "x"}}
-    path = _write_manifest(tmp_path, data)
-    with pytest.raises(ManifestError, match="no longer supported"):
-        load_manifest(path)
-
-
-def test_old_config_key_rejected(tmp_path):
-    """Adding config to valid manifest raises."""
-    data = {**MINIMAL_V3, "config": {"kind": "X"}}
-    path = _write_manifest(tmp_path, data)
-    with pytest.raises(ManifestError, match="no longer supported"):
-        load_manifest(path)
-
-
-def test_old_epp_image_key_rejected(tmp_path):
-    """Adding epp_image to valid manifest raises."""
-    data = {**MINIMAL_V3, "epp_image": {}}
-    path = _write_manifest(tmp_path, data)
-    with pytest.raises(ManifestError, match="no longer supported"):
-        load_manifest(path)
-
 
 # ── pipeline field (optional, v3 only) ─────────────────────────────────────
 

--- a/pipeline/tests/test_prepare.py
+++ b/pipeline/tests/test_prepare.py
@@ -24,11 +24,12 @@ MINIMAL_MANIFEST = {
         "defaults": "baseline",
     }],
     "workloads": ["sim2real_golden/workloads/wl1.yaml"],
-    "target": {"repo": "llm-d-inference-scheduler"},
-    "config": {
+    "component": {
+        "repo": "github.com/llm-d/llm-d-inference-scheduler",
+        "path": "llm-d-inference-scheduler",
         "kind": "EndpointPickerConfig",
+        "build": {"commands": [["go", "build", "./..."]]},
     },
-    "build": {"commands": [["go", "build", "./..."]]},
 }
 
 
@@ -593,8 +594,9 @@ class TestPhaseTranslate:
                 "defaults": "baseline",
             }],
             "workloads": ["sim2real_golden/workloads/wl1.yaml"],
-            "target": {"repo": "llm-d-inference-scheduler"},
-            "config": {
+            "component": {
+                "repo": "github.com/llm-d/llm-d-inference-scheduler",
+                "path": "llm-d-inference-scheduler",
                 "kind": "EndpointPickerConfig",
             },
         }
@@ -635,7 +637,7 @@ class TestValidateAssembly:
         run_dir = repo / "workspace" / "runs" / "test-run"
         run_dir.mkdir(parents=True, exist_ok=True)
 
-        resolved = {"target": {"repo": "llm-d-inference-scheduler"}, "config": {"kind": "EndpointPickerConfig"}}
+        resolved = {"repo": "github.com/llm-d/llm-d-inference-scheduler", "path": "llm-d-inference-scheduler", "kind": "EndpointPickerConfig"}
 
         # Set up translation output
         output = {
@@ -672,7 +674,7 @@ class TestValidateAssembly:
         run_dir = repo / "workspace" / "runs" / "test-run"
         run_dir.mkdir(parents=True, exist_ok=True)
 
-        resolved = {"target": {"repo": "llm-d-inference-scheduler"}, "config": {"kind": "EndpointPickerConfig"}}
+        resolved = {"repo": "github.com/llm-d/llm-d-inference-scheduler", "path": "llm-d-inference-scheduler", "kind": "EndpointPickerConfig"}
 
         output = {
             "plugin_type": "missing-scorer",
@@ -701,7 +703,7 @@ class TestValidateAssembly:
         run_dir = repo / "workspace" / "runs" / "test-run"
         run_dir.mkdir(parents=True, exist_ok=True)
 
-        resolved = {"target": {"repo": "llm-d-inference-scheduler"}, "config": {"kind": "EndpointPickerConfig"}}
+        resolved = {"repo": "github.com/llm-d/llm-d-inference-scheduler", "path": "llm-d-inference-scheduler", "kind": "EndpointPickerConfig"}
 
         output = {
             "plugin_type": "test-scorer",
@@ -729,7 +731,7 @@ class TestValidateAssembly:
         run_dir = repo / "workspace" / "runs" / "test-run"
         run_dir.mkdir(parents=True, exist_ok=True)
 
-        resolved = {"target": {"repo": "llm-d-inference-scheduler"}, "config": {"kind": "EndpointPickerConfig"}}
+        resolved = {"repo": "github.com/llm-d/llm-d-inference-scheduler", "path": "llm-d-inference-scheduler", "kind": "EndpointPickerConfig"}
 
         output = {
             "plugin_type": "test-scorer",
@@ -758,7 +760,7 @@ class TestValidateAssembly:
         run_dir = repo / "workspace" / "runs" / "test-run"
         run_dir.mkdir(parents=True, exist_ok=True)
 
-        resolved = {"target": {"repo": "llm-d-inference-scheduler"}, "config": {"kind": "EndpointPickerConfig"}}
+        resolved = {"repo": "github.com/llm-d/llm-d-inference-scheduler", "path": "llm-d-inference-scheduler", "kind": "EndpointPickerConfig"}
         output = {
             "plugin_type": "test-scorer",
             "files_created": [],
@@ -786,7 +788,7 @@ class TestValidateAssembly:
         run_dir = repo / "workspace" / "runs" / "test-run"
         run_dir.mkdir(parents=True, exist_ok=True)
 
-        resolved = {"target": {"repo": "llm-d-inference-scheduler"}, "config": {"kind": "EndpointPickerConfig"}}
+        resolved = {"repo": "github.com/llm-d/llm-d-inference-scheduler", "path": "llm-d-inference-scheduler", "kind": "EndpointPickerConfig"}
         output = {
             "plugin_type": "test-scorer",
             "files_created": [],
@@ -816,9 +818,9 @@ class TestConfigResolution:
         mod = _import_prepare_with_root(repo)
         manifest = dict(MINIMAL_MANIFEST)
         resolved = mod._load_resolved_config(manifest)
-        # Should have merged common + routing scenario
-        assert resolved["target"]["repo"] == "llm-d-inference-scheduler"
-        assert resolved["config"]["kind"] == "EndpointPickerConfig"
+        # Should return component section fields
+        assert resolved["path"] == "llm-d-inference-scheduler"
+        assert resolved["kind"] == "EndpointPickerConfig"
 
 
 
@@ -847,8 +849,7 @@ class TestExperimentRootSeparation:
             "baselines": [{"name": "baseline", "scenario": None}],
             "algorithms": [{"name": "treatment", "source": "algorithm/admission.go", "defaults": "baseline"}],
             "workloads": ["workloads/w1.yaml"],
-            "target": {"repo": "llm-d-inference-scheduler"},
-            "config": {"kind": "AdmissionConfig"},
+            "component": {"repo": "github.com/llm-d/llm-d-inference-scheduler", "path": "llm-d-inference-scheduler", "kind": "AdmissionConfig"},
         }
         _write_yaml(exp / "transfer.yaml", manifest_data)
         _write_text(exp / "algorithm" / "admission.go", "package main\n")
@@ -901,7 +902,7 @@ class TestExperimentRootSeparation:
         from pipeline.lib.manifest import load_manifest
         manifest = load_manifest(exp / "transfer.yaml")
         resolved = mod._load_resolved_config(manifest)
-        assert resolved["target"]["repo"] == "llm-d-inference-scheduler"
+        assert resolved["path"] == "llm-d-inference-scheduler"
 
     def test_workspace_created_in_experiment_root(self, tmp_path):
         """run_dir should be under EXPERIMENT_ROOT, not REPO_ROOT."""
@@ -1086,7 +1087,7 @@ class TestBaselineOnlyAssembly:
         run_dir = repo / "workspace" / "runs" / "test-run"
         run_dir.mkdir(parents=True, exist_ok=True)
 
-        resolved = {"target": {"repo": "llm-d-inference-scheduler"}, "config": {"kind": "EndpointPickerConfig"}}
+        resolved = {"repo": "github.com/llm-d/llm-d-inference-scheduler", "path": "llm-d-inference-scheduler", "kind": "EndpointPickerConfig"}
 
         # Do NOT create translation_output.json
         # Should return without raising or sys.exit

--- a/prompts/prepare/translate.md
+++ b/prompts/prepare/translate.md
@@ -23,7 +23,7 @@ Read `skill_input.json` from the run directory. It contains:
 | `context.text`     | Free-text instructions from the manifest author (in `context` object) |
 | `algorithm_source` | Path to the source algorithm file                    |
 | `algorithm_config` | Path to the algorithm's policy config                |
-| `target`           | Target repo info (repo, plugin_dir, register_file, package) |
+| `target`           | Component repo info (derived from `component.repo`)  |
 | `build_commands`   | List of build/test commands to validate the plugin   |
 | `config_kind`      | Expected kind for the treatment config YAML          |
 


### PR DESCRIPTION
Closes #98

## Summary

- Consolidates four top-level `transfer.yaml` sections (`target`, `config`, `build`, `epp_image`) into a single `component` section
- Renames `run_metadata.json` key from `epp_image` to `component_image` (setup.py writer + deploy.py reader updated in lockstep)
- Old top-level keys (`target`, `config`, `epp_image`) are silently ignored — consistent with how any unknown key is treated (no general unknown-key rejection exists)
- `skill_input.json` output shape is preserved (backward compat with translate skill)

## Breaking change

Users must update their `transfer.yaml` to use the new schema:

```yaml
component:
  repo: github.com/llm-d/llm-d-inference-scheduler
  kind: EndpointPickerConfig
  base_image:
    hub: ghcr.io/llm-d
    name: llm-d-inference-scheduler
    tag: v0.7.1
  build:
    commands:
      - [go, build, ./...]
```

## Migration: run_metadata.json

The `run_metadata.json` key was renamed from `epp_image` to `component_image`. Existing workspace runs that have the old key will not be recognized by `deploy.py`. **Users must re-run `setup.py`** to regenerate `run_metadata.json` with the new key. There is no backward-compat fallback — this is acceptable because `setup.py` is idempotent and always the first step after pulling new pipeline code.

## Design decisions

- **No old-key rejection:** Unknown top-level keys in `transfer.yaml` are silently ignored (there is no general unknown-key validation). Old keys get the same treatment — no special error messages for `target`/`config`/`epp_image`. Simpler code, consistent behavior.
- **No `run_metadata.json` fallback:** Assume users re-run `setup.py` after updating. The setup → prepare → deploy sequence is always run in order; setup always runs first.

## Reviewer attention

- `_load_resolved_config` now returns the `component` dict directly (flat structure) rather than a dict-of-dicts. All consumers updated.
- `component.path` is auto-defaulted from the last URL segment of `component.repo` if not explicitly set.
- The `inject_epp_image` function name is intentionally unchanged — it describes what it does (inject EPP container image into scenario YAML), not a manifest key.

## Test plan

- [x] All 476 pipeline tests pass
- [x] Lint clean (ruff check --select F)
- [x] No stale manifest key references in pipeline code