### PR TITLE
Derive build.image defaults from base_image; tag from run name

### DIFF
--- a/pipeline/lib/manifest.py
+++ b/pipeline/lib/manifest.py
@@ -148,7 +148,7 @@ def _validate_v3_fields(data: dict) -> None:
     if base_image is not None:
         if not isinstance(base_image, dict):
             raise ManifestError("component.base_image must be a mapping")
-        for f in ("hub", "name", "tag"):
+        for f in ("hub", "name"):
             if f not in base_image:
                 raise ManifestError(f"Missing required field: component.base_image.{f}")
 

--- a/pipeline/lib/manifest.py
+++ b/pipeline/lib/manifest.py
@@ -165,6 +165,9 @@ def _validate_v3_fields(data: dict) -> None:
         if build_image is not None:
             if not isinstance(build_image, dict):
                 raise ManifestError("component.build.image must be a mapping")
+            if base_image is not None:
+                build_image.setdefault("hub", base_image["hub"])
+                build_image.setdefault("name", base_image["name"])
             if "hub" not in build_image:
                 raise ManifestError("Missing required field: component.build.image.hub")
 

--- a/pipeline/tests/test_manifest.py
+++ b/pipeline/tests/test_manifest.py
@@ -341,6 +341,73 @@ def test_component_build_image_validates_hub(tmp_path):
         load_manifest(path)
 
 
+def test_build_image_defaults_hub_from_base_image(tmp_path):
+    """build.image without hub inherits from base_image.hub."""
+    data = {**MINIMAL_V3, "component": {
+        "repo": "github.com/llm-d/llm-d-inference-scheduler",
+        "kind": "EndpointPickerConfig",
+        "base_image": {"hub": "ghcr.io/llm-d", "name": "llm-d-inference-scheduler"},
+        "build": {"image": {"name": "custom-name"}},
+    }}
+    path = _write_manifest(tmp_path, data)
+    m = load_manifest(path)
+    assert m["component"]["build"]["image"]["hub"] == "ghcr.io/llm-d"
+    assert m["component"]["build"]["image"]["name"] == "custom-name"
+
+
+def test_build_image_defaults_name_from_base_image(tmp_path):
+    """build.image without name inherits from base_image.name."""
+    data = {**MINIMAL_V3, "component": {
+        "repo": "github.com/llm-d/llm-d-inference-scheduler",
+        "kind": "EndpointPickerConfig",
+        "base_image": {"hub": "ghcr.io/llm-d", "name": "llm-d-inference-scheduler"},
+        "build": {"image": {"hub": "quay.io/me"}},
+    }}
+    path = _write_manifest(tmp_path, data)
+    m = load_manifest(path)
+    assert m["component"]["build"]["image"]["hub"] == "quay.io/me"
+    assert m["component"]["build"]["image"]["name"] == "llm-d-inference-scheduler"
+
+
+def test_build_image_defaults_both_from_base_image(tmp_path):
+    """build.image: {} inherits both hub and name from base_image."""
+    data = {**MINIMAL_V3, "component": {
+        "repo": "github.com/llm-d/llm-d-inference-scheduler",
+        "kind": "EndpointPickerConfig",
+        "base_image": {"hub": "ghcr.io/llm-d", "name": "llm-d-inference-scheduler"},
+        "build": {"image": {}},
+    }}
+    path = _write_manifest(tmp_path, data)
+    m = load_manifest(path)
+    assert m["component"]["build"]["image"]["hub"] == "ghcr.io/llm-d"
+    assert m["component"]["build"]["image"]["name"] == "llm-d-inference-scheduler"
+
+
+def test_build_image_no_base_image_requires_hub(tmp_path):
+    """Without base_image, build.image still requires hub."""
+    data = {**MINIMAL_V3, "component": {
+        "repo": "github.com/llm-d/llm-d-inference-scheduler",
+        "kind": "EndpointPickerConfig",
+        "build": {"image": {"name": "foo"}},
+    }}
+    path = _write_manifest(tmp_path, data)
+    with pytest.raises(ManifestError, match="component.build.image.hub"):
+        load_manifest(path)
+
+
+def test_build_image_explicit_overrides_base_image(tmp_path):
+    """Explicit build.image fields are not overwritten by base_image."""
+    data = {**MINIMAL_V3, "component": {
+        "repo": "github.com/llm-d/llm-d-inference-scheduler",
+        "kind": "EndpointPickerConfig",
+        "base_image": {"hub": "ghcr.io/llm-d", "name": "llm-d-inference-scheduler"},
+        "build": {"image": {"hub": "quay.io/me", "name": "my-image"}},
+    }}
+    path = _write_manifest(tmp_path, data)
+    m = load_manifest(path)
+    assert m["component"]["build"]["image"]["hub"] == "quay.io/me"
+    assert m["component"]["build"]["image"]["name"] == "my-image"
+
 
 # ── pipeline field (optional, v3 only) ─────────────────────────────────────
 

