### PR TITLE
Add deploy.py run --remote for in-cluster orchestration (#127)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,7 @@ python pipeline/run.py     --experiment-root ../admission-control switch <run-na
 | `pod_pending.py` | Classifies pod scheduling failures as recoverable or non-recoverable |
 | `backoff.py` | Exponential backoff controller for GPU scarcity in `deploy.py run` |
 | `run_manager.py` | `list_runs`, `inspect_run`, `switch_run` logic |
+| `remote.py` | ConfigMap and Job generation for `deploy.py run --remote` |
 
 ## Workspace Artifacts
 

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -148,6 +148,7 @@ python pipeline/deploy.py pairs   [flags]   # list available pair keys, workload
 
 | Flag | Default | Description |
 |------|---------|-------------|
+| `--remote` | — | Submit orchestrator as in-cluster Job instead of running locally |
 | `--only PAIR` | — | Scope execution to one specific pair key (`wl-` prefix optional) |
 | `--workload NAME` | — | Scope execution to pairs matching this workload |
 | `--package NAME` | — | Scope execution to pairs matching this package |
@@ -168,6 +169,8 @@ python pipeline/deploy.py pairs   [flags]   # list available pair keys, workload
 **Pair statuses:** `pending` → `running` → `done`. Failure paths: `running` → `failed` (hard failure or non-recoverable pending), `running` → `timed-out` (4h timeout exceeded), `running` → `pending` (recoverable early reclaim, repeats up to `--max-pending-stalls` times) → `stalled`.
 
 **Auto-cleanup** — when a PipelineRun succeeds, the orchestrator deletes the PipelineRun CR from the cluster. Failed PipelineRuns are left in place for debugging (`kubectl describe`, pod logs). Use `reset` to remove them when done.
+
+**Remote mode** — `deploy.py run --remote` submits the orchestrator as a Kubernetes Job (`sim2real-orchestrator`) instead of running locally. The launcher builds the EPP image locally, packs workspace files into a ConfigMap, applies the Job, and waits for the pod to reach Running. Use `stop` to cancel, `status --remote` to check progress, and `collect` to pull results after completion. Requires `orchestrator_image` in `setup_config.json`.
 
 **`deploy.py status`** — prints the current state of all pairs. By default reads from `workspace/runs/<run>/progress.json`. When the orchestrator runs remotely (in-cluster), use `--remote` to read from the `sim2real-progress` ConfigMap instead. The ConfigMap is also used automatically when the local `progress.json` is absent.
 

--- a/pipeline/completions.bash
+++ b/pipeline/completions.bash
@@ -73,7 +73,7 @@ _sim2real_deploy() {
     if [[ "$cur" == -* ]]; then
         case "$subcmd" in
             run)
-                COMPREPLY=($(compgen -W "--only --workload --package --status --force --skip-build-epp --max-retries --poll-interval --gpu-resource-type --default-gpu-cost --pending-threshold --max-pending-stalls" -- "$cur"))
+                COMPREPLY=($(compgen -W "--remote --only --workload --package --status --force --skip-build-epp --max-retries --poll-interval --gpu-resource-type --default-gpu-cost --pending-threshold --max-pending-stalls --max-backoff" -- "$cur"))
                 ;;
             status)
                 COMPREPLY=($(compgen -W "--only --workload --package --status --remote" -- "$cur"))

--- a/pipeline/completions.zsh
+++ b/pipeline/completions.zsh
@@ -71,6 +71,7 @@ _sim2real_deploy() {
             case "${line[1]}" in
                 run)
                     _arguments \
+                        '--remote[Submit as in-cluster Job]' \
                         '--only[Scope to one pair key]:pair key:_deploy_py_pair_keys' \
                         '--workload[Scope to workload]:workload:_deploy_py_workloads' \
                         '--package[Scope to package]:package:_deploy_py_packages' \
@@ -82,7 +83,8 @@ _sim2real_deploy() {
                         '--gpu-resource-type[GPU resource type]:type:' \
                         '--default-gpu-cost[GPU cost per pod]:cost:' \
                         '--pending-threshold[Pending timeout in seconds]:seconds:' \
-                        '--max-pending-stalls[Max stall cycles]:count:'
+                        '--max-pending-stalls[Max stall cycles]:count:' \
+                        '--max-backoff[Max backoff interval]:seconds:'
                     ;;
                 status)
                     _arguments \

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1743,6 +1743,153 @@ def _cmd_stop(namespace: str) -> None:
     ok(f"Stopped {JOB_NAME} in {namespace}")
 
 
+# ── Remote run ──────────────────────────────────────────────────────────────
+
+_FAIL_FAST_REASONS = {
+    "ImagePullBackOff",
+    "ErrImagePull",
+    "CrashLoopBackOff",
+    "CreateContainerConfigError",
+    "InvalidImageName",
+}
+
+
+def _collect_run_flags(args) -> list[str]:
+    """Collect run subcommand flags to forward to the in-cluster Job."""
+    flags: list[str] = []
+    for name in ("only", "workload", "package", "status"):
+        val = getattr(args, name, None)
+        if val is not None:
+            flags.extend([f"--{name}", str(val)])
+    if getattr(args, "force", False):
+        flags.append("--force")
+    _defaults = {
+        "max_retries": 2,
+        "poll_interval": 30,
+        "gpu_resource_type": None,
+        "default_gpu_cost": 1,
+        "pending_threshold": 600,
+        "max_pending_stalls": 10,
+        "max_backoff": 600,
+    }
+    for attr, default in _defaults.items():
+        val = getattr(args, attr, default)
+        if val != default:
+            flag = f"--{attr.replace('_', '-')}"
+            flags.extend([flag, str(val)])
+    return flags
+
+
+def _check_existing_job(namespace: str) -> "str | None":
+    """Check whether the orchestrator Job already exists.
+
+    Returns "active" if the Job has active pods, "completed" if it exists
+    but is not active, or None if the Job doesn't exist.
+    """
+    result = run(["kubectl", "get", "job", JOB_NAME, "-n", namespace,
+                   "-o", "json"], check=False, capture=True)
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        if "(NotFound)" in stderr:
+            return None
+        err(f"Failed to check for orchestrator Job: {stderr}")
+        sys.exit(1)
+    data = json.loads(result.stdout)
+    if data.get("status", {}).get("active", 0) > 0:
+        return "active"
+    return "completed"
+
+
+def _wait_for_job_pod(namespace: str, *, timeout: int = 120, poll: int = 5) -> None:
+    """Poll until the orchestrator pod reaches Running or Succeeded."""
+    deadline = time.time() + timeout
+    while True:
+        result = run(
+            ["kubectl", "get", "pods",
+             "-l", f"job-name={JOB_NAME}",
+             "-n", namespace, "-o", "json"],
+            check=False, capture=True,
+        )
+        if result.returncode == 0:
+            data = json.loads(result.stdout)
+            for pod in data.get("items", []):
+                phase = pod.get("status", {}).get("phase", "")
+                if phase in ("Running", "Succeeded"):
+                    return
+                for cs in pod.get("status", {}).get("containerStatuses", []):
+                    waiting = cs.get("state", {}).get("waiting", {})
+                    reason = waiting.get("reason", "")
+                    if reason in _FAIL_FAST_REASONS:
+                        err(f"Pod failed: {reason} — {waiting.get('message', '')}")
+                        sys.exit(1)
+        if time.time() >= deadline:
+            err(f"Timed out waiting for {JOB_NAME} pod in {namespace}")
+            sys.exit(1)
+        time.sleep(poll)
+
+
+def _cmd_run_remote(args, run_dir: "Path", setup_config: dict) -> None:
+    """Submit the orchestrator as an in-cluster Job."""
+    from pipeline.lib.remote import (
+        build_run_inputs_configmap, build_orchestrator_job, JOB_NAME as _JOB,
+    )
+
+    namespaces = setup_config.get("namespaces") or [setup_config.get("namespace", "")]
+    namespace = namespaces[0] if namespaces else ""
+    if not namespace:
+        err("No namespaces configured. Run setup.py with --namespaces.")
+        sys.exit(1)
+
+    orchestrator_image = setup_config.get("orchestrator_image")
+    if not orchestrator_image:
+        err("orchestrator_image not set in setup_config.json. Re-run setup.py with --orchestrator-image.")
+        sys.exit(1)
+
+    status = _check_existing_job(namespace)
+    if status == "active":
+        err(f"Orchestrator Job already running in {namespace}. Use 'deploy.py stop' first.")
+        sys.exit(1)
+    elif status == "completed":
+        info(f"Deleting completed orchestrator Job in {namespace}")
+        run(["kubectl", "delete", "job", JOB_NAME, "-n", namespace], check=False, capture=True)
+
+    epp_action = _resolve_epp_action(run_dir, args.skip_build_epp)
+    if epp_action.startswith("error:"):
+        err(epp_action[len("error:"):]); sys.exit(1)
+    elif epp_action == "skip":
+        info("No component_image in run metadata — skipping EPP build")
+    else:
+        _build_epp_image(run_dir, run_dir.name, namespace)
+
+    workspace_dir = EXPERIMENT_ROOT / "workspace"
+    run_name = run_dir.name
+
+    cm = build_run_inputs_configmap(
+        run_dir=run_dir, workspace_dir=workspace_dir,
+        namespace=namespace, run_name=run_name,
+    )
+    info("Applying run-inputs ConfigMap")
+    subprocess.run(
+        ["kubectl", "apply", "-f", "-"],
+        input=json.dumps(cm), text=True, check=True, capture_output=True,
+    )
+
+    run_flags = _collect_run_flags(args)
+    job = build_orchestrator_job(
+        namespace=namespace, image=orchestrator_image,
+        run_name=run_name, run_flags=run_flags,
+    )
+    info("Applying orchestrator Job")
+    subprocess.run(
+        ["kubectl", "apply", "-f", "-"],
+        input=json.dumps(job), text=True, check=True, capture_output=True,
+    )
+
+    _wait_for_job_pod(namespace)
+    ok("Orchestrator pod is running")
+    info(f"Tail logs: kubectl logs -f job/{JOB_NAME} -n {namespace}")
+
+
 # ── CLI ──────────────────────────────────────────────────────────────────────
 
 def build_parser() -> argparse.ArgumentParser:
@@ -1792,6 +1939,8 @@ Examples:
                            help="Read progress from cluster ConfigMap instead of local file")
 
     run_p = sub.add_parser("run", help="Orchestrate parallel pool execution")
+    run_p.add_argument("--remote", action="store_true", default=False,
+                       help="Submit orchestrator as in-cluster Job instead of running locally")
     run_p.add_argument("--skip-build-epp", action="store_true", dest="skip_build_epp",
                        help="Skip EPP image build")
     run_p.add_argument("--only",         metavar="PAIR",  help="Scope execution to one specific pair key (wl- prefix optional)")
@@ -1882,7 +2031,10 @@ def main():
         sys.exit(1)
 
     if cmd == "run":
-        _cmd_run(args, run_dir, setup_config)
+        if getattr(args, "remote", False):
+            _cmd_run_remote(args, run_dir, setup_config)
+        else:
+            _cmd_run(args, run_dir, setup_config)
     elif cmd == "status":
         progress_path = run_dir / "progress.json"
         _cmd_status(args, progress_path, setup_config=setup_config)

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1760,10 +1760,10 @@ def _collect_run_flags(args) -> list[str]:
     """Collect run subcommand flags to forward to the in-cluster Job."""
     flags: list[str] = []
     for name in ("only", "workload", "package", "status"):
-        val = getattr(args, name, None)
+        val = getattr(args, name)
         if val is not None:
             flags.extend([f"--{name}", str(val)])
-    if getattr(args, "force", False):
+    if getattr(args, "force"):
         flags.append("--force")
     _defaults = {
         "max_retries": 2,
@@ -1775,7 +1775,7 @@ def _collect_run_flags(args) -> list[str]:
         "max_backoff": 600,
     }
     for attr, default in _defaults.items():
-        val = getattr(args, attr, default)
+        val = getattr(args, attr)
         if val != default:
             flag = f"--{attr.replace('_', '-')}"
             flags.extend([flag, str(val)])
@@ -1829,16 +1829,20 @@ def _wait_for_job_pod(namespace: str, *, timeout: int = 120, poll: int = 5) -> N
                 err(f"kubectl failed {consecutive_failures} times: {last_error}")
                 sys.exit(1)
         else:
-            consecutive_failures = 0
             try:
                 data = json.loads(result.stdout)
             except json.JSONDecodeError:
+                consecutive_failures += 1
+                if consecutive_failures >= 3:
+                    err("kubectl returned invalid JSON 3 times in a row")
+                    sys.exit(1)
                 warn("kubectl returned invalid JSON — retrying")
                 if time.time() >= deadline:
                     err(f"Timed out waiting for {JOB_NAME} pod in {namespace}")
                     sys.exit(1)
                 time.sleep(poll)
                 continue
+            consecutive_failures = 0
             for pod in data.get("items", []):
                 phase = pod.get("status", {}).get("phase", "")
                 if phase in ("Running", "Succeeded"):
@@ -1847,7 +1851,9 @@ def _wait_for_job_pod(namespace: str, *, timeout: int = 120, poll: int = 5) -> N
                     msg = pod.get("status", {}).get("message", "unknown reason")
                     err(f"Orchestrator pod failed: {msg}")
                     sys.exit(1)
-                for cs in pod.get("status", {}).get("containerStatuses", []):
+                all_statuses = (pod.get("status", {}).get("initContainerStatuses", [])
+                                + pod.get("status", {}).get("containerStatuses", []))
+                for cs in all_statuses:
                     waiting = cs.get("state", {}).get("waiting", {})
                     reason = waiting.get("reason", "")
                     if reason in _FAIL_FAST_REASONS:
@@ -1873,7 +1879,7 @@ def _cmd_run_remote(args, run_dir: "Path", setup_config: dict) -> None:
 
     orchestrator_image = setup_config.get("orchestrator_image")
     if not orchestrator_image:
-        err("orchestrator_image not set in setup_config.json. Re-run setup.py with --orchestrator-image.")
+        err("orchestrator_image not set in setup_config.json — add it before using --remote.")
         sys.exit(1)
 
     status = _check_existing_job(namespace)

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1796,7 +1796,11 @@ def _check_existing_job(namespace: str) -> "str | None":
             return None
         err(f"Failed to check for orchestrator Job: {stderr}")
         sys.exit(1)
-    data = json.loads(result.stdout)
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        err(f"kubectl get job returned invalid JSON: {result.stdout[:200]}")
+        sys.exit(1)
     if data.get("status", {}).get("active", 0) > 0:
         return "active"
     return "completed"
@@ -1826,7 +1830,15 @@ def _wait_for_job_pod(namespace: str, *, timeout: int = 120, poll: int = 5) -> N
                 sys.exit(1)
         else:
             consecutive_failures = 0
-            data = json.loads(result.stdout)
+            try:
+                data = json.loads(result.stdout)
+            except json.JSONDecodeError:
+                warn("kubectl returned invalid JSON — retrying")
+                if time.time() >= deadline:
+                    err(f"Timed out waiting for {JOB_NAME} pod in {namespace}")
+                    sys.exit(1)
+                time.sleep(poll)
+                continue
             for pod in data.get("items", []):
                 phase = pod.get("status", {}).get("phase", "")
                 if phase in ("Running", "Succeeded"):
@@ -1888,10 +1900,16 @@ def _cmd_run_remote(args, run_dir: "Path", setup_config: dict) -> None:
     workspace_dir = EXPERIMENT_ROOT / "workspace"
     run_name = run_dir.name
 
-    cm = build_run_inputs_configmap(
-        run_dir=run_dir, workspace_dir=workspace_dir,
-        namespace=namespace, run_name=run_name,
-    )
+    try:
+        cm = build_run_inputs_configmap(
+            run_dir=run_dir, workspace_dir=workspace_dir,
+            namespace=namespace, run_name=run_name,
+        )
+    except FileNotFoundError as exc:
+        err(f"{exc} — run setup.py and prepare.py first")
+        sys.exit(1)
+    # subprocess.run used directly because the module's run() helper doesn't
+    # support stdin input, which kubectl apply -f - requires.
     info("Applying run-inputs ConfigMap")
     result = subprocess.run(
         ["kubectl", "apply", "-f", "-"],

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1911,7 +1911,7 @@ def _cmd_run_remote(args, run_dir: "Path", setup_config: dict) -> None:
             run_dir=run_dir, workspace_dir=workspace_dir,
             namespace=namespace, run_name=run_name,
         )
