### PR TITLE
Write orchestrator progress to ConfigMap for remote status

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -167,10 +167,11 @@ python pipeline/deploy.py pairs   [flags]   # list available pair keys, workload
 
 **Auto-cleanup** — when a PipelineRun succeeds, the orchestrator deletes the PipelineRun CR from the cluster. Failed PipelineRuns are left in place for debugging (`kubectl describe`, pod logs). Use `reset` to remove them when done.
 
-**`deploy.py status`** — prints the current state of all pairs from `workspace/runs/<run>/progress.json`. When the orchestrator is in backoff, an additional line shows the current state and backoff level.
+**`deploy.py status`** — prints the current state of all pairs. By default reads from `workspace/runs/<run>/progress.json`. When the orchestrator runs remotely (in-cluster), use `--remote` to read from the `sim2real-progress` ConfigMap instead. The ConfigMap is also used automatically when the local `progress.json` is absent.
 
 | Flag | Description |
 |------|-------------|
+| `--remote` | Read progress from cluster ConfigMap instead of local file |
 | `--workload NAME` | Filter by workload name |
 | `--package NAME` | Filter by package name |
 
@@ -311,11 +312,14 @@ All paths are relative to the repo root and validated at Phase 1.
 
 ## Parallel Pool Execution
 
-`setup.py --namespaces NS1,NS2,...` provisions N namespace slots, each bootstrapped identically. `prepare.py` generates one shared Tekton Pipeline plus one PipelineRun per `(workload, package)` pair. `deploy.py run` orchestrates execution by assigning pairs to free slots, polling for completion, and retrying on timeout. Use `deploy.py collect` to pull results off-cluster. `deploy.py status` reads `workspace/runs/<run>/progress.json` and prints the current state of every pair.
+`setup.py --namespaces NS1,NS2,...` provisions N namespace slots, each bootstrapped identically. `prepare.py` generates one shared Tekton Pipeline plus one PipelineRun per `(workload, package)` pair. `deploy.py run` orchestrates execution by assigning pairs to free slots, polling for completion, and retrying on timeout. Use `deploy.py collect` to pull results off-cluster. `deploy.py status` reads progress from the local file or cluster ConfigMap.
 
 | Artifact | Written by | Read by |
 |----------|-----------|---------|
 | `runs/<run>/progress.json` | `deploy.py run` | `deploy.py status` |
+| ConfigMap `sim2real-progress` | `deploy.py run`, `deploy.py reset` | `deploy.py status --remote` |
+
+The orchestrator writes progress to both the local file and the `sim2real-progress` ConfigMap in the primary namespace on every poll cycle. This allows `deploy.py status --remote` to read progress directly from the cluster, which is required when the orchestrator runs as an in-cluster Job.
 
 ---
 

--- a/pipeline/completions.bash
+++ b/pipeline/completions.bash
@@ -76,7 +76,7 @@ _sim2real_deploy() {
                 COMPREPLY=($(compgen -W "--only --workload --package --status --force --skip-build-epp --max-retries --poll-interval --gpu-resource-type --default-gpu-cost --pending-threshold --max-pending-stalls" -- "$cur"))
                 ;;
             status)
-                COMPREPLY=($(compgen -W "--only --workload --package --status" -- "$cur"))
+                COMPREPLY=($(compgen -W "--only --workload --package --status --remote" -- "$cur"))
                 ;;
             reset)
                 COMPREPLY=($(compgen -W "--only --workload --package --status --dry-run" -- "$cur"))

--- a/pipeline/completions.zsh
+++ b/pipeline/completions.zsh
@@ -87,7 +87,8 @@ _sim2real_deploy() {
                         '--only[Scope to one pair key]:pair key:_deploy_py_pair_keys' \
                         '--workload[Scope to workload]:workload:_deploy_py_workloads' \
                         '--package[Scope to package]:package:_deploy_py_packages' \
-                        '--status[Scope to status]:status:_deploy_py_statuses'
+                        '--status[Scope to status]:status:_deploy_py_statuses' \
+                        '--remote[Read from cluster ConfigMap]'
                     ;;
                 collect)
                     _arguments \

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -68,13 +68,17 @@ def _configmap_namespace(setup_config: dict | None,
                          namespaces: list[str] | None = None) -> str:
     """Return the namespace for the sim2real-progress ConfigMap.
 
-    Checks setup_config["namespace"] first, then falls back to namespaces[0].
+    Checks setup_config["namespace"] first, then falls back to
+    namespaces[0] (or setup_config["namespaces"][0] if namespaces
+    is not passed).
     """
-    ns = (setup_config or {}).get("namespace", "")
+    cfg = setup_config or {}
+    ns = cfg.get("namespace", "")
     if ns:
         return ns