--- a/pipeline/tests/test_manifest.py
+++ b/pipeline/tests/test_manifest.py
@@ -250,8 +250,8 @@ def test_component_base_image_optional(tmp_path):
 
 
 def test_component_base_image_validates_fields(tmp_path):
-    """base_image missing hub/name/tag raises."""
-    for field in ("hub", "name", "tag"):
+    """base_image missing hub/name raises."""
+    for field in ("hub", "name"):
         base_image = {"hub": "a", "name": "b", "tag": "c"}
         del base_image[field]
         data = {**MINIMAL_V3, "component": {
@@ -262,6 +262,19 @@ def test_component_base_image_validates_fields(tmp_path):
         path = _write_manifest(tmp_path, data)
         with pytest.raises(ManifestError, match=f"component.base_image.{field}"):
             load_manifest(path)
+
+
+def test_component_base_image_tag_optional(tmp_path):
+    """base_image without tag is valid — tag is informational only."""
+    data = {**MINIMAL_V3, "component": {
+        "repo": "github.com/llm-d/llm-d-inference-scheduler",
+        "kind": "EndpointPickerConfig",
+        "base_image": {"hub": "ghcr.io/llm-d", "name": "llm-d-inference-scheduler"},
+    }}
+    path = _write_manifest(tmp_path, data)
+    m = load_manifest(path)
+    assert m["component"]["base_image"]["hub"] == "ghcr.io/llm-d"
+    assert "tag" not in m["component"]["base_image"]
 
 
 def test_component_base_image_loaded(tmp_path):


### PR DESCRIPTION
## Summary

- Make `component.base_image.tag` optional in manifest schema — it's never consumed by the pipeline (tag is always derived from the run name at build time via `build-epp.sh`)
- Default `component.build.image.hub` and `name` from `component.base_image` when those fields are absent — reduces manifest boilerplate (most users only need to override `hub` to push to their own registry)

Closes #100

## Details

Two commits:

1. **base_image.tag optional** — removes `tag` from the required fields tuple in `_validate_v3_fields`. Existing manifests with `tag` still load fine (optional ≠ forbidden).

2. **build.image defaults** — adds two `setdefault` calls guarded by `if base_image is not None`. Explicit `build.image` fields are never overwritten. Without `base_image`, `hub` is still required (backward compat).

## Test plan

- [x] `test_component_base_image_tag_optional` — base_image without tag loads
- [x] `test_build_image_defaults_hub_from_base_image` — hub inherited
- [x] `test_build_image_defaults_name_from_base_image` — name inherited
- [x] `test_build_image_defaults_both_from_base_image` — both inherited from empty `{}`
- [x] `test_build_image_no_base_image_requires_hub` — backward compat: still errors without base_image
- [x] `test_build_image_explicit_overrides_base_image` — explicit values not overwritten
- [x] Full suite: 482 tests pass, ruff clean