-    except FileNotFoundError as exc:
+    except OSError as exc:
         err(f"{exc} — run setup.py and prepare.py first")
         sys.exit(1)
     # subprocess.run used directly because the module's run() helper doesn't

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1900,6 +1900,7 @@ def build_parser() -> argparse.ArgumentParser:
         epilog="""
 Examples:
   python pipeline/deploy.py run                        # Build EPP + orchestrate all pairs
+  python pipeline/deploy.py run --remote               # Submit orchestrator as in-cluster Job
   python pipeline/deploy.py run --skip-build-epp       # Orchestrate without EPP build
   python pipeline/deploy.py status                     # Show progress snapshot
   python pipeline/deploy.py collect                    # Pull results for completed phases

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1718,7 +1718,7 @@ def _cmd_wipe(args, run_dir: Path,
 
 # ── Stop remote orchestrator ────────────────────────────────────────────────
 
-JOB_NAME = "sim2real-orchestrator"
+from pipeline.lib.remote import JOB_NAME
 
 
 def _cmd_stop(namespace: str) -> None:
@@ -1751,6 +1751,8 @@ _FAIL_FAST_REASONS = {
     "CrashLoopBackOff",
     "CreateContainerConfigError",
     "InvalidImageName",
+    "RunContainerError",
+    "ContainerCannotRun",
 }
 
 
@@ -1801,8 +1803,14 @@ def _check_existing_job(namespace: str) -> "str | None":
 
 
 def _wait_for_job_pod(namespace: str, *, timeout: int = 120, poll: int = 5) -> None:
-    """Poll until the orchestrator pod reaches Running or Succeeded."""
+    """Poll until the orchestrator pod reaches Running or Succeeded.
+
+    Fails fast on unrecoverable container states (ImagePullBackOff, etc.)
+    and on pod phase Failed. Exits early if kubectl fails 3 times in a row.
+    """
     deadline = time.time() + timeout
+    consecutive_failures = 0
+    last_error = ""
     while True:
         result = run(
             ["kubectl", "get", "pods",
@@ -1810,12 +1818,23 @@ def _wait_for_job_pod(namespace: str, *, timeout: int = 120, poll: int = 5) -> N
              "-n", namespace, "-o", "json"],
             check=False, capture=True,
         )
-        if result.returncode == 0:
+        if result.returncode != 0:
+            consecutive_failures += 1
+            last_error = (result.stderr or "").strip()
+            if consecutive_failures >= 3:
+                err(f"kubectl failed {consecutive_failures} times: {last_error}")
+                sys.exit(1)
+        else:
+            consecutive_failures = 0
             data = json.loads(result.stdout)
             for pod in data.get("items", []):
                 phase = pod.get("status", {}).get("phase", "")
                 if phase in ("Running", "Succeeded"):
                     return
+                if phase == "Failed":
+                    msg = pod.get("status", {}).get("message", "unknown reason")
+                    err(f"Orchestrator pod failed: {msg}")
+                    sys.exit(1)
                 for cs in pod.get("status", {}).get("containerStatuses", []):
                     waiting = cs.get("state", {}).get("waiting", {})
                     reason = waiting.get("reason", "")
@@ -1851,7 +1870,12 @@ def _cmd_run_remote(args, run_dir: "Path", setup_config: dict) -> None:
         sys.exit(1)
     elif status == "completed":
         info(f"Deleting completed orchestrator Job in {namespace}")
-        run(["kubectl", "delete", "job", JOB_NAME, "-n", namespace], check=False, capture=True)
+        result = run(["kubectl", "delete", "job", JOB_NAME, "-n", namespace],
+                     check=False, capture=True)
+        if result.returncode != 0:
+            detail = (result.stderr or "").strip()
+            err(f"Failed to delete completed Job: {detail}")
+            sys.exit(1)
 
     epp_action = _resolve_epp_action(run_dir, args.skip_build_epp)
     if epp_action.startswith("error:"):
@@ -1869,21 +1893,28 @@ def _cmd_run_remote(args, run_dir: "Path", setup_config: dict) -> None:
         namespace=namespace, run_name=run_name,
     )
     info("Applying run-inputs ConfigMap")
-    subprocess.run(
+    result = subprocess.run(
         ["kubectl", "apply", "-f", "-"],
-        input=json.dumps(cm), text=True, check=True, capture_output=True,
+        input=json.dumps(cm), text=True, check=False, capture_output=True,
     )
+    if result.returncode != 0:
+        err(f"Failed to apply ConfigMap: {(result.stderr or '').strip()}")
+        sys.exit(1)
 
     run_flags = _collect_run_flags(args)
     job = build_orchestrator_job(
         namespace=namespace, image=orchestrator_image,
         run_name=run_name, run_flags=run_flags,
+        configmap_data=cm["data"],
     )
     info("Applying orchestrator Job")
-    subprocess.run(
+    result = subprocess.run(
         ["kubectl", "apply", "-f", "-"],
-        input=json.dumps(job), text=True, check=True, capture_output=True,
+        input=json.dumps(job), text=True, check=False, capture_output=True,
     )
+    if result.returncode != 0:
+        err(f"Failed to apply Job: {(result.stderr or '').strip()}")
+        sys.exit(1)
 
     _wait_for_job_pod(namespace)
     ok("Orchestrator pod is running")

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1831,7 +1831,7 @@ def _wait_for_job_pod(namespace: str, *, timeout: int = 120, poll: int = 5) -> N
 def _cmd_run_remote(args, run_dir: "Path", setup_config: dict) -> None:
     """Submit the orchestrator as an in-cluster Job."""
     from pipeline.lib.remote import (
-        build_run_inputs_configmap, build_orchestrator_job, JOB_NAME as _JOB,
+        build_run_inputs_configmap, build_orchestrator_job,
     )
 
     namespaces = setup_config.get("namespaces") or [setup_config.get("namespace", "")]

--- a/pipeline/lib/remote.py
+++ b/pipeline/lib/remote.py
@@ -1,6 +1,5 @@
 """Remote run support — Kubernetes resource generation for --remote mode."""
 
-import sys
 from pathlib import Path
 
 CONFIGMAP_NAME = "sim2real-run-inputs"
@@ -48,8 +47,10 @@ def _configmap_items(data: dict, run_name: str) -> list[dict]:
             filename = key[len("cluster--"):]
             items.append({"key": key, "path": f"runs/{run_name}/cluster/{filename}"})
         else:
-            print(f"[WARN] Unrecognized ConfigMap key '{key}' — will not be mounted",
-                  file=sys.stderr)
+            raise ValueError(
+                f"Unrecognized ConfigMap key '{key}' — update _configmap_items "
+                f"to handle this key or remove it from build_run_inputs_configmap"
+            )
     return items
 
 

--- a/pipeline/lib/remote.py
+++ b/pipeline/lib/remote.py
@@ -3,6 +3,9 @@
 from pathlib import Path
 
 CONFIGMAP_NAME = "sim2real-run-inputs"
+JOB_NAME = "sim2real-orchestrator"
+SERVICE_ACCOUNT = "sim2real-runner"
+MOUNT_BASE = "/data"
 
 
 def build_run_inputs_configmap(
@@ -29,4 +32,48 @@ def build_run_inputs_configmap(
         "kind": "ConfigMap",
         "metadata": {"name": CONFIGMAP_NAME, "namespace": namespace},
         "data": data,
+    }
+
+
+def build_orchestrator_job(
+    *, namespace: str, image: str, run_name: str, run_flags: list[str]
+) -> dict:
+    mount_path = f"{MOUNT_BASE}/workspace/runs/{run_name}"
+    return {
+        "apiVersion": "batch/v1",
+        "kind": "Job",
+        "metadata": {"name": JOB_NAME, "namespace": namespace},
+        "spec": {
+            "backoffLimit": 0,
+            "activeDeadlineSeconds": 18000,
+            "template": {
+                "spec": {
+                    "serviceAccountName": SERVICE_ACCOUNT,
+                    "restartPolicy": "Never",
+                    "containers": [
+                        {
+                            "name": "orchestrator",
+                            "image": image,
+                            "args": [
+                                "--experiment-root", MOUNT_BASE,
+                                "--run", run_name,
+                                "run", "--skip-build-epp",
+                            ] + run_flags,
+                            "volumeMounts": [
+                                {
+                                    "name": "run-inputs",
+                                    "mountPath": mount_path,
+                                },
+                            ],
+                        },
+                    ],
+                    "volumes": [
+                        {
+                            "name": "run-inputs",
+                            "configMap": {"name": CONFIGMAP_NAME},
+                        },
+                    ],
+                },
+            },
+        },
     }

--- a/pipeline/lib/remote.py
+++ b/pipeline/lib/remote.py
@@ -1,0 +1,32 @@
+"""Remote run support — Kubernetes resource generation for --remote mode."""
+
+from pathlib import Path
+
+CONFIGMAP_NAME = "sim2real-run-inputs"
+
+
+def build_run_inputs_configmap(
+    *, run_dir: Path, workspace_dir: Path, namespace: str, run_name: str
+) -> dict:
+    setup_path = workspace_dir / "setup_config.json"
+    if not setup_path.exists():
+        raise FileNotFoundError(f"setup_config.json not found: {setup_path}")
+
+    metadata_path = run_dir / "run_metadata.json"
+    if not metadata_path.exists():
+        raise FileNotFoundError(f"run_metadata.json not found: {metadata_path}")
+
+    data = {
+        "setup_config.json": setup_path.read_text(),
+        "run_metadata.json": metadata_path.read_text(),
+    }
+
+    for yaml_file in sorted((run_dir / "cluster").glob("*.yaml")):
+        data[f"cluster--{yaml_file.name}"] = yaml_file.read_text()
+
+    return {
+        "apiVersion": "v1",
+        "kind": "ConfigMap",
+        "metadata": {"name": CONFIGMAP_NAME, "namespace": namespace},
+        "data": data,
+    }

--- a/pipeline/lib/remote.py
+++ b/pipeline/lib/remote.py
@@ -24,7 +24,13 @@ def build_run_inputs_configmap(
         "run_metadata.json": metadata_path.read_text(),
     }
 
-    for yaml_file in sorted((run_dir / "cluster").glob("*.yaml")):
+    cluster_dir = run_dir / "cluster"
+    yaml_files = sorted(cluster_dir.glob("*.yaml")) if cluster_dir.is_dir() else []
+    if not yaml_files:
+        raise FileNotFoundError(
+            f"No cluster YAML files in {cluster_dir} — run prepare.py first"
+        )
+    for yaml_file in yaml_files:
         data[f"cluster--{yaml_file.name}"] = yaml_file.read_text()
 
     return {

--- a/pipeline/lib/remote.py
+++ b/pipeline/lib/remote.py
@@ -1,5 +1,6 @@
 """Remote run support — Kubernetes resource generation for --remote mode."""
 
+import sys
 from pathlib import Path
 
 CONFIGMAP_NAME = "sim2real-run-inputs"
@@ -46,6 +47,9 @@ def _configmap_items(data: dict, run_name: str) -> list[dict]:
         elif key.startswith("cluster--"):
             filename = key[len("cluster--"):]
             items.append({"key": key, "path": f"runs/{run_name}/cluster/{filename}"})
+        else:
+            print(f"[WARN] Unrecognized ConfigMap key '{key}' — will not be mounted",
+                  file=sys.stderr)
     return items
 
 
@@ -53,8 +57,16 @@ def build_orchestrator_job(
     *, namespace: str, image: str, run_name: str, run_flags: list[str],
     configmap_data: dict,
 ) -> dict:
-    mount_path = f"{MOUNT_BASE}/workspace"
+    workspace_path = f"{MOUNT_BASE}/workspace"
+    config_path = f"{MOUNT_BASE}/config"
     items = _configmap_items(configmap_data, run_name)
+
+    args = [
+        "--experiment-root", MOUNT_BASE,
+        "--run", run_name,
+        "run", "--skip-build-epp",
+    ] + run_flags
+
     return {
         "apiVersion": "batch/v1",
         "kind": "Job",
@@ -66,30 +78,34 @@ def build_orchestrator_job(
                 "spec": {
                     "serviceAccountName": SERVICE_ACCOUNT,
                     "restartPolicy": "Never",
-                    "containers": [
-                        {
-                            "name": "orchestrator",
-                            "image": image,
-                            "args": [
-                                "--experiment-root", MOUNT_BASE,
-                                "--run", run_name,
-                                "run", "--skip-build-epp",
-                            ] + run_flags,
-                            "volumeMounts": [
-                                {
-                                    "name": "run-inputs",
-                                    "mountPath": mount_path,
-                                },
-                            ],
-                        },
-                    ],
+                    "initContainers": [{
+                        "name": "copy-inputs",
+                        "image": image,
+                        "command": ["cp", "-r", f"{config_path}/.", workspace_path],
+                        "volumeMounts": [
+                            {"name": "config", "mountPath": config_path, "readOnly": True},
+                            {"name": "workspace", "mountPath": workspace_path},
+                        ],
+                    }],
+                    "containers": [{
+                        "name": "orchestrator",
+                        "image": image,
+                        "args": args,
+                        "volumeMounts": [
+                            {"name": "workspace", "mountPath": workspace_path},
+                        ],
+                    }],
                     "volumes": [
                         {
-                            "name": "run-inputs",
+                            "name": "config",
                             "configMap": {
                                 "name": CONFIGMAP_NAME,
                                 "items": items,
                             },
+                        },
+                        {
+                            "name": "workspace",
+                            "emptyDir": {},
                         },
                     ],
                 },

--- a/pipeline/lib/remote.py
+++ b/pipeline/lib/remote.py
@@ -35,10 +35,26 @@ def build_run_inputs_configmap(
     }
 
 
+def _configmap_items(data: dict, run_name: str) -> list[dict]:
+    """Build the items list that maps ConfigMap keys to filesystem paths."""
+    items = []
+    for key in sorted(data):
+        if key == "setup_config.json":
+            items.append({"key": key, "path": key})
+        elif key == "run_metadata.json":
+            items.append({"key": key, "path": f"runs/{run_name}/{key}"})
+        elif key.startswith("cluster--"):
+            filename = key[len("cluster--"):]
+            items.append({"key": key, "path": f"runs/{run_name}/cluster/{filename}"})
+    return items
+
+
 def build_orchestrator_job(
-    *, namespace: str, image: str, run_name: str, run_flags: list[str]
+    *, namespace: str, image: str, run_name: str, run_flags: list[str],
+    configmap_data: dict,
 ) -> dict:
-    mount_path = f"{MOUNT_BASE}/workspace/runs/{run_name}"
+    mount_path = f"{MOUNT_BASE}/workspace"
+    items = _configmap_items(configmap_data, run_name)
     return {
         "apiVersion": "batch/v1",
         "kind": "Job",
@@ -70,7 +86,10 @@ def build_orchestrator_job(
                     "volumes": [
                         {
                             "name": "run-inputs",
-                            "configMap": {"name": CONFIGMAP_NAME},
+                            "configMap": {
+                                "name": CONFIGMAP_NAME,
+                                "items": items,
+                            },
                         },
                     ],
                 },

--- a/pipeline/tests/test_deploy_remote.py
+++ b/pipeline/tests/test_deploy_remote.py
@@ -301,8 +301,8 @@ def test_run_remote_creates_configmap_and_job(monkeypatch, tmp_path):
     assert apply_inputs[1]["kind"] == "Job"
 
 
-def test_run_remote_job_has_items_spec(monkeypatch, tmp_path):
-    """Job volume uses items to map ConfigMap keys to correct filesystem paths."""
+def test_run_remote_job_uses_initcontainer_and_emptydir(monkeypatch, tmp_path):
+    """Job uses initContainer to copy ConfigMap to a writable emptyDir."""
     run_dir = _setup_run_dir(tmp_path)
     monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)
     monkeypatch.setattr(mod, "_check_existing_job", lambda ns: None)
@@ -322,9 +322,14 @@ def test_run_remote_job_has_items_spec(monkeypatch, tmp_path):
         mod._cmd_run_remote(args, run_dir, setup_config)
 
     job = apply_inputs[1]
-    vol = job["spec"]["template"]["spec"]["volumes"][0]
-    assert "items" in vol["configMap"]
-    mount = job["spec"]["template"]["spec"]["containers"][0]["volumeMounts"][0]
+    spec = job["spec"]["template"]["spec"]
+    vols = {v["name"]: v for v in spec["volumes"]}
+    assert "config" in vols
+    assert "items" in vols["config"]["configMap"]
+    assert vols["workspace"] == {"name": "workspace", "emptyDir": {}}
+    assert spec["initContainers"][0]["name"] == "copy-inputs"
+    mount = spec["containers"][0]["volumeMounts"][0]
+    assert mount["name"] == "workspace"
     assert mount["mountPath"] == "/data/workspace"
 
 

--- a/pipeline/tests/test_deploy_remote.py
+++ b/pipeline/tests/test_deploy_remote.py
@@ -4,7 +4,7 @@ import argparse
 import json
 
 import pytest
-from unittest.mock import patch, call
+from unittest.mock import patch
 
 import pipeline.deploy as mod
 

--- a/pipeline/tests/test_deploy_remote.py
+++ b/pipeline/tests/test_deploy_remote.py
@@ -189,6 +189,31 @@ def test_wait_for_pod_consecutive_kubectl_failures_exits(monkeypatch):
     assert exc_info.value.code == 1
 
 
+def test_wait_for_pod_init_container_image_pull_exits(monkeypatch):
+    """ImagePullBackOff in initContainerStatuses triggers fail-fast."""
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = json.dumps({
+                "items": [{"status": {
+                    "phase": "Pending",
+                    "initContainerStatuses": [{
+                        "state": {"waiting": {
+                            "reason": "ImagePullBackOff",
+                            "message": "Back-off pulling image",
+                        }},
+                    }],
+                    "containerStatuses": [],
+                }}],
+            })
+            stderr = ""
+        return _R()
+    monkeypatch.setattr(mod, "run", fake_run)
+    with pytest.raises(SystemExit) as exc_info:
+        mod._wait_for_job_pod("ns", timeout=10, poll=1)
+    assert exc_info.value.code == 1
+
+
 # ── _cmd_run_remote tests ──────────────────────────────────────────────────
 
 def _setup_run_dir(tmp_path):

--- a/pipeline/tests/test_deploy_remote.py
+++ b/pipeline/tests/test_deploy_remote.py
@@ -1,0 +1,333 @@
+"""Tests for deploy.py --remote run mode."""
+
+import argparse
+import json
+
+import pytest
+from unittest.mock import patch, call
+
+import pipeline.deploy as mod
+
+
+def _make_run_args(*, remote=False, workload=None, only=None, package=None,
+                   status=None, force=False, skip_build_epp=False,
+                   max_retries=2, poll_interval=30, gpu_resource_type=None,
+                   default_gpu_cost=1, pending_threshold=600,
+                   max_pending_stalls=10, max_backoff=600):
+    return argparse.Namespace(
+        remote=remote, workload=workload, only=only, package=package,
+        status=status, force=force, skip_build_epp=skip_build_epp,
+        max_retries=max_retries, poll_interval=poll_interval,
+        gpu_resource_type=gpu_resource_type, default_gpu_cost=default_gpu_cost,
+        pending_threshold=pending_threshold, max_pending_stalls=max_pending_stalls,
+        max_backoff=max_backoff,
+    )
+
+
+# ── Parser tests ────────────────────────────────────────────────────────────
+
+def test_run_parser_has_remote_flag():
+    args = mod.build_parser().parse_args(["run", "--remote"])
+    assert args.remote is True
+
+
+def test_run_parser_remote_default_false():
+    args = mod.build_parser().parse_args(["run"])
+    assert args.remote is False
+
+
+# ── _collect_run_flags tests ────────────────────────────────────────────────
+
+def test_collect_run_flags_defaults():
+    args = _make_run_args()
+    assert mod._collect_run_flags(args) == []
+
+
+def test_collect_run_flags_workload():
+    args = _make_run_args(workload="wl-smoke")
+    assert mod._collect_run_flags(args) == ["--workload", "wl-smoke"]
+
+
+def test_collect_run_flags_force():
+    args = _make_run_args(force=True)
+    assert mod._collect_run_flags(args) == ["--force"]
+
+
+def test_collect_run_flags_non_default_retries():
+    args = _make_run_args(max_retries=5)
+    assert mod._collect_run_flags(args) == ["--max-retries", "5"]
+
+
+# ── _check_existing_job tests ──────────────────────────────────────────────
+
+def test_check_existing_job_active(monkeypatch):
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = json.dumps({"status": {"active": 1}})
+            stderr = ""
+        return _R()
+    monkeypatch.setattr(mod, "run", fake_run)
+    assert mod._check_existing_job("ns") == "active"
+
+
+def test_check_existing_job_completed(monkeypatch):
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = json.dumps({"status": {}})
+            stderr = ""
+        return _R()
+    monkeypatch.setattr(mod, "run", fake_run)
+    assert mod._check_existing_job("ns") == "completed"
+
+
+def test_check_existing_job_not_found(monkeypatch):
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 1
+            stdout = ""
+            stderr = 'Error from server (NotFound): jobs.batch "sim2real-orchestrator" not found'
+        return _R()
+    monkeypatch.setattr(mod, "run", fake_run)
+    assert mod._check_existing_job("ns") is None
+
+
+# ── _wait_for_job_pod tests ────────────────────────────────────────────────
+
+def test_wait_for_pod_running(monkeypatch):
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = json.dumps({
+                "items": [{
+                    "status": {"phase": "Running", "containerStatuses": []},
+                }],
+            })
+            stderr = ""
+        return _R()
+    monkeypatch.setattr(mod, "run", fake_run)
+    mod._wait_for_job_pod("ns", timeout=10, poll=1)
+
+
+def test_wait_for_pod_image_pull_backoff(monkeypatch):
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = json.dumps({
+                "items": [{
+                    "status": {
+                        "phase": "Pending",
+                        "containerStatuses": [{
+                            "state": {
+                                "waiting": {
+                                    "reason": "ImagePullBackOff",
+                                    "message": "Back-off pulling image",
+                                },
+                            },
+                        }],
+                    },
+                }],
+            })
+            stderr = ""
+        return _R()
+    monkeypatch.setattr(mod, "run", fake_run)
+    with pytest.raises(SystemExit) as exc_info:
+        mod._wait_for_job_pod("ns", timeout=10, poll=1)
+    assert exc_info.value.code == 1
+
+
+def test_wait_for_pod_no_pods_retries(monkeypatch):
+    call_count = [0]
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        call_count[0] += 1
+        if call_count[0] <= 2:
+            class _Empty:
+                returncode = 0
+                stdout = json.dumps({"items": []})
+                stderr = ""
+            return _Empty()
+        class _Running:
+            returncode = 0
+            stdout = json.dumps({
+                "items": [{
+                    "status": {"phase": "Running", "containerStatuses": []},
+                }],
+            })
+            stderr = ""
+        return _Running()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    monkeypatch.setattr(mod.time, "sleep", lambda _: None)
+    mod._wait_for_job_pod("ns", timeout=300, poll=1)
+    assert call_count[0] == 3
+
+
+# ── _cmd_run_remote tests ──────────────────────────────────────────────────
+
+def _setup_run_dir(tmp_path):
+    """Create minimal workspace structure for _cmd_run_remote."""
+    workspace = tmp_path / "workspace"
+    run_dir = workspace / "runs" / "test-run"
+    cluster_dir = run_dir / "cluster"
+    cluster_dir.mkdir(parents=True)
+    (workspace / "setup_config.json").write_text("{}")
+    (run_dir / "run_metadata.json").write_text(json.dumps({
+        "component_image": "registry.example.com/epp:latest",
+    }))
+    (cluster_dir / "pipelinerun-baseline.yaml").write_text("apiVersion: v1")
+    return run_dir
+
+
+def test_run_remote_refuses_when_active(monkeypatch, tmp_path):
+    run_dir = _setup_run_dir(tmp_path)
+    monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)
+    monkeypatch.setattr(mod, "_check_existing_job", lambda ns: "active")
+    monkeypatch.setattr(mod, "_resolve_epp_action", lambda *a: "skip")
+
+    args = _make_run_args(remote=True, skip_build_epp=True)
+    setup_config = {"namespaces": ["ns"], "orchestrator_image": "img:latest"}
+
+    with pytest.raises(SystemExit) as exc_info:
+        mod._cmd_run_remote(args, run_dir, setup_config)
+    assert exc_info.value.code == 1
+
+
+def test_run_remote_deletes_completed_job(monkeypatch, tmp_path):
+    run_dir = _setup_run_dir(tmp_path)
+    monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)
+    monkeypatch.setattr(mod, "_check_existing_job", lambda ns: "completed")
+    monkeypatch.setattr(mod, "_resolve_epp_action", lambda *a: "skip")
+    monkeypatch.setattr(mod, "_wait_for_job_pod", lambda *a, **kw: None)
+
+    calls = []
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        calls.append(cmd)
+        class _R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    with patch("subprocess.run") as mock_sp:
+        mock_sp.return_value = type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+        args = _make_run_args(remote=True, skip_build_epp=True)
+        setup_config = {"namespaces": ["ns"], "orchestrator_image": "img:latest"}
+        mod._cmd_run_remote(args, run_dir, setup_config)
+
+    delete_calls = [c for c in calls if "delete" in c]
+    assert len(delete_calls) == 1
+    assert "sim2real-orchestrator" in delete_calls[0]
+
+
+def test_run_remote_creates_configmap_and_job(monkeypatch, tmp_path):
+    run_dir = _setup_run_dir(tmp_path)
+    monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)
+    monkeypatch.setattr(mod, "_check_existing_job", lambda ns: None)
+    monkeypatch.setattr(mod, "_resolve_epp_action", lambda *a: "skip")
+    monkeypatch.setattr(mod, "_wait_for_job_pod", lambda *a, **kw: None)
+
+    apply_inputs = []
+
+    def fake_subprocess_run(cmd, *, input=None, text=True, check=True, capture_output=True, **kw):
+        if input:
+            apply_inputs.append(json.loads(input))
+        return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    with patch("subprocess.run", side_effect=fake_subprocess_run):
+        args = _make_run_args(remote=True, skip_build_epp=True)
+        setup_config = {"namespaces": ["ns"], "orchestrator_image": "img:latest"}
+        mod._cmd_run_remote(args, run_dir, setup_config)
+
+    assert len(apply_inputs) == 2
+    assert apply_inputs[0]["kind"] == "ConfigMap"
+    assert apply_inputs[1]["kind"] == "Job"
+
+
+def test_run_remote_passes_scoping_flags(monkeypatch, tmp_path):
+    run_dir = _setup_run_dir(tmp_path)
+    monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)
+    monkeypatch.setattr(mod, "_check_existing_job", lambda ns: None)
+    monkeypatch.setattr(mod, "_resolve_epp_action", lambda *a: "skip")
+    monkeypatch.setattr(mod, "_wait_for_job_pod", lambda *a, **kw: None)
+
+    apply_inputs = []
+
+    def fake_subprocess_run(cmd, *, input=None, text=True, check=True, capture_output=True, **kw):
+        if input:
+            apply_inputs.append(json.loads(input))
+        return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    with patch("subprocess.run", side_effect=fake_subprocess_run):
+        args = _make_run_args(remote=True, skip_build_epp=True, workload="wl-smoke")
+        setup_config = {"namespaces": ["ns"], "orchestrator_image": "img:latest"}
+        mod._cmd_run_remote(args, run_dir, setup_config)
+
+    job_dict = apply_inputs[1]
+    container_args = job_dict["spec"]["template"]["spec"]["containers"][0]["args"]
+    assert "--workload" in container_args
+    assert "wl-smoke" in container_args
+
+
+def test_run_remote_no_image_exits(monkeypatch, tmp_path):
+    run_dir = _setup_run_dir(tmp_path)
+    monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)
+
+    args = _make_run_args(remote=True, skip_build_epp=True)
+    setup_config = {"namespaces": ["ns"]}
+
+    with pytest.raises(SystemExit) as exc_info:
+        mod._cmd_run_remote(args, run_dir, setup_config)
+    assert exc_info.value.code == 1
+
+
+# ── main() routing tests ───────────────────────────────────────────────────
+
+def test_main_routes_run_remote(tmp_path, monkeypatch):
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    run_dir.mkdir(parents=True)
+
+    monkeypatch.setattr("sys.argv", [
+        "deploy.py", "--experiment-root", str(tmp_path), "run", "--remote",
+    ])
+
+    remote_calls = []
+
+    def mock_run_remote(args, rd, sc):
+        remote_calls.append(True)
+
+    with patch.object(mod, "_cmd_run_remote", mock_run_remote):
+        with patch.object(mod, "_load_setup_config", return_value={
+            "current_run": "test-run",
+            "namespaces": ["ns"],
+        }):
+            mod.main()
+
+    assert len(remote_calls) == 1
+
+
+def test_main_routes_run_local(tmp_path, monkeypatch):
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    run_dir.mkdir(parents=True)
+
+    monkeypatch.setattr("sys.argv", [
+        "deploy.py", "--experiment-root", str(tmp_path), "run",
+    ])
+
+    local_calls = []
+
+    def mock_run(args, rd, sc):
+        local_calls.append(True)
+
+    with patch.object(mod, "_cmd_run", mock_run):
+        with patch.object(mod, "_load_setup_config", return_value={
+            "current_run": "test-run",
+            "namespaces": ["ns"],
+        }):
+            mod.main()
+
+    assert len(local_calls) == 1

--- a/pipeline/tests/test_deploy_remote.py
+++ b/pipeline/tests/test_deploy_remote.py
@@ -100,9 +100,7 @@ def test_wait_for_pod_running(monkeypatch):
         class _R:
             returncode = 0
             stdout = json.dumps({
-                "items": [{
-                    "status": {"phase": "Running", "containerStatuses": []},
-                }],
+                "items": [{"status": {"phase": "Running", "containerStatuses": []}}],
             })
             stderr = ""
         return _R()
@@ -115,19 +113,13 @@ def test_wait_for_pod_image_pull_backoff(monkeypatch):
         class _R:
             returncode = 0
             stdout = json.dumps({
-                "items": [{
-                    "status": {
-                        "phase": "Pending",
-                        "containerStatuses": [{
-                            "state": {
-                                "waiting": {
-                                    "reason": "ImagePullBackOff",
-                                    "message": "Back-off pulling image",
-                                },
-                            },
-                        }],
-                    },
-                }],
+                "items": [{"status": {
+                    "phase": "Pending",
+                    "containerStatuses": [{"state": {"waiting": {
+                        "reason": "ImagePullBackOff",
+                        "message": "Back-off pulling image",
+                    }}}],
+                }}],
             })
             stderr = ""
         return _R()
@@ -151,9 +143,7 @@ def test_wait_for_pod_no_pods_retries(monkeypatch):
         class _Running:
             returncode = 0
             stdout = json.dumps({
-                "items": [{
-                    "status": {"phase": "Running", "containerStatuses": []},
-                }],
+                "items": [{"status": {"phase": "Running", "containerStatuses": []}}],
             })
             stderr = ""
         return _Running()
@@ -162,6 +152,41 @@ def test_wait_for_pod_no_pods_retries(monkeypatch):
     monkeypatch.setattr(mod.time, "sleep", lambda _: None)
     mod._wait_for_job_pod("ns", timeout=300, poll=1)
     assert call_count[0] == 3
+
+
+def test_wait_for_pod_failed_phase_exits(monkeypatch):
+    """Pod with phase=Failed triggers immediate exit."""
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = json.dumps({
+                "items": [{"status": {
+                    "phase": "Failed",
+                    "message": "OOMKilled",
+                    "containerStatuses": [],
+                }}],
+            })
+            stderr = ""
+        return _R()
+    monkeypatch.setattr(mod, "run", fake_run)
+    with pytest.raises(SystemExit) as exc_info:
+        mod._wait_for_job_pod("ns", timeout=10, poll=1)
+    assert exc_info.value.code == 1
+
+
+def test_wait_for_pod_consecutive_kubectl_failures_exits(monkeypatch):
+    """Three consecutive kubectl failures trigger early exit."""
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 1
+            stdout = ""
+            stderr = "connection refused"
+        return _R()
+    monkeypatch.setattr(mod, "run", fake_run)
+    monkeypatch.setattr(mod.time, "sleep", lambda _: None)
+    with pytest.raises(SystemExit) as exc_info:
+        mod._wait_for_job_pod("ns", timeout=300, poll=1)
+    assert exc_info.value.code == 1
 
 
 # ── _cmd_run_remote tests ──────────────────────────────────────────────────
@@ -178,6 +203,10 @@ def _setup_run_dir(tmp_path):
     }))
     (cluster_dir / "pipelinerun-baseline.yaml").write_text("apiVersion: v1")
     return run_dir
+
+
+def _mock_subprocess_ok(cmd, *, input=None, text=True, check=False, capture_output=True, **kw):
+    return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
 
 
 def test_run_remote_refuses_when_active(monkeypatch, tmp_path):
@@ -213,8 +242,7 @@ def test_run_remote_deletes_completed_job(monkeypatch, tmp_path):
 
     monkeypatch.setattr(mod, "run", fake_run)
 
-    with patch("subprocess.run") as mock_sp:
-        mock_sp.return_value = type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+    with patch("subprocess.run", side_effect=_mock_subprocess_ok):
         args = _make_run_args(remote=True, skip_build_epp=True)
         setup_config = {"namespaces": ["ns"], "orchestrator_image": "img:latest"}
         mod._cmd_run_remote(args, run_dir, setup_config)
@@ -222,6 +250,31 @@ def test_run_remote_deletes_completed_job(monkeypatch, tmp_path):
     delete_calls = [c for c in calls if "delete" in c]
     assert len(delete_calls) == 1
     assert "sim2real-orchestrator" in delete_calls[0]
+
+
+def test_run_remote_completed_delete_failure_exits(monkeypatch, tmp_path, capsys):
+    """If deleting a completed Job fails, exit with error."""
+    run_dir = _setup_run_dir(tmp_path)
+    monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)
+    monkeypatch.setattr(mod, "_check_existing_job", lambda ns: "completed")
+    monkeypatch.setattr(mod, "_resolve_epp_action", lambda *a: "skip")
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 1
+            stdout = ""
+            stderr = "error: forbidden"
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    args = _make_run_args(remote=True, skip_build_epp=True)
+    setup_config = {"namespaces": ["ns"], "orchestrator_image": "img:latest"}
+
+    with pytest.raises(SystemExit) as exc_info:
+        mod._cmd_run_remote(args, run_dir, setup_config)
+    assert exc_info.value.code == 1
+    assert "forbidden" in capsys.readouterr().err.lower()
 
 
 def test_run_remote_creates_configmap_and_job(monkeypatch, tmp_path):
@@ -233,7 +286,7 @@ def test_run_remote_creates_configmap_and_job(monkeypatch, tmp_path):
 
     apply_inputs = []
 
-    def fake_subprocess_run(cmd, *, input=None, text=True, check=True, capture_output=True, **kw):
+    def fake_subprocess_run(cmd, *, input=None, text=True, check=False, capture_output=True, **kw):
         if input:
             apply_inputs.append(json.loads(input))
         return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
@@ -248,6 +301,33 @@ def test_run_remote_creates_configmap_and_job(monkeypatch, tmp_path):
     assert apply_inputs[1]["kind"] == "Job"
 
 
+def test_run_remote_job_has_items_spec(monkeypatch, tmp_path):
+    """Job volume uses items to map ConfigMap keys to correct filesystem paths."""
+    run_dir = _setup_run_dir(tmp_path)
+    monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)
+    monkeypatch.setattr(mod, "_check_existing_job", lambda ns: None)
+    monkeypatch.setattr(mod, "_resolve_epp_action", lambda *a: "skip")
+    monkeypatch.setattr(mod, "_wait_for_job_pod", lambda *a, **kw: None)
+
+    apply_inputs = []
+
+    def fake_subprocess_run(cmd, *, input=None, text=True, check=False, capture_output=True, **kw):
+        if input:
+            apply_inputs.append(json.loads(input))
+        return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    with patch("subprocess.run", side_effect=fake_subprocess_run):
+        args = _make_run_args(remote=True, skip_build_epp=True)
+        setup_config = {"namespaces": ["ns"], "orchestrator_image": "img:latest"}
+        mod._cmd_run_remote(args, run_dir, setup_config)
+
+    job = apply_inputs[1]
+    vol = job["spec"]["template"]["spec"]["volumes"][0]
+    assert "items" in vol["configMap"]
+    mount = job["spec"]["template"]["spec"]["containers"][0]["volumeMounts"][0]
+    assert mount["mountPath"] == "/data/workspace"
+
+
 def test_run_remote_passes_scoping_flags(monkeypatch, tmp_path):
     run_dir = _setup_run_dir(tmp_path)
     monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)
@@ -257,7 +337,7 @@ def test_run_remote_passes_scoping_flags(monkeypatch, tmp_path):
 
     apply_inputs = []
 
-    def fake_subprocess_run(cmd, *, input=None, text=True, check=True, capture_output=True, **kw):
+    def fake_subprocess_run(cmd, *, input=None, text=True, check=False, capture_output=True, **kw):
         if input:
             apply_inputs.append(json.loads(input))
         return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
@@ -283,6 +363,25 @@ def test_run_remote_no_image_exits(monkeypatch, tmp_path):
     with pytest.raises(SystemExit) as exc_info:
         mod._cmd_run_remote(args, run_dir, setup_config)
     assert exc_info.value.code == 1
+
+
+def test_run_remote_configmap_apply_failure_exits(monkeypatch, tmp_path, capsys):
+    """kubectl apply for ConfigMap failing exits with error."""
+    run_dir = _setup_run_dir(tmp_path)
+    monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)
+    monkeypatch.setattr(mod, "_check_existing_job", lambda ns: None)
+    monkeypatch.setattr(mod, "_resolve_epp_action", lambda *a: "skip")
+
+    def fake_subprocess_run(cmd, *, input=None, text=True, check=False, capture_output=True, **kw):
+        return type("R", (), {"returncode": 1, "stdout": "", "stderr": "forbidden"})()
+
+    with patch("subprocess.run", side_effect=fake_subprocess_run):
+        args = _make_run_args(remote=True, skip_build_epp=True)
+        setup_config = {"namespaces": ["ns"], "orchestrator_image": "img:latest"}
+        with pytest.raises(SystemExit) as exc_info:
+            mod._cmd_run_remote(args, run_dir, setup_config)
+    assert exc_info.value.code == 1
+    assert "configmap" in capsys.readouterr().err.lower()
 
 
 # ── main() routing tests ───────────────────────────────────────────────────

--- a/pipeline/tests/test_remote.py
+++ b/pipeline/tests/test_remote.py
@@ -4,7 +4,12 @@ import json
 
 import pytest
 
-from pipeline.lib.remote import CONFIGMAP_NAME, build_run_inputs_configmap
+from pipeline.lib.remote import (
+    CONFIGMAP_NAME,
+    JOB_NAME,
+    build_orchestrator_job,
+    build_run_inputs_configmap,
+)
 
 
 @pytest.fixture()
@@ -81,3 +86,69 @@ def test_missing_run_metadata(workspace):
             run_dir=run_dir, workspace_dir=workspace_dir,
             namespace="ns", run_name="test-run",
         )
+
+
+# --- build_orchestrator_job tests ---
+
+RUN_NAME = "exp-001"
+NAMESPACE = "sim2real"
+IMAGE = "ghcr.io/inference-sim/sim2real-orchestrator:latest"
+
+
+def _build_job(**overrides):
+    defaults = dict(
+        namespace=NAMESPACE, image=IMAGE, run_name=RUN_NAME, run_flags=["--dry-run"],
+    )
+    defaults.update(overrides)
+    return build_orchestrator_job(**defaults)
+
+
+def test_job_name_matches_constant():
+    assert JOB_NAME == "sim2real-orchestrator"
+
+
+def test_job_structure():
+    job = _build_job()
+    assert job["kind"] == "Job"
+    assert job["metadata"]["name"] == JOB_NAME
+    assert job["metadata"]["namespace"] == NAMESPACE
+
+    spec = job["spec"]["template"]["spec"]
+    assert spec["serviceAccountName"] == "sim2real-runner"
+    assert spec["restartPolicy"] == "Never"
+
+    container = spec["containers"][0]
+    assert container["image"] == IMAGE
+    args = container["args"]
+    assert "--experiment-root" in args
+    assert "run" in args
+    assert "--skip-build-epp" in args
+    assert "--dry-run" in args
+
+
+def test_job_configmap_volume_mount():
+    job = _build_job()
+    spec = job["spec"]["template"]["spec"]
+
+    volume = spec["volumes"][0]
+    assert volume["configMap"]["name"] == CONFIGMAP_NAME
+
+    mount = spec["containers"][0]["volumeMounts"][0]
+    assert mount["mountPath"] == f"/data/workspace/runs/{RUN_NAME}"
+
+
+def test_job_experiment_root_matches_mount():
+    job = _build_job()
+    args = job["spec"]["template"]["spec"]["containers"][0]["args"]
+    idx = args.index("--experiment-root")
+    assert args[idx + 1] == "/data"
+
+
+def test_job_backoff_limit_zero():
+    job = _build_job()
+    assert job["spec"]["backoffLimit"] == 0
+
+
+def test_job_active_deadline():
+    job = _build_job()
+    assert job["spec"]["activeDeadlineSeconds"] == 18000

--- a/pipeline/tests/test_remote.py
+++ b/pipeline/tests/test_remote.py
@@ -28,6 +28,7 @@ def _write_defaults(workspace_dir, run_dir):
     (workspace_dir / "setup_config.json").write_text(json.dumps(setup))
     meta = {"run_name": "test-run"}
     (run_dir / "run_metadata.json").write_text(json.dumps(meta))
+    (run_dir / "cluster" / "pipelinerun-smoke-baseline.yaml").write_text("kind: PipelineRun")
 
 
 def test_setup_config_packed(workspace):
@@ -83,6 +84,33 @@ def test_missing_run_metadata(workspace):
     workspace_dir, run_dir = workspace
     (workspace_dir / "setup_config.json").write_text("{}")
     with pytest.raises(FileNotFoundError, match="run_metadata.json"):
+        build_run_inputs_configmap(
+            run_dir=run_dir, workspace_dir=workspace_dir,
+            namespace="ns", run_name="test-run",
+        )
+
+
+def test_empty_cluster_dir_raises(workspace):
+    """Empty cluster/ directory raises FileNotFoundError."""
+    workspace_dir, run_dir = workspace
+    (workspace_dir / "setup_config.json").write_text("{}")
+    (run_dir / "run_metadata.json").write_text("{}")
+    with pytest.raises(FileNotFoundError, match="No cluster YAML"):
+        build_run_inputs_configmap(
+            run_dir=run_dir, workspace_dir=workspace_dir,
+            namespace="ns", run_name="test-run",
+        )
+
+
+def test_missing_cluster_dir_raises(tmp_path):
+    """Missing cluster/ directory raises FileNotFoundError."""
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    run_dir = workspace_dir / "runs" / "test-run"
+    run_dir.mkdir(parents=True)
+    (workspace_dir / "setup_config.json").write_text("{}")
+    (run_dir / "run_metadata.json").write_text("{}")
+    with pytest.raises(FileNotFoundError, match="No cluster YAML"):
         build_run_inputs_configmap(
             run_dir=run_dir, workspace_dir=workspace_dir,
             namespace="ns", run_name="test-run",

--- a/pipeline/tests/test_remote.py
+++ b/pipeline/tests/test_remote.py
@@ -115,6 +115,15 @@ def test_configmap_items_cluster_yaml_nested():
     assert "runs/exp-1/cluster/pipelinerun-a.yaml" in paths
 
 
+def test_configmap_items_warns_on_unrecognized_key(capsys):
+    """Unrecognized keys produce a warning and are not mounted."""
+    data = {"setup_config.json": "{}", "unknown_file.txt": "data"}
+    items = _configmap_items(data, "run1")
+    keys = [i["key"] for i in items]
+    assert "unknown_file.txt" not in keys
+    assert "Unrecognized" in capsys.readouterr().err
+
+
 # --- build_orchestrator_job tests ---
 
 RUN_NAME = "exp-001"
@@ -159,23 +168,40 @@ def test_job_structure():
     assert "--dry-run" in args
 
 
-def test_job_volume_mount_at_workspace():
-    """Volume mounts at /data/workspace (not /data/workspace/runs/<name>)."""
+def test_job_workspace_is_writable_emptydir():
+    """Orchestrator mounts a writable emptyDir at /data/workspace."""
     job = _build_job()
-    mount = job["spec"]["template"]["spec"]["containers"][0]["volumeMounts"][0]
+    spec = job["spec"]["template"]["spec"]
+    mount = spec["containers"][0]["volumeMounts"][0]
+    assert mount["name"] == "workspace"
     assert mount["mountPath"] == "/data/workspace"
+    ws_vol = next(v for v in spec["volumes"] if v["name"] == "workspace")
+    assert ws_vol == {"name": "workspace", "emptyDir": {}}
 
 
-def test_job_volume_has_items_spec():
-    """Volume uses items to map keys to correct filesystem paths."""
+def test_job_configmap_volume_is_read_only():
+    """ConfigMap is mounted read-only at /data/config with items spec."""
     job = _build_job()
-    vol = job["spec"]["template"]["spec"]["volumes"][0]
-    assert vol["configMap"]["name"] == CONFIGMAP_NAME
-    items = vol["configMap"]["items"]
+    spec = job["spec"]["template"]["spec"]
+    cfg_vol = next(v for v in spec["volumes"] if v["name"] == "config")
+    assert cfg_vol["configMap"]["name"] == CONFIGMAP_NAME
+    items = cfg_vol["configMap"]["items"]
     paths = {i["path"] for i in items}
     assert "setup_config.json" in paths
     assert f"runs/{RUN_NAME}/run_metadata.json" in paths
     assert f"runs/{RUN_NAME}/cluster/baseline.yaml" in paths
+
+
+def test_job_has_init_container_that_copies_inputs():
+    """initContainer copies ConfigMap contents to the writable workspace."""
+    job = _build_job()
+    spec = job["spec"]["template"]["spec"]
+    init = spec["initContainers"][0]
+    assert init["name"] == "copy-inputs"
+    assert init["command"] == ["cp", "-r", "/data/config/.", "/data/workspace"]
+    mounts = {m["name"]: m for m in init["volumeMounts"]}
+    assert mounts["config"]["readOnly"] is True
+    assert "workspace" in mounts
 
 
 def test_job_experiment_root_matches_mount():

--- a/pipeline/tests/test_remote.py
+++ b/pipeline/tests/test_remote.py
@@ -1,0 +1,83 @@
+"""Tests for remote run support (ConfigMap packing)."""
+
+import json
+
+import pytest
+
+from pipeline.lib.remote import CONFIGMAP_NAME, build_run_inputs_configmap
+
+
+@pytest.fixture()
+def workspace(tmp_path):
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    run_dir = workspace_dir / "runs" / "test-run"
+    run_dir.mkdir(parents=True)
+    (run_dir / "cluster").mkdir()
+    return workspace_dir, run_dir
+
+
+def _write_defaults(workspace_dir, run_dir):
+    setup = {"namespace": "ns", "pipeline_name": "p"}
+    (workspace_dir / "setup_config.json").write_text(json.dumps(setup))
+    meta = {"run_name": "test-run"}
+    (run_dir / "run_metadata.json").write_text(json.dumps(meta))
+
+
+def test_setup_config_packed(workspace):
+    workspace_dir, run_dir = workspace
+    _write_defaults(workspace_dir, run_dir)
+    cm = build_run_inputs_configmap(
+        run_dir=run_dir, workspace_dir=workspace_dir,
+        namespace="ns", run_name="test-run",
+    )
+    assert cm["apiVersion"] == "v1"
+    assert cm["kind"] == "ConfigMap"
+    assert cm["metadata"]["name"] == CONFIGMAP_NAME
+    assert cm["metadata"]["namespace"] == "ns"
+    assert json.loads(cm["data"]["setup_config.json"]) == {
+        "namespace": "ns", "pipeline_name": "p",
+    }
+
+
+def test_run_metadata_packed(workspace):
+    workspace_dir, run_dir = workspace
+    _write_defaults(workspace_dir, run_dir)
+    cm = build_run_inputs_configmap(
+        run_dir=run_dir, workspace_dir=workspace_dir,
+        namespace="ns", run_name="test-run",
+    )
+    assert json.loads(cm["data"]["run_metadata.json"]) == {"run_name": "test-run"}
+
+
+def test_cluster_yamls_packed(workspace):
+    workspace_dir, run_dir = workspace
+    _write_defaults(workspace_dir, run_dir)
+    (run_dir / "cluster" / "baseline.yaml").write_text("base: true\n")
+    (run_dir / "cluster" / "treatment.yaml").write_text("treat: true\n")
+    cm = build_run_inputs_configmap(
+        run_dir=run_dir, workspace_dir=workspace_dir,
+        namespace="ns", run_name="test-run",
+    )
+    assert cm["data"]["cluster--baseline.yaml"] == "base: true\n"
+    assert cm["data"]["cluster--treatment.yaml"] == "treat: true\n"
+
+
+def test_missing_setup_config(workspace):
+    workspace_dir, run_dir = workspace
+    (run_dir / "run_metadata.json").write_text("{}")
+    with pytest.raises(FileNotFoundError, match="setup_config.json"):
+        build_run_inputs_configmap(
+            run_dir=run_dir, workspace_dir=workspace_dir,
+            namespace="ns", run_name="test-run",
+        )
+
+
+def test_missing_run_metadata(workspace):
+    workspace_dir, run_dir = workspace
+    (workspace_dir / "setup_config.json").write_text("{}")
+    with pytest.raises(FileNotFoundError, match="run_metadata.json"):
+        build_run_inputs_configmap(
+            run_dir=run_dir, workspace_dir=workspace_dir,
+            namespace="ns", run_name="test-run",
+        )

--- a/pipeline/tests/test_remote.py
+++ b/pipeline/tests/test_remote.py
@@ -1,4 +1,4 @@
-"""Tests for remote run support (ConfigMap packing)."""
+"""Tests for remote run support (ConfigMap packing + Job generation)."""
 
 import json
 
@@ -9,6 +9,7 @@ from pipeline.lib.remote import (
     JOB_NAME,
     build_orchestrator_job,
     build_run_inputs_configmap,
+    _configmap_items,
 )
 
 
@@ -88,16 +89,48 @@ def test_missing_run_metadata(workspace):
         )
 
 
+# --- _configmap_items tests ---
+
+
+def test_configmap_items_setup_config_at_root():
+    """setup_config.json maps to workspace root."""
+    data = {"setup_config.json": "{}"}
+    items = _configmap_items(data, "run1")
+    assert {"key": "setup_config.json", "path": "setup_config.json"} in items
+
+
+def test_configmap_items_run_metadata_under_run():
+    """run_metadata.json maps under runs/<name>/."""
+    data = {"run_metadata.json": "{}"}
+    items = _configmap_items(data, "run1")
+    assert {"key": "run_metadata.json", "path": "runs/run1/run_metadata.json"} in items
+
+
+def test_configmap_items_cluster_yaml_nested():
+    """cluster--foo.yaml maps to runs/<name>/cluster/foo.yaml."""
+    data = {"cluster--baseline.yaml": "x", "cluster--pipelinerun-a.yaml": "y"}
+    items = _configmap_items(data, "exp-1")
+    paths = {i["path"] for i in items}
+    assert "runs/exp-1/cluster/baseline.yaml" in paths
+    assert "runs/exp-1/cluster/pipelinerun-a.yaml" in paths
+
+
 # --- build_orchestrator_job tests ---
 
 RUN_NAME = "exp-001"
 NAMESPACE = "sim2real"
 IMAGE = "ghcr.io/inference-sim/sim2real-orchestrator:latest"
+SAMPLE_DATA = {
+    "setup_config.json": "{}",
+    "run_metadata.json": "{}",
+    "cluster--baseline.yaml": "x",
+}
 
 
 def _build_job(**overrides):
     defaults = dict(
-        namespace=NAMESPACE, image=IMAGE, run_name=RUN_NAME, run_flags=["--dry-run"],
+        namespace=NAMESPACE, image=IMAGE, run_name=RUN_NAME,
+        run_flags=["--dry-run"], configmap_data=SAMPLE_DATA,
     )
     defaults.update(overrides)
     return build_orchestrator_job(**defaults)
@@ -126,15 +159,23 @@ def test_job_structure():
     assert "--dry-run" in args
 
 
-def test_job_configmap_volume_mount():
+def test_job_volume_mount_at_workspace():
+    """Volume mounts at /data/workspace (not /data/workspace/runs/<name>)."""
     job = _build_job()
-    spec = job["spec"]["template"]["spec"]
+    mount = job["spec"]["template"]["spec"]["containers"][0]["volumeMounts"][0]
+    assert mount["mountPath"] == "/data/workspace"
 
-    volume = spec["volumes"][0]
-    assert volume["configMap"]["name"] == CONFIGMAP_NAME
 
-    mount = spec["containers"][0]["volumeMounts"][0]
-    assert mount["mountPath"] == f"/data/workspace/runs/{RUN_NAME}"
+def test_job_volume_has_items_spec():
+    """Volume uses items to map keys to correct filesystem paths."""
+    job = _build_job()
+    vol = job["spec"]["template"]["spec"]["volumes"][0]
+    assert vol["configMap"]["name"] == CONFIGMAP_NAME
+    items = vol["configMap"]["items"]
+    paths = {i["path"] for i in items}
+    assert "setup_config.json" in paths
+    assert f"runs/{RUN_NAME}/run_metadata.json" in paths
+    assert f"runs/{RUN_NAME}/cluster/baseline.yaml" in paths
 
 
 def test_job_experiment_root_matches_mount():

--- a/pipeline/tests/test_remote.py
+++ b/pipeline/tests/test_remote.py
@@ -115,13 +115,11 @@ def test_configmap_items_cluster_yaml_nested():
     assert "runs/exp-1/cluster/pipelinerun-a.yaml" in paths
 
 
-def test_configmap_items_warns_on_unrecognized_key(capsys):
-    """Unrecognized keys produce a warning and are not mounted."""
+def test_configmap_items_raises_on_unrecognized_key():
+    """Unrecognized keys raise ValueError (producer/consumer mismatch)."""
     data = {"setup_config.json": "{}", "unknown_file.txt": "data"}
-    items = _configmap_items(data, "run1")
-    keys = [i["key"] for i in items]
-    assert "unknown_file.txt" not in keys
-    assert "Unrecognized" in capsys.readouterr().err
+    with pytest.raises(ValueError, match="Unrecognized"):
+        _configmap_items(data, "run1")
 
 
 # --- build_orchestrator_job tests ---


### PR DESCRIPTION
## Summary

- Adds `--remote` flag to `deploy.py run` that submits the orchestrator as an in-cluster Kubernetes Job instead of running the polling loop locally
- The launcher builds the EPP image locally, packs workspace files into a ConfigMap, applies a Job that runs the same `deploy.py run` code with `--skip-build-epp`, and waits for the pod to reach Running
- Updates RBAC (`sim2real-pipeline-runner` Role) to add `delete`/`patch` for PipelineRuns and ConfigMap CRUD for the orchestrator
- Adds `pipeline/lib/remote.py` module with pure functions for ConfigMap and Job YAML generation

Closes #127

## Changes

| File | What |
|------|------|
| `pipeline/lib/remote.py` | New module: `build_run_inputs_configmap` and `build_orchestrator_job` |
| `pipeline/deploy.py` | `_cmd_run_remote`, `_wait_for_job_pod`, `_check_existing_job`, `_collect_run_flags`, `--remote` flag, main() routing |
| `pipeline/tests/test_remote.py` | 11 tests for remote module |
| `pipeline/tests/test_deploy_remote.py` | 19 tests for launcher, pod wait, flag collection, main() routing |
| `tektonc-data-collection` | Submodule bump: RBAC adds PipelineRun delete/patch + ConfigMap rules |
| `pipeline/completions.{bash,zsh}` | `--remote` and `--max-backoff` added to `run` completions |
| `pipeline/README.md` | `--remote` flag documented with "Remote mode" paragraph |

## Reviewer attention

- **ConfigMap key encoding**: cluster/ path separator is `--` (ConfigMap keys can't contain `/`). The in-cluster orchestrator mounts the ConfigMap at `/data/workspace/runs/<run-name>/` so the existing directory-based code sees the same layout. The `--` encoding is only visible in the ConfigMap data keys, not in the mounted filesystem.
- **`orchestrator_image` in setup_config**: The launcher reads `setup_config.get("orchestrator_image")` to know which image to use for the Job. This field needs to be written by `setup.py` (not in scope here — tracked separately).
- **`_wait_for_job_pod` timeout**: 120s default for the pod to reach Running. Fails fast on ImagePullBackOff, ErrImagePull, CrashLoopBackOff, CreateContainerConfigError, InvalidImageName.
- **RBAC**: The submodule pointer is bumped. The `sim2real-pipeline-runner` Role now has `delete`/`patch` on PipelineRuns (needed for orchestrator auto-cleanup) and ConfigMap CRUD (needed for progress writes).

## Test plan

- [x] `ruff check pipeline/ --select F` passes
- [x] `python -m pytest pipeline/ -v` — 614 tests pass, zero regressions
- [x] `deploy.py run --help` shows `--remote` flag
- [ ] Manual: `deploy.py run --remote` on a cluster with the orchestrator image available