### PR TITLE
Make component section optional when no algorithms present

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -86,6 +86,31 @@ def _load_setup_config() -> dict:
     return {}
 
 
+# ── EPP build decision ─────────────────────────────────────────────────────────
+
+def _resolve_epp_action(run_dir: Path, skip_build_epp: bool) -> str:
+    """Determine EPP build action based on run metadata.
+
+    Returns one of: "build", "skip", "error:<message>"
+    """
+    run_meta_path = run_dir / "run_metadata.json"
+    if not run_meta_path.exists():
+        return "error:run_metadata.json not found — run setup.py first."
+    try:
+        run_meta = json.loads(run_meta_path.read_text())
+    except json.JSONDecodeError as e:
+        return f"error:run_metadata.json is not valid JSON: {e}. Re-run setup.py."
+
+    component_image = run_meta.get("component_image")
+    if component_image is None:
+        return "skip"
+    if not component_image:
+        return "error:component_image is empty in run_metadata.json. Re-run setup.py with a valid --registry."
+    if skip_build_epp:
+        return "skip"
+    return "build"
+
+
 # ── EPP Image build ─────────────────────────────────────────────────────────
 
 def _build_epp_image(run_dir: Path, run_name: str, namespace: str) -> str:
@@ -997,20 +1022,11 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
         err("No namespaces configured. Run setup.py with --namespaces."); sys.exit(1)
 
     # Decide whether to build EPP image
-    run_meta_path = run_dir / "run_metadata.json"
-    if not run_meta_path.exists():
-        err("run_metadata.json not found — run setup.py first."); sys.exit(1)
-    try:
-        run_meta = json.loads(run_meta_path.read_text())
-    except json.JSONDecodeError as e:
-        err(f"run_metadata.json is not valid JSON: {e}. Re-run setup.py."); sys.exit(1)
-
-    has_component_image = bool(run_meta.get("component_image"))
-
-    if not has_component_image:
+    epp_action = _resolve_epp_action(run_dir, args.skip_build_epp)
+    if epp_action.startswith("error:"):
+        err(epp_action[len("error:"):]); sys.exit(1)
+    elif epp_action == "skip":
         info("No component_image in run metadata — skipping EPP build")
-    elif args.skip_build_epp:
-        info("Skipping EPP build (--skip-build-epp)")
     else:
         _build_epp_image(run_dir, run_dir.name, namespaces[0])
 

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -997,10 +997,17 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
         err("No namespaces configured. Run setup.py with --namespaces."); sys.exit(1)
 
     # Build EPP image (tag is deterministic — already embedded in PipelineRuns by prepare.py)
-    if not args.skip_build_epp:
-        _build_epp_image(run_dir, run_dir.name, namespaces[0])
-    else:
+    run_meta_path = run_dir / "run_metadata.json"
+    has_component_image = False
+    if run_meta_path.exists():
+        has_component_image = bool(json.loads(run_meta_path.read_text()).get("component_image"))
+
+    if not has_component_image:
+        info("No component_image in run metadata — skipping EPP build (baseline-only)")
+    elif args.skip_build_epp:
         info("Skipping EPP build (--skip-build-epp)")
+    else:
+        _build_epp_image(run_dir, run_dir.name, namespaces[0])
 
     max_retries = getattr(args, "max_retries", 2)
     poll_interval = getattr(args, "poll_interval", 30)

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -996,14 +996,19 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
     if not namespaces or not namespaces[0]:
         err("No namespaces configured. Run setup.py with --namespaces."); sys.exit(1)
 
-    # Build EPP image (tag is deterministic — already embedded in PipelineRuns by prepare.py)
+    # Decide whether to build EPP image
     run_meta_path = run_dir / "run_metadata.json"
-    has_component_image = False
-    if run_meta_path.exists():
-        has_component_image = bool(json.loads(run_meta_path.read_text()).get("component_image"))
+    if not run_meta_path.exists():
+        err("run_metadata.json not found — run setup.py first."); sys.exit(1)
+    try:
+        run_meta = json.loads(run_meta_path.read_text())
+    except json.JSONDecodeError as e:
+        err(f"run_metadata.json is not valid JSON: {e}. Re-run setup.py."); sys.exit(1)
+
+    has_component_image = bool(run_meta.get("component_image"))
 
     if not has_component_image:
-        info("No component_image in run metadata — skipping EPP build (baseline-only)")
+        info("No component_image in run metadata — skipping EPP build")
     elif args.skip_build_epp:
         info("Skipping EPP build (--skip-build-epp)")
     else:

--- a/pipeline/lib/manifest.py
+++ b/pipeline/lib/manifest.py
@@ -122,60 +122,65 @@ def load_manifest(path: "Path | str") -> dict:
 def _validate_v3_fields(data: dict) -> None:
     """Validate and apply defaults for v3-specific fields."""
 
-    # component (required)
+    # component (required only when algorithms are present)
     component = data.get("component")
+    has_algorithms = bool(data.get("algorithms"))
+
     if component is None:
-        raise ManifestError("Missing required field: component")
-    if not isinstance(component, dict):
+        if has_algorithms:
+            raise ManifestError(
+                "component is required when algorithms are specified"
+            )
+    elif not isinstance(component, dict):
         raise ManifestError("component must be a mapping")
+    else:
+        # component.repo (required)
+        repo = component.get("repo")
+        if not repo or not isinstance(repo, str):
+            raise ManifestError("Missing required field: component.repo")
 
-    # component.repo (required)
-    repo = component.get("repo")
-    if not repo or not isinstance(repo, str):
-        raise ManifestError("Missing required field: component.repo")
+        # component.kind (required)
+        kind = component.get("kind")
+        if not kind or not isinstance(kind, str):
+            raise ManifestError("Missing required field: component.kind")
 
-    # component.kind (required)
-    kind = component.get("kind")
-    if not kind or not isinstance(kind, str):
-        raise ManifestError("Missing required field: component.kind")
+        # component.path (optional, defaults from last segment of repo)
+        if "path" not in component:
+            component["path"] = repo.rstrip("/").rsplit("/", 1)[-1]
 
-    # component.path (optional, defaults from last segment of repo)
-    if "path" not in component:
-        component["path"] = repo.rstrip("/").rsplit("/", 1)[-1]
+        # component.ref (optional)
+        ref = component.get("ref")
+        if ref is not None:
+            if not isinstance(ref, str) or not ref.strip():
+                raise ManifestError("component.ref must be a non-empty string")
 
-    # component.ref (optional)
-    ref = component.get("ref")
-    if ref is not None:
-        if not isinstance(ref, str) or not ref.strip():
-            raise ManifestError("component.ref must be a non-empty string")
+        # component.base_image (optional)
+        base_image = component.get("base_image")
+        if base_image is not None:
+            if not isinstance(base_image, dict):
+                raise ManifestError("component.base_image must be a mapping")
+            for f in ("hub", "name"):
+                if f not in base_image:
+                    raise ManifestError(f"Missing required field: component.base_image.{f}")
 
-    # component.base_image (optional)
-    base_image = component.get("base_image")
-    if base_image is not None:
-        if not isinstance(base_image, dict):
-            raise ManifestError("component.base_image must be a mapping")
-        for f in ("hub", "name"):
-            if f not in base_image:
-                raise ManifestError(f"Missing required field: component.base_image.{f}")
-
-    # component.build (optional)
-    build = component.get("build")
-    if build is not None:
-        if not isinstance(build, dict):
-            raise ManifestError("component.build must be a mapping")
-        build.setdefault("commands", [])
-        cmds = build["commands"]
-        if not isinstance(cmds, list):
-            raise ManifestError("component.build.commands must be a list")
-        build_image = build.get("image")
-        if build_image is not None:
-            if not isinstance(build_image, dict):
-                raise ManifestError("component.build.image must be a mapping")
-            if base_image is not None:
-                build_image.setdefault("hub", base_image["hub"])
-                build_image.setdefault("name", base_image["name"])
-            if "hub" not in build_image:
-                raise ManifestError("Missing required field: component.build.image.hub")
+        # component.build (optional)
+        build = component.get("build")
+        if build is not None:
+            if not isinstance(build, dict):
+                raise ManifestError("component.build must be a mapping")
+            build.setdefault("commands", [])
+            cmds = build["commands"]
+            if not isinstance(cmds, list):
+                raise ManifestError("component.build.commands must be a list")
+            build_image = build.get("image")
+            if build_image is not None:
+                if not isinstance(build_image, dict):
+                    raise ManifestError("component.build.image must be a mapping")
+                if base_image is not None:
+                    build_image.setdefault("hub", base_image["hub"])
+                    build_image.setdefault("name", base_image["name"])
+                if "hub" not in build_image:
+                    raise ManifestError("Missing required field: component.build.image.hub")
 
     # pipeline (optional, defaults applied)
     pipeline = data.get("pipeline")

