### PR TITLE
Add deploy.py stop subcommand for remote orchestrator

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -177,7 +177,7 @@ python pipeline/deploy.py pairs   [flags]   # list available pair keys, workload
 
 **`deploy.py collect`** — extracts results from the cluster PVC and writes to `workspace/runs/<run>/results/{phase}/<workload>/`.
 
-**`deploy.py stop`** — deletes the `sim2real-orchestrator` Kubernetes Job (with cascading pod deletion) in the primary namespace. Only meaningful for remote execution (`run --remote`). Does not touch `progress.json` — pair state is left as-is. If no remote orchestrator Job exists, prints a message and returns. Use `reset` separately to clear failed/stalled pair state.
+**`deploy.py stop`** — deletes the `sim2real-orchestrator` Kubernetes Job (with cascading pod deletion) in the primary namespace. Only meaningful when the orchestrator runs as an in-cluster Job. Does not touch `progress.json` — pair state is left as-is. If no remote orchestrator Job exists, prints a message and returns. Use `reset` separately to clear failed/stalled pair state.
 
 **`deploy.py reset`** — removes cluster resources (PipelineRuns, Helm releases) for all non-pending pairs. Failed/running/timed-out pairs are reset to `pending` so they can be re-dispatched. Done pairs stay `done` — only their PipelineRun is deleted to free cluster resources.
 

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -115,7 +115,7 @@ Phase state is tracked per-run in `workspace/runs/<run>/.state.json`. Delete it 
 Builds the EPP image and orchestrates PipelineRun execution across namespace slots. Operates independently of `transfer.yaml` — driven by workspace files and `setup_config.json`.
 
 ```bash
-python pipeline/deploy.py {run|status|collect|reset|pairs} [flags]
+python pipeline/deploy.py {run|status|collect|stop|reset|pairs} [flags]
 ```
 
 Common flags (all subcommands):
@@ -138,6 +138,7 @@ Common flags (all subcommands):
 python pipeline/deploy.py run     [flags]   # orchestrate parallel pool execution across namespace slots
 python pipeline/deploy.py status            # show progress snapshot of all (workload, package) pairs
 python pipeline/deploy.py collect [--package NAME…]
