### PR TITLE
Add --workload/--only scoping flags to deploy.py collect (#122)

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -137,7 +137,7 @@ Common flags (all subcommands):
 ```bash
 python pipeline/deploy.py run     [flags]   # orchestrate parallel pool execution across namespace slots
 python pipeline/deploy.py status            # show progress snapshot of all (workload, package) pairs
-python pipeline/deploy.py collect [--package NAME…]
+python pipeline/deploy.py collect [flags]     # pull results from the cluster PVC
 python pipeline/deploy.py reset [flags]     # tear down cluster resources for failed/stalled pairs
 python pipeline/deploy.py pairs   [flags]   # list available pair keys, workloads, and packages
 ```
@@ -175,6 +175,15 @@ python pipeline/deploy.py pairs   [flags]   # list available pair keys, workload
 | `--package NAME` | Filter by package name |
 
 **`deploy.py collect`** — extracts results from the cluster PVC and writes to `workspace/runs/<run>/results/{phase}/<workload>/`.
+
+| Flag | Description |
+|------|-------------|
+| `--only PAIR` | Scope to one specific pair key (`wl-` prefix optional) |
+| `--workload NAME` | Scope to pairs matching this workload |
+| `--package NAME…` | Collect only these packages (phase-level filter) |
+| `--skip-logs` | Skip vLLM and EPP log files, collect only traces |
+
+When `--only` or `--workload` is given, only matching workload subdirectories are pulled from the PVC (instead of entire phase directories). These pair-level flags compose with `--package` as AND: `--workload X --package baseline` pulls workload X from the baseline phase only. Requires `progress.json` to resolve pairs.
 
 **`deploy.py reset`** — removes cluster resources (PipelineRuns, Helm releases) for all non-pending pairs. Failed/running/timed-out pairs are reset to `pending` so they can be re-dispatched. Done pairs stay `done` — only their PipelineRun is deleted to free cluster resources.
 

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -178,7 +178,7 @@ python pipeline/deploy.py pairs   [flags]   # list available pair keys, workload
 
 | Flag | Description |
 |------|-------------|
-| `--only PAIR` | Scope to one specific pair key (`wl-` prefix optional) |
+| `--only PAIR` | Scope to one pair key — narrows both workload and package (`wl-` prefix optional; takes precedence over `--workload`) |
 | `--workload NAME` | Scope to pairs matching this workload |
 | `--package NAME…` | Collect only these packages (phase-level filter) |
 | `--skip-logs` | Skip vLLM and EPP log files, collect only traces |

--- a/pipeline/completions.bash
+++ b/pipeline/completions.bash
@@ -82,7 +82,7 @@ _sim2real_deploy() {
                 COMPREPLY=($(compgen -W "--only --workload --package --status --dry-run" -- "$cur"))
                 ;;
             collect)
-                COMPREPLY=($(compgen -W "--package --skip-logs" -- "$cur"))
+                COMPREPLY=($(compgen -W "--only --workload --package --skip-logs" -- "$cur"))
                 ;;
             pairs)
                 COMPREPLY=($(compgen -W "--keys-only --workloads-only --packages-only" -- "$cur"))

--- a/pipeline/completions.zsh
+++ b/pipeline/completions.zsh
@@ -91,6 +91,8 @@ _sim2real_deploy() {
                     ;;
                 collect)
                     _arguments \
+                        '--only[Scope to one pair key]:pair key:_deploy_py_pair_keys' \
+                        '--workload[Scope to workload]:workload:_deploy_py_workloads' \
                         '*--package[Collect only these packages]:package:_deploy_py_packages' \
                         '--skip-logs[Skip vLLM and EPP log files]'
                     ;;

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -621,6 +621,10 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
     scope_workload = getattr(args, "workload", None)
     scoped = scope_only is not None or scope_workload is not None
 
+    if scoped and not progress:
+        err("--only/--workload require progress.json to resolve pairs, but none was found.")
+        sys.exit(1)
+
     if scoped and progress:
         # Build a lightweight args namespace for _resolve_scope with only
         # pair-level filters (--only, --workload).  Collect's --package is