-    if namespaces:
-        return namespaces[0]
+    ns_list = namespaces or cfg.get("namespaces") or []
+    if ns_list:
+        return ns_list[0]
     return ""
 
 

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -62,6 +62,22 @@ def run(cmd: list[str], *, check: bool = True, capture: bool = False,
     return subprocess.run(cmd, check=check, text=True, capture_output=capture, cwd=cwd)
 
 
+# ── ConfigMap namespace resolution ──────────────────────────────────────────
+
+def _configmap_namespace(setup_config: dict | None,
+                         namespaces: list[str] | None = None) -> str:
+    """Return the namespace for the sim2real-progress ConfigMap.
+
+    Checks setup_config["namespace"] first, then falls back to namespaces[0].
+    """
+    ns = (setup_config or {}).get("namespace", "")
+    if ns:
+        return ns
+    if namespaces:
+        return namespaces[0]
+    return ""
+
+
 # ── Phase discovery ─────────────────────────────────────────────────────────
 
 def _discover_phases(cluster_dir: "Path") -> list[str]:
@@ -210,11 +226,13 @@ def _cmd_status(args, progress_path: Path,
     use_remote = getattr(args, "remote", False)
 
     if use_remote or not progress_path.exists():
-        primary_ns = (setup_config or {}).get("namespace", "")
+        primary_ns = _configmap_namespace(setup_config)
         if primary_ns:
             from pipeline.lib.progress import ConfigMapProgressStore
             store = ConfigMapProgressStore(primary_ns)
         else:
+            if use_remote:
+                warn("--remote requested but no namespace configured — falling back to local file")
             from pipeline.lib.progress import LocalProgressStore
             store = LocalProgressStore(progress_path)
     else:
@@ -1204,7 +1222,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
     cluster_dir = run_dir / "cluster"
     progress_path = run_dir / "progress.json"
     local_store = LocalProgressStore(progress_path)
-    primary_ns = setup_config.get("namespace") or (namespaces[0] if namespaces else "")
+    primary_ns = _configmap_namespace(setup_config, namespaces)
     if primary_ns:
         cm_store = ConfigMapProgressStore(primary_ns)
         store = CompositeProgressStore(local_store, cm_store)
@@ -1540,7 +1558,7 @@ def _cmd_reset(args, progress_path: Path, discovered: dict,
         LocalProgressStore, ConfigMapProgressStore, CompositeProgressStore,
     )
     local_store = LocalProgressStore(progress_path)
-    primary_ns = (setup_config or {}).get("namespace", "")
+    primary_ns = _configmap_namespace(setup_config, namespaces)
     if primary_ns:
         cm_store = ConfigMapProgressStore(primary_ns)
         store = CompositeProgressStore(local_store, cm_store)

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -204,10 +204,23 @@ def _delete_pipelinerun(pr_name: str, namespace: str) -> None:
 
 # ── Status command ───────────────────────────────────────────────────────────
 
-def _cmd_status(args, progress_path: Path) -> None:
+def _cmd_status(args, progress_path: Path,
+                setup_config: dict | None = None) -> None:
     """Print a snapshot table of all (workload, package) pair statuses."""
-    from pipeline.lib.progress import LocalProgressStore
-    store = LocalProgressStore(progress_path)
+    use_remote = getattr(args, "remote", False)
+
+    if use_remote or not progress_path.exists():
+        primary_ns = (setup_config or {}).get("namespace", "")
+        if primary_ns:
+            from pipeline.lib.progress import ConfigMapProgressStore
+            store = ConfigMapProgressStore(primary_ns)
+        else:
+            from pipeline.lib.progress import LocalProgressStore
+            store = LocalProgressStore(progress_path)
+    else:
+        from pipeline.lib.progress import LocalProgressStore
+        store = LocalProgressStore(progress_path)
+
     progress = store.load()
 
     if not progress:
@@ -1618,6 +1631,8 @@ Examples:
     status_p.add_argument("--workload", metavar="NAME",  help="Scope to pairs matching this workload")
     status_p.add_argument("--package",  metavar="NAME",  help="Scope to pairs matching this package")
     status_p.add_argument("--status",   metavar="STATE", help="Scope to pairs with this status (e.g. running, done, failed)")
+    status_p.add_argument("--remote", action="store_true", default=False,
+                           help="Read progress from cluster ConfigMap instead of local file")
 
     run_p = sub.add_parser("run", help="Orchestrate parallel pool execution")
     run_p.add_argument("--skip-build-epp", action="store_true", dest="skip_build_epp",
@@ -1691,7 +1706,7 @@ def main():
         _cmd_run(args, run_dir, setup_config)
     elif cmd == "status":
         progress_path = run_dir / "progress.json"
-        _cmd_status(args, progress_path)
+        _cmd_status(args, progress_path, setup_config=setup_config)
     elif cmd == "collect":
         _cmd_collect(args, run_dir, setup_config)
     elif cmd == "reset":

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1162,7 +1162,9 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
     """Orchestrate parallel pool execution across namespace slots."""
     import datetime as _dt
     import tempfile as _tmp
-    from pipeline.lib.progress import LocalProgressStore
+    from pipeline.lib.progress import (
+        LocalProgressStore, ConfigMapProgressStore, CompositeProgressStore,
+    )
     from pipeline.lib.backoff import BackoffController
     from pipeline.lib.capacity import (
         probe_free_gpus, derive_gpu_resource_type, load_defaults
@@ -1188,7 +1190,13 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
 
     cluster_dir = run_dir / "cluster"
     progress_path = run_dir / "progress.json"
-    store = LocalProgressStore(progress_path)
+    local_store = LocalProgressStore(progress_path)
+    primary_ns = setup_config.get("namespace") or (namespaces[0] if namespaces else "")
+    if primary_ns:
+        cm_store = ConfigMapProgressStore(primary_ns)
+        store = CompositeProgressStore(local_store, cm_store)
+    else:
+        store = local_store
 
     # Derive GPU resource type from baseline scenario
     # CLI --gpu-resource-type overrides auto-derivation when explicitly set
@@ -1512,10 +1520,19 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
 
 
 def _cmd_reset(args, progress_path: Path, discovered: dict,
-               namespaces: list[str] | None = None) -> None:
+               namespaces: list[str] | None = None,
+               setup_config: dict | None = None) -> None:
     """Tear down cluster resources for all non-pending pairs."""
-    from pipeline.lib.progress import LocalProgressStore
-    store = LocalProgressStore(progress_path)
+    from pipeline.lib.progress import (
+        LocalProgressStore, ConfigMapProgressStore, CompositeProgressStore,
+    )
+    local_store = LocalProgressStore(progress_path)
+    primary_ns = (setup_config or {}).get("namespace", "")
+    if primary_ns:
+        cm_store = ConfigMapProgressStore(primary_ns)
+        store = CompositeProgressStore(local_store, cm_store)
+    else:
+        store = local_store
     progress = store.load()
 
     if not progress:
@@ -1685,7 +1702,9 @@ def main():
                       [setup_config.get("namespace", "")]) if ns]
         if not namespaces:
             warn("No namespaces in setup_config — PipelineRun deletion for done pairs may be incomplete")
-        _cmd_reset(args, progress_path, discovered, namespaces=namespaces or None)
+        _cmd_reset(args, progress_path, discovered,
+                   namespaces=namespaces or None,
+                   setup_config=setup_config)
     elif cmd == "pairs":
         cluster_dir = run_dir / "cluster"
         _cmd_pairs(cluster_dir, keys_only=args.keys_only,

--- a/pipeline/lib/progress.py
+++ b/pipeline/lib/progress.py
@@ -49,6 +49,8 @@ class ConfigMapProgressStore(ProgressStore):
     DATA_KEY = "progress"
 
     def __init__(self, namespace: str) -> None:
+        if not namespace:
+            raise ValueError("ConfigMapProgressStore requires a non-empty namespace")
         self._namespace = namespace
 
     def load(self) -> dict:
@@ -59,7 +61,13 @@ class ConfigMapProgressStore(ProgressStore):
             check=False, text=True, capture_output=True,
         )
         if result.returncode != 0:
-            return {}
+            stderr = result.stderr.strip().lower()
+            if "notfound" in stderr or "not found" in stderr:
+                return {}
+            raise RuntimeError(
+                f"kubectl get configmap {self.CONFIGMAP_NAME} failed: "
+                f"{result.stderr.strip()}"
+            )
         raw = result.stdout.strip()
         if not raw:
             return {}
@@ -125,4 +133,4 @@ class CompositeProgressStore(ProgressStore):
             try:
                 store.save(data)
             except Exception as exc:
-                print(f"[WARN] ConfigMap save failed: {exc}", file=sys.stderr)
+                print(f"[WARN] {type(store).__name__} save failed: {exc}", file=sys.stderr)

--- a/pipeline/lib/progress.py
+++ b/pipeline/lib/progress.py
@@ -97,8 +97,8 @@ class ConfigMapProgressStore(ProgressStore):
 class CompositeProgressStore(ProgressStore):
     """Write to all stores; read from the first that returns data.
 
-    Primary store failures propagate. Secondary store save failures
-    print a warning to stderr but do not raise.
+    Primary store failures propagate. Secondary store failures (both
+    save and load) print a warning to stderr but do not raise.
     """
 
     def __init__(self, primary: ProgressStore, *secondaries: ProgressStore) -> None:
@@ -114,7 +114,8 @@ class CompositeProgressStore(ProgressStore):
                 data = store.load()
                 if data:
                     return data
-            except Exception:
+            except Exception as exc:
+                print(f"[WARN] Secondary store load failed: {exc}", file=sys.stderr)
                 continue
         return {}
 

--- a/pipeline/lib/progress.py
+++ b/pipeline/lib/progress.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 import json
 import subprocess
+import sys
 import tempfile
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -91,3 +92,36 @@ class ConfigMapProgressStore(ProgressStore):
                 f"Failed to update ConfigMap {self.CONFIGMAP_NAME}: "
                 f"{result.stderr.strip()}"
             )
