### PR TITLE
Add deploy.py wipe subcommand for data cleanup (#123)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,8 +89,8 @@ All artifacts live under `<experiment-root>/workspace/` (gitignored). When no `-
 | `runs/<run>/cluster/treatment.yaml` | `prepare.py` Phase 4 | `deploy.py` |
 | `runs/<run>/cluster/pipelinerun-*.yaml` | `prepare.py` Phase 4 | `deploy.py run` |
 | `runs/<run>/run_summary.md` | `prepare.py` Phase 5 | human review |
-| `runs/<run>/results/{phase}/` | `deploy.py collect` | `/sim2real-analyze` skill |
-| `runs/<run>/progress.json` | `deploy.py run` | `deploy.py status`, `deploy.py collect` |
+| `runs/<run>/results/{phase}/` | `deploy.py collect` | `/sim2real-analyze` skill, `deploy.py wipe` |
+| `runs/<run>/progress.json` | `deploy.py run`, `deploy.py wipe` | `deploy.py status`, `deploy.py collect`, `deploy.py wipe` |
 | `runs/<run>/plans/<phase>/<workload>/` | `deploy.py run` | workload tasks |
 | `context/{scenario}/{hash}.md` | `prepare.py` Phase 2 | `prepare.py` Phase 2 (cache) |
 

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -115,7 +115,7 @@ Phase state is tracked per-run in `workspace/runs/<run>/.state.json`. Delete it 
 Builds the EPP image and orchestrates PipelineRun execution across namespace slots. Operates independently of `transfer.yaml` — driven by workspace files and `setup_config.json`.
 
 ```bash
-python pipeline/deploy.py {run|status|collect|stop|reset|pairs} [flags]
+python pipeline/deploy.py {run|status|collect|stop|reset|wipe|pairs} [flags]
 ```
 
 Common flags (all subcommands):
@@ -140,6 +140,7 @@ python pipeline/deploy.py status            # show progress snapshot of all (wor
 python pipeline/deploy.py collect [flags]     # pull results from the cluster PVC
 python pipeline/deploy.py stop               # stop the remote orchestrator Job
 python pipeline/deploy.py reset [flags]     # tear down cluster resources for failed/stalled pairs
+python pipeline/deploy.py wipe  [flags]     # delete local results and reset pairs to pending
 python pipeline/deploy.py pairs   [flags]   # list available pair keys, workloads, and packages
 ```
 
@@ -200,6 +201,18 @@ When `--only` or `--workload` is given, only matching workload subdirectories ar
 | `--dry-run` | Print what would be reset without acting |
 
 **Safety:** Results in `workspace/runs/<run>/results/` are preserved — only cluster resources are removed. For `done` pairs, only the PipelineRun is deleted (Tekton already tore down Helm releases).
+
+**`deploy.py wipe`** — deletes local results (`results/<package>/<workload>/`) for non-pending pairs and resets their status to `pending` in `progress.json`. Use when reusing a run name and stale results from prior executions need to be cleared before re-executing. Pending pairs are skipped (nothing to wipe). Empty package directories are cleaned up automatically.
+
+| Flag | Description |
+|------|-------------|
+| `--only PAIR` | Scope wipe to one specific pair key (`wl-` prefix optional) |
+| `--workload NAME` | Scope wipe to pairs matching this workload |
+| `--package NAME` | Scope wipe to pairs matching this package |
+| `--dry-run` | Print what would be wiped without acting |
+| `--yes` / `-y` | Skip confirmation prompt |
+
+**Interaction with `collect`:** Wiping resets pair status to `pending`, which makes any PVC data unreachable via `collect` (collect only pulls `done` pairs). Re-executing the pairs writes fresh data to the PVC.
 
 **`deploy.py pairs`** — lists available pair keys, workloads, and packages by scanning `cluster/pipelinerun-*.yaml`. Works without `progress.json`.
 

--- a/pipeline/completions.bash
+++ b/pipeline/completions.bash
@@ -12,7 +12,7 @@ _sim2real_deploy() {
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    local subcommands="run status collect stop reset pairs"
+    local subcommands="run status collect stop reset wipe pairs"
     local status_values="pending running done failed timed-out stalled"
 
     # Extract --experiment-root and --run values while finding the subcommand.
@@ -24,7 +24,7 @@ _sim2real_deploy() {
             --experiment-root) ((i++)); _exroot="${COMP_WORDS[i]}" ;;
             --run)             ((i++)); _run_name="${COMP_WORDS[i]}" ;;
             -*) ;;
-            run|status|collect|stop|reset|pairs)
+            run|status|collect|stop|reset|wipe|pairs)
                 subcmd="${COMP_WORDS[i]}"
                 break
                 ;;
@@ -80,6 +80,9 @@ _sim2real_deploy() {
                 ;;
             reset)
                 COMPREPLY=($(compgen -W "--only --workload --package --status --dry-run" -- "$cur"))
+                ;;
+            wipe)
+                COMPREPLY=($(compgen -W "--only --workload --package --dry-run --yes" -- "$cur"))
                 ;;
             collect)
                 COMPREPLY=($(compgen -W "--only --workload --package --skip-logs" -- "$cur"))

--- a/pipeline/completions.zsh
+++ b/pipeline/completions.zsh
@@ -105,7 +105,7 @@ _sim2real_deploy() {
                         '--workload[Scope to workload]:workload:_deploy_py_workloads' \
                         '--package[Scope to package]:package:_deploy_py_packages' \
                         '--status[Scope to status]:status:_deploy_py_statuses' \
-                        '--dry-run[Print what would be cleaned up]'
+                        '--dry-run[Print what would be reset]'
                     ;;
                 wipe)
                     _arguments \

--- a/pipeline/completions.zsh
+++ b/pipeline/completions.zsh
@@ -60,6 +60,7 @@ _sim2real_deploy() {
                 'collect:Pull results for completed packages'
                 'stop:Stop the remote orchestrator Job'
                 'reset:Tear down cluster resources for all non-pending pairs'
+                'wipe:Delete local results and reset pairs to pending'
                 'pairs:List available pair keys, workloads, and packages'
             )
             _describe 'subcommand' subcommands
@@ -105,6 +106,14 @@ _sim2real_deploy() {
                         '--package[Scope to package]:package:_deploy_py_packages' \
                         '--status[Scope to status]:status:_deploy_py_statuses' \
                         '--dry-run[Print what would be cleaned up]'
+                    ;;
+                wipe)
+                    _arguments \
+                        '--only[Scope to one pair key]:pair key:_deploy_py_pair_keys' \
+                        '--workload[Scope to workload]:workload:_deploy_py_workloads' \
+                        '--package[Scope to package]:package:_deploy_py_packages' \
+                        '--dry-run[Print what would be wiped]' \
+                        '(-y --yes)'{-y,--yes}'[Skip confirmation prompt]'
                     ;;
                 pairs)
                     _arguments \

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -14,6 +14,7 @@ Subcommands:
 import argparse
 import json
 import os
+import shutil
 import subprocess
 import sys
 import time
@@ -1634,15 +1635,11 @@ def _cmd_wipe(args, run_dir: Path) -> None:
         info("No pairs need wiping (all pending)")
         return
 
-    dry_run = getattr(args, "dry_run", False)
-    yes = getattr(args, "yes", False)
     total_pairs = sum(1 for k in progress if _is_pair_key(k))
     results_dir = run_dir / "results"
 
-    # Build targets from all scoped pairs for dir deletion;
-    # only actionable (non-pending) pairs get their status reset.
     targets = []
-    for key in sorted(_scope):
+    for key in sorted(actionable):
         entry = progress[key]
         pkg = entry.get("package", "")
         wl = entry.get("workload", "")
@@ -1651,56 +1648,56 @@ def _cmd_wipe(args, run_dir: Path) -> None:
             targets.append((key, pkg, wl, target_dir))
 
     info(f"Scope: {len(actionable)}/{total_pairs} pairs"
-         + (" [DRY-RUN]" if dry_run else ""))
+         + (" [DRY-RUN]" if args.dry_run else ""))
 
-    if dry_run:
+    if args.dry_run:
         for key, pkg, wl, target_dir in targets:
-            if key not in actionable:
-                continue
             exists = target_dir.exists()
             info(f"[DRY-RUN] {key}: would delete results/{pkg}/{wl}/"
                  + (" (exists)" if exists else " (not on disk)"))
             info(f"[DRY-RUN] {key}: would reset status to pending")
         return
 
-    if not yes:
-        dirs_on_disk = sum(1 for k, _, _, p in targets if k in actionable and p.exists())
-        prompt = f"Wipe {len(actionable)} pair(s) ({dirs_on_disk} with results on disk)? [y/N] "
-        if input(prompt).strip().lower() != "y":
+    if not args.yes:
+        dirs_on_disk = sum(1 for _, _, _, p in targets if p.exists())
+        prompt = f"Wipe {len(targets)} pair(s) ({dirs_on_disk} with results on disk)? [y/N] "
+        try:
+            answer = input(prompt).strip().lower()
+        except EOFError:
+            answer = ""
+        if answer != "y":
             info("Aborted")
             return
 
     wiped = 0
-    import shutil
-    touched_pkgs = set()
+    errors = 0
     for key, pkg, wl, target_dir in targets:
         if target_dir.exists():
-            shutil.rmtree(target_dir)
-            if key in actionable:
-                ok(f"Deleted: results/{pkg}/{wl}/")
-            touched_pkgs.add(pkg)
-        if key in actionable:
-            entry = progress[key]
-            entry["status"] = "pending"
-            entry["retries"] = 0
-            entry["pending_stalls"] = 0
-            entry["pending_since"] = None
-            entry["namespace"] = None
-            wiped += 1
-
-    # Remove package dirs whose tracked pairs are all now pending
-    for pkg in touched_pkgs:
-        pkg_dir = results_dir / pkg
-        if not pkg_dir.exists():
-            continue
-        active = [k for k, v in progress.items()
-                  if _is_pair_key(k) and v.get("package") == pkg
-                  and v.get("status") not in (None, "pending")]
-        if not active:
-            shutil.rmtree(pkg_dir)
+            try:
+                shutil.rmtree(target_dir)
+            except OSError as e:
+                warn(f"{key}: failed to delete results/{pkg}/{wl}/: {e}")
+                errors += 1
+                continue
+            ok(f"Deleted: results/{pkg}/{wl}/")
+            pkg_dir = results_dir / pkg
+            try:
+                pkg_dir.rmdir()
+            except OSError:
+                pass
+        entry = progress[key]
+        entry["status"] = "pending"
+        entry["retries"] = 0
+        entry["pending_stalls"] = 0
+        entry["pending_since"] = None
+        entry["namespace"] = None
+        wiped += 1
 
     store.save(progress)
-    ok(f"{wiped} pair(s) wiped")
+    msg = f"{wiped} pair(s) wiped"
+    if errors:
+        msg += f" ({errors} failed — check permissions)"
+    ok(msg)
 
 
 # ── Stop remote orchestrator ────────────────────────────────────────────────

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1675,7 +1675,8 @@ def _cmd_wipe(args, run_dir: Path,
         try:
             answer = input(prompt).strip().lower()
         except EOFError:
-            answer = ""
+            info("Aborted (non-interactive — use --yes to skip confirmation)")
+            return
         if answer != "y":
             info("Aborted")
             return

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1697,6 +1697,8 @@ def _cmd_wipe(args, run_dir: Path,
                 pkg_dir.rmdir()
             except OSError:
                 pass
+        else:
+            ok(f"Reset: {key} (no results on disk)")
         entry = progress[key]
         entry["status"] = "pending"
         entry["retries"] = 0
@@ -1709,6 +1711,8 @@ def _cmd_wipe(args, run_dir: Path,
     msg = f"{wiped} pair(s) wiped"
     if errors:
         msg += f" ({errors} failed — check permissions)"
+        warn(msg)
+        sys.exit(1)
     ok(msg)
 
 

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1615,11 +1615,20 @@ def _cmd_reset(args, progress_path: Path, discovered: dict,
     ok(msg)
 
 
-def _cmd_wipe(args, run_dir: Path) -> None:
+def _cmd_wipe(args, run_dir: Path,
+              setup_config: dict | None = None) -> None:
     """Delete local results and reset wiped pairs to pending."""
-    from pipeline.lib.progress import LocalProgressStore
+    from pipeline.lib.progress import (
+        LocalProgressStore, ConfigMapProgressStore, CompositeProgressStore,
+    )
     progress_path = run_dir / "progress.json"
-    store = LocalProgressStore(progress_path)
+    local_store = LocalProgressStore(progress_path)
+    primary_ns = _configmap_namespace(setup_config)
+    if primary_ns:
+        cm_store = ConfigMapProgressStore(primary_ns)
+        store = CompositeProgressStore(local_store, cm_store)
+    else:
+        store = local_store
     progress = store.load()
 
     if not progress:
@@ -1643,9 +1652,11 @@ def _cmd_wipe(args, run_dir: Path) -> None:
         entry = progress[key]
         pkg = entry.get("package", "")
         wl = entry.get("workload", "")
-        if pkg and wl:
-            target_dir = results_dir / pkg / wl
-            targets.append((key, pkg, wl, target_dir))
+        if not pkg or not wl:
+            warn(f"{key}: missing package/workload fields — skipping")
+            continue
+        target_dir = results_dir / pkg / wl
+        targets.append((key, pkg, wl, target_dir))
 
     info(f"Scope: {len(actionable)}/{total_pairs} pairs"
          + (" [DRY-RUN]" if args.dry_run else ""))
@@ -1884,7 +1895,7 @@ def main():
                    namespaces=namespaces or None,
                    setup_config=setup_config)
     elif cmd == "wipe":
-        _cmd_wipe(args, run_dir)
+        _cmd_wipe(args, run_dir, setup_config=setup_config)
     elif cmd == "pairs":
         cluster_dir = run_dir / "cluster"
         _cmd_pairs(cluster_dir, keys_only=args.keys_only,

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -7,6 +7,7 @@ Subcommands:
   collect  Pull results from cluster for completed phases
   stop     Stop the remote orchestrator Job
   reset    Tear down cluster resources for all non-pending pairs
+  wipe     Delete local results and reset pairs to pending
   pairs    List available pair keys, workloads, and packages
 """
 
@@ -1613,6 +1614,95 @@ def _cmd_reset(args, progress_path: Path, discovered: dict,
     ok(msg)
 
 
+def _cmd_wipe(args, run_dir: Path) -> None:
+    """Delete local results and reset wiped pairs to pending."""
+    from pipeline.lib.progress import LocalProgressStore
+    progress_path = run_dir / "progress.json"
+    store = LocalProgressStore(progress_path)
+    progress = store.load()
+
+    if not progress:
+        info("No progress data found — nothing to wipe")
+        return
+
+    _scope = _resolve_scope(progress, args)
+
+    actionable = {k for k in _scope
+                  if progress[k].get("status") not in (None, "pending")}
+
+    if not actionable:
+        info("No pairs need wiping (all pending)")
+        return
+
+    dry_run = getattr(args, "dry_run", False)
+    yes = getattr(args, "yes", False)
+    total_pairs = sum(1 for k in progress if _is_pair_key(k))
+    results_dir = run_dir / "results"
+
+    # Build targets from all scoped pairs for dir deletion;
+    # only actionable (non-pending) pairs get their status reset.
+    targets = []
+    for key in sorted(_scope):
+        entry = progress[key]
+        pkg = entry.get("package", "")
+        wl = entry.get("workload", "")
+        if pkg and wl:
+            target_dir = results_dir / pkg / wl
+            targets.append((key, pkg, wl, target_dir))
+
+    info(f"Scope: {len(actionable)}/{total_pairs} pairs"
+         + (" [DRY-RUN]" if dry_run else ""))
+
+    if dry_run:
+        for key, pkg, wl, target_dir in targets:
+            if key not in actionable:
+                continue
+            exists = target_dir.exists()
+            info(f"[DRY-RUN] {key}: would delete results/{pkg}/{wl}/"
+                 + (" (exists)" if exists else " (not on disk)"))
+            info(f"[DRY-RUN] {key}: would reset status to pending")
+        return
+
+    if not yes:
+        dirs_on_disk = sum(1 for k, _, _, p in targets if k in actionable and p.exists())
+        prompt = f"Wipe {len(actionable)} pair(s) ({dirs_on_disk} with results on disk)? [y/N] "
+        if input(prompt).strip().lower() != "y":
+            info("Aborted")
+            return
+
+    wiped = 0
+    import shutil
+    touched_pkgs = set()
+    for key, pkg, wl, target_dir in targets:
+        if target_dir.exists():
+            shutil.rmtree(target_dir)
+            if key in actionable:
+                ok(f"Deleted: results/{pkg}/{wl}/")
+            touched_pkgs.add(pkg)
+        if key in actionable:
+            entry = progress[key]
+            entry["status"] = "pending"
+            entry["retries"] = 0
+            entry["pending_stalls"] = 0
+            entry["pending_since"] = None
+            entry["namespace"] = None
+            wiped += 1
+
+    # Remove package dirs whose tracked pairs are all now pending
+    for pkg in touched_pkgs:
+        pkg_dir = results_dir / pkg
+        if not pkg_dir.exists():
+            continue
+        active = [k for k, v in progress.items()
+                  if _is_pair_key(k) and v.get("package") == pkg
+                  and v.get("status") not in (None, "pending")]
+        if not active:
+            shutil.rmtree(pkg_dir)
+
+    store.save(progress)
+    ok(f"{wiped} pair(s) wiped")
+
+
 # ── Stop remote orchestrator ────────────────────────────────────────────────
 
 JOB_NAME = "sim2real-orchestrator"
@@ -1657,6 +1747,9 @@ Examples:
   python pipeline/deploy.py stop                         # Stop remote orchestrator Job
   python pipeline/deploy.py reset                       # Reset stalled/failed pairs
   python pipeline/deploy.py reset --dry-run             # Preview what would be reset
+  python pipeline/deploy.py wipe                          # Wipe all results for current run
+  python pipeline/deploy.py wipe --workload sharegpt-32   # Wipe results for one workload
+  python pipeline/deploy.py wipe --dry-run                # Preview what would be wiped
   python pipeline/deploy.py pairs                       # List pairs with workloads and packages
   python pipeline/deploy.py pairs --keys-only           # Machine-readable: keys only
 """,
@@ -1718,6 +1811,15 @@ Examples:
     reset_p.add_argument("--status",   metavar="STATE", help="Scope to pairs with this status")
     reset_p.add_argument("--dry-run",  action="store_true", dest="dry_run",
                          help="Print what would be reset without doing it")
+
+    wipe_p = sub.add_parser("wipe", help="Delete local results and reset pairs to pending")
+    wipe_p.add_argument("--only",     metavar="PAIR",  help="Scope to one specific pair key (wl- prefix optional)")
+    wipe_p.add_argument("--workload", metavar="NAME",  help="Scope to pairs matching this workload")
+    wipe_p.add_argument("--package",  metavar="NAME",  help="Scope to pairs matching this package")
+    wipe_p.add_argument("--dry-run",  action="store_true", dest="dry_run",
+                         help="Print what would be wiped without doing it")
+    wipe_p.add_argument("--yes", "-y", action="store_true",
+                         help="Skip confirmation prompt")
 
     pairs_p = sub.add_parser("pairs", help="List available pair keys, workloads, and packages")
     pairs_group = pairs_p.add_mutually_exclusive_group()
@@ -1784,13 +1886,15 @@ def main():
         _cmd_reset(args, progress_path, discovered,
                    namespaces=namespaces or None,
                    setup_config=setup_config)
+    elif cmd == "wipe":
+        _cmd_wipe(args, run_dir)
     elif cmd == "pairs":
         cluster_dir = run_dir / "cluster"
         _cmd_pairs(cluster_dir, keys_only=args.keys_only,
                    workloads_only=args.workloads_only,
                    packages_only=args.packages_only)
     else:
-        err("No subcommand specified. Use: deploy.py run | status | collect | stop | reset | pairs")
+        err("No subcommand specified. Use: deploy.py run | status | collect | stop | reset | wipe | pairs")
         sys.exit(1)
 
 

--- a/pipeline/tests/test_deploy_wipe.py
+++ b/pipeline/tests/test_deploy_wipe.py
@@ -271,6 +271,8 @@ def test_wipe_eof_on_input_aborts(tmp_path, monkeypatch, capsys):
 
     saved = json.loads(progress_path.read_text())
     assert saved == _PROGRESS
+    captured = capsys.readouterr()
+    assert "--yes" in captured.out + captured.err
 
 
 def test_wipe_filter_mismatch_aborts(tmp_path, capsys):

--- a/pipeline/tests/test_deploy_wipe.py
+++ b/pipeline/tests/test_deploy_wipe.py
@@ -1,0 +1,261 @@
+"""Tests for deploy.py wipe subcommand."""
+
+import json
+from pathlib import Path
+
+
+_PROGRESS = {
+    "wl-smoke-baseline":   {"workload": "wl-smoke",  "package": "baseline",  "status": "done",      "namespace": None, "retries": 0},
+    "wl-smoke-treatment":  {"workload": "wl-smoke",  "package": "treatment", "status": "done",      "namespace": None, "retries": 0},
+    "wl-load-baseline":    {"workload": "wl-load",   "package": "baseline",  "status": "pending",   "namespace": None, "retries": 0},
+    "wl-load-treatment":   {"workload": "wl-load",   "package": "treatment", "status": "failed",    "namespace": None, "retries": 0},
+    "wl-heavy-baseline":   {"workload": "wl-heavy",  "package": "baseline",  "status": "timed-out", "namespace": None, "retries": 1},
+}
+
+
+def _setup_results(run_dir: Path) -> None:
+    """Create a realistic results directory tree under run_dir."""
+    for pkg in ("baseline", "treatment"):
+        for wl in ("wl-smoke", "wl-load", "wl-heavy"):
+            d = run_dir / "results" / pkg / wl
+            d.mkdir(parents=True, exist_ok=True)
+            (d / "trace_header.yaml").write_text("header")
+            (d / "trace_data.csv").write_text("data")
+
+
+def test_wipe_all_deletes_results_and_resets(tmp_path, monkeypatch):
+    """Unscoped wipe deletes all results and resets non-pending pairs."""
+    import pipeline.deploy as mod
+
+    run_dir = tmp_path / "run1"
+    run_dir.mkdir()
+    progress_path = run_dir / "progress.json"
+    progress_path.write_text(json.dumps(_PROGRESS))
+    _setup_results(run_dir)
+
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+
+    class _Args:
+        only = None; workload = None; package = None; dry_run = False; yes = True
+
+    mod._cmd_wipe(_Args(), run_dir)
+
+    saved = json.loads(progress_path.read_text())
+    # All non-pending pairs reset to pending
+    assert saved["wl-smoke-baseline"]["status"] == "pending"
+    assert saved["wl-smoke-treatment"]["status"] == "pending"
+    assert saved["wl-load-treatment"]["status"] == "pending"
+    assert saved["wl-heavy-baseline"]["status"] == "pending"
+    # Already-pending pair unchanged
+    assert saved["wl-load-baseline"]["status"] == "pending"
+    # Results directories deleted
+    assert not (run_dir / "results" / "baseline").exists()
+    assert not (run_dir / "results" / "treatment").exists()
+
+
+def test_wipe_scoped_by_workload(tmp_path, monkeypatch):
+    """--workload scopes wipe to matching pairs only."""
+    import pipeline.deploy as mod
+
+    run_dir = tmp_path / "run1"
+    run_dir.mkdir()
+    progress_path = run_dir / "progress.json"
+    progress_path.write_text(json.dumps(_PROGRESS))
+    _setup_results(run_dir)
+
+    class _Args:
+        only = None; workload = "wl-smoke"; package = None; dry_run = False; yes = True
+
+    mod._cmd_wipe(_Args(), run_dir)
+
+    saved = json.loads(progress_path.read_text())
+    # Scoped pairs reset
+    assert saved["wl-smoke-baseline"]["status"] == "pending"
+    assert saved["wl-smoke-treatment"]["status"] == "pending"
+    # Out-of-scope pairs unchanged
+    assert saved["wl-load-treatment"]["status"] == "failed"
+    assert saved["wl-heavy-baseline"]["status"] == "timed-out"
+    # Only wl-smoke directories deleted
+    assert not (run_dir / "results" / "baseline" / "wl-smoke").exists()
+    assert not (run_dir / "results" / "treatment" / "wl-smoke").exists()
+    # Other workloads untouched
+    assert (run_dir / "results" / "baseline" / "wl-load").exists()
+
+
+def test_wipe_scoped_by_only(tmp_path, monkeypatch):
+    """--only scopes wipe to a single pair."""
+    import pipeline.deploy as mod
+
+    run_dir = tmp_path / "run1"
+    run_dir.mkdir()
+    progress_path = run_dir / "progress.json"
+    progress_path.write_text(json.dumps(_PROGRESS))
+    _setup_results(run_dir)
+
+    class _Args:
+        only = "wl-heavy-baseline"; workload = None; package = None; dry_run = False; yes = True
+
+    mod._cmd_wipe(_Args(), run_dir)
+
+    saved = json.loads(progress_path.read_text())
+    assert saved["wl-heavy-baseline"]["status"] == "pending"
+    # Other pairs unchanged
+    assert saved["wl-smoke-baseline"]["status"] == "done"
+    # Only wl-heavy/baseline deleted
+    assert not (run_dir / "results" / "baseline" / "wl-heavy").exists()
+    assert (run_dir / "results" / "baseline" / "wl-smoke").exists()
+
+
+def test_wipe_scoped_by_package(tmp_path, monkeypatch):
+    """--package scopes wipe to pairs matching that package."""
+    import pipeline.deploy as mod
+
+    run_dir = tmp_path / "run1"
+    run_dir.mkdir()
+    progress_path = run_dir / "progress.json"
+    progress_path.write_text(json.dumps(_PROGRESS))
+    _setup_results(run_dir)
+
+    class _Args:
+        only = None; workload = None; package = "treatment"; dry_run = False; yes = True
+
+    mod._cmd_wipe(_Args(), run_dir)
+
+    saved = json.loads(progress_path.read_text())
+    # Treatment pairs reset
+    assert saved["wl-smoke-treatment"]["status"] == "pending"
+    assert saved["wl-load-treatment"]["status"] == "pending"
+    # Baseline pairs unchanged
+    assert saved["wl-smoke-baseline"]["status"] == "done"
+    assert saved["wl-heavy-baseline"]["status"] == "timed-out"
+    # Only treatment directories deleted
+    assert not (run_dir / "results" / "treatment" / "wl-smoke").exists()
+    assert (run_dir / "results" / "baseline" / "wl-smoke").exists()
+
+
+def test_wipe_dry_run_does_not_delete(tmp_path, capsys):
+    """--dry-run prints what would be deleted but does not mutate anything."""
+    import pipeline.deploy as mod
+
+    run_dir = tmp_path / "run1"
+    run_dir.mkdir()
+    progress_path = run_dir / "progress.json"
+    progress_path.write_text(json.dumps(_PROGRESS))
+    _setup_results(run_dir)
+
+    class _Args:
+        only = None; workload = None; package = None; dry_run = True; yes = False
+
+    mod._cmd_wipe(_Args(), run_dir)
+
+    # Nothing deleted
+    assert (run_dir / "results" / "baseline" / "wl-smoke").exists()
+    # Progress unchanged
+    saved = json.loads(progress_path.read_text())
+    assert saved == _PROGRESS
+    # DRY-RUN mentioned in output
+    captured = capsys.readouterr()
+    assert "DRY-RUN" in captured.out + captured.err
+
+
+def test_wipe_skips_pending_pairs(tmp_path):
+    """Pending pairs are skipped (nothing to wipe)."""
+    import pipeline.deploy as mod
+
+    run_dir = tmp_path / "run1"
+    run_dir.mkdir()
+    progress = {
+        "wl-a-baseline": {"workload": "wl-a", "package": "baseline", "status": "pending",
+                          "namespace": None, "retries": 0},
+    }
+    progress_path = run_dir / "progress.json"
+    progress_path.write_text(json.dumps(progress))
+
+    class _Args:
+        only = None; workload = None; package = None; dry_run = False; yes = True
+
+    mod._cmd_wipe(_Args(), run_dir)
+
+    saved = json.loads(progress_path.read_text())
+    assert saved["wl-a-baseline"]["status"] == "pending"
+
+
+def test_wipe_no_progress_reports_nothing(tmp_path, capsys):
+    """When progress.json doesn't exist, wipe reports nothing to do."""
+    import pipeline.deploy as mod
+
+    run_dir = tmp_path / "run1"
+    run_dir.mkdir()
+
+    class _Args:
+        only = None; workload = None; package = None; dry_run = False; yes = True
+
+    mod._cmd_wipe(_Args(), run_dir)
+
+    captured = capsys.readouterr()
+    assert "nothing to wipe" in (captured.out + captured.err).lower()
+
+
+def test_wipe_confirmation_abort(tmp_path, monkeypatch, capsys):
+    """User declining confirmation aborts without changes."""
+    import pipeline.deploy as mod
+
+    run_dir = tmp_path / "run1"
+    run_dir.mkdir()
+    progress_path = run_dir / "progress.json"
+    progress_path.write_text(json.dumps(_PROGRESS))
+    _setup_results(run_dir)
+
+    monkeypatch.setattr("builtins.input", lambda _: "n")
+
+    class _Args:
+        only = None; workload = None; package = None; dry_run = False; yes = False
+
+    mod._cmd_wipe(_Args(), run_dir)
+
+    # Nothing changed
+    saved = json.loads(progress_path.read_text())
+    assert saved == _PROGRESS
+    assert (run_dir / "results" / "baseline" / "wl-smoke").exists()
+
+
+def test_wipe_filter_mismatch_aborts(tmp_path, capsys):
+    """--only with non-existent pair aborts with error."""
+    import pipeline.deploy as mod
+
+    run_dir = tmp_path / "run1"
+    run_dir.mkdir()
+    progress_path = run_dir / "progress.json"
+    progress_path.write_text(json.dumps(_PROGRESS))
+
+    class _Args:
+        only = "nonexistent"; workload = None; package = None; dry_run = False; yes = True
+
+    with __import__("pytest").raises(SystemExit) as exc_info:
+        mod._cmd_wipe(_Args(), run_dir)
+    assert exc_info.value.code == 1
+
+
+def test_wipe_cleans_empty_parent_dirs(tmp_path):
+    """After wiping all workloads under a package, the package dir is removed."""
+    import pipeline.deploy as mod
+
+    run_dir = tmp_path / "run1"
+    run_dir.mkdir()
+    progress = {
+        "wl-only-baseline": {"workload": "wl-only", "package": "baseline", "status": "done",
+                             "namespace": None, "retries": 0},
+    }
+    progress_path = run_dir / "progress.json"
+    progress_path.write_text(json.dumps(progress))
+    d = run_dir / "results" / "baseline" / "wl-only"
+    d.mkdir(parents=True)
+    (d / "trace.csv").write_text("data")
+
+    class _Args:
+        only = None; workload = None; package = None; dry_run = False; yes = True
+
+    mod._cmd_wipe(_Args(), run_dir)
+
+    # The whole results tree is gone (package dir was left empty)
+    assert not (run_dir / "results" / "baseline").exists()

--- a/pipeline/tests/test_deploy_wipe.py
+++ b/pipeline/tests/test_deploy_wipe.py
@@ -5,12 +5,21 @@ from pathlib import Path
 
 
 _PROGRESS = {
-    "wl-smoke-baseline":   {"workload": "wl-smoke",  "package": "baseline",  "status": "done",      "namespace": None, "retries": 0},
-    "wl-smoke-treatment":  {"workload": "wl-smoke",  "package": "treatment", "status": "done",      "namespace": None, "retries": 0},
-    "wl-load-baseline":    {"workload": "wl-load",   "package": "baseline",  "status": "pending",   "namespace": None, "retries": 0},
-    "wl-load-treatment":   {"workload": "wl-load",   "package": "treatment", "status": "failed",    "namespace": None, "retries": 0},
-    "wl-heavy-baseline":   {"workload": "wl-heavy",  "package": "baseline",  "status": "timed-out", "namespace": None, "retries": 1},
+    "wl-smoke-baseline":   {"workload": "wl-smoke",  "package": "baseline",  "status": "done",      "namespace": "sim2real-0", "retries": 0, "pending_stalls": 0, "pending_since": None},
+    "wl-smoke-treatment":  {"workload": "wl-smoke",  "package": "treatment", "status": "done",      "namespace": "sim2real-1", "retries": 0, "pending_stalls": 0, "pending_since": None},
+    "wl-load-baseline":    {"workload": "wl-load",   "package": "baseline",  "status": "pending",   "namespace": None,         "retries": 0, "pending_stalls": 0, "pending_since": None},
+    "wl-load-treatment":   {"workload": "wl-load",   "package": "treatment", "status": "failed",    "namespace": "sim2real-2", "retries": 1, "pending_stalls": 2, "pending_since": "2026-05-14T10:00:00Z"},
+    "wl-heavy-baseline":   {"workload": "wl-heavy",  "package": "baseline",  "status": "timed-out", "namespace": "sim2real-0", "retries": 1, "pending_stalls": 3, "pending_since": "2026-05-14T11:00:00Z"},
 }
+
+
+def _assert_reset(entry: dict) -> None:
+    """Assert all fields are reset to their pending-state values."""
+    assert entry["status"] == "pending"
+    assert entry["retries"] == 0
+    assert entry["pending_stalls"] == 0
+    assert entry["pending_since"] is None
+    assert entry["namespace"] is None
 
 
 def _setup_results(run_dir: Path) -> None:
@@ -23,8 +32,8 @@ def _setup_results(run_dir: Path) -> None:
             (d / "trace_data.csv").write_text("data")
 
 
-def test_wipe_all_deletes_results_and_resets(tmp_path, monkeypatch):
-    """Unscoped wipe deletes all results and resets non-pending pairs."""
+def test_wipe_all_deletes_results_and_resets(tmp_path):
+    """Unscoped wipe deletes results for non-pending pairs and resets them."""
     import pipeline.deploy as mod
 
     run_dir = tmp_path / "run1"
@@ -33,27 +42,28 @@ def test_wipe_all_deletes_results_and_resets(tmp_path, monkeypatch):
     progress_path.write_text(json.dumps(_PROGRESS))
     _setup_results(run_dir)
 
-    monkeypatch.setattr("builtins.input", lambda _: "y")
-
     class _Args:
         only = None; workload = None; package = None; dry_run = False; yes = True
 
     mod._cmd_wipe(_Args(), run_dir)
 
     saved = json.loads(progress_path.read_text())
-    # All non-pending pairs reset to pending
-    assert saved["wl-smoke-baseline"]["status"] == "pending"
-    assert saved["wl-smoke-treatment"]["status"] == "pending"
-    assert saved["wl-load-treatment"]["status"] == "pending"
-    assert saved["wl-heavy-baseline"]["status"] == "pending"
+    _assert_reset(saved["wl-smoke-baseline"])
+    _assert_reset(saved["wl-smoke-treatment"])
+    _assert_reset(saved["wl-load-treatment"])
+    _assert_reset(saved["wl-heavy-baseline"])
     # Already-pending pair unchanged
     assert saved["wl-load-baseline"]["status"] == "pending"
-    # Results directories deleted
-    assert not (run_dir / "results" / "baseline").exists()
-    assert not (run_dir / "results" / "treatment").exists()
+    # Non-pending workload dirs deleted
+    assert not (run_dir / "results" / "baseline" / "wl-smoke").exists()
+    assert not (run_dir / "results" / "baseline" / "wl-heavy").exists()
+    assert not (run_dir / "results" / "treatment" / "wl-smoke").exists()
+    assert not (run_dir / "results" / "treatment" / "wl-load").exists()
+    # Pending pair's dir survives
+    assert (run_dir / "results" / "baseline" / "wl-load").exists()
 
 
-def test_wipe_scoped_by_workload(tmp_path, monkeypatch):
+def test_wipe_scoped_by_workload(tmp_path):
     """--workload scopes wipe to matching pairs only."""
     import pipeline.deploy as mod
 
@@ -69,9 +79,8 @@ def test_wipe_scoped_by_workload(tmp_path, monkeypatch):
     mod._cmd_wipe(_Args(), run_dir)
 
     saved = json.loads(progress_path.read_text())
-    # Scoped pairs reset
-    assert saved["wl-smoke-baseline"]["status"] == "pending"
-    assert saved["wl-smoke-treatment"]["status"] == "pending"
+    _assert_reset(saved["wl-smoke-baseline"])
+    _assert_reset(saved["wl-smoke-treatment"])
     # Out-of-scope pairs unchanged
     assert saved["wl-load-treatment"]["status"] == "failed"
     assert saved["wl-heavy-baseline"]["status"] == "timed-out"
@@ -82,7 +91,7 @@ def test_wipe_scoped_by_workload(tmp_path, monkeypatch):
     assert (run_dir / "results" / "baseline" / "wl-load").exists()
 
 
-def test_wipe_scoped_by_only(tmp_path, monkeypatch):
+def test_wipe_scoped_by_only(tmp_path):
     """--only scopes wipe to a single pair."""
     import pipeline.deploy as mod
 
@@ -98,7 +107,7 @@ def test_wipe_scoped_by_only(tmp_path, monkeypatch):
     mod._cmd_wipe(_Args(), run_dir)
 
     saved = json.loads(progress_path.read_text())
-    assert saved["wl-heavy-baseline"]["status"] == "pending"
+    _assert_reset(saved["wl-heavy-baseline"])
     # Other pairs unchanged
     assert saved["wl-smoke-baseline"]["status"] == "done"
     # Only wl-heavy/baseline deleted
@@ -106,7 +115,7 @@ def test_wipe_scoped_by_only(tmp_path, monkeypatch):
     assert (run_dir / "results" / "baseline" / "wl-smoke").exists()
 
 
-def test_wipe_scoped_by_package(tmp_path, monkeypatch):
+def test_wipe_scoped_by_package(tmp_path):
     """--package scopes wipe to pairs matching that package."""
     import pipeline.deploy as mod
 
@@ -122,9 +131,8 @@ def test_wipe_scoped_by_package(tmp_path, monkeypatch):
     mod._cmd_wipe(_Args(), run_dir)
 
     saved = json.loads(progress_path.read_text())
-    # Treatment pairs reset
-    assert saved["wl-smoke-treatment"]["status"] == "pending"
-    assert saved["wl-load-treatment"]["status"] == "pending"
+    _assert_reset(saved["wl-smoke-treatment"])
+    _assert_reset(saved["wl-load-treatment"])
     # Baseline pairs unchanged
     assert saved["wl-smoke-baseline"]["status"] == "done"
     assert saved["wl-heavy-baseline"]["status"] == "timed-out"
@@ -158,7 +166,7 @@ def test_wipe_dry_run_does_not_delete(tmp_path, capsys):
     assert "DRY-RUN" in captured.out + captured.err
 
 
-def test_wipe_skips_pending_pairs(tmp_path):
+def test_wipe_skips_pending_pairs(tmp_path, capsys):
     """Pending pairs are skipped (nothing to wipe)."""
     import pipeline.deploy as mod
 
@@ -166,7 +174,7 @@ def test_wipe_skips_pending_pairs(tmp_path):
     run_dir.mkdir()
     progress = {
         "wl-a-baseline": {"workload": "wl-a", "package": "baseline", "status": "pending",
-                          "namespace": None, "retries": 0},
+                          "namespace": None, "retries": 0, "pending_stalls": 0, "pending_since": None},
     }
     progress_path = run_dir / "progress.json"
     progress_path.write_text(json.dumps(progress))
@@ -219,6 +227,52 @@ def test_wipe_confirmation_abort(tmp_path, monkeypatch, capsys):
     assert (run_dir / "results" / "baseline" / "wl-smoke").exists()
 
 
+def test_wipe_confirmation_accept(tmp_path, monkeypatch):
+    """User confirming with 'y' proceeds with wipe."""
+    import pipeline.deploy as mod
+
+    run_dir = tmp_path / "run1"
+    run_dir.mkdir()
+    progress_path = run_dir / "progress.json"
+    progress_path.write_text(json.dumps(_PROGRESS))
+    _setup_results(run_dir)
+
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+
+    class _Args:
+        only = None; workload = None; package = None; dry_run = False; yes = False
+
+    mod._cmd_wipe(_Args(), run_dir)
+
+    saved = json.loads(progress_path.read_text())
+    _assert_reset(saved["wl-smoke-baseline"])
+    assert not (run_dir / "results" / "baseline" / "wl-smoke").exists()
+
+
+def test_wipe_eof_on_input_aborts(tmp_path, monkeypatch, capsys):
+    """EOFError from input() (non-interactive) aborts without changes."""
+    import pipeline.deploy as mod
+
+    run_dir = tmp_path / "run1"
+    run_dir.mkdir()
+    progress_path = run_dir / "progress.json"
+    progress_path.write_text(json.dumps(_PROGRESS))
+    _setup_results(run_dir)
+
+    def raise_eof(_):
+        raise EOFError
+
+    monkeypatch.setattr("builtins.input", raise_eof)
+
+    class _Args:
+        only = None; workload = None; package = None; dry_run = False; yes = False
+
+    mod._cmd_wipe(_Args(), run_dir)
+
+    saved = json.loads(progress_path.read_text())
+    assert saved == _PROGRESS
+
+
 def test_wipe_filter_mismatch_aborts(tmp_path, capsys):
     """--only with non-existent pair aborts with error."""
     import pipeline.deploy as mod
@@ -244,7 +298,7 @@ def test_wipe_cleans_empty_parent_dirs(tmp_path):
     run_dir.mkdir()
     progress = {
         "wl-only-baseline": {"workload": "wl-only", "package": "baseline", "status": "done",
-                             "namespace": None, "retries": 0},
+                             "namespace": None, "retries": 0, "pending_stalls": 0, "pending_since": None},
     }
     progress_path = run_dir / "progress.json"
     progress_path.write_text(json.dumps(progress))
@@ -257,5 +311,57 @@ def test_wipe_cleans_empty_parent_dirs(tmp_path):
 
     mod._cmd_wipe(_Args(), run_dir)
 
-    # The whole results tree is gone (package dir was left empty)
     assert not (run_dir / "results" / "baseline").exists()
+
+
+def test_wipe_no_results_on_disk(tmp_path, capsys):
+    """Wipe succeeds even when results directories don't exist on disk."""
+    import pipeline.deploy as mod
+
+    run_dir = tmp_path / "run1"
+    run_dir.mkdir()
+    progress = {
+        "wl-a-baseline": {"workload": "wl-a", "package": "baseline", "status": "done",
+                          "namespace": None, "retries": 0, "pending_stalls": 0, "pending_since": None},
+    }
+    progress_path = run_dir / "progress.json"
+    progress_path.write_text(json.dumps(progress))
+    # No results/ directory created
+
+    class _Args:
+        only = None; workload = None; package = None; dry_run = False; yes = True
+
+    mod._cmd_wipe(_Args(), run_dir)
+
+    saved = json.loads(progress_path.read_text())
+    _assert_reset(saved["wl-a-baseline"])
+
+
+def test_wipe_parent_not_removed_when_siblings_remain(tmp_path):
+    """Package dir is kept when out-of-scope workloads remain under it."""
+    import pipeline.deploy as mod
+
+    run_dir = tmp_path / "run1"
+    run_dir.mkdir()
+    progress = {
+        "wl-a-baseline": {"workload": "wl-a", "package": "baseline", "status": "done",
+                          "namespace": None, "retries": 0, "pending_stalls": 0, "pending_since": None},
+        "wl-b-baseline": {"workload": "wl-b", "package": "baseline", "status": "done",
+                          "namespace": None, "retries": 0, "pending_stalls": 0, "pending_since": None},
+    }
+    progress_path = run_dir / "progress.json"
+    progress_path.write_text(json.dumps(progress))
+    for wl in ("wl-a", "wl-b"):
+        d = run_dir / "results" / "baseline" / wl
+        d.mkdir(parents=True)
+        (d / "trace.csv").write_text("data")
+
+    class _Args:
+        only = "wl-a-baseline"; workload = None; package = None; dry_run = False; yes = True
+
+    mod._cmd_wipe(_Args(), run_dir)
+
+    # wl-a deleted, wl-b untouched, parent kept
+    assert not (run_dir / "results" / "baseline" / "wl-a").exists()
+    assert (run_dir / "results" / "baseline" / "wl-b").exists()
+    assert (run_dir / "results" / "baseline").exists()

--- a/pipeline/tests/test_deploy_wipe.py
+++ b/pipeline/tests/test_deploy_wipe.py
@@ -365,3 +365,75 @@ def test_wipe_parent_not_removed_when_siblings_remain(tmp_path):
     assert not (run_dir / "results" / "baseline" / "wl-a").exists()
     assert (run_dir / "results" / "baseline" / "wl-b").exists()
     assert (run_dir / "results" / "baseline").exists()
+
+
+def test_wipe_rmtree_failure_skips_pair(tmp_path, monkeypatch, capsys):
+    """When rmtree fails for one pair, that pair's status is preserved."""
+    import shutil
+    import pipeline.deploy as mod
+
+    run_dir = tmp_path / "run1"
+    run_dir.mkdir()
+    progress = {
+        "wl-a-baseline": {"workload": "wl-a", "package": "baseline", "status": "done",
+                          "namespace": None, "retries": 0, "pending_stalls": 0, "pending_since": None},
+        "wl-b-baseline": {"workload": "wl-b", "package": "baseline", "status": "done",
+                          "namespace": None, "retries": 0, "pending_stalls": 0, "pending_since": None},
+    }
+    progress_path = run_dir / "progress.json"
+    progress_path.write_text(json.dumps(progress))
+    for wl in ("wl-a", "wl-b"):
+        d = run_dir / "results" / "baseline" / wl
+        d.mkdir(parents=True)
+        (d / "trace.csv").write_text("data")
+
+    orig_rmtree = shutil.rmtree
+
+    def failing_rmtree(path, *a, **kw):
+        if "wl-a" in str(path):
+            raise OSError("permission denied")
+        return orig_rmtree(path, *a, **kw)
+
+    monkeypatch.setattr("shutil.rmtree", failing_rmtree)
+
+    class _Args:
+        only = None; workload = None; package = None; dry_run = False; yes = True
+
+    mod._cmd_wipe(_Args(), run_dir)
+
+    saved = json.loads(progress_path.read_text())
+    # wl-a: rmtree failed → status NOT reset
+    assert saved["wl-a-baseline"]["status"] == "done"
+    # wl-b: succeeded → status reset
+    _assert_reset(saved["wl-b-baseline"])
+    # Error count in summary
+    captured = capsys.readouterr()
+    assert "1 failed" in captured.out + captured.err
+
+
+def test_wipe_warns_on_missing_package_workload(tmp_path, capsys):
+    """Entries missing package/workload fields emit a warning."""
+    import pipeline.deploy as mod
+
+    run_dir = tmp_path / "run1"
+    run_dir.mkdir()
+    progress = {
+        "wl-broken": {"status": "done", "namespace": None, "retries": 0,
+                      "pending_stalls": 0, "pending_since": None},
+        "wl-ok-baseline": {"workload": "wl-ok", "package": "baseline", "status": "done",
+                           "namespace": None, "retries": 0, "pending_stalls": 0, "pending_since": None},
+    }
+    progress_path = run_dir / "progress.json"
+    progress_path.write_text(json.dumps(progress))
+
+    class _Args:
+        only = None; workload = None; package = None; dry_run = False; yes = True
+
+    mod._cmd_wipe(_Args(), run_dir)
+
+    saved = json.loads(progress_path.read_text())
+    _assert_reset(saved["wl-ok-baseline"])
+    # Broken entry was skipped — status unchanged
+    assert saved["wl-broken"]["status"] == "done"
+    captured = capsys.readouterr()
+    assert "missing package/workload" in (captured.out + captured.err).lower()

--- a/pipeline/tests/test_deploy_wipe.py
+++ b/pipeline/tests/test_deploy_wipe.py
@@ -337,6 +337,8 @@ def test_wipe_no_results_on_disk(tmp_path, capsys):
 
     saved = json.loads(progress_path.read_text())
     _assert_reset(saved["wl-a-baseline"])
+    captured = capsys.readouterr()
+    assert "no results on disk" in (captured.out + captured.err).lower()
 
 
 def test_wipe_parent_not_removed_when_siblings_remain(tmp_path):
@@ -401,7 +403,9 @@ def test_wipe_rmtree_failure_skips_pair(tmp_path, monkeypatch, capsys):
     class _Args:
         only = None; workload = None; package = None; dry_run = False; yes = True
 
-    mod._cmd_wipe(_Args(), run_dir)
+    with __import__("pytest").raises(SystemExit) as exc_info:
+        mod._cmd_wipe(_Args(), run_dir)
+    assert exc_info.value.code == 1
 
     saved = json.loads(progress_path.read_text())
     # wl-a: rmtree failed → status NOT reset


### PR DESCRIPTION
Partially addresses #123 (`--remote` flag deferred — see issue comment)

## Summary

- Adds `deploy.py wipe` subcommand that deletes local results (`results/<package>/<workload>/`) and resets wiped pairs to `pending` in `progress.json`
- Supports `--only`, `--workload`, `--package` scoping flags (reuses `_resolve_scope`)
- Supports `--dry-run` to preview what would be deleted without acting
- Interactive confirmation prompt, skippable with `--yes` / `-y`
- Updates bash and zsh shell completions
- Documents `wipe` in `pipeline/README.md`

## Design decisions

- **No `--remote` flag**: `collect` is gated on `status == "done"`, so resetting to `pending` makes PVC data unreachable. PVC data is overwritten on re-execution anyway, making remote deletion redundant.
- **Wipe resets status to `pending`**: ensures a subsequent `collect` won't re-pull stale data, and `deploy.py run` will re-dispatch the pair.
- **Pending pairs are skipped**: their directories are left untouched (nothing to wipe for a pending pair).
- **Empty parent cleanup**: after deleting a workload dir, `rmdir()` attempts to remove the package dir — succeeds only if it's empty, so sibling workloads are safe.
- **Error resilience**: `shutil.rmtree` failures are caught per-pair (logged, pair skipped), so one permission error doesn't abort the entire wipe or leave `progress.json` unsaved.

## Test plan

- [x] 14 dedicated tests covering: unscoped wipe, `--workload`/`--only`/`--package` scoping, `--dry-run`, pending-skip, missing progress, confirmation abort/accept, EOFError on input, filter mismatch, empty parent cleanup, no-results-on-disk, sibling preservation
- [x] Full suite: 582/582 tests pass
- [x] Lint: `ruff check pipeline/ --select F` clean
- [x] CLI help: `wipe` appears in help text with correct flags
- [x] README updated with `wipe` documentation