@@ -688,7 +692,9 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
                     skip_logs=skip_logs, workload=wl_name)
             except RuntimeError as e:
                 warn(f"Extractor pod failed for workload {wl_name}: {e}")
-                failed.extend(phases_to_collect)
+                for p in phases_to_collect:
+                    if p not in failed:
+                        failed.append(p)
             else:
                 for phase, exc in errors.items():
                     if exc is None:

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -451,9 +451,9 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
       /data/{runName}/{phase}/{workloadName}/trace_data.csv
 
     When *workload* is set, only that workload's subdirectory is copied for
-    each phase (used by inline collection during parallel pool execution).
+    each phase (used by scoped ``collect --only/--workload``).
     When *workload* is None (default), the entire phase directory is copied
-    (used by `deploy.py collect` for bulk collection).
+    (used by unscoped ``deploy.py collect`` for bulk collection).
 
     When *skip_logs* is True, only trace files are copied (skipping vLLM and
     EPP log files which typically account for the bulk of the data).
@@ -637,38 +637,31 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
 
         in_scope = _resolve_scope(progress, _ScopeArgs())
 
-        # Warn about non-done scoped pairs
-        for key in sorted(in_scope):
-            entry = progress.get(key, {})
-            st = entry.get("status", "")
-            if st not in ("done", "collecting"):
-                warn(f"Scoped pair {key} has status '{st}' — skipping")
-
-        # Derive phases and workloads from done/collecting scoped pairs
-        scoped_phases = sorted({
-            progress[k].get("package", "")
-            for k in in_scope
+        # Filter to collectible pairs (done/collecting) and warn about the rest
+        collectible = {
+            k for k in in_scope
             if isinstance(progress[k], dict) and progress[k].get("status") in ("done", "collecting")
+        }
+        for key in sorted(in_scope - collectible):
+            warn(f"Scoped pair {key} has status '{progress[key].get('status', '')}' — skipping")
+
+        scoped_phases = sorted({
+            progress[k].get("package", "") for k in collectible
         } - {""})
         scoped_workloads = sorted({
-            progress[k].get("workload", "")
-            for k in in_scope
-            if isinstance(progress[k], dict) and progress[k].get("status") in ("done", "collecting")
+            progress[k].get("workload", "") for k in collectible
         } - {""})
 
         if not scoped_phases:
             warn("No done/collecting phases for scoped pairs.")
-            print()
-            return
-
-        # Apply --package phase-level filter on top
-        if args.package:
+            phases_to_collect: list[str] = []
+        elif args.package:
             valid = set(scoped_phases) | {"experiment"}
             unknown = set(args.package) - valid
             if unknown:
                 err(f"Unknown packages: {sorted(unknown)}. Valid: {sorted(valid)}")
                 sys.exit(1)
-            phases_to_collect: list[str] = []
+            phases_to_collect = []
             for p in args.package:
                 if p == "experiment":
                     phases_to_collect.extend(scoped_phases)
@@ -706,7 +699,7 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
                         if phase not in failed:
                             failed.append(phase)
     else:
-        # ── Unscoped path (original behavior) ────────────────────────────
+        # ── Unscoped path (no --only/--workload) ─────────────────────────
         if progress:
             known_phases = sorted({
                 entry.get("package", "")

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -616,63 +616,147 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
     else:
         progress = None
 
-    if progress:
-        known_phases = sorted({
-            entry.get("package", "")
-            for entry in progress.values()
-            if isinstance(entry, dict) and entry.get("status") in ("done", "collecting")
+    # ── Pair-level scoping (--only / --workload) ──────────────────────────
+    scope_only = getattr(args, "only", None)
+    scope_workload = getattr(args, "workload", None)
+    scoped = scope_only is not None or scope_workload is not None
+
+    if scoped and progress:
+        # Build a lightweight args namespace for _resolve_scope with only
+        # pair-level filters (--only, --workload).  Collect's --package is
+        # a phase-level filter (nargs="+") and must NOT be mixed in.
+        class _ScopeArgs:
+            only = scope_only
+            workload = scope_workload
+            package = None
+            status = None
+
+        in_scope = _resolve_scope(progress, _ScopeArgs())
+
+        # Warn about non-done scoped pairs
+        for key in sorted(in_scope):
+            entry = progress.get(key, {})
+            st = entry.get("status", "")
+            if st not in ("done", "collecting"):
+                warn(f"Scoped pair {key} has status '{st}' — skipping")
+
+        # Derive phases and workloads from done/collecting scoped pairs
+        scoped_phases = sorted({
+            progress[k].get("package", "")
+            for k in in_scope
+            if isinstance(progress[k], dict) and progress[k].get("status") in ("done", "collecting")
         } - {""})
-    else:
-        known_phases = []
+        scoped_workloads = sorted({
+            progress[k].get("workload", "")
+            for k in in_scope
+            if isinstance(progress[k], dict) and progress[k].get("status") in ("done", "collecting")
+        } - {""})
 
-    if not known_phases:
-        cluster_dir = run_dir / "cluster"
-        known_phases = _discover_phases(cluster_dir)
-        if progress is None and not progress_path.exists():
-            warn(f"No progress.json found — discovered phases from cluster/: {known_phases}")
-        elif progress is not None:
-            warn(f"No done/collecting phases in progress — discovered from cluster/: {known_phases}")
+        if not scoped_phases:
+            warn("No done/collecting phases for scoped pairs.")
+            print()
+            return
 
-    if args.package:
-        valid = set(known_phases) | {"experiment"}
-        unknown = set(args.package) - valid
-        if unknown:
-            err(f"Unknown packages: {sorted(unknown)}. Valid: {sorted(valid)}")
-            sys.exit(1)
-        phases_to_collect: list[str] = []
-        for p in args.package:
-            if p == "experiment":
-                phases_to_collect.extend(known_phases)
-            else:
-                phases_to_collect.append(p)
-        seen: set[str] = set()
-        phases_to_collect = [p for p in phases_to_collect
-                             if not (p in seen or seen.add(p))]  # type: ignore[func-returns-value]
-    else:
-        phases_to_collect = list(known_phases)
-
-    step(1, "Collecting Results")
-
-    collected: list[str] = []
-    failed: list[str] = []
-
-    if phases_to_collect:
-        try:
-            skip_logs = getattr(args, "skip_logs", False)
-            errors = _extract_phases_from_pvc(
-                phases_to_collect, run_name, namespace, run_dir,
-                skip_logs=skip_logs)
-        except RuntimeError as e:
-            warn(f"Extractor pod failed: {e}")
-            failed.extend(phases_to_collect)
-        else:
-            for phase, exc in errors.items():
-                if exc is None:
-                    ok(f"Collected: {phase}")
-                    collected.append(phase)
+        # Apply --package phase-level filter on top
+        if args.package:
+            valid = set(scoped_phases) | {"experiment"}
+            unknown = set(args.package) - valid
+            if unknown:
+                err(f"Unknown packages: {sorted(unknown)}. Valid: {sorted(valid)}")
+                sys.exit(1)
+            phases_to_collect: list[str] = []
+            for p in args.package:
+                if p == "experiment":
+                    phases_to_collect.extend(scoped_phases)
                 else:
-                    warn(f"Extraction failed for {phase}: {exc}")
-                    failed.append(phase)
+                    phases_to_collect.append(p)
+            seen: set[str] = set()
+            phases_to_collect = [p for p in phases_to_collect
+                                 if not (p in seen or seen.add(p))]  # type: ignore[func-returns-value]
+        else:
+            phases_to_collect = list(scoped_phases)
+
+        step(1, "Collecting Results")
+        collected: list[str] = []
+        failed: list[str] = []
+
+        for wl_name in scoped_workloads:
+            try:
+                skip_logs = getattr(args, "skip_logs", False)
+                errors = _extract_phases_from_pvc(
+                    phases_to_collect, run_name, namespace, run_dir,
+                    skip_logs=skip_logs, workload=wl_name)
+            except RuntimeError as e:
+                warn(f"Extractor pod failed for workload {wl_name}: {e}")
+                failed.extend(phases_to_collect)
+            else:
+                for phase, exc in errors.items():
+                    if exc is None:
+                        ok(f"Collected: {phase}/{wl_name}")
+                        if phase not in collected:
+                            collected.append(phase)
+                    else:
+                        warn(f"Extraction failed for {phase}/{wl_name}: {exc}")
+                        if phase not in failed:
+                            failed.append(phase)
+    else:
+        # ── Unscoped path (original behavior) ────────────────────────────
+        if progress:
+            known_phases = sorted({
+                entry.get("package", "")
+                for entry in progress.values()
+                if isinstance(entry, dict) and entry.get("status") in ("done", "collecting")
+            } - {""})
+        else:
+            known_phases = []
+
+        if not known_phases:
+            cluster_dir = run_dir / "cluster"
+            known_phases = _discover_phases(cluster_dir)
+            if progress is None and not progress_path.exists():
+                warn(f"No progress.json found — discovered phases from cluster/: {known_phases}")
+            elif progress is not None:
+                warn(f"No done/collecting phases in progress — discovered from cluster/: {known_phases}")
+
+        if args.package:
+            valid = set(known_phases) | {"experiment"}
+            unknown = set(args.package) - valid
+            if unknown:
+                err(f"Unknown packages: {sorted(unknown)}. Valid: {sorted(valid)}")
+                sys.exit(1)
+            phases_to_collect = []
+            for p in args.package:
+                if p == "experiment":
+                    phases_to_collect.extend(known_phases)
+                else:
+                    phases_to_collect.append(p)
+            seen = set()
+            phases_to_collect = [p for p in phases_to_collect
+                                 if not (p in seen or seen.add(p))]  # type: ignore[func-returns-value]
+        else:
+            phases_to_collect = list(known_phases)
+
+        step(1, "Collecting Results")
+        collected = []
+        failed = []
+
+        if phases_to_collect:
+            try:
+                skip_logs = getattr(args, "skip_logs", False)
+                errors = _extract_phases_from_pvc(
+                    phases_to_collect, run_name, namespace, run_dir,
+                    skip_logs=skip_logs)
+            except RuntimeError as e:
+                warn(f"Extractor pod failed: {e}")
+                failed.extend(phases_to_collect)
+            else:
+                for phase, exc in errors.items():
+                    if exc is None:
+                        ok(f"Collected: {phase}")
+                        collected.append(phase)
+                    else:
+                        warn(f"Extraction failed for {phase}: {exc}")
+                        failed.append(phase)
 
     # Print summary
     print(f"\n  Collected: {len(collected)}/{len(phases_to_collect)} phases")

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -451,8 +451,7 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
       /data/{runName}/{phase}/{workloadName}/trace_data.csv
 
     When *workload* is set, only that workload's subdirectory is copied for
-    each phase (used by scoped ``collect --only/--workload`` and by the
-    orchestrator during inline collection).
+    each phase (used by scoped ``collect --only/--workload``).
     When *workload* is None (default), the entire phase directory is copied
     (used by unscoped ``deploy.py collect`` for bulk collection).
 
@@ -701,6 +700,8 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
                         warn(f"Extraction failed for {phase}/{wl_name}: {exc}")
                         if phase not in failed:
                             failed.append(phase)
+
+        collected = [p for p in collected if p not in failed]
     else:
         # ── Unscoped path (no --only/--workload) ─────────────────────────
         if progress:

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1533,6 +1533,10 @@ Examples:
 
     sub = p.add_subparsers(dest="command")
     collect_p = sub.add_parser("collect", help="Pull results for completed packages")
+    collect_p.add_argument("--only",     metavar="PAIR",
+                           help="Scope to one specific pair key (wl- prefix optional)")
+    collect_p.add_argument("--workload", metavar="NAME",
+                           help="Scope to pairs matching this workload")
     collect_p.add_argument("--package", nargs="+", metavar="NAME",
                            help="Collect only these packages")
     collect_p.add_argument("--skip-logs", action="store_true", dest="skip_logs",

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -451,7 +451,8 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
       /data/{runName}/{phase}/{workloadName}/trace_data.csv
 
     When *workload* is set, only that workload's subdirectory is copied for
-    each phase (used by scoped ``collect --only/--workload``).
+    each phase (used by scoped ``collect --only/--workload`` and by the
+    orchestrator during inline collection).
     When *workload* is None (default), the entire phase directory is copied
     (used by unscoped ``deploy.py collect`` for bulk collection).
 
@@ -643,7 +644,9 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
             if isinstance(progress[k], dict) and progress[k].get("status") in ("done", "collecting")
         }
         for key in sorted(in_scope - collectible):
-            warn(f"Scoped pair {key} has status '{progress[key].get('status', '')}' — skipping")
+            entry = progress[key]
+            st = entry.get("status", "") if isinstance(entry, dict) else str(entry)
+            warn(f"Scoped pair {key} has status '{st}' — skipping")
 
         scoped_phases = sorted({
             progress[k].get("package", "") for k in collectible

--- a/pipeline/tests/test_deploy_collect.py
+++ b/pipeline/tests/test_deploy_collect.py
@@ -512,3 +512,20 @@ def test_collect_unscoped_unchanged(tmp_path):
     assert len(extract_calls) == 1
     assert extract_calls[0]["workload"] is None
     assert sorted(extract_calls[0]["phases"]) == ["baseline", "treatment"]
+
+
+def test_collect_scoped_without_progress_exits(tmp_path):
+    """--workload without progress.json exits with error."""
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    run_dir.mkdir(parents=True)
+
+    class Args:
+        only = None
+        workload = "smoke"
+        package = None
+        skip_logs = False
+
+    with pytest.raises(SystemExit):
+        deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})

--- a/pipeline/tests/test_deploy_collect.py
+++ b/pipeline/tests/test_deploy_collect.py
@@ -303,3 +303,212 @@ def test_collect_fallback_discovers_from_pipelinerun_files(tmp_path):
         deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
 
     assert collected_phases == ["b1", "b2"]
+
+
+def test_collect_with_workload_scope(tmp_path):
+    """--workload scopes extraction to matching workloads only."""
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    _write_progress(run_dir, {
+        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done"},
+        "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "done"},
+        "wl-load-baseline": {"workload": "load", "package": "baseline", "status": "done"},
+        "wl-load-treatment": {"workload": "load", "package": "treatment", "status": "done"},
+    })
+
+    class Args:
+        only = None
+        workload = "smoke"
+        package = None
+        skip_logs = False
+
+    extract_calls = []
+
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None):
+        extract_calls.append({"phases": phases, "workload": workload})
+        return {p: None for p in phases}
+
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
+        deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
+
+    assert len(extract_calls) == 1
+    assert extract_calls[0]["workload"] == "smoke"
+    assert sorted(extract_calls[0]["phases"]) == ["baseline", "treatment"]
+
+
+def test_collect_with_only_scope(tmp_path):
+    """--only scopes extraction to one pair's workload and package."""
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    _write_progress(run_dir, {
+        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done"},
+        "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "done"},
+        "wl-load-baseline": {"workload": "load", "package": "baseline", "status": "done"},
+    })
+
+    class Args:
+        only = "wl-smoke-baseline"
+        workload = None
+        package = None
+        skip_logs = False
+
+    extract_calls = []
+
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None):
+        extract_calls.append({"phases": phases, "workload": workload})
+        return {p: None for p in phases}
+
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
+        deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
+
+    assert len(extract_calls) == 1
+    assert extract_calls[0]["workload"] == "smoke"
+    assert extract_calls[0]["phases"] == ["baseline"]
+
+
+def test_collect_only_without_prefix(tmp_path):
+    """--only resolves wl- prefix automatically."""
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    _write_progress(run_dir, {
+        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done"},
+    })
+
+    class Args:
+        only = "smoke-baseline"
+        workload = None
+        package = None
+        skip_logs = False
+
+    extract_calls = []
+
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None):
+        extract_calls.append({"phases": phases, "workload": workload})
+        return {p: None for p in phases}
+
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
+        deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
+
+    assert len(extract_calls) == 1
+    assert extract_calls[0]["workload"] == "smoke"
+
+
+def test_collect_workload_with_package_filter(tmp_path):
+    """--workload + --package compose: workload scopes within specified phases."""
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    _write_progress(run_dir, {
+        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done"},
+        "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "done"},
+        "wl-load-baseline": {"workload": "load", "package": "baseline", "status": "done"},
+    })
+
+    class Args:
+        only = None
+        workload = "smoke"
+        package = ["baseline"]
+        skip_logs = False
+
+    extract_calls = []
+
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None):
+        extract_calls.append({"phases": phases, "workload": workload})
+        return {p: None for p in phases}
+
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
+        deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
+
+    assert len(extract_calls) == 1
+    assert extract_calls[0]["workload"] == "smoke"
+    assert extract_calls[0]["phases"] == ["baseline"]
+
+
+def test_collect_workload_no_match_exits(tmp_path):
+    """--workload with no matching pairs exits with error."""
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    _write_progress(run_dir, {
+        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done"},
+    })
+
+    class Args:
+        only = None
+        workload = "nonexistent"
+        package = None
+        skip_logs = False
+
+    with pytest.raises(SystemExit):
+        deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
+
+
+def test_collect_warns_nondone_scoped_pairs(tmp_path):
+    """When scoped pairs include non-done entries, warn but continue with done ones."""
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    _write_progress(run_dir, {
+        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done"},
+        "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "running"},
+    })
+
+    class Args:
+        only = None
+        workload = "smoke"
+        package = None
+        skip_logs = False
+
+    extract_calls = []
+
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None):
+        extract_calls.append({"phases": phases, "workload": workload})
+        return {p: None for p in phases}
+
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract), \
+         patch.object(deploy, "warn") as mock_warn:
+        deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
+
+    assert len(extract_calls) == 1
+    assert extract_calls[0]["phases"] == ["baseline"]
+    assert any("running" in str(c) for c in mock_warn.call_args_list)
+
+
+def test_collect_unscoped_unchanged(tmp_path):
+    """Without --only/--workload, collect behaves exactly as before (no workload param)."""
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    _write_progress(run_dir, {
+        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done"},
+        "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "done"},
+    })
+
+    class Args:
+        only = None
+        workload = None
+        package = None
+        skip_logs = False
+
+    extract_calls = []
+
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None):
+        extract_calls.append({"phases": phases, "workload": workload})
+        return {p: None for p in phases}
+
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
+        deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
+
+    assert len(extract_calls) == 1
+    assert extract_calls[0]["workload"] is None
+    assert sorted(extract_calls[0]["phases"]) == ["baseline", "treatment"]