+
+
+class CompositeProgressStore(ProgressStore):
+    """Write to all stores; read from the first that returns data.
+
+    Primary store failures propagate. Secondary store save failures
+    print a warning to stderr but do not raise.
+    """
+
+    def __init__(self, primary: ProgressStore, *secondaries: ProgressStore) -> None:
+        self._primary = primary
+        self._secondaries = secondaries
+
+    def load(self) -> dict:
+        data = self._primary.load()
+        if data:
+            return data
+        for store in self._secondaries:
+            try:
+                data = store.load()
+                if data:
+                    return data
+            except Exception:
+                continue
+        return {}
+
+    def save(self, data: dict) -> None:
+        self._primary.save(data)
+        for store in self._secondaries:
+            try:
+                store.save(data)
+            except Exception as exc:
+                print(f"[WARN] ConfigMap save failed: {exc}", file=sys.stderr)

--- a/pipeline/lib/progress.py
+++ b/pipeline/lib/progress.py
@@ -1,6 +1,7 @@
 """Progress persistence for the parallel pool orchestrator."""
 from __future__ import annotations
 import json
+import subprocess
 import tempfile
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -38,3 +39,55 @@ class LocalProgressStore(ProgressStore):
         except BaseException:
             Path(tmp).unlink(missing_ok=True)
             raise
