### PR TITLE
Build and publish sim2real-orchestrator container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,9 +7,10 @@
 __pycache__
 *.pyc
 workspace
-workspace */
 inference-sim
+llm-d-benchmark
 tektonc-data-collection
+pipeline/tests
 docs
 prompts
 *.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -17,4 +17,5 @@ prompts
 *.log
 .env
 .env.local
+go.work
 .DS_Store

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,19 @@
+.git
+.github
+.gitignore
+.gitmodules
+.claude
+.venv
+__pycache__
+*.pyc
+workspace
+workspace */
+inference-sim
+tektonc-data-collection
+docs
+prompts
+*.md
+*.log
+.env
+.env.local
+.DS_Store

--- a/.github/workflows/orchestrator-image.yml
+++ b/.github/workflows/orchestrator-image.yml
@@ -1,0 +1,45 @@
+name: Build Orchestrator Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "pipeline/**"
+      - "Dockerfile"
+      - ".github/workflows/orchestrator-image.yml"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: inference-sim/sim2real/orchestrator
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/orchestrator-image.yml
+++ b/.github/workflows/orchestrator-image.yml
@@ -33,13 +33,27 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ github.sha }}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          push: false
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Smoke test
+        run: docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} --help
+
+      - name: Push
+        run: docker push --all-tags ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}

--- a/.github/workflows/orchestrator-image.yml
+++ b/.github/workflows/orchestrator-image.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "pipeline/**"
       - "Dockerfile"
+      - ".dockerignore"
       - ".github/workflows/orchestrator-image.yml"
   workflow_dispatch:
 
@@ -53,7 +54,10 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Smoke test
-        run: docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} --help
+        run: |
+          docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} --help
+          docker run --rm --entrypoint kubectl ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} version --client
+          docker run --rm --entrypoint python ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} -c "from pipeline.lib import assemble, backoff, capacity, context_builder, epp, health, manifest, pod_pending, progress, run_manager, state_machine, tekton, values; print('OK')"
 
       - name: Push
         run: docker push --all-tags ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM python:3.12-slim
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl ca-certificates && \
-    curl -LO "https://dl.k8s.io/release/$(curl -Ls https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
+    KUBE_VERSION=$(curl -fsSL https://dl.k8s.io/release/stable.txt) && \
+    curl -fLO "https://dl.k8s.io/release/${KUBE_VERSION}/bin/linux/amd64/kubectl" && \
     install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
     rm kubectl && \
     apt-get purge -y curl && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.12-slim
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl ca-certificates && \
+    curl -LO "https://dl.k8s.io/release/$(curl -Ls https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
+    install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
+    rm kubectl && \
+    apt-get purge -y curl && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir PyYAML
+
+WORKDIR /app
+COPY pipeline/ pipeline/
+
+ENTRYPOINT ["python", "pipeline/deploy.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,15 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends curl ca-certificates && \
     KUBE_VERSION=$(curl -fsSL https://dl.k8s.io/release/stable.txt) && \
     curl -fLO "https://dl.k8s.io/release/${KUBE_VERSION}/bin/linux/amd64/kubectl" && \
+    curl -fLO "https://dl.k8s.io/release/${KUBE_VERSION}/bin/linux/amd64/kubectl.sha256" && \
+    echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check && \
     install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
-    rm kubectl && \
+    rm kubectl kubectl.sha256 && \
     apt-get purge -y curl && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir PyYAML
+RUN pip install --no-cache-dir "PyYAML>=6.0,<7"
 
 WORKDIR /app
 COPY pipeline/ pipeline/


### PR DESCRIPTION
## Summary

Closes #139

Adds the build infrastructure for the sim2real orchestrator container image — prerequisite for #127 (remote orchestrator Job).

- **`.dockerignore`** — excludes non-runtime files (submodules, workspace, docs, .git) from build context
- **`Dockerfile`** — minimal image: `python:3.12-slim` + kubectl + PyYAML + `pipeline/` code (~200MB)
- **`.github/workflows/orchestrator-image.yml`** — builds and pushes to `ghcr.io/inference-sim/sim2real/orchestrator` on main pushes (when pipeline code changes) and manual dispatch; tags with git SHA + `latest`; uses GHA Docker layer cache

## Design choices worth noting

- **Only PyYAML installed** (not the full `requirements.txt`). `deploy.py` and `pipeline/lib/` only import `yaml` as a third-party dependency. Skipping matplotlib/numpy/anthropic keeps the image small.
- **kubectl from latest stable** rather than pinning a version. The orchestrator only uses version-tolerant operations (`apply`, `get`, `delete`).
- **curl installed then removed** in the same RUN layer to minimize image size.
- **No PR-trigger build** — PRs don't push images. A build-only PR check could be added later if needed.

## Test plan

- [x] 568 existing tests pass
- [x] Lint clean (`ruff check pipeline/ --select F`)
- [ ] Docker build succeeds (no local Docker — CI will verify on merge)