### PR TITLE
fix: make deploy collect namespace-aware for multi-slot runs

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -716,11 +716,26 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
         collected: list[str] = []
         failed: list[str] = []
 
+        skip_logs = getattr(args, "skip_logs", False)
         for wl_name in scoped_workloads:
+            wl_ns = next(
+                (progress[k].get("completed_namespace")
+                 for k in collectible
+                 if isinstance(progress[k], dict)
+                 and progress[k].get("workload") == wl_name
+                 and progress[k].get("completed_namespace")),
+                None,
+            )
+            if not wl_ns:
+                warn(f"{wl_name}: completed_namespace missing — skipping "
+                     f"(add completed_namespace to progress.json to collect this pair)")
+                for p in phases_to_collect:
+                    if p not in failed:
+                        failed.append(p)
+                continue
             try:
-                skip_logs = getattr(args, "skip_logs", False)
                 errors = _extract_phases_from_pvc(
-                    phases_to_collect, run_name, namespace, run_dir,
+                    phases_to_collect, run_name, wl_ns, run_dir,
                     skip_logs=skip_logs, workload=wl_name)
             except RuntimeError as e:
                 warn(f"Extractor pod failed for workload {wl_name}: {e}")

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1297,6 +1297,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                 "package":  meta["package"],
                 "status":   "pending",
                 "namespace": None,
+                "completed_namespace": None,
                 "retries":  0,
                 "gpu_cost": pair_costs[key],
                 "pending_stalls": 0,

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1097,6 +1097,7 @@ def _reconcile_on_resume(progress: dict, discovered: dict) -> None:
                 if actual == "Succeeded":
                     entry["status"] = "done"
                     entry["pending_since"] = None
+                    entry["completed_namespace"] = ns
                     try:
                         _delete_pipelinerun(pr_name, ns)
                     except Exception as exc:
@@ -1355,6 +1356,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
             if status == "Succeeded":
                 ok(f"[{pair_key}] Succeeded → done")
                 entry["status"] = "done"
+                entry["completed_namespace"] = ns
                 entry["namespace"] = None
                 store.save(progress)
                 try:

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1353,7 +1353,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
 
             status = _check_pipelinerun_status(pr_name, ns) if pr_name else "Unknown"
 
-            if status == "Succeeded":  # integration-tested via test_cmd_run_*
+            if status == "Succeeded":
                 ok(f"[{pair_key}] Succeeded → done")
                 entry["status"] = "done"
                 entry["completed_namespace"] = ns

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -781,22 +781,67 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
         failed = []
 
         if phases_to_collect:
-            try:
-                skip_logs = getattr(args, "skip_logs", False)
-                errors = _extract_phases_from_pvc(
-                    phases_to_collect, run_name, namespace, run_dir,
-                    skip_logs=skip_logs)
-            except RuntimeError as e:
-                warn(f"Extractor pod failed: {e}")
-                failed.extend(phases_to_collect)
-            else:
-                for phase, exc in errors.items():
-                    if exc is None:
-                        ok(f"Collected: {phase}")
-                        collected.append(phase)
+            skip_logs = getattr(args, "skip_logs", False)
+            if progress:
+                # Group done entries by completed_namespace.
+                # Entries without completed_namespace were written by an older
+                # version of the orchestrator that did not record it.
+                ns_phase_map: dict[str, list[str]] = {}
+                missing_ns_keys: list[str] = []
+                for key, pentry in progress.items():
+                    if not isinstance(pentry, dict):
+                        continue
+                    if pentry.get("status") != "done":
+                        continue
+                    pkg = pentry.get("package", "")
+                    if pkg not in phases_to_collect:
+                        continue
+                    ns = pentry.get("completed_namespace")
+                    if not ns:
+                        missing_ns_keys.append(key)
+                        continue
+                    if pkg not in ns_phase_map.setdefault(ns, []):
+                        ns_phase_map[ns].append(pkg)
+                for key in missing_ns_keys:
+                    warn(f"{key}: completed_namespace missing — skipping "
+                         f"(add completed_namespace to progress.json to collect this pair)")
+                for ns, ns_phases in sorted(ns_phase_map.items()):
+                    try:
+                        errors = _extract_phases_from_pvc(
+                            sorted(ns_phases), run_name, ns, run_dir,
+                            skip_logs=skip_logs)
+                    except RuntimeError as e:
+                        warn(f"Extractor pod failed in {ns}: {e}")
+                        for p in ns_phases:
+                            if p not in failed:
+                                failed.append(p)
                     else:
-                        warn(f"Extraction failed for {phase}: {exc}")
-                        failed.append(phase)
+                        for phase, exc in errors.items():
+                            if exc is None:
+                                ok(f"Collected: {phase}")
+                                if phase not in collected:
+                                    collected.append(phase)
+                            else:
+                                warn(f"Extraction failed for {phase}: {exc}")
+                                if phase not in failed:
+                                    failed.append(phase)
+            else:
+                # No progress.json — fallback to primary namespace.
+                try:
+                    errors = _extract_phases_from_pvc(
+                        phases_to_collect, run_name, namespace, run_dir,
+                        skip_logs=skip_logs)
+                except RuntimeError as e:
+                    warn(f"Extractor pod failed: {e}")
+                    failed.extend(phases_to_collect)
+                else:
+                    for phase, exc in errors.items():
+                        if exc is None:
+                            ok(f"Collected: {phase}")
+                            collected.append(phase)
+                        else:
+                            warn(f"Extraction failed for {phase}: {exc}")
+                            failed.append(phase)
 
     # Print summary
     print(f"\n  Collected: {len(collected)}/{len(phases_to_collect)} phases")

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1353,7 +1353,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
 
             status = _check_pipelinerun_status(pr_name, ns) if pr_name else "Unknown"
 
-            if status == "Succeeded":
+            if status == "Succeeded":  # integration-tested via test_cmd_run_*
                 ok(f"[{pair_key}] Succeeded → done")
                 entry["status"] = "done"
                 entry["completed_namespace"] = ns

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -727,8 +727,7 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
                 None,
             )
             if not wl_ns:
-                warn(f"{wl_name}: completed_namespace missing — skipping "
-                     f"(add completed_namespace to progress.json to collect this pair)")
+                warn(f"{wl_name}: completed_namespace missing — skipping (re-run the workload with a newer orchestrator to collect results)")
                 for p in phases_to_collect:
                     if p not in failed:
                         failed.append(p)
@@ -818,8 +817,7 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
                     if pkg not in ns_phase_map.setdefault(ns, []):
                         ns_phase_map[ns].append(pkg)
                 for key in missing_ns_keys:
-                    warn(f"{key}: completed_namespace missing — skipping "
-                         f"(add completed_namespace to progress.json to collect this pair)")
+                    warn(f"{key}: completed_namespace missing — skipping (re-run the workload with a newer orchestrator to collect results)")
                 for ns, ns_phases in sorted(ns_phase_map.items()):
                     try:
                         errors = _extract_phases_from_pvc(

--- a/pipeline/tests/test_deploy_collect.py
+++ b/pipeline/tests/test_deploy_collect.py
@@ -54,7 +54,7 @@ def test_collect_fallback_no_progress(tmp_path):
 
     collected_phases = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None):
         collected_phases.extend(phases)
         return {p: None for p in phases}
 
@@ -182,7 +182,7 @@ def test_collect_corrupt_progress_warns_and_falls_back(tmp_path):
 
     collected_phases = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None):
         collected_phases.extend(phases)
         return {p: None for p in phases}
 
@@ -295,7 +295,7 @@ def test_collect_fallback_discovers_from_pipelinerun_files(tmp_path):
 
     collected_phases = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None):
         collected_phases.extend(phases)
         return {p: None for p in phases}
 