+
+
+class ConfigMapProgressStore(ProgressStore):
+    """Read/write progress as a Kubernetes ConfigMap."""
+
+    CONFIGMAP_NAME = "sim2real-progress"
+    DATA_KEY = "progress"
+
+    def __init__(self, namespace: str) -> None:
+        self._namespace = namespace
+
+    def load(self) -> dict:
+        result = subprocess.run(
+            ["kubectl", "get", "configmap", self.CONFIGMAP_NAME,
+             "-n", self._namespace,
+             "-o", f"jsonpath={{.data.{self.DATA_KEY}}}"],
+            check=False, text=True, capture_output=True,
+        )
+        if result.returncode != 0:
+            return {}
+        raw = result.stdout.strip()
+        if not raw:
+            return {}
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"Corrupt ConfigMap {self.CONFIGMAP_NAME} in {self._namespace}"
+            ) from exc
+
+    def save(self, data: dict) -> None:
+        cm = {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {
+                "name": self.CONFIGMAP_NAME,
+                "namespace": self._namespace,
+            },
+            "data": {
+                self.DATA_KEY: json.dumps(data, indent=2),
+            },
+        }
+        result = subprocess.run(
+            ["kubectl", "apply", "-f", "-"],
+            input=json.dumps(cm),
+            check=False, text=True, capture_output=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Failed to update ConfigMap {self.CONFIGMAP_NAME}: "
+                f"{result.stderr.strip()}"
+            )

--- a/pipeline/lib/progress.py
+++ b/pipeline/lib/progress.py
@@ -61,8 +61,7 @@ class ConfigMapProgressStore(ProgressStore):
             check=False, text=True, capture_output=True,
         )
         if result.returncode != 0:
-            stderr = result.stderr.strip().lower()
-            if "notfound" in stderr or "not found" in stderr:
+            if "(NotFound)" in result.stderr:
                 return {}
             raise RuntimeError(
                 f"kubectl get configmap {self.CONFIGMAP_NAME} failed: "

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -1,6 +1,7 @@
 """Tests for deploy.py run orchestrator and status subcommand."""
 import argparse
 import json
+import pytest
 from unittest.mock import patch
 
 
@@ -1775,13 +1776,113 @@ def test_configmap_namespace_from_setup_config():
     from pipeline.deploy import _configmap_namespace
     assert _configmap_namespace({"namespace": "sim2real-ns"}) == "sim2real-ns"
 
-def test_configmap_namespace_fallback_to_namespaces():
-    """Falls back to namespaces[0] when setup_config has no namespace."""
+def test_configmap_namespace_fallback_to_namespaces_arg():
+    """Falls back to explicit namespaces[0] when setup_config has no namespace."""
     from pipeline.deploy import _configmap_namespace
     assert _configmap_namespace({}, ["sim2real-0", "sim2real-1"]) == "sim2real-0"
+
+def test_configmap_namespace_fallback_to_setup_config_namespaces():
+    """Falls back to setup_config['namespaces'][0] when namespace key is empty."""
+    from pipeline.deploy import _configmap_namespace
+    assert _configmap_namespace({"namespaces": ["sim2real-0"]}) == "sim2real-0"
 
 def test_configmap_namespace_empty():
     """Returns '' when no namespace source is available."""
     from pipeline.deploy import _configmap_namespace
     assert _configmap_namespace({}) == ""
     assert _configmap_namespace(None) == ""
+
+
+# ── Composite store wiring in _cmd_run / _cmd_reset ─────────────────────────
+
+def test_cmd_run_creates_composite_store_when_namespace_available(monkeypatch, tmp_path):
+    """_cmd_run creates CompositeProgressStore with ConfigMap secondary."""
+    import pipeline.deploy as mod
+    from pipeline.lib.progress import CompositeProgressStore
+
+    stores_created = []
+    _original_init = CompositeProgressStore.__init__
+
+    def track(self, primary, *secondaries):
+        stores_created.append([type(s).__name__ for s in secondaries])
+        _original_init(self, primary, *secondaries)
+
+    monkeypatch.setattr(CompositeProgressStore, "__init__", track)
+    monkeypatch.setattr(mod, "_resolve_epp_action", lambda *a: "skip")
+    monkeypatch.setattr(mod, "_load_pairs", lambda d: {})
+
+    run_dir = tmp_path / "runs" / "test-run"
+    run_dir.mkdir(parents=True)
+    (run_dir / "run_metadata.json").write_text('{}')
+    (run_dir / "cluster").mkdir()
+
+    args = argparse.Namespace(
+        skip_build_epp=True, only=None, workload=None, package=None,
+        status=None, force=False, max_retries=2, poll_interval=30,
+        gpu_resource_type=None, default_gpu_cost=1,
+        pending_threshold=600, max_pending_stalls=10, max_backoff=600,
+    )
+    setup = {"namespace": "sim2real-ns", "namespaces": ["sim2real-ns"]}
+
+    with pytest.raises(SystemExit):
+        mod._cmd_run(args, run_dir, setup)
+
+    assert len(stores_created) == 1
+    assert "ConfigMapProgressStore" in stores_created[0]
+
+def test_cmd_reset_creates_composite_store_when_namespace_available(monkeypatch, tmp_path):
+    """_cmd_reset creates CompositeProgressStore with ConfigMap secondary."""
+    import pipeline.deploy as mod
+    from pipeline.lib.progress import CompositeProgressStore
+
+    stores_created = []
+    _original_init = CompositeProgressStore.__init__
+
+    def track(self, primary, *secondaries):
+        stores_created.append([type(s).__name__ for s in secondaries])
+        _original_init(self, primary, *secondaries)
+
+    monkeypatch.setattr(CompositeProgressStore, "__init__", track)
+
+    progress_path = tmp_path / "progress.json"
+    progress_path.write_text(json.dumps({
+        "wl-a-baseline": {"workload": "wl-a", "package": "baseline",
+                          "status": "done", "namespace": None, "retries": 0},
+    }))
+
+    args = argparse.Namespace(only=None, workload=None, package=None,
+                              status=None, dry_run=False)
+    mod._cmd_reset(args, progress_path, {},
+                   namespaces=["sim2real-ns"],
+                   setup_config={"namespace": "sim2real-ns"})
+
+    assert len(stores_created) == 1
+    assert "ConfigMapProgressStore" in stores_created[0]
+
+
+# ── --remote with existing local file ────────────────────────────────────────
+
+def test_status_remote_prefers_configmap_over_existing_local(tmp_path, capsys):
+    """--remote reads from ConfigMap even when local progress.json exists."""
+    from unittest.mock import patch, MagicMock
+    from pipeline.deploy import _cmd_status
+
+    local_data = {"wl-local-baseline": {"workload": "wl-local", "package": "baseline",
+                                        "status": "done", "namespace": None, "retries": 0}}
+    progress_path = tmp_path / "progress.json"
+    progress_path.write_text(json.dumps(local_data))
+
+    remote_data = {"wl-remote-baseline": {"workload": "wl-remote", "package": "baseline",
+                                          "status": "running", "namespace": "ns-0", "retries": 0}}
+
+    class _Args:
+        only = None; workload = None; package = None; status = None
+        remote = True
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps(remote_data))
+        _cmd_status(_Args(), progress_path, setup_config={"namespace": "sim2real-ns"})
+
+    out = capsys.readouterr().out
+    assert "wl-remote-baseline" in out
+    assert "wl-local-baseline" not in out

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -1744,3 +1744,44 @@ def test_status_no_configmap_no_local_reports_no_run(tmp_path, capsys):
 
     out = capsys.readouterr().out
     assert "0 pairs" in out
