### PR TITLE
Rename deploy.py cleanup subcommand to reset

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -115,7 +115,7 @@ Phase state is tracked per-run in `workspace/runs/<run>/.state.json`. Delete it 
 Builds the EPP image and orchestrates PipelineRun execution across namespace slots. Operates independently of `transfer.yaml` — driven by workspace files and `setup_config.json`.
 
 ```bash
-python pipeline/deploy.py {run|status|collect|cleanup|pairs} [flags]
+python pipeline/deploy.py {run|status|collect|reset|pairs} [flags]
 ```
 
 Common flags (all subcommands):
@@ -138,7 +138,7 @@ Common flags (all subcommands):
 python pipeline/deploy.py run     [flags]   # orchestrate parallel pool execution across namespace slots
 python pipeline/deploy.py status            # show progress snapshot of all (workload, package) pairs
 python pipeline/deploy.py collect [--package NAME…]
-python pipeline/deploy.py cleanup [flags]   # tear down cluster resources for failed/stalled pairs
+python pipeline/deploy.py reset [flags]     # tear down cluster resources for failed/stalled pairs
 python pipeline/deploy.py pairs   [flags]   # list available pair keys, workloads, and packages
 ```
 
@@ -165,7 +165,7 @@ python pipeline/deploy.py pairs   [flags]   # list available pair keys, workload
 
 **Pair statuses:** `pending` → `running` → `collecting` → `done` | `collect-failed`. Failure paths: `running` → `failed` (hard failure or non-recoverable pending), `running` → `timed-out` (4h timeout exceeded), `running` → `pending` (recoverable early reclaim, repeats up to `--max-pending-stalls` times) → `stalled`.
 
-**Auto-cleanup** — when a PipelineRun succeeds and results are collected, the orchestrator deletes the PipelineRun CR from the cluster. Failed PipelineRuns are left in place for debugging (`kubectl describe`, pod logs). Use `cleanup` to remove them when done.
+**Auto-cleanup** — when a PipelineRun succeeds and results are collected, the orchestrator deletes the PipelineRun CR from the cluster. Failed PipelineRuns are left in place for debugging (`kubectl describe`, pod logs). Use `reset` to remove them when done.
 
 **`deploy.py status`** — prints the current state of all pairs from `workspace/runs/<run>/progress.json`. When the orchestrator is in backoff, an additional line shows the current state and backoff level.
 
@@ -176,15 +176,15 @@ python pipeline/deploy.py pairs   [flags]   # list available pair keys, workload
 
 **`deploy.py collect`** — extracts results from the cluster PVC and writes to `workspace/runs/<run>/results/{phase}/<workload>/`.
 
-**`deploy.py cleanup`** — removes cluster resources (PipelineRuns, Helm releases) for all non-pending pairs. Failed/running/timed-out pairs are reset to `pending` so they can be re-dispatched. Done pairs stay `done` — only their PipelineRun is deleted to free cluster resources.
+**`deploy.py reset`** — removes cluster resources (PipelineRuns, Helm releases) for all non-pending pairs. Failed/running/timed-out pairs are reset to `pending` so they can be re-dispatched. Done pairs stay `done` — only their PipelineRun is deleted to free cluster resources.
 
 | Flag | Description |
 |------|-------------|
-| `--only PAIR` | Scope cleanup to one specific pair key (`wl-` prefix optional) |
-| `--workload NAME` | Scope cleanup to pairs matching this workload |
-| `--package NAME` | Scope cleanup to pairs matching this package |
-| `--status STATE` | Scope cleanup to pairs with this status |
-| `--dry-run` | Print what would be cleaned up without acting |
+| `--only PAIR` | Scope reset to one specific pair key (`wl-` prefix optional) |
+| `--workload NAME` | Scope reset to pairs matching this workload |
+| `--package NAME` | Scope reset to pairs matching this package |
+| `--status STATE` | Scope reset to pairs with this status |
+| `--dry-run` | Print what would be reset without acting |
 
 **Safety:** Results in `workspace/runs/<run>/results/` are preserved — only cluster resources are removed. For `done` pairs, only the PipelineRun is deleted (Tekton already tore down Helm releases).
 

--- a/pipeline/completions.bash
+++ b/pipeline/completions.bash
@@ -12,7 +12,7 @@ _sim2real_deploy() {
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    local subcommands="run status collect cleanup pairs"
+    local subcommands="run status collect reset pairs"
     local status_values="pending running done failed timed-out stalled collect-failed collecting"
 
     # Extract --experiment-root and --run values while finding the subcommand.
@@ -24,7 +24,7 @@ _sim2real_deploy() {
             --experiment-root) ((i++)); _exroot="${COMP_WORDS[i]}" ;;
             --run)             ((i++)); _run_name="${COMP_WORDS[i]}" ;;
             -*) ;;
-            run|status|collect|cleanup|pairs)
+            run|status|collect|reset|pairs)
                 subcmd="${COMP_WORDS[i]}"
                 break
                 ;;
@@ -78,7 +78,7 @@ _sim2real_deploy() {
             status)
                 COMPREPLY=($(compgen -W "--only --workload --package --status" -- "$cur"))
                 ;;
-            cleanup)
+            reset)
                 COMPREPLY=($(compgen -W "--only --workload --package --status --dry-run" -- "$cur"))
                 ;;
             collect)

--- a/pipeline/completions.zsh
+++ b/pipeline/completions.zsh
@@ -58,7 +58,7 @@ _sim2real_deploy() {
                 'run:Orchestrate parallel pool execution'
                 'status:Show progress of all (workload, package) pairs'
                 'collect:Pull results for completed packages'
-                'cleanup:Tear down cluster resources for all non-pending pairs'
+                'reset:Tear down cluster resources for all non-pending pairs'
                 'pairs:List available pair keys, workloads, and packages'
             )
             _describe 'subcommand' subcommands
@@ -94,7 +94,7 @@ _sim2real_deploy() {
                         '*--package[Collect only these packages]:package:_deploy_py_packages' \
                         '--skip-logs[Skip vLLM and EPP log files]'
                     ;;
-                cleanup)
+                reset)
                     _arguments \
                         '--only[Scope to one pair key]:pair key:_deploy_py_pair_keys' \
                         '--workload[Scope to workload]:workload:_deploy_py_workloads' \

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -5,7 +5,7 @@ Subcommands:
   run      Build EPP image, submit PipelineRuns
   status   Show progress of all (workload, package) pairs
   collect  Pull results from cluster for completed phases
-  cleanup  Tear down cluster resources for all non-pending pairs
+  reset    Tear down cluster resources for all non-pending pairs
   pairs    List available pair keys, workloads, and packages
 """
 
@@ -717,14 +717,14 @@ def _load_pairs(cluster_dir: Path) -> dict:
     return pairs
 
 
-def _cleanup_pair(key: str, entry: dict, discovered: dict, *,
-                  dry_run: bool = False, namespaces: list[str] | None = None) -> bool:
+def _reset_pair(key: str, entry: dict, discovered: dict, *,
+                dry_run: bool = False, namespaces: list[str] | None = None) -> bool:
     """Delete PipelineRun and Helm releases for a pair.
 
     For non-done pairs: also resets state to pending.
     For done pairs: deletes PipelineRun only (Helm already torn down by Tekton).
 
-    Returns True if cleanup was performed, False if it failed and state was NOT reset.
+    Returns True if reset was performed, False if it failed and state was NOT reset.
     """
     ns = entry.get("namespace")
     pr_name = discovered.get(key, {}).get("pr_name", "")
@@ -785,7 +785,7 @@ def _cleanup_pair(key: str, entry: dict, discovered: dict, *,
     if ns:
         result = run(["helm", "list", "-n", ns, "-q"], check=False, capture=True)
         if result.returncode != 0:
-            warn(f"{key}: helm list failed in {ns} — skipping cleanup (manual intervention needed)")
+            warn(f"{key}: helm list failed in {ns} — skipping reset (manual intervention needed)")
             return False
         if result.stdout.strip():
             helm_failed = False
@@ -813,19 +813,19 @@ def _force_reset(progress: dict, scope: set, discovered: dict | None = None,
                  namespaces: list[str] | None = None) -> int:
     """Reset non-pending, non-done pairs in scope to pending.
 
-    Calls _cleanup_pair for cluster teardown when possible. Pairs where
-    cleanup fails are skipped (not counted, state preserved).
+    Calls _reset_pair for cluster teardown when possible. Pairs where
+    reset fails are skipped (not counted, state preserved).
     """
     reset = 0
     for key in scope:
         entry = progress.get(key, {})
         if entry.get("status") not in (None, "pending", "done"):
             try:
-                if _cleanup_pair(key, entry, discovered or {},
-                                 namespaces=namespaces):
+                if _reset_pair(key, entry, discovered or {},
+                              namespaces=namespaces):
                     reset += 1
             except Exception as e:
-                warn(f"{key}: cleanup failed during --force: {e}")
+                warn(f"{key}: reset failed during --force: {e}")
     return reset
 
 
@@ -1457,25 +1457,25 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
     print()
 
 
-def _cmd_cleanup(args, progress_path: Path, discovered: dict,
-                 namespaces: list[str] | None = None) -> None:
+def _cmd_reset(args, progress_path: Path, discovered: dict,
+               namespaces: list[str] | None = None) -> None:
     """Tear down cluster resources for all non-pending pairs."""
     from pipeline.lib.progress import LocalProgressStore
     store = LocalProgressStore(progress_path)
     progress = store.load()
 
     if not progress:
-        info("No progress data found — nothing to clean up")
+        info("No progress data found — nothing to reset")
         return
 
     _scope = _resolve_scope(progress, args)
 
-    # Exclude pending (nothing to clean)
+    # Exclude pending (nothing to reset)
     actionable = {k for k in _scope
                   if progress[k].get("status") not in (None, "pending")}
 
     if not actionable:
-        info("No pairs need cleanup (all pending)")
+        info("No pairs need reset (all pending)")
         return
 
     dry_run = getattr(args, "dry_run", False)
@@ -1488,19 +1488,19 @@ def _cmd_cleanup(args, progress_path: Path, discovered: dict,
     for key in sorted(actionable):
         entry = progress[key]
         try:
-            if _cleanup_pair(key, entry, discovered, dry_run=dry_run,
-                             namespaces=namespaces):
+            if _reset_pair(key, entry, discovered, dry_run=dry_run,
+                          namespaces=namespaces):
                 cleaned += 1
             else:
                 errors += 1
         except Exception as e:
-            err(f"{key}: cleanup failed — {e}")
+            err(f"{key}: reset failed — {e}")
             errors += 1
 
     if not dry_run:
         store.save(progress)
 
-    msg = f"{cleaned} pair(s) cleaned up"
+    msg = f"{cleaned} pair(s) reset"
     if errors:
         msg += f" ({errors} failed — manual intervention needed)"
     ok(msg)
@@ -1520,8 +1520,8 @@ Examples:
   python pipeline/deploy.py status                     # Show progress snapshot
   python pipeline/deploy.py collect                    # Pull results for completed phases
   python pipeline/deploy.py collect --skip-logs        # Collect traces only (skip large logs)
-  python pipeline/deploy.py cleanup                    # Tear down stalled/failed pairs
-  python pipeline/deploy.py cleanup --dry-run          # Preview what would be cleaned
+  python pipeline/deploy.py reset                       # Reset stalled/failed pairs
+  python pipeline/deploy.py reset --dry-run             # Preview what would be reset
   python pipeline/deploy.py pairs                       # List pairs with workloads and packages
   python pipeline/deploy.py pairs --keys-only           # Machine-readable: keys only
 """,
@@ -1568,13 +1568,13 @@ Examples:
     run_p.add_argument("--max-backoff", type=int, default=600, dest="max_backoff",
                        help="Maximum backoff interval in seconds during GPU scarcity [600]")
 
-    cleanup_p = sub.add_parser("cleanup", help="Tear down cluster resources for all non-pending pairs")
-    cleanup_p.add_argument("--only",     metavar="PAIR",  help="Scope to one specific pair key (wl- prefix optional)")
-    cleanup_p.add_argument("--workload", metavar="NAME",  help="Scope to pairs matching this workload")
-    cleanup_p.add_argument("--package",  metavar="NAME",  help="Scope to pairs matching this package")
-    cleanup_p.add_argument("--status",   metavar="STATE", help="Scope to pairs with this status")
-    cleanup_p.add_argument("--dry-run",  action="store_true", dest="dry_run",
-                           help="Print what would be cleaned up without doing it")
+    reset_p = sub.add_parser("reset", help="Tear down cluster resources for all non-pending pairs")
+    reset_p.add_argument("--only",     metavar="PAIR",  help="Scope to one specific pair key (wl- prefix optional)")
+    reset_p.add_argument("--workload", metavar="NAME",  help="Scope to pairs matching this workload")
+    reset_p.add_argument("--package",  metavar="NAME",  help="Scope to pairs matching this package")
+    reset_p.add_argument("--status",   metavar="STATE", help="Scope to pairs with this status")
+    reset_p.add_argument("--dry-run",  action="store_true", dest="dry_run",
+                         help="Print what would be reset without doing it")
 
     pairs_p = sub.add_parser("pairs", help="List available pair keys, workloads, and packages")
     pairs_group = pairs_p.add_mutually_exclusive_group()
@@ -1619,7 +1619,7 @@ def main():
         _cmd_status(args, progress_path)
     elif cmd == "collect":
         _cmd_collect(args, run_dir, setup_config)
-    elif cmd == "cleanup":
+    elif cmd == "reset":
         progress_path = run_dir / "progress.json"
         cluster_dir = run_dir / "cluster"
         discovered = _load_pairs(cluster_dir)
@@ -1627,14 +1627,14 @@ def main():
                       [setup_config.get("namespace", "")]) if ns]
         if not namespaces:
             warn("No namespaces in setup_config — PipelineRun deletion for done pairs may be incomplete")
-        _cmd_cleanup(args, progress_path, discovered, namespaces=namespaces or None)
+        _cmd_reset(args, progress_path, discovered, namespaces=namespaces or None)
     elif cmd == "pairs":
         cluster_dir = run_dir / "cluster"
         _cmd_pairs(cluster_dir, keys_only=args.keys_only,
                    workloads_only=args.workloads_only,
                    packages_only=args.packages_only)
     else:
-        err("No subcommand specified. Use: deploy.py run | status | collect | cleanup | pairs")
+        err("No subcommand specified. Use: deploy.py run | status | collect | reset | pairs")
         sys.exit(1)
 
 

--- a/pipeline/tests/test_completions.py
+++ b/pipeline/tests/test_completions.py
@@ -38,13 +38,13 @@ def test_bash_syntax_valid():
 
 def test_zsh_declares_subcommands():
     content = COMPLETIONS_ZSH.read_text()
-    for subcmd in ("run", "status", "collect", "cleanup", "pairs"):
+    for subcmd in ("run", "status", "collect", "reset", "pairs"):
         assert subcmd in content
 
 
 def test_bash_declares_subcommands():
     content = COMPLETIONS_BASH.read_text()
-    for subcmd in ("run", "status", "collect", "cleanup", "pairs"):
+    for subcmd in ("run", "status", "collect", "reset", "pairs"):
         assert subcmd in content
 
 

--- a/pipeline/tests/test_deploy_reset.py
+++ b/pipeline/tests/test_deploy_reset.py
@@ -1,4 +1,4 @@
-"""Tests for deploy.py cleanup subcommand and _cleanup_pair helper."""
+"""Tests for deploy.py reset subcommand and _reset_pair helper."""
 
 import json
 
@@ -20,7 +20,7 @@ _DISCOVERED = {
 }
 
 
-def test_cleanup_pair_failed_deletes_pr_and_helm(monkeypatch):
+def test_reset_pair_failed_deletes_pr_and_helm(monkeypatch):
     """A failed pair gets its PipelineRun deleted and Helm releases uninstalled."""
     import pipeline.deploy as mod
 
@@ -37,7 +37,7 @@ def test_cleanup_pair_failed_deletes_pr_and_helm(monkeypatch):
 
     monkeypatch.setattr(mod, "run", fake_run)
 
-    mod._cleanup_pair("wl-heavy-baseline", entry, _DISCOVERED)
+    mod._reset_pair("wl-heavy-baseline", entry, _DISCOVERED)
 
     assert entry["status"] == "pending"
     assert entry["namespace"] is None
@@ -55,7 +55,7 @@ def test_cleanup_pair_failed_deletes_pr_and_helm(monkeypatch):
     assert len(helm_uninstalls) == 2
 
 
-def test_cleanup_pair_running_cancels_first(monkeypatch):
+def test_reset_pair_running_cancels_first(monkeypatch):
     """A running pair gets cancelled before deletion."""
     import pipeline.deploy as mod
 
@@ -75,27 +75,27 @@ def test_cleanup_pair_running_cancels_first(monkeypatch):
     monkeypatch.setattr(mod, "_cancel_and_delete_pipelinerun", fake_cancel)
     monkeypatch.setattr(mod, "run", fake_run)
 
-    mod._cleanup_pair("wl-smoke-treatment", entry, _DISCOVERED)
+    mod._reset_pair("wl-smoke-treatment", entry, _DISCOVERED)
 
     assert cancelled == [("treatment-smoke-run1", "sim2real-1")]
     assert entry["status"] == "pending"
     assert entry["namespace"] is None
 
 
-def test_cleanup_pair_none_namespace_resets_state(monkeypatch):
+def test_reset_pair_none_namespace_resets_state(monkeypatch):
     """Pairs with no namespace still get reset (e.g. collect-failed)."""
     import pipeline.deploy as mod
 
     entry = {"workload": "wl-load", "package": "baseline", "status": "collect-failed",
              "namespace": None, "retries": 2}
 
-    result = mod._cleanup_pair("wl-load-baseline", entry, _DISCOVERED)
+    result = mod._reset_pair("wl-load-baseline", entry, _DISCOVERED)
     assert result is True
     assert entry["status"] == "pending"
     assert entry["retries"] == 0
 
 
-def test_cleanup_pair_kubectl_delete_failure_does_not_reset(monkeypatch):
+def test_reset_pair_kubectl_delete_failure_does_not_reset(monkeypatch):
     """When kubectl delete pipelinerun fails, state is NOT reset."""
     import pipeline.deploy as mod
 
@@ -110,13 +110,13 @@ def test_cleanup_pair_kubectl_delete_failure_does_not_reset(monkeypatch):
 
     monkeypatch.setattr(mod, "run", fake_run)
 
-    result = mod._cleanup_pair("wl-heavy-baseline", entry, _DISCOVERED)
+    result = mod._reset_pair("wl-heavy-baseline", entry, _DISCOVERED)
     assert result is False
     assert entry["status"] == "failed"
     assert entry["namespace"] == "sim2real-0"
 
 
-def test_cleanup_pair_helm_list_failure_does_not_reset(monkeypatch):
+def test_reset_pair_helm_list_failure_does_not_reset(monkeypatch):
     """When helm list fails, state is NOT reset — operator needs manual intervention."""
     import pipeline.deploy as mod
 
@@ -131,13 +131,13 @@ def test_cleanup_pair_helm_list_failure_does_not_reset(monkeypatch):
 
     monkeypatch.setattr(mod, "run", fake_run)
 
-    result = mod._cleanup_pair("wl-heavy-baseline", entry, _DISCOVERED)
+    result = mod._reset_pair("wl-heavy-baseline", entry, _DISCOVERED)
     assert result is False
     assert entry["status"] == "failed"
     assert entry["namespace"] == "sim2real-0"
 
 
-def test_cleanup_pair_helm_uninstall_failure_does_not_reset(monkeypatch):
+def test_reset_pair_helm_uninstall_failure_does_not_reset(monkeypatch):
     """When helm uninstall fails, state is NOT reset."""
     import pipeline.deploy as mod
 
@@ -152,13 +152,13 @@ def test_cleanup_pair_helm_uninstall_failure_does_not_reset(monkeypatch):
 
     monkeypatch.setattr(mod, "run", fake_run)
 
-    result = mod._cleanup_pair("wl-heavy-baseline", entry, _DISCOVERED)
+    result = mod._reset_pair("wl-heavy-baseline", entry, _DISCOVERED)
     assert result is False
     assert entry["status"] == "failed"
     assert entry["namespace"] == "sim2real-0"
 
 
-def test_cleanup_pair_missing_pr_name_warns(monkeypatch, capsys):
+def test_reset_pair_missing_pr_name_warns(monkeypatch, capsys):
     """When pr_name is not in discovered, a warning is emitted."""
     import pipeline.deploy as mod
 
@@ -173,15 +173,15 @@ def test_cleanup_pair_missing_pr_name_warns(monkeypatch, capsys):
 
     monkeypatch.setattr(mod, "run", fake_run)
 
-    result = mod._cleanup_pair("wl-unknown-baseline", entry, {})
+    result = mod._reset_pair("wl-unknown-baseline", entry, {})
     assert result is True
     assert entry["status"] == "pending"
     err = capsys.readouterr().err
     assert "no PipelineRun name found" in err
 
 
-def test_cmd_cleanup_continues_on_exception(tmp_path, monkeypatch, capsys):
-    """One pair raising an exception does not abort cleanup of remaining pairs."""
+def test_cmd_reset_continues_on_exception(tmp_path, monkeypatch, capsys):
+    """One pair raising an exception does not abort reset of remaining pairs."""
     import pipeline.deploy as mod
 
     progress = {
@@ -195,7 +195,7 @@ def test_cmd_cleanup_continues_on_exception(tmp_path, monkeypatch, capsys):
 
     call_count = []
 
-    def exploding_cleanup(key, entry, disc, dry_run=False, namespaces=None):
+    def exploding_reset(key, entry, disc, dry_run=False, namespaces=None):
         call_count.append(key)
         if key == "wl-a-baseline":
             raise RuntimeError("kubectl not found")
@@ -204,22 +204,22 @@ def test_cmd_cleanup_continues_on_exception(tmp_path, monkeypatch, capsys):
         entry["retries"] = 0
         return True
 
-    monkeypatch.setattr(mod, "_cleanup_pair", exploding_cleanup)
+    monkeypatch.setattr(mod, "_reset_pair", exploding_reset)
 
     class _Args:
         only = None; workload = None; package = None; status = None; dry_run = False
 
-    mod._cmd_cleanup(_Args(), progress_path, _DISCOVERED)
+    mod._cmd_reset(_Args(), progress_path, _DISCOVERED)
 
     # Both pairs should have been attempted
     assert "wl-a-baseline" in call_count
     assert "wl-b-baseline" in call_count
-    # Progress should still be saved (wl-b was cleaned)
+    # Progress should still be saved (wl-b was reset)
     saved = json.loads(progress_path.read_text())
     assert saved["wl-b-baseline"]["status"] == "pending"
 
 
-def test_cleanup_pair_done_deletes_pr_without_state_reset(monkeypatch):
+def test_reset_pair_done_deletes_pr_without_state_reset(monkeypatch):
     """Done pairs get PipelineRun deleted but stay in done state."""
     import pipeline.deploy as mod
 
@@ -236,8 +236,8 @@ def test_cleanup_pair_done_deletes_pr_without_state_reset(monkeypatch):
 
     monkeypatch.setattr(mod, "run", fake_run)
 
-    result = mod._cleanup_pair("wl-smoke-baseline", entry, _DISCOVERED,
-                               namespaces=["sim2real-0", "sim2real-1"])
+    result = mod._reset_pair("wl-smoke-baseline", entry, _DISCOVERED,
+                             namespaces=["sim2real-0", "sim2real-1"])
 
     assert result is True
     # State stays done
@@ -252,78 +252,77 @@ def test_cleanup_pair_done_deletes_pr_without_state_reset(monkeypatch):
     assert helm_calls == []
 
 
-def test_cmd_cleanup_skips_pending_only(tmp_path, monkeypatch, capsys):
-    """cleanup acts on all non-pending pairs, including done."""
+def test_cmd_reset_skips_pending_only(tmp_path, monkeypatch, capsys):
+    """reset acts on all non-pending pairs, including done."""
     import pipeline.deploy as mod
 
     progress_path = tmp_path / "progress.json"
     progress_path.write_text(json.dumps(_PROGRESS))
 
     cleaned = []
-    monkeypatch.setattr(mod, "_cleanup_pair",
+    monkeypatch.setattr(mod, "_reset_pair",
                         lambda k, e, d, dry_run=False, namespaces=None: cleaned.append(k) or True)
 
     class _Args:
         only = None; workload = None; package = None; status = None; dry_run = False
 
-    mod._cmd_cleanup(_Args(), progress_path, _DISCOVERED)
+    mod._cmd_reset(_Args(), progress_path, _DISCOVERED)
 
     # pending (wl-load-baseline) should be skipped
     assert "wl-load-baseline" not in cleaned
-    # done, running, timed-out, failed should all be cleaned
+    # done, running, timed-out, failed should all be reset
     assert "wl-smoke-baseline" in cleaned
     assert "wl-smoke-treatment" in cleaned
     assert "wl-load-treatment" in cleaned
     assert "wl-heavy-baseline" in cleaned
 
 
-def test_cmd_cleanup_respects_only_filter(tmp_path, monkeypatch, capsys):
-    """--only scopes cleanup to a single pair."""
+def test_cmd_reset_respects_only_filter(tmp_path, monkeypatch, capsys):
+    """--only scopes reset to a single pair."""
     import pipeline.deploy as mod
 
     progress_path = tmp_path / "progress.json"
     progress_path.write_text(json.dumps(_PROGRESS))
 
     cleaned = []
-    monkeypatch.setattr(mod, "_cleanup_pair",
+    monkeypatch.setattr(mod, "_reset_pair",
                         lambda k, e, d, dry_run=False, namespaces=None: cleaned.append(k) or True)
 
     class _Args:
         only = "wl-heavy-baseline"; workload = None; package = None; status = None; dry_run = False
 
-    mod._cmd_cleanup(_Args(), progress_path, _DISCOVERED)
+    mod._cmd_reset(_Args(), progress_path, _DISCOVERED)
 
     assert cleaned == ["wl-heavy-baseline"]
 
 
-def test_cmd_cleanup_dry_run_does_not_save(tmp_path, monkeypatch, capsys):
+def test_cmd_reset_dry_run_does_not_save(tmp_path, monkeypatch, capsys):
     """--dry-run does not mutate progress.json."""
     import pipeline.deploy as mod
 
     progress_path = tmp_path / "progress.json"
     progress_path.write_text(json.dumps(_PROGRESS))
 
-    monkeypatch.setattr(mod, "_cleanup_pair",
+    monkeypatch.setattr(mod, "_reset_pair",
                         lambda k, e, d, dry_run=False, namespaces=None: True)
 
     class _Args:
         only = None; workload = None; package = None; status = None; dry_run = True
 
-    mod._cmd_cleanup(_Args(), progress_path, _DISCOVERED)
+    mod._cmd_reset(_Args(), progress_path, _DISCOVERED)
 
     # Progress should not be modified
     saved = json.loads(progress_path.read_text())
     assert saved == _PROGRESS
 
 
-def test_cmd_cleanup_saves_progress_on_success(tmp_path, monkeypatch, capsys):
-    """After cleanup, progress.json is updated with reset entries."""
+def test_cmd_reset_saves_progress_on_success(tmp_path, monkeypatch, capsys):
+    """After reset, progress.json is updated with reset entries."""
     import pipeline.deploy as mod
 
     progress_path = tmp_path / "progress.json"
     progress_path.write_text(json.dumps(_PROGRESS))
 
-    # Use real _cleanup_pair logic but mock subprocess calls
     def fake_run(cmd, *, check=True, capture=False, cwd=None):
         class _R:
             returncode = 0
@@ -339,8 +338,8 @@ def test_cmd_cleanup_saves_progress_on_success(tmp_path, monkeypatch, capsys):
     class _Args:
         only = None; workload = None; package = None; status = None; dry_run = False
 
-    mod._cmd_cleanup(_Args(), progress_path, _DISCOVERED,
-                     namespaces=["sim2real-0", "sim2real-1", "sim2real-2"])
+    mod._cmd_reset(_Args(), progress_path, _DISCOVERED,
+                   namespaces=["sim2real-0", "sim2real-1", "sim2real-2"])
 
     saved = json.loads(progress_path.read_text())
     # Non-done pairs reset to pending
@@ -353,8 +352,8 @@ def test_cmd_cleanup_saves_progress_on_success(tmp_path, monkeypatch, capsys):
     assert saved["wl-load-baseline"]["status"] == "pending"
 
 
-def test_force_reset_calls_cleanup_for_non_pending_non_done(monkeypatch):
-    """_force_reset cleans non-pending, non-done pairs via _cleanup_pair."""
+def test_force_reset_calls_reset_for_non_pending_non_done(monkeypatch):
+    """_force_reset resets non-pending, non-done pairs via _reset_pair."""
     import pipeline.deploy as mod
 
     progress = {
@@ -376,14 +375,14 @@ def test_force_reset_calls_cleanup_for_non_pending_non_done(monkeypatch):
 
     cleaned = []
 
-    def fake_cleanup(key, entry, disc, dry_run=False, namespaces=None):
+    def fake_reset(key, entry, disc, dry_run=False, namespaces=None):
         cleaned.append(key)
         entry["status"] = "pending"
         entry["namespace"] = None
         entry["retries"] = 0
         return True
 
-    monkeypatch.setattr(mod, "_cleanup_pair", fake_cleanup)
+    monkeypatch.setattr(mod, "_reset_pair", fake_reset)
 
     scope = set(progress.keys())
     n = mod._force_reset(progress, scope, discovered,
@@ -392,15 +391,15 @@ def test_force_reset_calls_cleanup_for_non_pending_non_done(monkeypatch):
     # Pending and done should be skipped
     assert "wl-a-treatment" not in cleaned
     assert "wl-c-baseline" not in cleaned
-    # Failed and timed-out should be cleaned
+    # Failed and timed-out should be reset
     assert "wl-a-baseline" in cleaned
     assert "wl-b-baseline" in cleaned
     assert n == 2
     assert progress["wl-c-baseline"]["status"] == "done"
 
 
-def test_force_reset_skips_count_on_cleanup_failure(monkeypatch):
-    """_force_reset does not count pairs where _cleanup_pair returned False."""
+def test_force_reset_skips_count_on_reset_failure(monkeypatch):
+    """_force_reset does not count pairs where _reset_pair returned False."""
     import pipeline.deploy as mod
 
     progress = {
@@ -409,7 +408,7 @@ def test_force_reset_skips_count_on_cleanup_failure(monkeypatch):
     }
     discovered = {"wl-a-baseline": {"pr_name": "pr1", "workload": "wl-a", "package": "baseline"}}
 
-    monkeypatch.setattr(mod, "_cleanup_pair", lambda *a, **kw: False)
+    monkeypatch.setattr(mod, "_reset_pair", lambda *a, **kw: False)
 
     n = mod._force_reset(progress, {"wl-a-baseline"}, discovered)
     assert n == 0
@@ -442,7 +441,7 @@ def test_force_reset_continues_on_exception(monkeypatch):
         entry["retries"] = 0
         return True
 
-    monkeypatch.setattr(mod, "_cleanup_pair", sometimes_fails)
+    monkeypatch.setattr(mod, "_reset_pair", sometimes_fails)
 
     n = mod._force_reset(progress, set(progress.keys()), discovered)
 
@@ -452,8 +451,8 @@ def test_force_reset_continues_on_exception(monkeypatch):
     assert progress["wl-b-baseline"]["status"] == "pending"
 
 
-def test_cmd_cleanup_aborts_on_filter_mismatch(tmp_path, capsys):
-    """cleanup exits with error when --only doesn't match any pair."""
+def test_cmd_reset_aborts_on_filter_mismatch(tmp_path, capsys):
+    """reset exits with error when --only doesn't match any pair."""
     import pipeline.deploy as mod
 
     progress_path = tmp_path / "progress.json"
@@ -463,7 +462,7 @@ def test_cmd_cleanup_aborts_on_filter_mismatch(tmp_path, capsys):
         only = "nonexistent"; workload = None; package = None; status = None; dry_run = False
 
     with __import__("pytest").raises(SystemExit) as exc_info:
-        mod._cmd_cleanup(_Args(), progress_path, _DISCOVERED)
+        mod._cmd_reset(_Args(), progress_path, _DISCOVERED)
     assert exc_info.value.code == 1
     captured = capsys.readouterr()
     assert "No pairs matched" in captured.out + captured.err


### PR DESCRIPTION
## Summary

Closes #124

- Renames the `cleanup` subcommand to `reset` to disambiguate from `wipe` (#123, data cleanup)
- Renames internal functions: `_cleanup_pair` → `_reset_pair`, `_cmd_cleanup` → `_cmd_reset`
- Updates all user-facing messages, help text, epilog examples, shell completions (bash + zsh), and `pipeline/README.md`
- Renames test file `test_deploy_cleanup.py` → `test_deploy_reset.py` with all function names updated
- Updates issue #51 title to reflect the new subcommand name

No behavior change — same flags, same semantics, new name.

## Test plan

- [x] All 517 tests pass (`python -m pytest pipeline/ -v`)
- [x] Lint clean (`ruff check pipeline/ --select F`)
- [x] Zero remaining `cleanup` references in pipeline code/docs (only unrelated `run_manager` "stale cleanup" remains)
- [ ] Verify `deploy.py reset --help` shows correct help text
- [ ] Verify `deploy.py reset --dry-run` works on a live run