### PR TITLE
Record HF secret name in setup_config.json instead of hardcoding

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -902,7 +902,7 @@ def _report_filter_mismatch(progress: dict, args) -> None:
     print(f"  Valid --status values:   {', '.join(valid_statuses)}", file=sys.stderr)
 
 
-def _check_slot_ready(namespace: str) -> tuple[bool, list[str]]:
+def _check_slot_ready(namespace: str, hf_secret_name: str = "hf-secret") -> tuple[bool, list[str]]:
     """Check that a namespace slot is ready to accept a new PipelineRun.
 
     Checks: PVCs bound, HF secret present.
@@ -924,11 +924,11 @@ def _check_slot_ready(namespace: str) -> tuple[bool, list[str]]:
             failures.append(f"PVC {pvc} not Bound in {namespace}{hint}")
 
     result = run(
-        ["kubectl", "get", "secret", "hf-secret", f"-n={namespace}"],
+        ["kubectl", "get", "secret", hf_secret_name, f"-n={namespace}"],
         check=False, capture=True,
     )
     if result.returncode != 0:
-        failures.append(f"Secret hf-secret missing in {namespace}")
+        failures.append(f"Secret {hf_secret_name} missing in {namespace}")
 
     return len(failures) == 0, failures
 
@@ -1320,7 +1320,8 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
             dispatchable = pending
 
         for ns, pair_key in zip(free_slots, dispatchable):
-            ready, reasons = _check_slot_ready(ns)
+            hf_secret_name = setup_config.get("hf_secret_name", "hf-secret")
+            ready, reasons = _check_slot_ready(ns, hf_secret_name=hf_secret_name)
             if not ready:
                 warn(f"Slot {ns} not ready: {'; '.join(reasons)}")
                 continue

--- a/pipeline/lib/assemble.py
+++ b/pipeline/lib/assemble.py
@@ -190,3 +190,18 @@ def assemble_packages(
                     )
 
     return packages
+
+
+def inject_hf_secret_name(scenario_dict: dict, hf_secret_name: str) -> bool:
+    """Inject huggingface.secretName into all scenario entries.
+
+    Does not overwrite an explicitly set secretName.
+    Returns True if injection occurred, False if skipped (no scenarios).
+    """
+    scenario_list = scenario_dict.get("scenario", [])
+    if not scenario_list:
+        return False
+    for entry in scenario_list:
+        hf = entry.setdefault("huggingface", {})
+        hf.setdefault("secretName", hf_secret_name)
+    return True

--- a/pipeline/prepare.py
+++ b/pipeline/prepare.py
@@ -471,7 +471,9 @@ def _phase_assembly(args, state: StateMachine, manifest: dict, run_dir: Path,
         sys.exit(1)
     hf_secret_name = setup_config.get("hf_secret_name", "hf-secret")
     for pkg in packages:
-        inject_hf_secret_name(pkg.resolved, hf_secret_name)
+        if not inject_hf_secret_name(pkg.resolved, hf_secret_name):
+            err(f"{pkg.name} has no 'scenario' entries — huggingface.secretName cannot be injected.")
+            sys.exit(1)
 
     # 4c: Write resolved scenarios
     cluster_dir = run_dir / "cluster"

--- a/pipeline/prepare.py
+++ b/pipeline/prepare.py
@@ -29,7 +29,7 @@ from pipeline.lib.manifest import load_manifest, ManifestError
 from pipeline.lib.state_machine import StateMachine
 from pipeline.lib.context_builder import build_context
 from pipeline.lib.tekton import make_pipelinerun_scenario
-from pipeline.lib.assemble import assemble_packages, AssemblyError
+from pipeline.lib.assemble import assemble_packages, AssemblyError, inject_hf_secret_name
 from pipeline.lib.epp import inject_epp_image
 
 # ── Repo layout ──────────────────────────────────────────────────────────────
@@ -464,6 +464,15 @@ def _phase_assembly(args, state: StateMachine, manifest: dict, run_dir: Path,
                     err(f"{pkg.name} has no 'scenario' entries — EPP image cannot be injected.")
                     sys.exit(1)
 
+    # 4b.6: Inject huggingface.secretName into all packages
+    setup_config = _load_setup_config()
+    if not setup_config:
+        err("setup_config.json not found. Run setup.py first to bootstrap cluster resources.")
+        sys.exit(1)
+    hf_secret_name = setup_config.get("hf_secret_name", "hf-secret")
+    for pkg in packages:
+        inject_hf_secret_name(pkg.resolved, hf_secret_name)
+
     # 4c: Write resolved scenarios
     cluster_dir = run_dir / "cluster"
     cluster_dir.mkdir(parents=True, exist_ok=True)
@@ -500,10 +509,6 @@ def _phase_assembly(args, state: StateMachine, manifest: dict, run_dir: Path,
         return
 
     # 4e: Pipeline resource
-    setup_config = _load_setup_config()
-    if not setup_config:
-        err("setup_config.json not found. Run setup.py first to bootstrap cluster resources.")
-        sys.exit(1)
     run_name = run_dir.name
     pipeline_name = manifest.get("pipeline", {}).get("name", "sim2real")
 

--- a/pipeline/setup.py
+++ b/pipeline/setup.py
@@ -30,6 +30,7 @@ class SetupConfig:
 # ── Repo layout ──────────────────────────────────────────────────────
 REPO_ROOT = Path(__file__).resolve().parent.parent
 TEKTONC_DIR = REPO_ROOT / "tektonc-data-collection"
+_DEFAULT_HF_SECRET_NAME = "hf-secret"
 
 # Overridden in main() when --experiment-root is specified.
 EXPERIMENT_ROOT = REPO_ROOT
@@ -390,7 +391,7 @@ def step_secrets(cfg: SetupConfig, container_rt: str) -> None:
     if cfg.no_cluster:
         ok("Secrets (skipped — --no-cluster)"); return
 
-    hf_secret_name = "hf-secret"
+    hf_secret_name = _DEFAULT_HF_SECRET_NAME
 
     if not cfg.hf_token and secret_exists(hf_secret_name, cfg.namespace):
         ok(f"{hf_secret_name} already exists (reusing)")
@@ -667,7 +668,7 @@ def step_config_output(cfg: SetupConfig, run_dir: Path, container_rt: str) -> No
         "container_runtime": container_rt,
         "current_run": cfg.run_name,
         "setup_timestamp": now_iso,
-        "hf_secret_name": "hf-secret",
+        "hf_secret_name": _DEFAULT_HF_SECRET_NAME,
         "workspaces": {
             "data-storage":   {"persistentVolumeClaim": {"claimName": "data-pvc"}},
             "source":         {"persistentVolumeClaim": {"claimName": "source-pvc"}},

--- a/pipeline/setup.py
+++ b/pipeline/setup.py
@@ -390,21 +390,22 @@ def step_secrets(cfg: SetupConfig, container_rt: str) -> None:
     if cfg.no_cluster:
         ok("Secrets (skipped — --no-cluster)"); return
 
-    # hf-secret — skip if token is empty and secret already exists (reuse mode)
-    if not cfg.hf_token and secret_exists("hf-secret", cfg.namespace):
-        ok("hf-secret already exists (reusing)")
+    hf_secret_name = "hf-secret"
+
+    if not cfg.hf_token and secret_exists(hf_secret_name, cfg.namespace):
+        ok(f"{hf_secret_name} already exists (reusing)")
     elif not cfg.hf_token:
-        err("HF_TOKEN is required and hf-secret does not exist in namespace"); sys.exit(1)
+        err(f"HF_TOKEN is required and {hf_secret_name} does not exist in namespace"); sys.exit(1)
     else:
         yaml_out = run(
-            ["kubectl", "create", "secret", "generic", "hf-secret",
+            ["kubectl", "create", "secret", "generic", hf_secret_name,
              f"--namespace={cfg.namespace}",
              f"--from-literal=HF_TOKEN={cfg.hf_token}",
              "--dry-run=client", "-o", "yaml"],
             capture=True,
         ).stdout
         run(["kubectl", "apply", "-f", "-"], input=yaml_out)
-        ok("hf-secret created/updated")
+        ok(f"{hf_secret_name} created/updated")
 
     # github-token — used by install-llmdbenchmark to clone private repos
     github_token = cfg.github_token
@@ -666,6 +667,7 @@ def step_config_output(cfg: SetupConfig, run_dir: Path, container_rt: str) -> No
         "container_runtime": container_rt,
         "current_run": cfg.run_name,
         "setup_timestamp": now_iso,
+        "hf_secret_name": "hf-secret",
         "workspaces": {
             "data-storage":   {"persistentVolumeClaim": {"claimName": "data-pvc"}},
             "source":         {"persistentVolumeClaim": {"claimName": "source-pvc"}},

--- a/pipeline/tests/test_assemble.py
+++ b/pipeline/tests/test_assemble.py
@@ -3,7 +3,7 @@ import pytest
 import yaml
 
 from pipeline.lib.assemble import assemble_scenarios
-from pipeline.lib.assemble import assemble_packages, AssemblyError
+from pipeline.lib.assemble import assemble_packages, AssemblyError, inject_hf_secret_name
 
 
 BASELINE = {
@@ -273,3 +273,36 @@ def test_assemble_packages_algorithm_unknown_baseline_raises(tmp_path):
             algorithms=[{"name": "ac1", "scenario_path": tmp_path / "t.yaml", "defaults": "nonexistent"}],
             generated_dir=tmp_path / "generated",
         )
+
+
+class TestInjectHfSecretName:
+    """inject_hf_secret_name sets huggingface.secretName on all scenario entries."""
+
+    def test_injects_into_scenario_entries(self):
+        scenario_dict = {"scenario": [
+            {"name": "baseline", "model": {"name": "Qwen/Qwen3-14B"}},
+        ]}
+        result = inject_hf_secret_name(scenario_dict, "hf-secret")
+        assert result is True
+        assert scenario_dict["scenario"][0]["huggingface"] == {"secretName": "hf-secret"}
+
+    def test_preserves_existing_huggingface_fields(self):
+        scenario_dict = {"scenario": [
+            {"name": "baseline", "huggingface": {"existingField": "value"}},
+        ]}
+        inject_hf_secret_name(scenario_dict, "my-token")
+        assert scenario_dict["scenario"][0]["huggingface"] == {
+            "existingField": "value",
+            "secretName": "my-token",
+        }
+
+    def test_returns_false_for_empty_scenarios(self):
+        assert inject_hf_secret_name({"scenario": []}, "hf-secret") is False
+        assert inject_hf_secret_name({}, "hf-secret") is False
+
+    def test_does_not_overwrite_explicit_secret_name(self):
+        scenario_dict = {"scenario": [
+            {"name": "baseline", "huggingface": {"secretName": "explicit-override"}},
+        ]}
+        inject_hf_secret_name(scenario_dict, "hf-secret")
+        assert scenario_dict["scenario"][0]["huggingface"]["secretName"] == "explicit-override"

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -1,6 +1,7 @@
 """Tests for deploy.py run orchestrator and status subcommand."""
 import argparse
 import json
+from unittest.mock import patch
 
 
 _PROGRESS = {
@@ -1354,3 +1355,44 @@ def test_epp_action_build(tmp_path):
     (tmp_path / "run_metadata.json").write_text(json.dumps({"component_image": "quay.io/me/sched:run1"}))
     result = _resolve_epp_action(tmp_path, skip_build_epp=False)
     assert result == "build"
+
+
+# ── _check_slot_ready hf_secret_name parameter ──────────────────────────────
+
+
+class TestCheckSlotReadyHfSecret:
+    """_check_slot_ready uses the hf_secret_name parameter."""
+
+    @patch("pipeline.deploy.run")
+    def test_uses_configured_secret_name(self, mock_run):
+        from pipeline.deploy import _check_slot_ready
+
+        mock_run.return_value.returncode = 0
+        mock_run.return_value.stdout = "Bound"
+
+        ready, failures = _check_slot_ready("test-ns", hf_secret_name="my-hf-token")
+
+        secret_calls = [c for c in mock_run.call_args_list
+                        if "secret" in str(c) and "my-hf-token" in str(c)]
+        assert len(secret_calls) == 1
+        assert ready
+
+    @patch("pipeline.deploy.run")
+    def test_reports_configured_secret_name_in_failure(self, mock_run):
+        from pipeline.deploy import _check_slot_ready
+
+        def side_effect(cmd, *, check=True, capture=False, input=None):
+            class R:
+                returncode = 0
+                stdout = "Bound"
+            r = R()
+            if "secret" in cmd:
+                r.returncode = 1
+            return r
+
+        mock_run.side_effect = side_effect
+
+        ready, failures = _check_slot_ready("test-ns", hf_secret_name="my-hf-token")
+
+        assert not ready
+        assert any("my-hf-token" in f for f in failures)

--- a/pipeline/tests/test_prepare.py
+++ b/pipeline/tests/test_prepare.py
@@ -1334,6 +1334,11 @@ class TestBaselineOnlyNoAlgorithm:
         # baseline.yaml must exist for assembly
         (repo / "baseline.yaml").write_text(yaml.dump({"model": {"name": "test"}}))
 
+        # setup_config.json required for HF secret injection
+        ws_dir = repo / "workspace"
+        ws_dir.mkdir(parents=True, exist_ok=True)
+        (ws_dir / "setup_config.json").write_text(json.dumps({"namespace": "default"}))
+
         run_dir = repo / "workspace" / "runs" / "test-run"
         run_dir.mkdir(parents=True, exist_ok=True)
 

--- a/pipeline/tests/test_prepare.py
+++ b/pipeline/tests/test_prepare.py
@@ -1331,8 +1331,8 @@ class TestBaselineOnlyNoAlgorithm:
         # Empty workloads to skip PipelineRun generation (avoids setup_config dep)
         manifest["workloads"] = []
 
-        # baseline.yaml must exist for assembly
-        (repo / "baseline.yaml").write_text(yaml.dump({"model": {"name": "test"}}))
+        # baseline.yaml must exist for assembly (needs scenario list for HF injection)
+        (repo / "baseline.yaml").write_text(yaml.dump({"scenario": [{"name": "test", "model": {"name": "test"}}]}))
 
         # setup_config.json required for HF secret injection
         ws_dir = repo / "workspace"

--- a/pipeline/tests/test_setup_pipeline.py
+++ b/pipeline/tests/test_setup_pipeline.py
@@ -188,6 +188,28 @@ class TestSetupConfigJson:
             setup_module.EXPERIMENT_ROOT = original_experiment_root
 
 
+    def test_config_output_includes_hf_secret_name(self, tmp_path):
+        """setup_config.json includes hf_secret_name field."""
+        from pipeline.setup import step_config_output
+        import pipeline.setup as setup_module
+
+        original_experiment_root = setup_module.EXPERIMENT_ROOT
+        setup_module.EXPERIMENT_ROOT = tmp_path
+
+        try:
+            run_dir = tmp_path / "workspace" / "runs" / "test-run"
+            run_dir.mkdir(parents=True)
+
+            cfg = _make_config()
+            step_config_output(cfg, run_dir, "podman")
+
+            config_path = tmp_path / "workspace" / "setup_config.json"
+            data = json.loads(config_path.read_text())
+            assert data["hf_secret_name"] == "hf-secret"
+        finally:
+            setup_module.EXPERIMENT_ROOT = original_experiment_root
+
+
 class TestBuildParser:
     """build_parser includes --pipeline-yaml flag."""
 


### PR DESCRIPTION
Closes #115

## Summary

- Adds `hf_secret_name` field (default `"hf-secret"`) to `setup_config.json`, making the secret name a single-source-of-truth setup-time decision
- Replaces all hardcoded `"hf-secret"` string literals in `setup.py` and `deploy.py` with reads from config
- Adds `inject_hf_secret_name()` to the assembly module that stamps `huggingface.secretName` into all resolved scenario entries during Phase 4 — closing the mismatch with llm-d-benchmark's expected field

## Reviewer notes

- `inject_hf_secret_name` uses `setdefault` so it won't overwrite an explicit `secretName` already present in bundle YAML — bundles that already declare their own secret name are respected
- The `setup_config` load in `prepare.py` Phase 4 was moved earlier (before scenario writing) so the HF injection has access to it. The PipelineRun generation that previously triggered the load still works since `setup_config` remains in scope.

## Test plan

- [x] New tests for `hf_secret_name` in `setup_config.json` output
- [x] New tests for `_check_slot_ready` honoring the parameter
- [x] New tests for `inject_hf_secret_name` (basic injection, preserve existing fields, no-overwrite, empty scenarios)
- [x] Full suite: 510 tests pass
- [x] Lint: `ruff check pipeline/ --select F` clean