+
+def test_status_remote_no_namespace_warns(tmp_path, capsys):
+    """--remote with no namespace configured warns and falls back to local."""
+    from pipeline.deploy import _cmd_status
+
+    progress_path = tmp_path / "progress.json"
+    progress_path.write_text(json.dumps({
+        "wl-smoke-baseline": {
+            "workload": "wl-smoke", "package": "baseline",
+            "status": "done", "namespace": None, "retries": 0,
+        },
+    }))
+
+    class _Args:
+        only = None; workload = None; package = None; status = None
+        remote = True
+
+    _cmd_status(_Args(), progress_path, setup_config={})
+
+    captured = capsys.readouterr()
+    assert "--remote requested but no namespace" in captured.err
+    assert "wl-smoke-baseline" in captured.out
+
+
+# ── _configmap_namespace helper ──────────────────────────────────────────────
+
+def test_configmap_namespace_from_setup_config():
+    """Primary namespace comes from setup_config['namespace']."""
+    from pipeline.deploy import _configmap_namespace
+    assert _configmap_namespace({"namespace": "sim2real-ns"}) == "sim2real-ns"
+
+def test_configmap_namespace_fallback_to_namespaces():
+    """Falls back to namespaces[0] when setup_config has no namespace."""
+    from pipeline.deploy import _configmap_namespace
+    assert _configmap_namespace({}, ["sim2real-0", "sim2real-1"]) == "sim2real-0"
+
+def test_configmap_namespace_empty():
+    """Returns '' when no namespace source is available."""
+    from pipeline.deploy import _configmap_namespace
+    assert _configmap_namespace({}) == ""
+    assert _configmap_namespace(None) == ""

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -1739,7 +1739,10 @@ def test_status_no_configmap_no_local_reports_no_run(tmp_path, capsys):
         remote = True
 
     with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="not found")
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout="",
+            stderr='Error from server (NotFound): configmaps "sim2real-progress" not found',
+        )
         _cmd_status(_Args(), tmp_path / "missing.json",
                     setup_config={"namespace": "sim2real-ns"})
 

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -1657,3 +1657,90 @@ def test_init_progress_per_pair_heterogeneous_cost(tmp_path):
 
     assert progress["wl-a-baseline"]["gpu_cost"] == 8
     assert progress["wl-b-treatment"]["gpu_cost"] == 2
