### PR TITLE
Auto-delete successful PipelineRuns after collection

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -165,6 +165,8 @@ python pipeline/deploy.py pairs   [flags]   # list available pair keys, workload
 
 **Pair statuses:** `pending` → `running` → `collecting` → `done` | `collect-failed`. Failure paths: `running` → `failed` (hard failure or non-recoverable pending), `running` → `timed-out` (4h timeout exceeded), `running` → `pending` (recoverable early reclaim, repeats up to `--max-pending-stalls` times) → `stalled`.
 
+**Auto-cleanup** — when a PipelineRun succeeds and results are collected, the orchestrator deletes the PipelineRun CR from the cluster. Failed PipelineRuns are left in place for debugging (`kubectl describe`, pod logs). Use `cleanup` to remove them when done.
+
 **`deploy.py status`** — prints the current state of all pairs from `workspace/runs/<run>/progress.json`. When the orchestrator is in backoff, an additional line shows the current state and backoff level.
 
 | Flag | Description |

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -195,7 +195,9 @@ def _delete_pipelinerun(pr_name: str, namespace: str) -> None:
         check=False, capture=True,
     )
     if result.returncode != 0:
-        warn(f"Failed to delete PipelineRun {pr_name!r} in {namespace}")
+        detail = result.stderr.strip() if result.stderr else ""
+        warn(f"Failed to delete PipelineRun {pr_name!r} in {namespace}" +
+             (f": {detail}" if detail else ""))
 
 
 # ── Deploy command ───────────────────────────────────────────────────────────
@@ -994,7 +996,10 @@ def _do_collect(pair_key: str, entry: dict, run_dir: Path, store, progress: dict
         entry["namespace"] = None
         store.save(progress)
     if ok and pr_name and namespace:
-        _delete_pipelinerun(pr_name, namespace)
+        try:
+            _delete_pipelinerun(pr_name, namespace)
+        except Exception as exc:
+            warn(f"Failed to delete PipelineRun {pr_name!r} in {namespace}: {exc}")
     return ok
 
 

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -187,6 +187,17 @@ def _cancel_and_delete_pipelinerun(pr_name: str, namespace: str) -> None:
     )
 
 
+def _delete_pipelinerun(pr_name: str, namespace: str) -> None:
+    """Delete a completed PipelineRun. Best-effort — warns on failure."""
+    result = run(
+        ["kubectl", "delete", "pipelinerun", pr_name, "-n", namespace,
+         "--ignore-not-found"],
+        check=False, capture=True,
+    )
+    if result.returncode != 0:
+        warn(f"Failed to delete PipelineRun {pr_name!r} in {namespace}")
+
+
 # ── Deploy command ───────────────────────────────────────────────────────────
 
 # ── Status command ───────────────────────────────────────────────────────────
@@ -969,7 +980,9 @@ def _reconcile_collecting(key: str, entry: dict, run_dir: Path) -> None:
     entry["namespace"] = None
 
 
-def _do_collect(pair_key: str, entry: dict, run_dir: Path, store, progress: dict) -> bool:
+def _do_collect(pair_key: str, entry: dict, run_dir: Path, store, progress: dict,
+                *, pr_name: str = "") -> bool:
+    namespace = entry.get("namespace", "")
     ok = False
     try:
         ok = _collect_pair(pair_key, entry, run_dir)