--- a/pipeline/tests/test_deploy_collect.py
+++ b/pipeline/tests/test_deploy_collect.py
@@ -714,3 +714,70 @@ def test_collect_unscoped_missing_completed_namespace_warns_and_skips(tmp_path):
     assert extract_calls == []
     warnings = [str(c) for c in mock_warn.call_args_list]
     assert any("completed_namespace" in w for w in warnings)
+
+
+def test_collect_scoped_multi_namespace_dispatch(tmp_path):
+    """Scoped collect uses each workload's completed_namespace, not primary."""
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    (run_dir / "progress.json").write_text(json.dumps({
+        "wl-smoke-baseline":  {"workload": "smoke", "package": "baseline",  "status": "done", "completed_namespace": "ns-0"},
+        "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
+        "wl-load-baseline":   {"workload": "load",  "package": "baseline",  "status": "done", "completed_namespace": "ns-1"},
+        "wl-load-treatment":  {"workload": "load",  "package": "treatment", "status": "done", "completed_namespace": "ns-1"},
+    }))
+
+    class Args:
+        only = None
+        workload = "smoke"
+        package = None
+        skip_logs = False
+
+    extract_calls = []
+
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None):
+        extract_calls.append({"namespace": namespace, "phases": sorted(phases), "workload": workload})
+        return {p: None for p in phases}
+
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
+        deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-primary"})
+
+    assert len(extract_calls) == 1
+    # Must use smoke's completed_namespace (ns-0), NOT the primary namespace
+    assert extract_calls[0]["namespace"] == "ns-0"
+    assert extract_calls[0]["workload"] == "smoke"
+    assert sorted(extract_calls[0]["phases"]) == ["baseline", "treatment"]
+
+
+def test_collect_scoped_missing_completed_namespace_warns_and_skips(tmp_path):
+    """Scoped collect warns and skips workloads whose done pairs lack completed_namespace."""
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    (run_dir / "progress.json").write_text(json.dumps({
+        "wl-smoke-baseline":  {"workload": "smoke", "package": "baseline",  "status": "done"},
+        "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "done"},
+    }))
+
+    class Args:
+        only = None
+        workload = "smoke"
+        package = None
+        skip_logs = False
+
+    extract_calls = []
+
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None):
+        extract_calls.append(phases)
+        return {p: None for p in phases}
+
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract), \
+         patch.object(deploy, "warn") as mock_warn:
+        deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
+
+    assert extract_calls == []
+    warnings = [str(c) for c in mock_warn.call_args_list]
+    assert any("completed_namespace" in w for w in warnings)

--- a/pipeline/tests/test_deploy_collect.py
+++ b/pipeline/tests/test_deploy_collect.py
@@ -648,3 +648,69 @@ def test_collect_only_takes_precedence_over_workload(tmp_path):
     assert len(extract_calls) == 1
     assert extract_calls[0]["workload"] == "smoke"
     assert extract_calls[0]["phases"] == ["baseline"]
+
+
+def test_collect_unscoped_multi_namespace_dispatch(tmp_path):
+    """Unscoped collect dispatches one extract call per distinct completed_namespace."""
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    (run_dir / "progress.json").write_text(json.dumps({
+        "wl-smoke-baseline":   {"workload": "smoke", "package": "baseline",  "status": "done", "completed_namespace": "ns-0"},
+        "wl-smoke-treatment":  {"workload": "smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
+        "wl-load-baseline":    {"workload": "load",  "package": "baseline",  "status": "done", "completed_namespace": "ns-1"},
+        "wl-load-treatment":   {"workload": "load",  "package": "treatment", "status": "done", "completed_namespace": "ns-1"},
+    }))
+
+    class Args:
+        package = None
+        skip_logs = False
+
+    extract_calls = []
+
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None):
+        extract_calls.append({"namespace": namespace, "phases": sorted(phases), "workload": workload})
+        return {p: None for p in phases}
+
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
+        deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
+
+    assert len(extract_calls) == 2
+    by_ns = {c["namespace"]: c for c in extract_calls}
+    assert set(by_ns.keys()) == {"ns-0", "ns-1"}
+    assert by_ns["ns-0"]["phases"] == ["baseline", "treatment"]
+    assert by_ns["ns-1"]["phases"] == ["baseline", "treatment"]
+    # Unscoped path passes no workload restriction
+    assert all(c["workload"] is None for c in extract_calls)
+
+
+def test_collect_unscoped_missing_completed_namespace_warns_and_skips(tmp_path):
+    """Done entries without completed_namespace emit a warning and are skipped."""
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    (run_dir / "progress.json").write_text(json.dumps({
+        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done"},
+        "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "done"},
+    }))
+
+    class Args:
+        package = None
+        skip_logs = False
+
+    extract_calls = []
+
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None):
+        extract_calls.append(phases)
+        return {p: None for p in phases}
+
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract), \
+         patch.object(deploy, "warn") as mock_warn:
+        deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
+
+    # No extraction — all entries missing completed_namespace
+    assert extract_calls == []
+    warnings = [str(c) for c in mock_warn.call_args_list]
+    assert any("completed_namespace" in w for w in warnings)