+
+
+# ── status --remote / ConfigMap fallback ─────────────────────────────────────
+
+def test_status_parser_has_remote_flag():
+    """status subcommand should accept --remote flag."""
+    from pipeline.deploy import build_parser
+    parser = build_parser()
+    args = parser.parse_args(["status", "--remote"])
+    assert args.remote is True
+
+def test_status_parser_remote_default_false():
+    """--remote defaults to False."""
+    from pipeline.deploy import build_parser
+    parser = build_parser()
+    args = parser.parse_args(["status"])
+    assert args.remote is False
+
+def test_status_remote_reads_configmap(tmp_path, capsys):
+    """status --remote reads from ConfigMap instead of local file."""
+    from unittest.mock import patch, MagicMock
+    from pipeline.deploy import _cmd_status
+
+    progress_data = {
+        "wl-smoke-baseline": {
+            "workload": "wl-smoke", "package": "baseline",
+            "status": "running", "namespace": "sim2real-0", "retries": 0,
+        },
+    }
+
+    class _Args:
+        only = None; workload = None; package = None; status = None
+        remote = True
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout=json.dumps(progress_data),
+        )
+        _cmd_status(_Args(), tmp_path / "progress.json",
+                    setup_config={"namespace": "sim2real-ns"})
+
+    out = capsys.readouterr().out
+    assert "wl-smoke-baseline" in out
+
+def test_status_fallback_to_configmap_when_no_local(tmp_path, capsys):
+    """status reads ConfigMap when local progress.json doesn't exist."""
+    from unittest.mock import patch, MagicMock
+    from pipeline.deploy import _cmd_status
+
+    progress_data = {
+        "wl-smoke-baseline": {
+            "workload": "wl-smoke", "package": "baseline",
+            "status": "done", "namespace": None, "retries": 0,
+        },
+    }
+
+    class _Args:
+        only = None; workload = None; package = None; status = None
+        remote = False
+
+    missing_path = tmp_path / "nonexistent" / "progress.json"
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout=json.dumps(progress_data),
+        )
+        _cmd_status(_Args(), missing_path,
+                    setup_config={"namespace": "sim2real-ns"})
+
+    out = capsys.readouterr().out
+    assert "wl-smoke-baseline" in out
+
+def test_status_no_configmap_no_local_reports_no_run(tmp_path, capsys):
+    """No local file and no ConfigMap reports '0 pairs'."""
+    from unittest.mock import patch, MagicMock
+    from pipeline.deploy import _cmd_status
+
+    class _Args:
+        only = None; workload = None; package = None; status = None
+        remote = True
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="not found")
+        _cmd_status(_Args(), tmp_path / "missing.json",
+                    setup_config={"namespace": "sim2real-ns"})
+
+    out = capsys.readouterr().out
+    assert "0 pairs" in out

--- a/pipeline/tests/test_deploy_standalone.py
+++ b/pipeline/tests/test_deploy_standalone.py
@@ -39,7 +39,7 @@ def test_main_works_without_transfer_yaml(tmp_path, monkeypatch):
 
     status_called = []
 
-    def mock_status(args, progress_path):
+    def mock_status(args, progress_path, setup_config=None):
         status_called.append(progress_path)
 
     with patch.object(deploy, "_cmd_status", mock_status):

--- a/pipeline/tests/test_progress.py
+++ b/pipeline/tests/test_progress.py
@@ -47,7 +47,7 @@ def test_load_corrupt_file_raises(tmp_path):
 # --- ConfigMapProgressStore tests ---
 
 def test_configmap_load_not_found_returns_empty():
-    """ConfigMap not found on cluster returns {}."""
+    """ConfigMap NotFound on cluster returns {}."""
     with patch("subprocess.run") as mock:
         mock.return_value = MagicMock(
             returncode=1, stdout="",
@@ -55,6 +55,17 @@ def test_configmap_load_not_found_returns_empty():
         )
         store = ConfigMapProgressStore("sim2real-ns")
         assert store.load() == {}
+
+def test_configmap_load_generic_not_found_raises():
+    """Generic 'not found' without K8s reason code raises (not silently ignored)."""
+    with patch("subprocess.run") as mock:
+        mock.return_value = MagicMock(
+            returncode=1, stdout="",
+            stderr="error: the path \"sim2real-progress\" does not exist, not found anywhere",
+        )
+        store = ConfigMapProgressStore("sim2real-ns")
+        with pytest.raises(RuntimeError, match="kubectl get configmap"):
+            store.load()
 
 def test_configmap_load_kubectl_error_raises():
     """Non-NotFound kubectl errors raise RuntimeError."""

--- a/pipeline/tests/test_progress.py
+++ b/pipeline/tests/test_progress.py
@@ -4,6 +4,8 @@ from unittest.mock import patch, MagicMock
 from pipeline.lib.progress import (
     LocalProgressStore,
     ConfigMapProgressStore,
+    CompositeProgressStore,
+    ProgressStore,
 )
 
 def test_load_missing_returns_empty(tmp_path):
@@ -98,3 +100,64 @@ def test_configmap_save_failure_raises():
         store = ConfigMapProgressStore("sim2real-ns")
         with pytest.raises(RuntimeError, match="Failed to update ConfigMap"):
             store.save({"x": 1})