+python pipeline/deploy.py stop               # stop the remote orchestrator Job
 python pipeline/deploy.py reset [flags]     # tear down cluster resources for failed/stalled pairs
 python pipeline/deploy.py pairs   [flags]   # list available pair keys, workloads, and packages
 ```
@@ -175,6 +176,8 @@ python pipeline/deploy.py pairs   [flags]   # list available pair keys, workload
 | `--package NAME` | Filter by package name |
 
 **`deploy.py collect`** — extracts results from the cluster PVC and writes to `workspace/runs/<run>/results/{phase}/<workload>/`.
+
+**`deploy.py stop`** — deletes the `sim2real-orchestrator` Kubernetes Job (with cascading pod deletion) in the primary namespace. Only meaningful for remote execution (`run --remote`). Does not touch `progress.json` — pair state is left as-is. If no remote orchestrator Job exists, prints a message and returns. Use `reset` separately to clear failed/stalled pair state.
 
 **`deploy.py reset`** — removes cluster resources (PipelineRuns, Helm releases) for all non-pending pairs. Failed/running/timed-out pairs are reset to `pending` so they can be re-dispatched. Done pairs stay `done` — only their PipelineRun is deleted to free cluster resources.
 

--- a/pipeline/completions.bash
+++ b/pipeline/completions.bash
@@ -12,7 +12,7 @@ _sim2real_deploy() {
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    local subcommands="run status collect reset pairs"
+    local subcommands="run status collect stop reset pairs"
     local status_values="pending running done failed timed-out stalled"
 
     # Extract --experiment-root and --run values while finding the subcommand.
@@ -24,7 +24,7 @@ _sim2real_deploy() {
             --experiment-root) ((i++)); _exroot="${COMP_WORDS[i]}" ;;
             --run)             ((i++)); _run_name="${COMP_WORDS[i]}" ;;
             -*) ;;
-            run|status|collect|reset|pairs)
+            run|status|collect|stop|reset|pairs)
                 subcmd="${COMP_WORDS[i]}"
                 break
                 ;;

--- a/pipeline/completions.zsh
+++ b/pipeline/completions.zsh
@@ -58,6 +58,7 @@ _sim2real_deploy() {
                 'run:Orchestrate parallel pool execution'
                 'status:Show progress of all (workload, package) pairs'
                 'collect:Pull results for completed packages'
+                'stop:Stop the remote orchestrator Job'
                 'reset:Tear down cluster resources for all non-pending pairs'
                 'pairs:List available pair keys, workloads, and packages'
             )

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -5,6 +5,7 @@ Subcommands:
   run      Build EPP image, submit PipelineRuns
   status   Show progress of all (workload, package) pairs
   collect  Pull results from cluster for completed phases
+  stop     Stop the remote orchestrator Job
   reset    Tear down cluster resources for all non-pending pairs
   pairs    List available pair keys, workloads, and packages
 """
@@ -1457,15 +1458,23 @@ JOB_NAME = "sim2real-orchestrator"
 
 def _cmd_stop(namespace: str) -> None:
     """Stop the remote orchestrator Job."""
-    try:
-        run(["kubectl", "get", "job", JOB_NAME, "-n", namespace],
-            check=True, capture=True)
-    except subprocess.CalledProcessError:
-        info(f"No remote orchestrator started in {namespace}")
-        return
+    result = run(["kubectl", "get", "job", JOB_NAME, "-n", namespace],
+                 check=False, capture=True)
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        if "NotFound" in stderr or "not found" in stderr:
+            info(f"No remote orchestrator started in {namespace}")
+            return
+        err(f"Failed to check for orchestrator Job in {namespace}: {stderr}")
+        sys.exit(1)
 
-    run(["kubectl", "delete", "job", JOB_NAME, "-n", namespace,
-         "--cascade=foreground"])
+    result = run(["kubectl", "delete", "job", JOB_NAME, "-n", namespace,
+                   "--cascade=foreground"], check=False, capture=True)
+    if result.returncode != 0:
+        detail = (result.stderr or "").strip()
+        err(f"Failed to delete {JOB_NAME} in {namespace}"
+            + (f": {detail}" if detail else ""))
+        sys.exit(1)
     ok(f"Stopped {JOB_NAME} in {namespace}")
 
 
@@ -1567,6 +1576,18 @@ def main():
     EXPERIMENT_ROOT = Path(args.experiment_root).resolve() if args.experiment_root else Path.cwd()
 
     setup_config = _load_setup_config()
+
+    cmd = args.command
+
+    if cmd == "stop":
+        namespaces = [ns for ns in (setup_config.get("namespaces") or
+                      [setup_config.get("namespace", "")]) if ns]
+        if not namespaces:
+            err("No namespaces configured. Run setup.py first.")
+            sys.exit(1)
+        _cmd_stop(namespace=namespaces[0])
+        return
+
     run_name = args.run or setup_config.get("current_run", "")
     if not run_name:
         err("No run name. Use --run NAME or set current_run in setup_config.json.")
@@ -1577,7 +1598,6 @@ def main():
         err(f"Run directory not found: {run_dir}")
         sys.exit(1)
 
-    cmd = args.command
     if cmd == "run":
         _cmd_run(args, run_dir, setup_config)
     elif cmd == "status":
@@ -1585,13 +1605,6 @@ def main():
         _cmd_status(args, progress_path)
     elif cmd == "collect":
         _cmd_collect(args, run_dir, setup_config)
-    elif cmd == "stop":
-        namespaces = [ns for ns in (setup_config.get("namespaces") or
-                      [setup_config.get("namespace", "")]) if ns]
-        if not namespaces:
-            err("No namespaces configured. Run setup.py first.")
-            sys.exit(1)
-        _cmd_stop(namespace=namespaces[0])
     elif cmd == "reset":
         progress_path = run_dir / "progress.json"
         cluster_dir = run_dir / "cluster"

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1450,6 +1450,25 @@ def _cmd_reset(args, progress_path: Path, discovered: dict,
     ok(msg)
 
 
+# ── Stop remote orchestrator ────────────────────────────────────────────────
+
+JOB_NAME = "sim2real-orchestrator"
+
+
+def _cmd_stop(namespace: str) -> None:
+    """Stop the remote orchestrator Job."""
+    try:
+        run(["kubectl", "get", "job", JOB_NAME, "-n", namespace],
+            check=True, capture=True)
+    except subprocess.CalledProcessError:
+        info(f"No remote orchestrator started in {namespace}")
+        return
+
+    run(["kubectl", "delete", "job", JOB_NAME, "-n", namespace,
+         "--cascade=foreground"])
+    ok(f"Stopped {JOB_NAME} in {namespace}")
+
+
 # ── CLI ──────────────────────────────────────────────────────────────────────
 
 def build_parser() -> argparse.ArgumentParser:
@@ -1464,6 +1483,7 @@ Examples:
   python pipeline/deploy.py status                     # Show progress snapshot
   python pipeline/deploy.py collect                    # Pull results for completed phases
   python pipeline/deploy.py collect --skip-logs        # Collect traces only (skip large logs)
+  python pipeline/deploy.py stop                         # Stop remote orchestrator Job
   python pipeline/deploy.py reset                       # Reset stalled/failed pairs
   python pipeline/deploy.py reset --dry-run             # Preview what would be reset
   python pipeline/deploy.py pairs                       # List pairs with workloads and packages
@@ -1511,6 +1531,8 @@ Examples:
                        help="Max early reclaims before marking pair stalled [10]")
     run_p.add_argument("--max-backoff", type=int, default=600, dest="max_backoff",
                        help="Maximum backoff interval in seconds during GPU scarcity [600]")
+
+    sub.add_parser("stop", help="Stop the remote orchestrator Job")
 
     reset_p = sub.add_parser("reset", help="Tear down cluster resources for all non-pending pairs")
     reset_p.add_argument("--only",     metavar="PAIR",  help="Scope to one specific pair key (wl- prefix optional)")
@@ -1563,6 +1585,13 @@ def main():
         _cmd_status(args, progress_path)
     elif cmd == "collect":
         _cmd_collect(args, run_dir, setup_config)
+    elif cmd == "stop":
+        namespaces = [ns for ns in (setup_config.get("namespaces") or
+                      [setup_config.get("namespace", "")]) if ns]
+        if not namespaces:
+            err("No namespaces configured. Run setup.py first.")
+            sys.exit(1)
+        _cmd_stop(namespace=namespaces[0])
     elif cmd == "reset":
         progress_path = run_dir / "progress.json"
         cluster_dir = run_dir / "cluster"
@@ -1578,7 +1607,7 @@ def main():
                    workloads_only=args.workloads_only,
                    packages_only=args.packages_only)
     else:
-        err("No subcommand specified. Use: deploy.py run | status | collect | reset | pairs")
+        err("No subcommand specified. Use: deploy.py run | status | collect | stop | reset | pairs")
         sys.exit(1)
 
 

--- a/pipeline/tests/test_deploy_stop.py
+++ b/pipeline/tests/test_deploy_stop.py
@@ -1,9 +1,18 @@
 """Tests for deploy.py stop subcommand."""
 
-import subprocess
 from unittest.mock import patch
 
+import pytest
+
 import pipeline.deploy as mod
+
+
+def _fake_run_ok(cmd, *, check=True, capture=False, cwd=None):
+    class _R:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+    return _R()
 
 
 def test_stop_deletes_orchestrator_job(monkeypatch, capsys):
@@ -12,10 +21,7 @@ def test_stop_deletes_orchestrator_job(monkeypatch, capsys):
 
     def fake_run(cmd, *, check=True, capture=False, cwd=None):
         calls.append(cmd)
-        class _R:
-            returncode = 0
-            stdout = ""
-        return _R()
+        return _fake_run_ok(cmd)
 
     monkeypatch.setattr(mod, "run", fake_run)
 
@@ -36,11 +42,13 @@ def test_stop_deletes_orchestrator_job(monkeypatch, capsys):
 
 
 def test_stop_no_job_prints_message(monkeypatch, capsys):
-    """When no orchestrator Job exists, print message and return."""
+    """When no orchestrator Job exists, print info message and return."""
     def fake_run(cmd, *, check=True, capture=False, cwd=None):
-        if cmd[:2] == ["kubectl", "get"]:
-            raise subprocess.CalledProcessError(1, cmd)
-        raise AssertionError(f"Unexpected call: {cmd}")
+        class _R:
+            returncode = 1
+            stdout = ""
+            stderr = 'Error from server (NotFound): jobs.batch "sim2real-orchestrator" not found'
+        return _R()
 
     monkeypatch.setattr(mod, "run", fake_run)
 
@@ -50,11 +58,51 @@ def test_stop_no_job_prints_message(monkeypatch, capsys):
     assert "no remote orchestrator started" in out.lower()
 
 
+def test_stop_kubectl_get_error_exits(monkeypatch, capsys):
+    """Non-NotFound kubectl get errors exit with code 1."""
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 1
+            stdout = ""
+            stderr = "error: You must be logged in to the server"
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    with pytest.raises(SystemExit) as exc_info:
+        mod._cmd_stop(namespace="sim2real-dev")
+    assert exc_info.value.code == 1
+
+    captured = capsys.readouterr()
+    assert "logged in" in captured.err.lower()
+
+
+def test_stop_kubectl_delete_error_exits(monkeypatch, capsys):
+    """When Job exists but delete fails, exit with code 1."""
+    call_count = [0]
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return _fake_run_ok(cmd)
+        class _R:
+            returncode = 1
+            stdout = ""
+            stderr = "error: forbidden"
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    with pytest.raises(SystemExit) as exc_info:
+        mod._cmd_stop(namespace="sim2real-dev")
+    assert exc_info.value.code == 1
+
+    captured = capsys.readouterr()
+    assert "forbidden" in captured.err.lower()
+
+
 def test_main_dispatches_stop(tmp_path, monkeypatch):
     """main() routes 'stop' to _cmd_stop with the primary namespace."""
-    run_dir = tmp_path / "workspace" / "runs" / "test-run"
-    run_dir.mkdir(parents=True)
-
     monkeypatch.setattr("sys.argv", [
         "deploy.py", "--experiment-root", str(tmp_path), "stop",
     ])
@@ -76,19 +124,59 @@ def test_main_dispatches_stop(tmp_path, monkeypatch):
     assert stop_calls == ["sim2real-0"]
 
 
-def test_main_stop_no_namespace_exits(tmp_path, monkeypatch):
-    """stop exits with error when no namespaces configured."""
-    run_dir = tmp_path / "workspace" / "runs" / "test-run"
-    run_dir.mkdir(parents=True)
-
+def test_main_dispatches_stop_singular_namespace(tmp_path, monkeypatch):
+    """main() falls back to singular 'namespace' key when 'namespaces' is absent."""
     monkeypatch.setattr("sys.argv", [
         "deploy.py", "--experiment-root", str(tmp_path), "stop",
     ])
     monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)
 
-    import pytest
+    stop_calls = []
+
+    def mock_stop(namespace):
+        stop_calls.append(namespace)
+
+    with patch.object(mod, "_cmd_stop", mock_stop):
+        with patch.object(mod, "_load_setup_config", return_value={
+            "current_run": "test-run",
+            "namespace": "sim2real-legacy",
+        }):
+            mod.main()
+
+    assert stop_calls == ["sim2real-legacy"]
+
+
+def test_main_stop_no_namespace_exits(tmp_path, monkeypatch):
+    """stop exits with code 1 when no namespaces configured."""
+    monkeypatch.setattr("sys.argv", [
+        "deploy.py", "--experiment-root", str(tmp_path), "stop",
+    ])
+    monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)
+
     with patch.object(mod, "_load_setup_config", return_value={
         "current_run": "test-run",
     }):
-        with pytest.raises(SystemExit):
+        with pytest.raises(SystemExit) as exc_info:
             mod.main()
+        assert exc_info.value.code == 1
+
+
+def test_main_stop_does_not_require_run_dir(tmp_path, monkeypatch):
+    """stop works without a run directory or run name configured."""
+    monkeypatch.setattr("sys.argv", [
+        "deploy.py", "--experiment-root", str(tmp_path), "stop",
+    ])
+    monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)
+
+    stop_calls = []
+
+    def mock_stop(namespace):
+        stop_calls.append(namespace)
+
+    with patch.object(mod, "_cmd_stop", mock_stop):
+        with patch.object(mod, "_load_setup_config", return_value={
+            "namespace": "sim2real-0",
+        }):
+            mod.main()
+
+    assert stop_calls == ["sim2real-0"]

--- a/pipeline/tests/test_deploy_stop.py
+++ b/pipeline/tests/test_deploy_stop.py
@@ -1,0 +1,94 @@
+"""Tests for deploy.py stop subcommand."""
+
+import subprocess
+from unittest.mock import patch
+
+import pipeline.deploy as mod
+
+
+def test_stop_deletes_orchestrator_job(monkeypatch, capsys):
+    """When the orchestrator Job exists, stop deletes it."""
+    calls = []
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        calls.append(cmd)
+        class _R:
+            returncode = 0
+            stdout = ""
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    mod._cmd_stop(namespace="sim2real-dev")
+
+    assert len(calls) == 2
+    assert calls[0] == [
+        "kubectl", "get", "job", "sim2real-orchestrator",
+        "-n", "sim2real-dev",
+    ]
+    assert calls[1] == [
+        "kubectl", "delete", "job", "sim2real-orchestrator",
+        "-n", "sim2real-dev", "--cascade=foreground",
+    ]
+    out = capsys.readouterr().out
+    assert "sim2real-orchestrator" in out
+    assert "sim2real-dev" in out
+
+
+def test_stop_no_job_prints_message(monkeypatch, capsys):
+    """When no orchestrator Job exists, print message and return."""
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        if cmd[:2] == ["kubectl", "get"]:
+            raise subprocess.CalledProcessError(1, cmd)
+        raise AssertionError(f"Unexpected call: {cmd}")
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    mod._cmd_stop(namespace="sim2real-dev")
+
+    out = capsys.readouterr().out
+    assert "no remote orchestrator started" in out.lower()
+
+
+def test_main_dispatches_stop(tmp_path, monkeypatch):
+    """main() routes 'stop' to _cmd_stop with the primary namespace."""
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    run_dir.mkdir(parents=True)
+
+    monkeypatch.setattr("sys.argv", [
+        "deploy.py", "--experiment-root", str(tmp_path), "stop",
+    ])
+    monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)
+
+    stop_calls = []
+
+    def mock_stop(namespace):
+        stop_calls.append(namespace)
+
+    with patch.object(mod, "_cmd_stop", mock_stop):
+        with patch.object(mod, "_load_setup_config", return_value={
+            "current_run": "test-run",
+            "namespace": "sim2real-0",
+            "namespaces": ["sim2real-0", "sim2real-1"],
+        }):
+            mod.main()
+
+    assert stop_calls == ["sim2real-0"]
+
+
+def test_main_stop_no_namespace_exits(tmp_path, monkeypatch):
+    """stop exits with error when no namespaces configured."""
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    run_dir.mkdir(parents=True)
+
+    monkeypatch.setattr("sys.argv", [
+        "deploy.py", "--experiment-root", str(tmp_path), "stop",
+    ])
+    monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)
+
+    import pytest
+    with patch.object(mod, "_load_setup_config", return_value={
+        "current_run": "test-run",
+    }):
+        with pytest.raises(SystemExit):
+            mod.main()


### PR DESCRIPTION
Closes #125

## Summary

- Adds `deploy.py stop` subcommand that deletes the `sim2real-orchestrator` Kubernetes Job in the primary namespace (`namespaces[0]`) with `--cascade=foreground`
- If no Job exists, prints "No remote orchestrator started in {namespace}" and returns — wording avoids implying there's no orchestrator at all (a local one might be running)
- Does NOT touch `progress.json` — pair state is left as-is per the issue spec

## Reviewer notes

- Namespace resolution uses `namespaces[0]` from `setup_config.json`, same pattern as `_cmd_run` (line 1061 in the original) which uses `namespaces[0]` for the EPP image build
- The `stop` subcommand is only meaningful once #127 (remote execution) lands — until then the Job won't exist, and `stop` will always be a no-op with a message
- No new CLI flags on `stop` — it reads namespace from `setup_config.json` like every other subcommand

## Test plan

- [x] `test_stop_deletes_orchestrator_job` — verifies kubectl get + delete sequence with correct namespace and `--cascade=foreground`
- [x] `test_stop_no_job_prints_message` — verifies no-op message when Job doesn't exist
- [x] `test_main_dispatches_stop` — verifies main() routes to `_cmd_stop` with primary namespace
- [x] `test_main_stop_no_namespace_exits` — verifies exit when no namespaces configured
- [x] Full suite: 524 tests pass, lint clean