--- a/pipeline/lib/manifest.py
+++ b/pipeline/lib/manifest.py
@@ -131,6 +131,7 @@ def _validate_v3_fields(data: dict) -> None:
             raise ManifestError(
                 "component is required when algorithms are specified"
             )
+        # Remove explicit null so downstream .get("component", {}) returns {} not None
         data.pop("component", None)
     elif not isinstance(component, dict):
         raise ManifestError("component must be a mapping")

--- a/pipeline/lib/manifest.py
+++ b/pipeline/lib/manifest.py
@@ -131,6 +131,7 @@ def _validate_v3_fields(data: dict) -> None:
             raise ManifestError(
                 "component is required when algorithms are specified"
             )
+        data.pop("component", None)
     elif not isinstance(component, dict):
         raise ManifestError("component must be a mapping")
     else:

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -1302,3 +1302,55 @@ def test_status_empty_pairs_only_orchestrator(tmp_path, capsys):
     _cmd_status(args, pf)
     out = capsys.readouterr().out
     assert "0 pairs" in out
+
+
+# ── EPP build decision (_resolve_epp_action) ──────────────────────────────────
+
+def test_epp_action_missing_metadata(tmp_path):
+    """Missing run_metadata.json → error."""
+    from pipeline.deploy import _resolve_epp_action
+    result = _resolve_epp_action(tmp_path, skip_build_epp=False)
+    assert result.startswith("error:")
+    assert "run_metadata.json not found" in result
+
+
+def test_epp_action_malformed_json(tmp_path):
+    """Corrupt run_metadata.json → error."""
+    from pipeline.deploy import _resolve_epp_action
+    (tmp_path / "run_metadata.json").write_text("{bad json")
+    result = _resolve_epp_action(tmp_path, skip_build_epp=False)
+    assert result.startswith("error:")
+    assert "not valid JSON" in result
+
+
+def test_epp_action_no_component_image(tmp_path):
+    """component_image absent → skip."""
+    from pipeline.deploy import _resolve_epp_action
+    (tmp_path / "run_metadata.json").write_text(json.dumps({"registry": "quay.io/me"}))
+    result = _resolve_epp_action(tmp_path, skip_build_epp=False)
+    assert result == "skip"
+
+
+def test_epp_action_empty_component_image(tmp_path):
+    """component_image is empty string → error (misconfigured setup)."""
+    from pipeline.deploy import _resolve_epp_action
+    (tmp_path / "run_metadata.json").write_text(json.dumps({"component_image": ""}))
+    result = _resolve_epp_action(tmp_path, skip_build_epp=False)
+    assert result.startswith("error:")
+    assert "empty" in result
+
+
+def test_epp_action_skip_build_flag(tmp_path):
+    """component_image present + --skip-build-epp → skip."""
+    from pipeline.deploy import _resolve_epp_action
+    (tmp_path / "run_metadata.json").write_text(json.dumps({"component_image": "quay.io/me/sched:run1"}))
+    result = _resolve_epp_action(tmp_path, skip_build_epp=True)
+    assert result == "skip"
+
+
+def test_epp_action_build(tmp_path):
+    """component_image present, no skip flag → build."""
+    from pipeline.deploy import _resolve_epp_action
+    (tmp_path / "run_metadata.json").write_text(json.dumps({"component_image": "quay.io/me/sched:run1"}))
+    result = _resolve_epp_action(tmp_path, skip_build_epp=False)
+    assert result == "build"

--- a/pipeline/tests/test_manifest.py
+++ b/pipeline/tests/test_manifest.py
@@ -187,12 +187,38 @@ def test_load_valid_v3_minimal(tmp_path):
 
 # ── component section ─────────────────────────────────────────────────────────
 