+
+
+# --- CompositeProgressStore tests ---
+
+def test_composite_save_writes_to_all_stores(tmp_path):
+    """save() writes to both primary and secondary stores."""
+    primary = LocalProgressStore(tmp_path / "a.json")
+    secondary = LocalProgressStore(tmp_path / "b.json")
+    store = CompositeProgressStore(primary, secondary)
+    data = {"wl-x": {"status": "done"}}
+    store.save(data)
+    assert primary.load() == data
+    assert secondary.load() == data
+
+def test_composite_load_returns_primary(tmp_path):
+    """load() returns data from primary when available."""
+    primary = LocalProgressStore(tmp_path / "a.json")
+    secondary = LocalProgressStore(tmp_path / "b.json")
+    primary.save({"from": "primary"})
+    secondary.save({"from": "secondary"})
+    store = CompositeProgressStore(primary, secondary)
+    assert store.load() == {"from": "primary"}
+
+def test_composite_load_falls_back_to_secondary(tmp_path):
+    """load() falls back to secondary when primary is empty."""
+    primary = LocalProgressStore(tmp_path / "a.json")
+    secondary = LocalProgressStore(tmp_path / "b.json")
+    secondary.save({"from": "secondary"})
+    store = CompositeProgressStore(primary, secondary)
+    assert store.load() == {"from": "secondary"}
+
+def test_composite_load_all_empty(tmp_path):
+    """load() returns {} when all stores are empty."""
+    primary = LocalProgressStore(tmp_path / "a.json")
+    secondary = LocalProgressStore(tmp_path / "b.json")
+    store = CompositeProgressStore(primary, secondary)
+    assert store.load() == {}
+
+def test_composite_secondary_save_failure_warns(tmp_path, capsys):
+    """Secondary store save failure warns but doesn't raise."""
+    primary = LocalProgressStore(tmp_path / "a.json")
+
+    class FailStore(ProgressStore):
+        def load(self): return {}
+        def save(self, data): raise RuntimeError("kubectl fail")
+
+    store = CompositeProgressStore(primary, FailStore())
+    store.save({"wl-x": {"status": "done"}})
+    assert primary.load() == {"wl-x": {"status": "done"}}
+    assert "kubectl fail" in capsys.readouterr().err
+
+def test_composite_secondary_load_failure_skipped(tmp_path):
+    """Secondary store load failure is skipped silently."""
+    primary = LocalProgressStore(tmp_path / "a.json")
+
+    class FailStore(ProgressStore):
+        def load(self): raise RuntimeError("boom")
+        def save(self, data): pass
+
+    store = CompositeProgressStore(primary, FailStore())
+    assert store.load() == {}

--- a/pipeline/tests/test_progress.py
+++ b/pipeline/tests/test_progress.py
@@ -151,8 +151,8 @@ def test_composite_secondary_save_failure_warns(tmp_path, capsys):
     assert primary.load() == {"wl-x": {"status": "done"}}
     assert "kubectl fail" in capsys.readouterr().err
 
-def test_composite_secondary_load_failure_skipped(tmp_path):
-    """Secondary store load failure is skipped silently."""
+def test_composite_secondary_load_failure_warns(tmp_path, capsys):
+    """Secondary store load failure warns and is skipped."""
     primary = LocalProgressStore(tmp_path / "a.json")
 
     class FailStore(ProgressStore):
@@ -161,3 +161,4 @@ def test_composite_secondary_load_failure_skipped(tmp_path):
 
     store = CompositeProgressStore(primary, FailStore())
     assert store.load() == {}
+    assert "boom" in capsys.readouterr().err

--- a/pipeline/tests/test_progress.py
+++ b/pipeline/tests/test_progress.py
@@ -46,12 +46,31 @@ def test_load_corrupt_file_raises(tmp_path):
 
 # --- ConfigMapProgressStore tests ---
 
-def test_configmap_load_missing_returns_empty():
+def test_configmap_load_not_found_returns_empty():
     """ConfigMap not found on cluster returns {}."""
     with patch("subprocess.run") as mock:
-        mock.return_value = MagicMock(returncode=1, stdout="", stderr="not found")
+        mock.return_value = MagicMock(
+            returncode=1, stdout="",
+            stderr='Error from server (NotFound): configmaps "sim2real-progress" not found',
+        )
         store = ConfigMapProgressStore("sim2real-ns")
         assert store.load() == {}
+
+def test_configmap_load_kubectl_error_raises():
+    """Non-NotFound kubectl errors raise RuntimeError."""
+    with patch("subprocess.run") as mock:
+        mock.return_value = MagicMock(
+            returncode=1, stdout="",
+            stderr="error: You must be logged in to the server (Unauthorized)",
+        )
+        store = ConfigMapProgressStore("sim2real-ns")
+        with pytest.raises(RuntimeError, match="kubectl get configmap"):
+            store.load()
+
+def test_configmap_empty_namespace_raises():
+    """Empty namespace is rejected at construction time."""
+    with pytest.raises(ValueError, match="non-empty namespace"):
+        ConfigMapProgressStore("")
 
 def test_configmap_load_returns_data():
     """ConfigMap with valid JSON returns parsed dict."""
@@ -149,7 +168,9 @@ def test_composite_secondary_save_failure_warns(tmp_path, capsys):
     store = CompositeProgressStore(primary, FailStore())
     store.save({"wl-x": {"status": "done"}})
     assert primary.load() == {"wl-x": {"status": "done"}}
-    assert "kubectl fail" in capsys.readouterr().err
+    err_output = capsys.readouterr().err
+    assert "FailStore save failed" in err_output
+    assert "kubectl fail" in err_output
 
 def test_composite_secondary_load_failure_warns(tmp_path, capsys):
     """Secondary store load failure warns and is skipped."""