@@ -980,6 +993,8 @@ def _do_collect(pair_key: str, entry: dict, run_dir: Path, store, progress: dict
     finally:
         entry["namespace"] = None
         store.save(progress)
+    if ok and pr_name and namespace:
+        _delete_pipelinerun(pr_name, namespace)
     return ok
 
 
@@ -1233,7 +1248,8 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                 store.save(progress)
                 ok_collect = False
                 try:
-                    ok_collect = _do_collect(pair_key, entry, run_dir, store, progress)
+                    ok_collect = _do_collect(pair_key, entry, run_dir, store, progress,
+                                            pr_name=pr_name)
                 finally:
                     del slots_busy[ns]
                 if ok_collect:

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -570,6 +570,26 @@ def test_do_collect_skips_delete_on_interrupt(tmp_path, monkeypatch):
     assert deleted == []
 
 
+def test_do_collect_returns_true_when_delete_raises(tmp_path, monkeypatch):
+    """If _delete_pipelinerun raises OSError, _do_collect still returns True."""
+    import pipeline.deploy as mod
+    from pipeline.lib.progress import LocalProgressStore
+
+    monkeypatch.setattr(mod, "_collect_pair", lambda *a: True)
+    monkeypatch.setattr(mod, "_delete_pipelinerun",
+                        lambda pr, ns: (_ for _ in ()).throw(OSError("kubectl not found")))
+
+    entry = {"workload": "wl-x", "package": "baseline", "status": "collecting",
+             "namespace": "sim2real-0", "retries": 0}
+    progress = {"wl-x-baseline": entry}
+    store = LocalProgressStore(tmp_path / "progress.json")
+    store.save(progress)
+    result = mod._do_collect("wl-x-baseline", entry, tmp_path, store, progress,
+                             pr_name="baseline-x-run1")
+    assert result is True
+    assert entry["status"] == "done"
+
+
 # ── _force_reset ──────────────────────────────────────────────────────────────
 
 def _mock_run(monkeypatch):

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -499,6 +499,77 @@ def test_do_collect_interrupt_saves_collect_failed(tmp_path, monkeypatch):
     assert saved["wl-x-baseline"]["namespace"] is None
 
 
+# ── _do_collect + _delete_pipelinerun ─────────────────────────────────────────
+
+def test_do_collect_deletes_pipelinerun_on_success(tmp_path, monkeypatch):
+    """Successful collection triggers PipelineRun deletion."""
+    import pipeline.deploy as mod
+    from pipeline.lib.progress import LocalProgressStore
+
+    monkeypatch.setattr(mod, "_collect_pair", lambda *a: True)
+
+    deleted = []
+    monkeypatch.setattr(mod, "_delete_pipelinerun",
+                        lambda pr, ns: deleted.append((pr, ns)))
+
+    entry = {"workload": "wl-x", "package": "baseline", "status": "collecting",
+             "namespace": "sim2real-0", "retries": 0}
+    progress = {"wl-x-baseline": entry}
+    store = LocalProgressStore(tmp_path / "progress.json")
+    store.save(progress)
+    result = mod._do_collect("wl-x-baseline", entry, tmp_path, store, progress,
+                             pr_name="baseline-x-run1")
+    assert result is True
+    assert deleted == [("baseline-x-run1", "sim2real-0")]
+
+
+def test_do_collect_skips_delete_on_failure(tmp_path, monkeypatch):
+    """Failed collection does NOT delete the PipelineRun."""
+    import pipeline.deploy as mod
+    from pipeline.lib.progress import LocalProgressStore
+
+    monkeypatch.setattr(mod, "_collect_pair", lambda *a: False)
+
+    deleted = []
+    monkeypatch.setattr(mod, "_delete_pipelinerun",
+                        lambda pr, ns: deleted.append((pr, ns)))
+
+    entry = {"workload": "wl-x", "package": "baseline", "status": "collecting",
+             "namespace": "sim2real-0", "retries": 0}
+    progress = {"wl-x-baseline": entry}
+    store = LocalProgressStore(tmp_path / "progress.json")
+    store.save(progress)
+    result = mod._do_collect("wl-x-baseline", entry, tmp_path, store, progress,
+                             pr_name="baseline-x-run1")
+    assert result is False
+    assert deleted == []
+
+
+def test_do_collect_skips_delete_on_interrupt(tmp_path, monkeypatch):
+    """KeyboardInterrupt during collection does NOT delete PipelineRun."""
+    import pytest
+    import pipeline.deploy as mod
+    from pipeline.lib.progress import LocalProgressStore
+
+    def _raise(*a):
+        raise KeyboardInterrupt()
+    monkeypatch.setattr(mod, "_collect_pair", _raise)
+
+    deleted = []
+    monkeypatch.setattr(mod, "_delete_pipelinerun",
+                        lambda pr, ns: deleted.append((pr, ns)))
+
+    entry = {"workload": "wl-x", "package": "baseline", "status": "collecting",
+             "namespace": "sim2real-0", "retries": 0}
+    progress = {"wl-x-baseline": entry}
+    store = LocalProgressStore(tmp_path / "progress.json")
+    store.save(progress)
+    with pytest.raises(KeyboardInterrupt):
+        mod._do_collect("wl-x-baseline", entry, tmp_path, store, progress,
+                        pr_name="baseline-x-run1")
+    assert deleted == []
+
+
 # ── _force_reset ──────────────────────────────────────────────────────────────
 
 def _mock_run(monkeypatch):


### PR DESCRIPTION
Closes #121

## Summary

- Adds `_delete_pipelinerun` helper — best-effort `kubectl delete pipelinerun --ignore-not-found` with a warning on failure
- Modifies `_do_collect` to accept an optional `pr_name` kwarg; when collection succeeds, deletes the PipelineRun CR before returning
- Updates the poll loop call site to pass `pr_name` through

## Design notes

- **Namespace capture**: `_do_collect` captures `entry["namespace"]` before the try/finally block, because `finally` clears it to `None`. The captured value is used for the deletion call.
- **Best-effort**: Deletion failure warns but doesn't crash — the PipelineRun will be cleaned up by `reset` later.
- **Backward compatible**: `pr_name` defaults to `""`, so existing internal callers (`_reconcile_collecting`) are unaffected.
- **Failed runs untouched**: Only the `Succeeded` branch calls `_do_collect` with `pr_name`; the failure branch never triggers deletion.

## Test plan

- [x] `test_do_collect_deletes_pipelinerun_on_success` — verifies deletion is called with correct pr_name and namespace
- [x] `test_do_collect_skips_delete_on_failure` — verifies no deletion when collection fails
- [x] `test_do_collect_skips_delete_on_interrupt` — verifies no deletion on KeyboardInterrupt
- [x] Existing `test_do_collect_saves_done_on_success` still passes (backward compat)
- [x] Existing `test_do_collect_interrupt_saves_collect_failed` still passes
- [x] Full suite: 520 tests pass
- [x] Lint: `ruff check pipeline/ --select F` clean