### PR TITLE
Per-pair GPU cost derivation from scenarioContent

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -991,10 +991,12 @@ def _derive_pair_gpu_costs(
 ) -> dict[str, int]:
     """Compute GPU cost per pair from its scenarioContent.
 
-    Fallback chain per pair:
+    If defaults is None, returns fallback_cost for all pairs immediately.
+
+    Otherwise, per pair:
       1. Parse scenarioContent → gpu_cost_per_pair(scenario, defaults)
       2. If scenarioContent missing/invalid → gpu_cost_per_pair({}, defaults)
-      3. If defaults unavailable or derivation fails → fallback_cost
+      3. If derivation returns an error → fallback_cost
     """
     from pipeline.lib.capacity import gpu_cost_per_pair
 
@@ -1009,8 +1011,8 @@ def _derive_pair_gpu_costs(
         if scenario_content:
             try:
                 resolved = yaml.safe_load(scenario_content)
-            except yaml.YAMLError:
-                pass
+            except yaml.YAMLError as e:
+                warn(f"{key}: scenarioContent is invalid YAML ({e}) — deriving cost from defaults")
 
         if resolved and isinstance(resolved, dict):
             result = gpu_cost_per_pair(resolved, defaults)
@@ -1020,6 +1022,7 @@ def _derive_pair_gpu_costs(
         if isinstance(result, int):
             costs[key] = result
         else:
+            warn(f"{key}: GPU cost derivation failed: {result} — using fallback ({fallback_cost})")
             costs[key] = fallback_cost
 
     return costs

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -983,6 +983,48 @@ def _do_collect(pair_key: str, entry: dict, run_dir: Path, store, progress: dict
     return ok
 
 
+def _derive_pair_gpu_costs(
+    discovered: dict,
+    *,
+    defaults: dict | None,
+    fallback_cost: int,
+) -> dict[str, int]:
+    """Compute GPU cost per pair from its scenarioContent.
+
+    Fallback chain per pair:
+      1. Parse scenarioContent → gpu_cost_per_pair(scenario, defaults)
+      2. If scenarioContent missing/invalid → gpu_cost_per_pair({}, defaults)
+      3. If defaults unavailable or derivation fails → fallback_cost
+    """
+    from pipeline.lib.capacity import gpu_cost_per_pair
+
+    costs = {}
+    for key, meta in discovered.items():
+        if defaults is None:
+            costs[key] = fallback_cost
+            continue
+
+        scenario_content = meta.get("scenario_content")
+        resolved = None
+        if scenario_content:
+            try:
+                resolved = yaml.safe_load(scenario_content)
+            except yaml.YAMLError:
+                pass
+
+        if resolved and isinstance(resolved, dict):
+            result = gpu_cost_per_pair(resolved, defaults)
+        else:
+            result = gpu_cost_per_pair({}, defaults)
+
+        if isinstance(result, int):
+            costs[key] = result
+        else:
+            costs[key] = fallback_cost
+
+    return costs
+
+
 def _capacity_limited_pairs(
     pending: list[str],
     progress: dict,

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -696,6 +696,7 @@ def _load_pairs(cluster_dir: Path) -> dict:
                 "pr_name": pr_name,
                 "pr_path": str(pr_path),
                 "namespace": pr_data.get("metadata", {}).get("namespace", ""),
+                "scenario_content": params.get("scenarioContent"),
             }
         except Exception as e:
             warn(f"Skipping {pr_path.name}: {e}")

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1057,7 +1057,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
     from pipeline.lib.progress import LocalProgressStore
     from pipeline.lib.backoff import BackoffController
     from pipeline.lib.capacity import (
-        probe_free_gpus, gpu_cost_per_pair, derive_gpu_resource_type, load_defaults
+        probe_free_gpus, derive_gpu_resource_type, load_defaults
     )
 
     namespaces = setup_config.get("namespaces") or [setup_config.get("namespace", "")]
@@ -1082,10 +1082,10 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
     progress_path = run_dir / "progress.json"
     store = LocalProgressStore(progress_path)
 
-    # Derive GPU resource type and cost from scenario + defaults
+    # Derive GPU resource type from baseline scenario
     # CLI --gpu-resource-type overrides auto-derivation when explicitly set
     gpu_resource_type = args.gpu_resource_type  # None means auto-derive
-    pair_gpu_cost = args.default_gpu_cost
+    fallback_cost = args.default_gpu_cost
     defaults_result = load_defaults(REPO_ROOT)
     if isinstance(defaults_result, str):
         warn(defaults_result)
@@ -1106,18 +1106,12 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
         if resolved:
             if gpu_resource_type is None:
                 gpu_resource_type = derive_gpu_resource_type(resolved, defaults_result)
-            derived_cost = gpu_cost_per_pair(resolved, defaults_result)
-            if isinstance(derived_cost, int):
-                pair_gpu_cost = derived_cost
-            else:
-                warn(f"GPU cost derivation failed: {derived_cost} — using fallback ({pair_gpu_cost})")
     elif defaults_result is None and not scenario_path.exists():
         info("Defaults or scenario not found — using CLI defaults")
     if gpu_resource_type is None:
         gpu_resource_type = "nvidia.com/gpu"
     if gpu_resource_type != "nvidia.com/gpu":
         info(f"GPU resource type: {gpu_resource_type}")
-    info(f"GPU cost per pair: {pair_gpu_cost}")
     _probe_fail_count = 0
     _last_probe_error = ""
 
@@ -1137,6 +1131,15 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
     if not discovered:
         err("No pairs found in cluster/. Run prepare.py first."); sys.exit(1)
 
+    pair_costs = _derive_pair_gpu_costs(
+        discovered, defaults=defaults_result, fallback_cost=fallback_cost,
+    )
+    unique_costs = set(pair_costs.values())
+    if len(unique_costs) == 1:
+        info(f"GPU cost per pair: {unique_costs.pop()}")
+    else:
+        info(f"GPU cost per pair: {min(unique_costs)}–{max(unique_costs)} (heterogeneous)")
+
     # Initialize new entries (first run or new pairs added)
     for key, meta in discovered.items():
         if key not in progress:
@@ -1146,7 +1149,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                 "status":   "pending",
                 "namespace": None,
                 "retries":  0,
-                "gpu_cost": pair_gpu_cost,
+                "gpu_cost": pair_costs[key],
                 "pending_stalls": 0,
                 "pending_since": None,
             }
@@ -1325,8 +1328,8 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
             backoff.last_probe_free_gpus = free_gpus
         pending = _pending_pairs()
         if free_gpus is not None and pending:
-            min_cost = min(progress[k].get("gpu_cost", pair_gpu_cost) for k in pending)
-            max_cost = max(progress[k].get("gpu_cost", pair_gpu_cost) for k in pending)
+            min_cost = min(progress[k].get("gpu_cost", fallback_cost) for k in pending)
+            max_cost = max(progress[k].get("gpu_cost", fallback_cost) for k in pending)
             if free_gpus < min_cost:
                 prev_state = backoff.state
                 backoff.signal_scarcity(free_gpus=free_gpus, min_cost=min_cost)
@@ -1343,17 +1346,17 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
         free_slots = [ns for ns in namespaces if ns not in slots_busy]
         pending = _pending_pairs()
         if free_gpus is not None and pending:
-            min_cost = min(progress[k].get("gpu_cost", pair_gpu_cost) for k in pending)
+            min_cost = min(progress[k].get("gpu_cost", fallback_cost) for k in pending)
             if not backoff.should_dispatch(free_gpus=free_gpus, min_cost=min_cost):
                 info(f"Backoff: skipping dispatch ({len(pending)} pending, {free_gpus} free GPUs)")
                 dispatchable = []
             else:
                 dispatchable = _capacity_limited_pairs(
                     pending, progress,
-                    free_gpus=free_gpus, default_gpu_cost=pair_gpu_cost,
+                    free_gpus=free_gpus, default_gpu_cost=fallback_cost,
                 )
                 if len(dispatchable) == 0 and pending:
-                    smallest = min(progress[k].get("gpu_cost", pair_gpu_cost) for k in pending)
+                    smallest = min(progress[k].get("gpu_cost", fallback_cost) for k in pending)
                     warn(f"Dispatching 0/{len(pending)} pending pairs — smallest cost ({smallest}) exceeds free GPUs ({free_gpus})")
                 elif len(dispatchable) < len(pending):
                     info(f"Dispatching {len(dispatchable)}/{len(pending)} pending pairs (capacity-limited: {free_gpus} free GPUs)")

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -1441,3 +1441,72 @@ def test_load_pairs_missing_scenario_content(tmp_path):
 
     pairs = _load_pairs(cluster_dir)
     assert pairs["wl-wl1-baseline"]["scenario_content"] is None
+
+
+# ── _derive_pair_gpu_costs ───────────────────────────────────────────────────
+
+
+def test_derive_pair_gpu_costs_heterogeneous():
+    """Per-pair cost derivation produces different costs for different scenarios."""
+    import yaml as _yaml
+    from pipeline.deploy import _derive_pair_gpu_costs
+
+    defaults = {
+        "accelerator": {"count": 1},
+        "decode": {"enabled": True, "replicas": 1},
+    }
+
+    scenario_a = {"scenario": [{"decode": {"replicas": 2}}]}
+    scenario_b = {"scenario": [{"decode": {"replicas": 4}}]}
+
+    discovered = {
+        "wl-a-baseline": {"scenario_content": _yaml.dump(scenario_a)},
+        "wl-b-treatment": {"scenario_content": _yaml.dump(scenario_b)},
+    }
+
+    costs = _derive_pair_gpu_costs(discovered, defaults=defaults, fallback_cost=1)
+    assert costs["wl-a-baseline"] == 2
+    assert costs["wl-b-treatment"] == 4
+
+
+def test_derive_pair_gpu_costs_fallback_on_missing_scenario():
+    """When scenarioContent is None, falls back to defaults-only derivation."""
+    from pipeline.deploy import _derive_pair_gpu_costs
+
+    defaults = {
+        "decode": {"enabled": True, "replicas": 1},
+        "accelerator": {"count": 4},
+    }
+
+    discovered = {
+        "wl-a-baseline": {"scenario_content": None},
+    }
+
+    costs = _derive_pair_gpu_costs(discovered, defaults=defaults, fallback_cost=1)
+    assert costs["wl-a-baseline"] == 4
+
+
+def test_derive_pair_gpu_costs_fallback_on_bad_yaml():
+    """When scenarioContent is invalid YAML, falls back to defaults-only derivation."""
+    from pipeline.deploy import _derive_pair_gpu_costs
+
+    defaults = {"decode": {"enabled": True, "replicas": 1}, "accelerator": {"count": 2}}
+
+    discovered = {
+        "wl-a-baseline": {"scenario_content": ": invalid: yaml: ["},
+    }
+
+    costs = _derive_pair_gpu_costs(discovered, defaults=defaults, fallback_cost=99)
+    assert costs["wl-a-baseline"] == 2
+
+
+def test_derive_pair_gpu_costs_no_defaults():
+    """When defaults is None, uses fallback_cost for all pairs."""
+    from pipeline.deploy import _derive_pair_gpu_costs
+
+    discovered = {
+        "wl-a-baseline": {"scenario_content": "scenario:\n- decode:\n    replicas: 2\n"},
+    }
+
+    costs = _derive_pair_gpu_costs(discovered, defaults=None, fallback_cost=7)
+    assert costs["wl-a-baseline"] == 7

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -1510,3 +1510,54 @@ def test_derive_pair_gpu_costs_no_defaults():
 
     costs = _derive_pair_gpu_costs(discovered, defaults=None, fallback_cost=7)
     assert costs["wl-a-baseline"] == 7
+
+
+def test_init_progress_per_pair_heterogeneous_cost(tmp_path):
+    """Progress entries get individually-derived gpu_cost from scenarioContent."""
+    import yaml as _yaml
+    from pipeline.deploy import _load_pairs, _derive_pair_gpu_costs
+
+    cluster_dir = tmp_path / "cluster"
+    cluster_dir.mkdir()
+
+    scenario_a = {"scenario": [{"decode": {"replicas": 2, "accelerator": {"count": 4}}}]}
+    pr_a = {
+        "metadata": {"name": "baseline-a-run1", "namespace": "ns"},
+        "spec": {"params": [
+            {"name": "workloadName", "value": "wl-a"},
+            {"name": "phase", "value": "baseline"},
+            {"name": "scenarioContent", "value": _yaml.dump(scenario_a)},
+        ]},
+    }
+    (cluster_dir / "pipelinerun-a-baseline.yaml").write_text(_yaml.dump(pr_a))
+
+    scenario_b = {"scenario": [{"decode": {"replicas": 1, "accelerator": {"count": 2}}}]}
+    pr_b = {
+        "metadata": {"name": "treatment-b-run1", "namespace": "ns"},
+        "spec": {"params": [
+            {"name": "workloadName", "value": "wl-b"},
+            {"name": "phase", "value": "treatment"},
+            {"name": "scenarioContent", "value": _yaml.dump(scenario_b)},
+        ]},
+    }
+    (cluster_dir / "pipelinerun-b-treatment.yaml").write_text(_yaml.dump(pr_b))
+
+    defaults = {"decode": {"enabled": True, "replicas": 1}, "accelerator": {"count": 1}}
+    discovered = _load_pairs(cluster_dir)
+    costs = _derive_pair_gpu_costs(discovered, defaults=defaults, fallback_cost=1)
+
+    progress = {}
+    for key, meta in discovered.items():
+        progress[key] = {
+            "workload": meta["workload"],
+            "package":  meta["package"],
+            "status":   "pending",
+            "namespace": None,
+            "retries":  0,
+            "gpu_cost": costs[key],
+            "pending_stalls": 0,
+            "pending_since": None,
+        }
+
+    assert progress["wl-a-baseline"]["gpu_cost"] == 8
+    assert progress["wl-b-treatment"]["gpu_cost"] == 2

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -1396,3 +1396,48 @@ class TestCheckSlotReadyHfSecret:
 
         assert not ready
         assert any("my-hf-token" in f for f in failures)
+
+
+def test_load_pairs_includes_scenario_content(tmp_path):
+    """_load_pairs extracts scenarioContent param from PipelineRun YAMLs."""
+    import yaml as _yaml
+    from pipeline.deploy import _load_pairs
+
+    cluster_dir = tmp_path / "cluster"
+    cluster_dir.mkdir()
+
+    scenario = {"scenario": [{"decode": {"replicas": 2}}]}
+    pr = {
+        "metadata": {"name": "baseline-wl1-run1", "namespace": "ns"},
+        "spec": {"params": [
+            {"name": "workloadName", "value": "wl1"},
+            {"name": "phase", "value": "baseline"},
+            {"name": "scenarioContent", "value": _yaml.dump(scenario)},
+        ]},
+    }
+    (cluster_dir / "pipelinerun-wl1-baseline.yaml").write_text(_yaml.dump(pr))
+
+    pairs = _load_pairs(cluster_dir)
+    assert "wl-wl1-baseline" in pairs
+    assert pairs["wl-wl1-baseline"]["scenario_content"] == _yaml.dump(scenario)
+
+
+def test_load_pairs_missing_scenario_content(tmp_path):
+    """_load_pairs sets scenario_content to None when param is absent."""
+    import yaml as _yaml
+    from pipeline.deploy import _load_pairs
+
+    cluster_dir = tmp_path / "cluster"
+    cluster_dir.mkdir()
+
+    pr = {
+        "metadata": {"name": "baseline-wl1-run1", "namespace": "ns"},
+        "spec": {"params": [
+            {"name": "workloadName", "value": "wl1"},
+            {"name": "phase", "value": "baseline"},
+        ]},
+    }
+    (cluster_dir / "pipelinerun-wl1-baseline.yaml").write_text(_yaml.dump(pr))
+
+    pairs = _load_pairs(cluster_dir)
+    assert pairs["wl-wl1-baseline"]["scenario_content"] is None


### PR DESCRIPTION
## Summary

- Extends `_load_pairs` to extract the `scenarioContent` param from each PipelineRun YAML
- Adds `_derive_pair_gpu_costs()` which computes GPU cost individually per pair using `gpu_cost_per_pair()` with fallback chain: scenarioContent → defaults-only → CLI `--default-gpu-cost`
- Replaces the uniform `pair_gpu_cost` scalar in the orchestrator init with per-pair costs dict
- Log output now shows a range ("4–8 (heterogeneous)") when pairs have different costs

Closes #87

## Reviewer notes

- The `gpu_cost_per_pair` import moves from `_cmd_run` (no longer needed there) into `_derive_pair_gpu_costs` as a local import
- Existing progress entries without a `gpu_cost` field still fall back to `fallback_cost` (the CLI `--default-gpu-cost` value) — backward compatible with running progress.json files
- The capacity log UX changes (per-pair cost at dispatch time, suppressing idle polls) are tracked separately in #117

## Test plan

- [x] `test_load_pairs_includes_scenario_content` — extraction when param present
- [x] `test_load_pairs_missing_scenario_content` — None when param absent
- [x] `test_derive_pair_gpu_costs_heterogeneous` — different scenarios → different costs
- [x] `test_derive_pair_gpu_costs_fallback_on_missing_scenario` — None scenario → defaults-only
- [x] `test_derive_pair_gpu_costs_fallback_on_bad_yaml` — invalid YAML → defaults-only
- [x] `test_derive_pair_gpu_costs_no_defaults` — no defaults → fallback_cost
- [x] `test_init_progress_per_pair_heterogeneous_cost` — end-to-end integration
- [x] All 517 existing tests pass (no regressions)
- [x] Lint clean (`ruff check pipeline/ --select F`)