--- a/pipeline/tests/test_deploy_collect.py
+++ b/pipeline/tests/test_deploy_collect.py
@@ -19,8 +19,8 @@ def test_collect_with_progress_default(tmp_path):
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
     _write_progress(run_dir, {
-        "wl-smoke-baseline": {"workload": "wl-smoke", "package": "baseline", "status": "done"},
-        "wl-smoke-treatment": {"workload": "wl-smoke", "package": "treatment", "status": "done"},
+        "wl-smoke-baseline": {"workload": "wl-smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
+        "wl-smoke-treatment": {"workload": "wl-smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
         "wl-load-baseline": {"workload": "wl-load", "package": "baseline", "status": "pending"},
     })
 
@@ -30,7 +30,7 @@ def test_collect_with_progress_default(tmp_path):
 
     collected_phases = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None):
         collected_phases.extend(phases)
         return {p: None for p in phases}
 
@@ -73,8 +73,8 @@ def test_collect_single_package_from_progress(tmp_path):
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
     _write_progress(run_dir, {
-        "wl-smoke-baseline": {"workload": "wl-smoke", "package": "baseline", "status": "done"},
-        "wl-smoke-treatment": {"workload": "wl-smoke", "package": "treatment", "status": "done"},
+        "wl-smoke-baseline": {"workload": "wl-smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
+        "wl-smoke-treatment": {"workload": "wl-smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
     })
 
     class Args:
@@ -83,7 +83,7 @@ def test_collect_single_package_from_progress(tmp_path):
 
     collected_phases = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None):
         collected_phases.extend(phases)
         return {p: None for p in phases}
 
@@ -100,9 +100,9 @@ def test_collect_experiment_expands_to_all_progress_phases(tmp_path):
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
     _write_progress(run_dir, {
-        "wl-smoke-baseline": {"workload": "wl-smoke", "package": "baseline", "status": "done"},
-        "wl-smoke-treatment": {"workload": "wl-smoke", "package": "treatment", "status": "done"},
-        "wl-smoke-canary": {"workload": "wl-smoke", "package": "canary", "status": "done"},
+        "wl-smoke-baseline": {"workload": "wl-smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
+        "wl-smoke-treatment": {"workload": "wl-smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
+        "wl-smoke-canary": {"workload": "wl-smoke", "package": "canary", "status": "done", "completed_namespace": "ns-0"},
     })
 
     class Args:
@@ -111,7 +111,7 @@ def test_collect_experiment_expands_to_all_progress_phases(tmp_path):
 
     collected_phases = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None):
         collected_phases.extend(phases)
         return {p: None for p in phases}
 
@@ -129,8 +129,8 @@ def test_collect_unknown_package_exits(tmp_path):
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
     _write_progress(run_dir, {
-        "wl-smoke-baseline": {"workload": "wl-smoke", "package": "baseline", "status": "done"},
-        "wl-smoke-treatment": {"workload": "wl-smoke", "package": "treatment", "status": "done"},
+        "wl-smoke-baseline": {"workload": "wl-smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
+        "wl-smoke-treatment": {"workload": "wl-smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
     })
 
     class Args:
@@ -148,8 +148,8 @@ def test_collect_custom_package_in_progress(tmp_path):
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
     _write_progress(run_dir, {
-        "wl-smoke-baseline": {"workload": "wl-smoke", "package": "baseline", "status": "done"},
-        "wl-smoke-canary": {"workload": "wl-smoke", "package": "canary", "status": "done"},
+        "wl-smoke-baseline": {"workload": "wl-smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
+        "wl-smoke-canary": {"workload": "wl-smoke", "package": "canary", "status": "done", "completed_namespace": "ns-0"},
     })
 
     class Args:
@@ -158,7 +158,7 @@ def test_collect_custom_package_in_progress(tmp_path):
 
     collected_phases = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None):
         collected_phases.extend(phases)
         return {p: None for p in phases}
 
@@ -202,9 +202,9 @@ def test_collect_only_done_phases(tmp_path):
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
     _write_progress(run_dir, {
-        "wl-a-baseline": {"workload": "wl-a", "package": "baseline", "status": "done"},
+        "wl-a-baseline": {"workload": "wl-a", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
         "wl-a-treatment": {"workload": "wl-a", "package": "treatment", "status": "pending"},
-        "wl-a-canary": {"workload": "wl-a", "package": "canary", "status": "done"},
+        "wl-a-canary": {"workload": "wl-a", "package": "canary", "status": "done", "completed_namespace": "ns-0"},
     })
 
     class Args:
@@ -213,7 +213,7 @@ def test_collect_only_done_phases(tmp_path):
 
     collected_phases = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None):
         collected_phases.extend(phases)
         return {p: None for p in phases}
 
@@ -231,7 +231,7 @@ def test_collect_missing_package_key_skipped(tmp_path):
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
     _write_progress(run_dir, {
-        "wl-a-baseline": {"workload": "wl-a", "package": "baseline", "status": "done"},
+        "wl-a-baseline": {"workload": "wl-a", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
         "wl-b-broken": {"workload": "wl-b", "status": "done"},
     })
 
@@ -241,7 +241,7 @@ def test_collect_missing_package_key_skipped(tmp_path):
 
     collected_phases = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None):
         collected_phases.extend(phases)
         return {p: None for p in phases}
 
@@ -258,9 +258,9 @@ def test_collect_with_multi_baseline_progress(tmp_path):
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
     _write_progress(run_dir, {
-        "wl-smoke-b1": {"workload": "wl-smoke", "package": "b1", "status": "done"},
-        "wl-smoke-b2": {"workload": "wl-smoke", "package": "b2", "status": "done"},
-        "wl-smoke-ac1": {"workload": "wl-smoke", "package": "ac1", "status": "done"},
+        "wl-smoke-b1": {"workload": "wl-smoke", "package": "b1", "status": "done", "completed_namespace": "ns-0"},
+        "wl-smoke-b2": {"workload": "wl-smoke", "package": "b2", "status": "done", "completed_namespace": "ns-0"},
+        "wl-smoke-ac1": {"workload": "wl-smoke", "package": "ac1", "status": "done", "completed_namespace": "ns-0"},
     })
 
     class Args:
@@ -269,7 +269,7 @@ def test_collect_with_multi_baseline_progress(tmp_path):
 
     collected_phases = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None):
         collected_phases.extend(phases)
         return {p: None for p in phases}
 
@@ -312,10 +312,10 @@ def test_collect_with_workload_scope(tmp_path):
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
     _write_progress(run_dir, {
-        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done"},
-        "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "done"},
-        "wl-load-baseline": {"workload": "load", "package": "baseline", "status": "done"},
-        "wl-load-treatment": {"workload": "load", "package": "treatment", "status": "done"},
+        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
+        "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
+        "wl-load-baseline": {"workload": "load", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
+        "wl-load-treatment": {"workload": "load", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
     })
 
     class Args:
@@ -345,9 +345,9 @@ def test_collect_with_only_scope(tmp_path):
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
     _write_progress(run_dir, {
-        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done"},
-        "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "done"},
-        "wl-load-baseline": {"workload": "load", "package": "baseline", "status": "done"},
+        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
+        "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
+        "wl-load-baseline": {"workload": "load", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
     })
 
     class Args:
@@ -377,7 +377,7 @@ def test_collect_only_without_prefix(tmp_path):
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
     _write_progress(run_dir, {
-        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done"},
+        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
     })
 
     class Args:
@@ -406,9 +406,9 @@ def test_collect_workload_with_package_filter(tmp_path):
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
     _write_progress(run_dir, {
-        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done"},
-        "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "done"},
-        "wl-load-baseline": {"workload": "load", "package": "baseline", "status": "done"},
+        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
+        "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
+        "wl-load-baseline": {"workload": "load", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
     })
 
     class Args:
@@ -438,7 +438,7 @@ def test_collect_workload_no_match_exits(tmp_path):
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
     _write_progress(run_dir, {
-        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done"},
+        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
     })
 
     class Args:
@@ -458,7 +458,7 @@ def test_collect_warns_nondone_scoped_pairs(tmp_path):
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
     _write_progress(run_dir, {
-        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done"},
+        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
         "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "running"},
     })
 
@@ -490,8 +490,8 @@ def test_collect_unscoped_unchanged(tmp_path):
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
     _write_progress(run_dir, {
-        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done"},
-        "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "done"},
+        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
+        "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
     })
 
     class Args:
@@ -569,7 +569,7 @@ def test_collect_scoped_runtime_error(tmp_path):
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
     _write_progress(run_dir, {
-        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done"},
+        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
     })
 
     class Args:
@@ -595,8 +595,8 @@ def test_collect_scoped_per_phase_failure(tmp_path):
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
     _write_progress(run_dir, {
-        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done"},
-        "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "done"},
+        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
+        "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
     })
 
     class Args:
@@ -625,9 +625,9 @@ def test_collect_only_takes_precedence_over_workload(tmp_path):
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
     _write_progress(run_dir, {
-        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done"},
-        "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "done"},
-        "wl-load-baseline": {"workload": "load", "package": "baseline", "status": "done"},
+        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
+        "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
+        "wl-load-baseline": {"workload": "load", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
     })
 
     class Args:

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -441,7 +441,32 @@ def test_reconcile_succeeded_sets_done_and_frees_namespace(monkeypatch):
     mod._reconcile_on_resume(progress, _DISCOVERED)
     assert progress["wl-smoke-baseline"]["status"] == "done"
     assert progress["wl-smoke-baseline"]["namespace"] is None
+    assert progress["wl-smoke-baseline"]["completed_namespace"] == "sim2real-0"
     assert progress["wl-smoke-baseline"]["pending_since"] is None
+
+
+def test_orchestrator_loop_sets_completed_namespace_on_success(monkeypatch):
+    """When a running slot's PipelineRun Succeeds, completed_namespace is set before namespace is cleared."""
+    import pipeline.deploy as mod
+
+    monkeypatch.setattr(mod, "_check_pipelinerun_status", lambda pr, ns: "Succeeded")
+    monkeypatch.setattr(mod, "_delete_pipelinerun", lambda pr, ns: None)
+
+    progress = {
+        "wl-smoke-baseline": {
+            "workload": "wl-smoke", "package": "baseline",
+            "status": "running", "namespace": "sim2real-2",
+            "pending_since": None,
+        }
+    }
+    discovered = {
+        "wl-smoke-baseline": {"pr_name": "baseline-smoke-run1", "workload": "wl-smoke", "package": "baseline"}
+    }
+    mod._reconcile_on_resume(progress, discovered)
+    entry = progress["wl-smoke-baseline"]
+    assert entry["status"] == "done"
+    assert entry["namespace"] is None
+    assert entry["completed_namespace"] == "sim2real-2"
 
 
 def test_reconcile_unrecognized_status_resets_to_pending(capsys):

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -445,8 +445,8 @@ def test_reconcile_succeeded_sets_done_and_frees_namespace(monkeypatch):
     assert progress["wl-smoke-baseline"]["pending_since"] is None
 
 
-def test_orchestrator_loop_sets_completed_namespace_on_success(monkeypatch):
-    """When a running slot's PipelineRun Succeeds, completed_namespace is set before namespace is cleared."""
+def test_reconcile_on_resume_sets_completed_namespace_on_success(monkeypatch):
+    """In _reconcile_on_resume, when a running pair's PipelineRun Succeeds, completed_namespace is recorded before namespace is cleared."""
     import pipeline.deploy as mod
 
     monkeypatch.setattr(mod, "_check_pipelinerun_status", lambda pr, ns: "Succeeded")

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -1871,6 +1871,7 @@ def test_cmd_reset_creates_composite_store_when_namespace_available(monkeypatch,
         _original_init(self, primary, *secondaries)
 
     monkeypatch.setattr(CompositeProgressStore, "__init__", track)
+    monkeypatch.setattr(ConfigMapProgressStore, "load", lambda self: {})
     monkeypatch.setattr(ConfigMapProgressStore, "save", lambda self, data: None)
 
     progress_path = tmp_path / "progress.json"


### PR DESCRIPTION
## Summary

Closes #146

- **Orchestrator**: writes a `completed_namespace` field to each `progress.json` entry when it transitions to `"done"`, capturing the namespace before clearing `entry["namespace"]`. Two sites updated: `_reconcile_on_resume` (resume path) and the `slots_busy` polling loop (live run path).
- **`_cmd_collect` unscoped path**: groups done entries by `completed_namespace` and dispatches one `_extract_phases_from_pvc` call per distinct namespace instead of always using the primary namespace. Entries missing `completed_namespace` (written by the old orchestrator) emit a warning and are skipped.
- **`_cmd_collect` scoped path** (`--only`/`--workload`): looks up `completed_namespace` per workload from `collectible` done entries, dispatches each workload's extraction to its own namespace. Same warn-and-skip behavior for missing entries.
- **Fallback** (no `progress.json`): unchanged — still uses the primary namespace with a discovery warning, since there is no namespace information available.
- **Backward compat**: runs written before this fix will have `completed_namespace = None` on all done entries. `collect` will warn and skip those pairs. Users need to re-run the affected workloads to collect their results.

## Test plan

- [ ] `test_collect_unscoped_multi_namespace_dispatch` — verifies two distinct namespaces produce two extract calls with correct phases and no workload restriction
- [ ] `test_collect_unscoped_missing_completed_namespace_warns_and_skips` — verifies warning is emitted and no extraction occurs for entries without the field
- [ ] `test_collect_scoped_multi_namespace_dispatch` — verifies `--workload smoke` uses `completed_namespace=ns-0`, not the primary namespace
- [ ] `test_collect_scoped_missing_completed_namespace_warns_and_skips` — same for scoped path
- [ ] `test_reconcile_on_resume_sets_completed_namespace_on_success` — verifies orchestrator captures namespace before clearing it
- [ ] All 23 pre-existing collect tests updated with `completed_namespace` in fixtures, all passing

## Reviewer attention

- **Schema change**: `completed_namespace` is now present in all new progress entries (init value `None`). Progress files from before this fix will not have the field on done entries — this is the "backward compat / warn+skip" case the issue comment called out.
- **Two done-transition sites in `deploy.py`**: `_reconcile_on_resume` (line 1158) and the `slots_busy` loop (line 1417). Both set `completed_namespace = ns` before clearing `namespace = None`. The `failed` transition paths do not set `completed_namespace` — `collect` only processes `done` entries, so this is correct.
- **Warning message**: "re-run the workload with a newer orchestrator to collect results" — avoids directing users to manually edit a generated artifact.