--- a/pipeline/tests/test_deploy_collect.py
+++ b/pipeline/tests/test_deploy_collect.py
@@ -529,3 +529,90 @@ def test_collect_scoped_without_progress_exits(tmp_path):
 
     with pytest.raises(SystemExit):
         deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
+
+
+def test_collect_scoped_all_nondone_no_extraction(tmp_path):
+    """When all scoped pairs are non-done, no extraction is attempted and summary prints 0/0."""
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    _write_progress(run_dir, {
+        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "running"},
+        "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "pending"},
+    })
+
+    class Args:
+        only = None
+        workload = "smoke"
+        package = None
+        skip_logs = False
+
+    extract_calls = []
+
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None):
+        extract_calls.append({"phases": phases, "workload": workload})
+        return {p: None for p in phases}
+
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract), \
+         patch.object(deploy, "warn") as mock_warn:
+        deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
+
+    assert len(extract_calls) == 0
+    assert any("running" in str(c) or "pending" in str(c) for c in mock_warn.call_args_list)
+
+
+def test_collect_scoped_runtime_error(tmp_path):
+    """RuntimeError from extractor pod is caught and reported."""
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    _write_progress(run_dir, {
+        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done"},
+    })
+
+    class Args:
+        only = None
+        workload = "smoke"
+        package = None
+        skip_logs = False
+
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None):
+        raise RuntimeError("pod failed")
+
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract), \
+         patch.object(deploy, "warn") as mock_warn:
+        deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
+
+    assert any("pod failed" in str(c) for c in mock_warn.call_args_list)
+
+
+def test_collect_scoped_per_phase_failure(tmp_path):
+    """Per-phase extraction failure in scoped path populates failed list."""
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    _write_progress(run_dir, {
+        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done"},
+        "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "done"},
+    })
+
+    class Args:
+        only = None
+        workload = "smoke"
+        package = None
+        skip_logs = False
+
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None):
+        return {
+            "baseline": None,
+            "treatment": RuntimeError("tar failed"),
+        }
+
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract), \
+         patch.object(deploy, "warn") as mock_warn:
+        deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
+
+    assert any("tar failed" in str(c) for c in mock_warn.call_args_list)