-def test_component_required(tmp_path):
-    """Missing component raises ManifestError."""
+def test_component_required_when_algorithms_present(tmp_path):
+    """Missing component raises when algorithms are specified."""
     data = {k: v for k, v in MINIMAL_V3.items() if k != "component"}
     path = _write_manifest(tmp_path, data)
-    with pytest.raises(ManifestError, match="component"):
+    with pytest.raises(ManifestError, match="component.*required.*algorithms"):
         load_manifest(path)
+
+
+def test_no_algorithms_no_component_valid(tmp_path):
+    """Baseline-only: no algorithms, no component → valid."""
+    data = {k: v for k, v in MINIMAL_V3.items() if k not in ("algorithms", "component")}
+    path = _write_manifest(tmp_path, data)
+    m = load_manifest(path)
+    assert m["algorithms"] == []
+    assert m.get("component") is None
+
+
+def test_algorithms_without_component_raises(tmp_path):
+    """algorithms present but component missing → ManifestError."""
+    data = {k: v for k, v in MINIMAL_V3.items() if k != "component"}
+    path = _write_manifest(tmp_path, data)
+    with pytest.raises(ManifestError, match="component.*required.*algorithms"):
+        load_manifest(path)
+
+
+def test_no_algorithms_with_component_valid(tmp_path):
+    """No algorithms but component present → valid (component used for SHA tracking)."""
+    data = {k: v for k, v in MINIMAL_V3.items() if k != "algorithms"}
+    path = _write_manifest(tmp_path, data)
+    m = load_manifest(path)
+    assert m["algorithms"] == []
+    assert m["component"]["repo"] == "github.com/llm-d/llm-d-inference-scheduler"
 
 
 def test_component_must_be_mapping(tmp_path):

--- a/pipeline/tests/test_manifest.py
+++ b/pipeline/tests/test_manifest.py
@@ -204,14 +204,6 @@ def test_no_algorithms_no_component_valid(tmp_path):
     assert m.get("component") is None
 
 
-def test_algorithms_without_component_raises(tmp_path):
-    """algorithms present but component missing → ManifestError."""
-    data = {k: v for k, v in MINIMAL_V3.items() if k != "component"}
-    path = _write_manifest(tmp_path, data)
-    with pytest.raises(ManifestError, match="component.*required.*algorithms"):
-        load_manifest(path)
-
-
 def test_no_algorithms_with_component_valid(tmp_path):
     """No algorithms but component present → valid (component used for SHA tracking)."""
     data = {k: v for k, v in MINIMAL_V3.items() if k != "algorithms"}
@@ -219,6 +211,15 @@ def test_no_algorithms_with_component_valid(tmp_path):
     m = load_manifest(path)
     assert m["algorithms"] == []
     assert m["component"]["repo"] == "github.com/llm-d/llm-d-inference-scheduler"
+
+
+def test_explicit_component_null_normalized(tmp_path):
+    """component: null (explicit YAML null) is removed from manifest, not left as None."""
+    data = {k: v for k, v in MINIMAL_V3.items() if k not in ("algorithms", "component")}
+    data["component"] = None
+    path = _write_manifest(tmp_path, data)
+    m = load_manifest(path)
+    assert "component" not in m
 
 
 def test_component_must_be_mapping(tmp_path):


### PR DESCRIPTION
## Summary

- Relaxes `transfer.yaml` validation so the `component` section is only required when `algorithms` is non-empty
- Auto-skips EPP image build in `deploy.py run` when `run_metadata.json` has no `component_image` (baseline-only mode)
- Adds tests for all four combinations: algorithms+component, algorithms-only (error), component-only (valid), neither (valid)

Closes #112

## Reviewer notes

- The `setup.py` change mentioned in the issue is unnecessary — line 689 already gates `component_image` on `if cfg.registry`, and the deploy.py guard handles the downstream case
- All existing tests pass unchanged; the `MULTI_BASELINE_V3` fixture (no algorithms, has component) validates test case 4 implicitly

## Test plan

- [x] `python -m pytest pipeline/ -v` — 497 tests pass
- [x] `ruff check pipeline/ --select F` — clean
- [ ] CI passes