--- a/pipeline/tests/test_progress.py
+++ b/pipeline/tests/test_progress.py
@@ -1,6 +1,10 @@
 import json
 import pytest
-from pipeline.lib.progress import LocalProgressStore
+from unittest.mock import patch, MagicMock
+from pipeline.lib.progress import (
+    LocalProgressStore,
+    ConfigMapProgressStore,
+)
 
 def test_load_missing_returns_empty(tmp_path):
     store = LocalProgressStore(tmp_path / "progress.json")
@@ -36,3 +40,61 @@ def test_load_corrupt_file_raises(tmp_path):
     store = LocalProgressStore(path)
     with pytest.raises((json.JSONDecodeError, ValueError)):
         store.load()
+
+
+# --- ConfigMapProgressStore tests ---
+
+def test_configmap_load_missing_returns_empty():
+    """ConfigMap not found on cluster returns {}."""
+    with patch("subprocess.run") as mock:
+        mock.return_value = MagicMock(returncode=1, stdout="", stderr="not found")
+        store = ConfigMapProgressStore("sim2real-ns")
+        assert store.load() == {}
+
+def test_configmap_load_returns_data():
+    """ConfigMap with valid JSON returns parsed dict."""
+    data = '{"wl-smoke-baseline": {"status": "done"}}'
+    with patch("subprocess.run") as mock:
+        mock.return_value = MagicMock(returncode=0, stdout=data)
+        store = ConfigMapProgressStore("sim2real-ns")
+        assert store.load() == {"wl-smoke-baseline": {"status": "done"}}
+
+def test_configmap_load_corrupt_raises():
+    """ConfigMap with corrupt JSON raises ValueError."""
+    with patch("subprocess.run") as mock:
+        mock.return_value = MagicMock(returncode=0, stdout="{truncated")
+        store = ConfigMapProgressStore("sim2real-ns")
+        with pytest.raises(ValueError, match="Corrupt ConfigMap"):
+            store.load()
+
+def test_configmap_load_empty_data_returns_empty():
+    """ConfigMap exists but data key is empty string returns {}."""
+    with patch("subprocess.run") as mock:
+        mock.return_value = MagicMock(returncode=0, stdout="")
+        store = ConfigMapProgressStore("sim2real-ns")
+        assert store.load() == {}
+
+def test_configmap_save_calls_kubectl_apply():
+    """save() calls kubectl apply with correct ConfigMap JSON on stdin."""
+    data = {"wl-smoke-baseline": {"status": "done"}}
+    with patch("subprocess.run") as mock:
+        mock.return_value = MagicMock(returncode=0)
+        store = ConfigMapProgressStore("sim2real-ns")
+        store.save(data)
+    call_args = mock.call_args
+    cmd = call_args[0][0]
+    assert cmd == ["kubectl", "apply", "-f", "-"]
+    assert call_args[1]["input"]
+    import json as _json
+    cm = _json.loads(call_args[1]["input"])
+    assert cm["metadata"]["name"] == "sim2real-progress"
+    assert cm["metadata"]["namespace"] == "sim2real-ns"
+    assert _json.loads(cm["data"]["progress"]) == data
+
+def test_configmap_save_failure_raises():
+    """save() raises RuntimeError when kubectl apply fails."""
+    with patch("subprocess.run") as mock:
+        mock.return_value = MagicMock(returncode=1, stderr="forbidden")
+        store = ConfigMapProgressStore("sim2real-ns")
+        with pytest.raises(RuntimeError, match="Failed to update ConfigMap"):
+            store.save({"x": 1})


### PR DESCRIPTION
Closes #128

## Summary

- Add `ConfigMapProgressStore` class to `pipeline/lib/progress.py` — reads/writes progress as a Kubernetes ConfigMap (`sim2real-progress`) via kubectl
- Add `CompositeProgressStore` — wraps primary (local file) and secondary (ConfigMap) stores; saves to both, loads from primary with fallback
- Wire up `_cmd_run` and `_cmd_reset` to use `CompositeProgressStore`, so the ConfigMap is updated every poll cycle alongside `progress.json`
- Add `--remote` flag to `deploy.py status` — reads from ConfigMap instead of local file; also falls back to ConfigMap automatically when local `progress.json` is absent

## Design choices

- **ConfigMap vs local file for status reads:** Status doesn't use `CompositeProgressStore` — it picks one source. `--remote` or missing local file → ConfigMap; otherwise → local file. This avoids unnecessary kubectl calls when the local file is available.
- **Secondary save failures are best-effort:** `CompositeProgressStore` warns on stderr but doesn't fail the orchestrator if the ConfigMap write fails. The local file remains authoritative.
- **Single ConfigMap per namespace:** `sim2real-progress` in the primary namespace. One active run per namespace, so no per-run partitioning needed.

## Test plan

- [x] ConfigMapProgressStore: load (missing, valid, corrupt, empty), save (success, failure) — 6 tests
- [x] CompositeProgressStore: save fan-out, load priority/fallback, error handling — 6 tests
- [x] Status `--remote` flag: parser, ConfigMap read, fallback on missing local, no-data case — 5 tests
- [x] All 537 existing tests pass, lint clean