--- a/pipeline/tests/test_deploy_collect.py
+++ b/pipeline/tests/test_deploy_collect.py
@@ -616,3 +616,35 @@ def test_collect_scoped_per_phase_failure(tmp_path):
         deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
 
     assert any("tar failed" in str(c) for c in mock_warn.call_args_list)
+
+
+def test_collect_only_takes_precedence_over_workload(tmp_path):
+    """When both --only and --workload are given, --only takes precedence."""
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    _write_progress(run_dir, {
+        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done"},
+        "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "done"},
+        "wl-load-baseline": {"workload": "load", "package": "baseline", "status": "done"},
+    })
+
+    class Args:
+        only = "wl-smoke-baseline"
+        workload = "load"
+        package = None
+        skip_logs = False
+
+    extract_calls = []
+
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None):
+        extract_calls.append({"phases": phases, "workload": workload})
+        return {p: None for p in phases}
+
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
+        deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
+
+    assert len(extract_calls) == 1
+    assert extract_calls[0]["workload"] == "smoke"
+    assert extract_calls[0]["phases"] == ["baseline"]


### PR DESCRIPTION
Closes #122

## Summary

- Add `--only PAIR` and `--workload NAME` scoping flags to `deploy.py collect`
- When scoped, collection pulls only matching workload subdirectories from the PVC (instead of entire phase directories)
- Existing `--package` flag (phase-level filter) composes orthogonally: `--workload X --package baseline` pulls workload X from baseline only
- Non-done scoped pairs emit a warning and are skipped
- Unscoped behavior is unchanged
- Updated bash and zsh completions

## Design notes

**`--package` semantics differ between collect and other subcommands.** Collect's `--package` is `nargs="+"` (a list of phase names like `baseline`, `treatment`). Other subcommands' `--package` is a single string used as a pair-level filter in `_resolve_scope()`. To avoid mixing these, the scoped path builds a proxy `_ScopeArgs` namespace with `package=None` so `_resolve_scope` only operates on `--only`/`--workload`. Collect's `--package` is then applied separately as a phase-level filter on top.

**No `--status` flag.** Unlike `run`/`status`/`reset`, collect implicitly scopes to done/collecting pairs. Adding `--status` would be confusing since you'd never want to collect from non-done pairs.

## Test plan

- [x] `--workload` scopes extraction to matching workloads only
- [x] `--only` scopes to one pair's workload and package
- [x] `--only` auto-resolves `wl-` prefix
- [x] `--workload` + `--package` compose correctly (AND semantics)
- [x] `--workload` with no match exits with error and helpful message
- [x] Non-done scoped pairs produce a warning, done ones proceed
- [x] Unscoped path unchanged (backward compat, `workload=None`)
- [x] All 11 existing collect tests still pass (no regressions)
- [x] Full suite: 528 tests pass, lint clean