### PR TITLE
fix: make all deploy.py subcommands use ConfigMap-primary progress store

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,8 @@ All artifacts live under `<experiment-root>/workspace/` (gitignored). When no `-
 | `runs/<run>/cluster/pipelinerun-*.yaml` | `prepare.py` Phase 4 | `deploy.py run` |
 | `runs/<run>/run_summary.md` | `prepare.py` Phase 5 | human review |
 | `runs/<run>/results/{phase}/` | `deploy.py collect` | `/sim2real-analyze` skill, `deploy.py wipe` |
-| `runs/<run>/progress.json` | `deploy.py run`, `deploy.py wipe` | `deploy.py status`, `deploy.py collect`, `deploy.py wipe` |
+| ConfigMap `sim2real-progress` | `deploy.py run`, `deploy.py reset` | All `deploy.py` subcommands (primary) |
+| `runs/<run>/progress.json` | `deploy.py run`, `deploy.py wipe` | All `deploy.py` subcommands (fallback) |
 | `runs/<run>/plans/<phase>/<workload>/` | `deploy.py run` | workload tasks |
 | `context/{scenario}/{hash}.md` | `prepare.py` Phase 2 | `prepare.py` Phase 2 (cache) |
 

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -170,13 +170,12 @@ python pipeline/deploy.py pairs   [flags]   # list available pair keys, workload
 
 **Auto-cleanup** — when a PipelineRun succeeds, the orchestrator deletes the PipelineRun CR from the cluster. Failed PipelineRuns are left in place for debugging (`kubectl describe`, pod logs). Use `reset` to remove them when done.
 
-**Remote mode** — `deploy.py run --remote` submits the orchestrator as a Kubernetes Job (`sim2real-orchestrator`) instead of running locally. The launcher builds the EPP image locally, packs workspace files into a ConfigMap, applies the Job, and waits for the pod to reach Running. Use `stop` to cancel, `status --remote` to check progress, and `collect` to pull results after completion. Requires `orchestrator_image` in `setup_config.json`.
+**Remote mode** — `deploy.py run --remote` submits the orchestrator as a Kubernetes Job (`sim2real-orchestrator`) instead of running locally. The launcher builds the EPP image locally, packs workspace files into a ConfigMap, applies the Job, and waits for the pod to reach Running. Use `stop` to cancel, `status` to check progress, and `collect` to pull results after completion. Requires `orchestrator_image` in `setup_config.json`.
 
-**`deploy.py status`** — prints the current state of all pairs. By default reads from `workspace/runs/<run>/progress.json`. When the orchestrator runs remotely (in-cluster), use `--remote` to read from the `sim2real-progress` ConfigMap instead. The ConfigMap is also used automatically when the local `progress.json` is absent.
+**`deploy.py status`** — prints the current state of all pairs. Always reads from the `sim2real-progress` ConfigMap first (primary), falling back to the local `progress.json` if the ConfigMap is empty or the namespace is not configured.
 
 | Flag | Description |
 |------|-------------|
-| `--remote` | Read progress from cluster ConfigMap instead of local file |
 | `--workload NAME` | Filter by workload name |
 | `--package NAME` | Filter by package name |
 
@@ -331,14 +330,14 @@ All paths are relative to the repo root and validated at Phase 1.
 
 ## Parallel Pool Execution
 
-`setup.py --namespaces NS1,NS2,...` provisions N namespace slots, each bootstrapped identically. `prepare.py` generates one shared Tekton Pipeline plus one PipelineRun per `(workload, package)` pair. `deploy.py run` orchestrates execution by assigning pairs to free slots, polling for completion, and retrying on timeout. Use `deploy.py collect` to pull results off-cluster. `deploy.py status` reads progress from the local file or cluster ConfigMap.
+`setup.py --namespaces NS1,NS2,...` provisions N namespace slots, each bootstrapped identically. `prepare.py` generates one shared Tekton Pipeline plus one PipelineRun per `(workload, package)` pair. `deploy.py run` orchestrates execution by assigning pairs to free slots, polling for completion, and retrying on timeout. Use `deploy.py collect` to pull results off-cluster. `deploy.py status` reads progress from the ConfigMap (primary) or local file (fallback).
 
 | Artifact | Written by | Read by |
 |----------|-----------|---------|
-| `runs/<run>/progress.json` | `deploy.py run` | `deploy.py status` |
-| ConfigMap `sim2real-progress` | `deploy.py run`, `deploy.py reset` | `deploy.py status --remote` |
+| ConfigMap `sim2real-progress` | `deploy.py run`, `deploy.py reset` | All subcommands (primary) |
+| `runs/<run>/progress.json` | `deploy.py run` | All subcommands (fallback) |
 
-The orchestrator writes progress to both the local file and the `sim2real-progress` ConfigMap in the primary namespace on every poll cycle. This allows `deploy.py status --remote` to read progress directly from the cluster, which is required when the orchestrator runs as an in-cluster Job.
+The orchestrator writes progress to both the `sim2real-progress` ConfigMap and the local file on every poll cycle. All subcommands (`status`, `collect`, `run`, `reset`, `wipe`) read from the ConfigMap first, falling back to the local file when the ConfigMap is empty or the namespace is not configured.
 
 ---
 

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -128,7 +128,7 @@ Common flags (all subcommands):
 
 **Pair discovery** — `deploy.py run` discovers `pipelinerun-*.yaml` files at the `cluster/` root. Each file's pair key is derived as `wl-` + filename stem minus the `pipelinerun-` prefix.
 
-**Collection phases** — `deploy.py collect` derives valid phases dynamically from `progress.json` (packages with status `done`). Falls back to `[baseline, treatment]` when no progress exists. Use `--package` to filter, or `--package experiment` to collect all known phases.
+**Collection phases** — `deploy.py collect` derives valid phases dynamically from progress data (packages with status `done`). Falls back to `[baseline, treatment]` when no progress exists. Use `--package` to filter, or `--package experiment` to collect all known phases.
 
 **`--skip-build-epp`** — skips the image build; use when resubmitting after a failed PipelineRun without changing the scorer.
 
@@ -144,7 +144,7 @@ python pipeline/deploy.py wipe  [flags]     # delete local results and reset pai
 python pipeline/deploy.py pairs   [flags]   # list available pair keys, workloads, and packages
 ```
 
-**`deploy.py run`** — assigns `(workload, package)` pairs to free namespace slots, polls for completion, and retries pairs that time out. Reads `progress.json` to resume interrupted runs. Use `deploy.py collect` to pull results off-cluster after runs complete.
+**`deploy.py run`** — assigns `(workload, package)` pairs to free namespace slots, polls for completion, and retries pairs that time out. Reads progress from the ConfigMap (primary) or local file (fallback) to resume interrupted runs. Use `deploy.py collect` to pull results off-cluster after runs complete.
 
 | Flag | Default | Description |
 |------|---------|-------------|
@@ -164,7 +164,7 @@ python pipeline/deploy.py pairs   [flags]   # list available pair keys, workload
 
 **Early reclaim** — on each poll cycle, pods in `Running`/`Started` PipelineRuns are checked for scheduling failures. Recoverable reasons (e.g. `Insufficient nvidia.com/gpu`) trigger early reclaim after `--pending-threshold` seconds. Non-recoverable reasons (e.g. node affinity mismatch, PVC not found) fail the pair immediately. Each early reclaim increments `pending_stalls`; at `--max-pending-stalls` the pair transitions to `stalled` (terminal).
 
-**Backoff controller** — when the capacity probe shows `free_gpus < min(pending workload GPU costs)`, the orchestrator enters exponential backoff: poll interval doubles each cycle (capped at `--max-backoff`), and dispatch is skipped until capacity returns. Backoff is also triggered when 3 early reclaims (recoverable only) occur within 10 minutes. The controller resets to normal when a pod successfully schedules or the probe shows sufficient capacity for the largest pending workload. Already-running slots continue to be monitored during backoff. Orchestrator state is persisted in `progress.json` under the `_orchestrator` metadata key.
+**Backoff controller** — when the capacity probe shows `free_gpus < min(pending workload GPU costs)`, the orchestrator enters exponential backoff: poll interval doubles each cycle (capped at `--max-backoff`), and dispatch is skipped until capacity returns. Backoff is also triggered when 3 early reclaims (recoverable only) occur within 10 minutes. The controller resets to normal when a pod successfully schedules or the probe shows sufficient capacity for the largest pending workload. Already-running slots continue to be monitored during backoff. Orchestrator state is persisted in the progress store under the `_orchestrator` metadata key.
 
 **Pair statuses:** `pending` → `running` → `done`. Failure paths: `running` → `failed` (hard failure or non-recoverable pending), `running` → `timed-out` (4h timeout exceeded), `running` → `pending` (recoverable early reclaim, repeats up to `--max-pending-stalls` times) → `stalled`.
 
@@ -176,8 +176,10 @@ python pipeline/deploy.py pairs   [flags]   # list available pair keys, workload
 
 | Flag | Description |
 |------|-------------|
+| `--only PAIR` | Scope to one pair key (`wl-` prefix optional) |
 | `--workload NAME` | Filter by workload name |
 | `--package NAME` | Filter by package name |
+| `--status STATE` | Filter by status (e.g. `running`, `done`, `failed`) |
 
 **`deploy.py collect`** — extracts results from the cluster PVC and writes to `workspace/runs/<run>/results/{phase}/<workload>/`.
 
@@ -188,7 +190,7 @@ python pipeline/deploy.py pairs   [flags]   # list available pair keys, workload
 | `--package NAME…` | Collect only these packages (phase-level filter) |
 | `--skip-logs` | Skip vLLM and EPP log files, collect only traces |
 
-When `--only` or `--workload` is given, only matching workload subdirectories are pulled from the PVC (instead of entire phase directories). These pair-level flags compose with `--package` as AND: `--workload X --package baseline` pulls workload X from the baseline phase only. Requires `progress.json` to resolve pairs.
+When `--only` or `--workload` is given, only matching workload subdirectories are pulled from the PVC (instead of entire phase directories). These pair-level flags compose with `--package` as AND: `--workload X --package baseline` pulls workload X from the baseline phase only. Requires progress data to resolve pairs.
 
 **`deploy.py stop`** — deletes the `sim2real-orchestrator` Kubernetes Job (with cascading pod deletion) in the primary namespace. Only meaningful when the orchestrator runs as an in-cluster Job. Does not touch `progress.json` — pair state is left as-is. If no remote orchestrator Job exists, prints a message and returns. Use `reset` separately to clear failed/stalled pair state.
 

--- a/pipeline/completions.bash
+++ b/pipeline/completions.bash
@@ -76,7 +76,7 @@ _sim2real_deploy() {
                 COMPREPLY=($(compgen -W "--remote --only --workload --package --status --force --skip-build-epp --max-retries --poll-interval --gpu-resource-type --default-gpu-cost --pending-threshold --max-pending-stalls --max-backoff" -- "$cur"))
                 ;;
             status)
-                COMPREPLY=($(compgen -W "--only --workload --package --status --remote" -- "$cur"))
+                COMPREPLY=($(compgen -W "--only --workload --package --status" -- "$cur"))
                 ;;
             reset)
                 COMPREPLY=($(compgen -W "--only --workload --package --status --dry-run" -- "$cur"))

--- a/pipeline/completions.zsh
+++ b/pipeline/completions.zsh
@@ -91,8 +91,7 @@ _sim2real_deploy() {
                         '--only[Scope to one pair key]:pair key:_deploy_py_pair_keys' \
                         '--workload[Scope to workload]:workload:_deploy_py_workloads' \
                         '--package[Scope to package]:package:_deploy_py_packages' \
-                        '--status[Scope to status]:status:_deploy_py_statuses' \
-                        '--remote[Read from cluster ConfigMap]'
+                        '--status[Scope to status]:status:_deploy_py_statuses'
                     ;;
                 collect)
                     _arguments \

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -663,7 +663,7 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
         warn(f"Failed to load progress from primary store: {exc}")
         try:
             progress = local_store.load() or None
-        except (ValueError, RuntimeError):
+        except (ValueError, RuntimeError, OSError):
             progress = None
         if progress:
             warn("Using local progress data as fallback")

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -242,10 +242,19 @@ def _cmd_status(args, run_dir: Path,
     else:
         store = local_store
 
-    progress = store.load()
+    try:
+        progress = store.load()
+    except (ValueError, RuntimeError) as exc:
+        warn(f"Failed to load progress from primary store: {exc}")
+        try:
+            progress = local_store.load()
+        except (ValueError, RuntimeError):
+            progress = {}
+        if progress:
+            warn("Using local progress data as fallback")
 
     if not progress:
-        suffix = " (no progress file)" if not progress_path.exists() else ""
+        suffix = " (no progress data)" if not progress_path.exists() else ""
         filters_given = any([
             getattr(args, "only", None) is not None,
             getattr(args, "workload", None) is not None,
@@ -649,8 +658,15 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
     try:
         progress = store.load() or None
     except (ValueError, RuntimeError) as exc:
-        warn(f"Failed to load progress: {exc} — falling back to default phases")
-        progress = None
+        warn(f"Failed to load progress from primary store: {exc}")
+        try:
+            progress = local_store.load() or None
+        except (ValueError, RuntimeError):
+            progress = None
+        if progress:
+            warn("Using local progress data as fallback")
+        else:
+            warn("No local fallback available — falling back to default phases")
 
     # ── Pair-level scoping (--only / --workload) ──────────────────────────
     scope_only = getattr(args, "only", None)
@@ -767,7 +783,7 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
             cluster_dir = run_dir / "cluster"
             known_phases = _discover_phases(cluster_dir)
             if progress is None and not progress_path.exists():
-                warn(f"No progress.json found — discovered phases from cluster/: {known_phases}")
+                warn(f"No progress data found — discovered phases from cluster/: {known_phases}")
             elif progress is not None:
                 warn(f"No done phases in progress — discovered from cluster/: {known_phases}")
 
@@ -838,7 +854,7 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
                                 if phase not in failed:
                                     failed.append(phase)
             else:
-                # No progress.json — fallback to primary namespace.
+                # No progress data — fallback to primary namespace.
                 try:
                     errors = _extract_phases_from_pvc(
                         phases_to_collect, run_name, namespace, run_dir,
@@ -1613,7 +1629,10 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
             counts[v["status"]] = counts.get(v["status"], 0) + 1
     print()
     ok("Run complete: " + "  ".join(f"{v} {k}" for k, v in sorted(counts.items())))
-    print(f"  Progress: {progress_path}")
+    if primary_ns:
+        print(f"  Progress: ConfigMap {ConfigMapProgressStore.CONFIGMAP_NAME} in {primary_ns}")
+    else:
+        print(f"  Progress: {progress_path}")
     print()
 
 

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1290,7 +1290,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
     primary_ns = _configmap_namespace(setup_config, namespaces)
     if primary_ns:
         cm_store = ConfigMapProgressStore(primary_ns)
-        store = CompositeProgressStore(local_store, cm_store)
+        store = CompositeProgressStore(cm_store, local_store)
     else:
         store = local_store
 

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -244,14 +244,16 @@ def _cmd_status(args, run_dir: Path,
 
     try:
         progress = store.load()
-    except (ValueError, RuntimeError) as exc:
+    except (ValueError, RuntimeError, OSError) as exc:
         warn(f"Failed to load progress from primary store: {exc}")
         try:
             progress = local_store.load()
-        except (ValueError, RuntimeError):
+        except (ValueError, RuntimeError, OSError):
             progress = {}
         if progress:
             warn("Using local progress data as fallback")
+        else:
+            warn("No local fallback available")
 
     if not progress:
         suffix = " (no progress data)" if not progress_path.exists() else ""
@@ -657,7 +659,7 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
         store = local_store
     try:
         progress = store.load() or None
-    except (ValueError, RuntimeError) as exc:
+    except (ValueError, RuntimeError, OSError) as exc:
         warn(f"Failed to load progress from primary store: {exc}")
         try:
             progress = local_store.load() or None

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -638,19 +638,22 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
 
     run_name = run_dir.name
 
-    # Derive known phases from progress.json, fall back to _discover_phases()
+    # Derive known phases from CompositeProgressStore (CM primary, local fallback)
+    from pipeline.lib.progress import (
+        LocalProgressStore, ConfigMapProgressStore, CompositeProgressStore,
+    )
     progress_path = run_dir / "progress.json"
-    if progress_path.exists():
-        try:
-            progress = json.loads(progress_path.read_text())
-        except json.JSONDecodeError:
-            warn(f"Corrupt progress.json at {progress_path} — falling back to default phases")
-            progress = None
-        else:
-            if not isinstance(progress, dict):
-                warn("progress.json is not a JSON object — falling back to default phases")
-                progress = None
+    local_store = LocalProgressStore(progress_path)
+    primary_ns = _configmap_namespace(setup_config)
+    if primary_ns:
+        cm_store = ConfigMapProgressStore(primary_ns)
+        store = CompositeProgressStore(cm_store, local_store)
     else:
+        store = local_store
+    try:
+        progress = store.load() or None
+    except (ValueError, RuntimeError) as exc:
+        warn(f"Failed to load progress: {exc} — falling back to default phases")
         progress = None
 
     # ── Pair-level scoping (--only / --workload) ──────────────────────────
@@ -659,7 +662,7 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
     scoped = scope_only is not None or scope_workload is not None
 
     if scoped and not progress:
-        err("--only/--workload require progress.json to resolve pairs, but none was found.")
+        err("--only/--workload require progress data to resolve pairs, but none was found.")
         sys.exit(1)
 
     if scoped and progress:

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -227,24 +227,20 @@ def _delete_pipelinerun(pr_name: str, namespace: str) -> None:
 
 # ── Status command ───────────────────────────────────────────────────────────
 
-def _cmd_status(args, progress_path: Path,
+def _cmd_status(args, run_dir: Path,
                 setup_config: dict | None = None) -> None:
     """Print a snapshot table of all (workload, package) pair statuses."""
-    use_remote = getattr(args, "remote", False)
-
-    if use_remote or not progress_path.exists():
-        primary_ns = _configmap_namespace(setup_config)
-        if primary_ns:
-            from pipeline.lib.progress import ConfigMapProgressStore
-            store = ConfigMapProgressStore(primary_ns)
-        else:
-            if use_remote:
-                warn("--remote requested but no namespace configured — falling back to local file")
-            from pipeline.lib.progress import LocalProgressStore
-            store = LocalProgressStore(progress_path)
+    from pipeline.lib.progress import (
+        LocalProgressStore, ConfigMapProgressStore, CompositeProgressStore,
+    )
+    progress_path = run_dir / "progress.json"
+    local_store = LocalProgressStore(progress_path)
+    primary_ns = _configmap_namespace(setup_config)
+    if primary_ns:
+        cm_store = ConfigMapProgressStore(primary_ns)
+        store = CompositeProgressStore(cm_store, local_store)
     else:
-        from pipeline.lib.progress import LocalProgressStore
-        store = LocalProgressStore(progress_path)
+        store = local_store
 
     progress = store.load()
 
@@ -2055,8 +2051,6 @@ Examples:
     status_p.add_argument("--workload", metavar="NAME",  help="Scope to pairs matching this workload")
     status_p.add_argument("--package",  metavar="NAME",  help="Scope to pairs matching this package")
     status_p.add_argument("--status",   metavar="STATE", help="Scope to pairs with this status (e.g. running, done, failed)")
-    status_p.add_argument("--remote", action="store_true", default=False,
-                           help="Read progress from cluster ConfigMap instead of local file")
 
     run_p = sub.add_parser("run", help="Orchestrate parallel pool execution")
     run_p.add_argument("--remote", action="store_true", default=False,
@@ -2156,8 +2150,7 @@ def main():
         else:
             _cmd_run(args, run_dir, setup_config)
     elif cmd == "status":
-        progress_path = run_dir / "progress.json"
-        _cmd_status(args, progress_path, setup_config=setup_config)
+        _cmd_status(args, run_dir, setup_config=setup_config)
     elif cmd == "collect":
         _cmd_collect(args, run_dir, setup_config)
     elif cmd == "reset":

--- a/pipeline/lib/progress.py
+++ b/pipeline/lib/progress.py
@@ -121,7 +121,7 @@ class CompositeProgressStore(ProgressStore):
                 data = store.load()
                 if data:
                     return data
-            except Exception as exc:
+            except (ValueError, RuntimeError, OSError) as exc:
                 print(f"[WARN] Secondary store load failed: {exc}", file=sys.stderr)
                 continue
         return {}
@@ -131,5 +131,5 @@ class CompositeProgressStore(ProgressStore):
         for store in self._secondaries:
             try:
                 store.save(data)
-            except Exception as exc:
+            except (ValueError, RuntimeError, OSError) as exc:
                 print(f"[WARN] {type(store).__name__} save failed: {exc}", file=sys.stderr)

--- a/pipeline/tests/test_deploy_collect.py
+++ b/pipeline/tests/test_deploy_collect.py
@@ -1,7 +1,7 @@
 """Tests for deploy.py _cmd_collect phase selection logic."""
 
 import json
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 import pytest
 
@@ -168,7 +168,7 @@ def test_collect_custom_package_in_progress(tmp_path):
     assert collected_phases == ["canary"]
 
 
-def test_collect_corrupt_progress_warns_and_falls_back(tmp_path):
+def test_collect_corrupt_progress_warns_and_falls_back(tmp_path, capsys):
     """Corrupt progress.json warns with correct message and falls back."""
     from pipeline import deploy
 
@@ -186,13 +186,14 @@ def test_collect_corrupt_progress_warns_and_falls_back(tmp_path):
         collected_phases.extend(phases)
         return {p: None for p in phases}
 
-    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract), \
-         patch.object(deploy, "warn") as mock_warn:
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
         deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
 
     assert collected_phases == ["baseline", "treatment"]
-    warnings = [str(c) for c in mock_warn.call_args_list]
-    assert any("Corrupt" in w for w in warnings)
+    # The corrupt-file warning goes through CompositeProgressStore's secondary
+    # error path, which prints directly to stderr rather than through deploy.warn.
+    captured = capsys.readouterr()
+    assert "Corrupt" in captured.err
 
 
 def test_collect_only_done_phases(tmp_path):
@@ -781,3 +782,34 @@ def test_collect_scoped_missing_completed_namespace_warns_and_skips(tmp_path):
     assert extract_calls == []
     warnings = [str(c) for c in mock_warn.call_args_list]
     assert any("completed_namespace" in w for w in warnings)
+
+
+def test_collect_reads_from_configmap_when_no_local_file(tmp_path):
+    """collect uses CompositeProgressStore to read from ConfigMap when no local file."""
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+
+    cm_data = {
+        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
+        "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
+    }
+
+    class Args:
+        package = None
+        skip_logs = False
+
+    extract_calls = []
+
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None):
+        extract_calls.append({"phases": phases, "workload": workload})
+        return {p: None for p in phases}
+
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract), \
+         patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps(cm_data))
+        deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
+
+    assert len(extract_calls) == 1
+    assert sorted(extract_calls[0]["phases"]) == ["baseline", "treatment"]

--- a/pipeline/tests/test_deploy_collect.py
+++ b/pipeline/tests/test_deploy_collect.py
@@ -169,7 +169,7 @@ def test_collect_custom_package_in_progress(tmp_path):
 
 
 def test_collect_corrupt_progress_warns_and_falls_back(tmp_path, capsys):
-    """Corrupt progress.json warns with correct message and falls back."""
+    """Corrupt progress.json warns with correct message and falls back to default phases."""
     from pipeline import deploy
 
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
@@ -186,12 +186,14 @@ def test_collect_corrupt_progress_warns_and_falls_back(tmp_path, capsys):
         collected_phases.extend(phases)
         return {p: None for p in phases}
 
-    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
+    # CM primary returns empty (ConfigMap not found), local secondary has corrupt JSON.
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract), \
+         patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=1, stderr="Error from server (NotFound): configmaps \"sim2real-progress\" not found")
         deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
 
     assert collected_phases == ["baseline", "treatment"]
-    # The corrupt-file warning goes through CompositeProgressStore's secondary
-    # error path, which prints directly to stderr rather than through deploy.warn.
     captured = capsys.readouterr()
     assert "Corrupt" in captured.err
 
@@ -813,3 +815,65 @@ def test_collect_reads_from_configmap_when_no_local_file(tmp_path):
 
     assert len(extract_calls) == 1
     assert sorted(extract_calls[0]["phases"]) == ["baseline", "treatment"]
+
+
+def test_collect_cm_failure_falls_back_to_local(tmp_path):
+    """When CM primary raises RuntimeError, collect falls back to local progress.json."""
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    _write_progress(run_dir, {
+        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
+        "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
+    })
+
+    class Args:
+        package = None
+        skip_logs = False
+
+    extract_calls = []
+
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None):
+        extract_calls.append({"phases": phases, "workload": workload})
+        return {p: None for p in phases}
+
+    # CM primary raises RuntimeError (cluster unreachable)
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract), \
+         patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=1, stderr="Unable to connect to the server: dial tcp: lookup cluster: no such host")
+        deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
+
+    assert len(extract_calls) == 1
+    assert sorted(extract_calls[0]["phases"]) == ["baseline", "treatment"]
+
+
+def test_collect_cm_failure_no_local_falls_back_to_discovery(tmp_path):
+    """When CM primary raises and no local file, collect falls back to phase discovery."""
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    cluster_dir = run_dir / "cluster"
+    cluster_dir.mkdir(parents=True)
+    (cluster_dir / "pipelinerun-wl-smoke-baseline.yaml").write_text("apiVersion: tekton.dev/v1")
+    (cluster_dir / "pipelinerun-wl-smoke-treatment.yaml").write_text("apiVersion: tekton.dev/v1")
+
+    class Args:
+        package = None
+        skip_logs = False
+
+    extract_calls = []
+
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None):
+        extract_calls.append(phases)
+        return {p: None for p in phases}
+
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract), \
+         patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=1, stderr="Unable to connect to the server: dial tcp: lookup cluster: no such host")
+        deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
+
+    assert len(extract_calls) == 1
+    assert sorted(extract_calls[0]) == ["baseline", "treatment"]

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -1814,7 +1814,7 @@ def test_configmap_namespace_empty():
 # ── Composite store wiring in _cmd_run / _cmd_reset ─────────────────────────
 
 def test_cmd_run_creates_composite_store_when_namespace_available(monkeypatch, tmp_path):
-    """_cmd_run creates CompositeProgressStore with ConfigMap secondary."""
+    """_cmd_run creates CompositeProgressStore with ConfigMap as primary."""
     import pipeline.deploy as mod
     from pipeline.lib.progress import CompositeProgressStore
 
@@ -1822,7 +1822,7 @@ def test_cmd_run_creates_composite_store_when_namespace_available(monkeypatch, t
     _original_init = CompositeProgressStore.__init__
 
     def track(self, primary, *secondaries):
-        stores_created.append([type(s).__name__ for s in secondaries])
+        stores_created.append((type(primary).__name__, [type(s).__name__ for s in secondaries]))
         _original_init(self, primary, *secondaries)
 
     monkeypatch.setattr(CompositeProgressStore, "__init__", track)
@@ -1846,7 +1846,9 @@ def test_cmd_run_creates_composite_store_when_namespace_available(monkeypatch, t
         mod._cmd_run(args, run_dir, setup)
 
     assert len(stores_created) == 1
-    assert "ConfigMapProgressStore" in stores_created[0]
+    primary_type, secondary_types = stores_created[0]
+    assert primary_type == "ConfigMapProgressStore"
+    assert "LocalProgressStore" in secondary_types
 
 def test_cmd_reset_creates_composite_store_when_namespace_available(monkeypatch, tmp_path):
     """_cmd_reset creates CompositeProgressStore with ConfigMap as primary."""

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -17,8 +17,8 @@ _PROGRESS = {
 
 def test_status_output_contains_all_pairs(tmp_path, capsys):
     from pipeline.deploy import _cmd_status
-    progress_path = tmp_path / "progress.json"
-    progress_path.write_text(json.dumps(_PROGRESS))
+    run_dir = tmp_path
+    (run_dir / "progress.json").write_text(json.dumps(_PROGRESS))
 
     class _Args:
         only = None
@@ -27,7 +27,7 @@ def test_status_output_contains_all_pairs(tmp_path, capsys):
         status = None
         live = False
 
-    _cmd_status(_Args(), progress_path)
+    _cmd_status(_Args(), run_dir)
     out = capsys.readouterr().out
     for key in _PROGRESS:
         if not key.startswith("_"):
@@ -36,8 +36,8 @@ def test_status_output_contains_all_pairs(tmp_path, capsys):
 
 def test_status_filter_by_workload(tmp_path, capsys):
     from pipeline.deploy import _cmd_status
-    progress_path = tmp_path / "progress.json"
-    progress_path.write_text(json.dumps(_PROGRESS))
+    run_dir = tmp_path
+    (run_dir / "progress.json").write_text(json.dumps(_PROGRESS))
 
     class _Args:
         only = None
@@ -46,7 +46,7 @@ def test_status_filter_by_workload(tmp_path, capsys):
         status = None
         live = False
 
-    _cmd_status(_Args(), progress_path)
+    _cmd_status(_Args(), run_dir)
     out = capsys.readouterr().out
     assert "wl-smoke-baseline" in out
     assert "wl-smoke-treatment" in out
@@ -55,8 +55,8 @@ def test_status_filter_by_workload(tmp_path, capsys):
 
 def test_status_filter_by_package(tmp_path, capsys):
     from pipeline.deploy import _cmd_status
-    progress_path = tmp_path / "progress.json"
-    progress_path.write_text(json.dumps(_PROGRESS))
+    run_dir = tmp_path
+    (run_dir / "progress.json").write_text(json.dumps(_PROGRESS))
 
     class _Args:
         only = None
@@ -65,7 +65,7 @@ def test_status_filter_by_package(tmp_path, capsys):
         status = None
         live = False
 
-    _cmd_status(_Args(), progress_path)
+    _cmd_status(_Args(), run_dir)
     out = capsys.readouterr().out
     assert "wl-smoke-treatment" in out
     assert "wl-load-treatment" in out
@@ -74,8 +74,8 @@ def test_status_filter_by_package(tmp_path, capsys):
 
 def test_status_summary_line(tmp_path, capsys):
     from pipeline.deploy import _cmd_status
-    progress_path = tmp_path / "progress.json"
-    progress_path.write_text(json.dumps(_PROGRESS))
+    run_dir = tmp_path
+    (run_dir / "progress.json").write_text(json.dumps(_PROGRESS))
 
     class _Args:
         only = None
@@ -84,7 +84,7 @@ def test_status_summary_line(tmp_path, capsys):
         status = None
         live = False
 
-    _cmd_status(_Args(), progress_path)
+    _cmd_status(_Args(), run_dir)
     out = capsys.readouterr().out
     assert "5 pairs" in out
     assert "1 done" in out
@@ -102,7 +102,7 @@ def test_status_missing_progress_file(tmp_path, capsys):
         status = None
         live = False
 
-    _cmd_status(_Args(), tmp_path / "missing.json")
+    _cmd_status(_Args(), tmp_path / "missing-run-dir")
     out = capsys.readouterr().out
     assert "0 pairs" in out
 
@@ -110,13 +110,13 @@ def test_status_missing_progress_file(tmp_path, capsys):
 def test_status_filter_by_only(tmp_path, capsys):
     """status subcommand supports --only filter."""
     from pipeline.deploy import _cmd_status
-    progress_path = tmp_path / "progress.json"
-    progress_path.write_text(json.dumps(_PROGRESS))
+    run_dir = tmp_path
+    (run_dir / "progress.json").write_text(json.dumps(_PROGRESS))
 
     class _Args:
         only = "wl-smoke-baseline"; workload = None; package = None; status = None; live = False
 
-    _cmd_status(_Args(), progress_path)
+    _cmd_status(_Args(), run_dir)
     out = capsys.readouterr().out
     assert "wl-smoke-baseline" in out
     assert "wl-load-baseline" not in out
@@ -125,13 +125,13 @@ def test_status_filter_by_only(tmp_path, capsys):
 def test_status_filter_by_status(tmp_path, capsys):
     """status subcommand supports --status filter."""
     from pipeline.deploy import _cmd_status
-    progress_path = tmp_path / "progress.json"
-    progress_path.write_text(json.dumps(_PROGRESS))
+    run_dir = tmp_path
+    (run_dir / "progress.json").write_text(json.dumps(_PROGRESS))
 
     class _Args:
         only = None; workload = None; package = None; status = "running"; live = False
 
-    _cmd_status(_Args(), progress_path)
+    _cmd_status(_Args(), run_dir)
     out = capsys.readouterr().out
     assert "wl-smoke-treatment" in out
     assert "wl-load-baseline" not in out
@@ -141,14 +141,14 @@ def test_status_mismatch_shows_valid_values(tmp_path, capsys):
     """status subcommand shows valid values on filter mismatch."""
     import pytest
     from pipeline.deploy import _cmd_status
-    progress_path = tmp_path / "progress.json"
-    progress_path.write_text(json.dumps(_PROGRESS))
+    run_dir = tmp_path
+    (run_dir / "progress.json").write_text(json.dumps(_PROGRESS))
 
     class _Args:
         only = None; workload = "nonexistent"; package = None; status = None; live = False
 
     with pytest.raises(SystemExit) as exc_info:
-        _cmd_status(_Args(), progress_path)
+        _cmd_status(_Args(), run_dir)
     assert exc_info.value.code == 1
     captured = capsys.readouterr().err
     assert "No pairs matched" in captured
@@ -158,13 +158,13 @@ def test_status_mismatch_shows_valid_values(tmp_path, capsys):
 def test_status_empty_progress_with_filters(tmp_path, capsys):
     """status with empty progress and active filters warns filters are ignored."""
     from pipeline.deploy import _cmd_status
-    progress_path = tmp_path / "progress.json"
-    progress_path.write_text("{}")
+    run_dir = tmp_path
+    (run_dir / "progress.json").write_text("{}")
 
     class _Args:
         only = None; workload = "foo"; package = None; status = None; live = False
 
-    _cmd_status(_Args(), progress_path)
+    _cmd_status(_Args(), run_dir)
     out = capsys.readouterr().out
     assert "0 pairs" in out
     assert "filters ignored" in out
@@ -1341,12 +1341,12 @@ def test_status_ignores_orchestrator_metadata_as_pair(tmp_path, capsys):
         "wl-foo-baseline": {"workload": "foo", "package": "baseline", "status": "running", "namespace": "ns-1", "retries": 0},
         "_orchestrator": {"state": "backing_off", "backoff_level": 2, "last_probe_free_gpus": 0},
     }
-    pf = tmp_path / "progress.json"
-    pf.write_text(json.dumps(progress))
+    run_dir = tmp_path
+    (run_dir / "progress.json").write_text(json.dumps(progress))
 
     from pipeline.deploy import _cmd_status
     args = argparse.Namespace(only=None, workload=None, package=None, status=None)
-    _cmd_status(args, pf)
+    _cmd_status(args, run_dir)
     out = capsys.readouterr().out
     assert "wl-foo-baseline" in out
     lines = out.strip().split("\n")
@@ -1361,12 +1361,12 @@ def test_status_shows_orchestrator_state_backing_off(tmp_path, capsys):
         "wl-foo-baseline": {"workload": "foo", "package": "baseline", "status": "running", "namespace": "ns-1", "retries": 0},
         "_orchestrator": {"state": "backing_off", "backoff_level": 2, "last_probe_free_gpus": 0, "last_scarcity_time": "2026-05-08T14:32:00+00:00"},
     }
-    pf = tmp_path / "progress.json"
-    pf.write_text(json.dumps(progress))
+    run_dir = tmp_path
+    (run_dir / "progress.json").write_text(json.dumps(progress))
 
     from pipeline.deploy import _cmd_status
     args = argparse.Namespace(only=None, workload=None, package=None, status=None)
-    _cmd_status(args, pf)
+    _cmd_status(args, run_dir)
     out = capsys.readouterr().out
     assert "backing_off" in out
     assert "level 2" in out
@@ -1378,12 +1378,12 @@ def test_status_no_orchestrator_section_when_normal(tmp_path, capsys):
         "wl-foo-baseline": {"workload": "foo", "package": "baseline", "status": "running", "namespace": "ns-1", "retries": 0},
         "_orchestrator": {"state": "normal", "backoff_level": 0, "last_probe_free_gpus": 8},
     }
-    pf = tmp_path / "progress.json"
-    pf.write_text(json.dumps(progress))
+    run_dir = tmp_path
+    (run_dir / "progress.json").write_text(json.dumps(progress))
 
     from pipeline.deploy import _cmd_status
     args = argparse.Namespace(only=None, workload=None, package=None, status=None)
-    _cmd_status(args, pf)
+    _cmd_status(args, run_dir)
     out = capsys.readouterr().out
     assert "backing_off" not in out
 
@@ -1418,11 +1418,11 @@ def test_status_empty_pairs_only_orchestrator(tmp_path, capsys):
     progress = {
         "_orchestrator": {"state": "backing_off", "backoff_level": 3, "last_probe_free_gpus": 0},
     }
-    pf = tmp_path / "progress.json"
-    pf.write_text(json.dumps(progress))
+    run_dir = tmp_path
+    (run_dir / "progress.json").write_text(json.dumps(progress))
     from pipeline.deploy import _cmd_status
     args = argparse.Namespace(only=None, workload=None, package=None, status=None)
-    _cmd_status(args, pf)
+    _cmd_status(args, run_dir)
     out = capsys.readouterr().out
     assert "0 pairs" in out
 
@@ -1685,24 +1685,18 @@ def test_init_progress_per_pair_heterogeneous_cost(tmp_path):
     assert progress["wl-b-treatment"]["gpu_cost"] == 2
 
 
-# ── status --remote / ConfigMap fallback ─────────────────────────────────────
+# ── status ConfigMap / composite store behavior ───────────────────────────────
 
-def test_status_parser_has_remote_flag():
-    """status subcommand should accept --remote flag."""
+def test_status_parser_has_no_remote_flag():
+    """status subcommand does NOT accept --remote (flag removed)."""
+    import argparse as _argparse
     from pipeline.deploy import build_parser
     parser = build_parser()
-    args = parser.parse_args(["status", "--remote"])
-    assert args.remote is True
+    with pytest.raises(SystemExit):
+        parser.parse_args(["status", "--remote"])
 
-def test_status_parser_remote_default_false():
-    """--remote defaults to False."""
-    from pipeline.deploy import build_parser
-    parser = build_parser()
-    args = parser.parse_args(["status"])
-    assert args.remote is False
-
-def test_status_remote_reads_configmap(tmp_path, capsys):
-    """status --remote reads from ConfigMap instead of local file."""
+def test_status_reads_configmap_when_namespace_configured(tmp_path, capsys):
+    """status reads from ConfigMap (CM primary) when namespace is configured."""
     from unittest.mock import patch, MagicMock
     from pipeline.deploy import _cmd_status
 
@@ -1715,20 +1709,19 @@ def test_status_remote_reads_configmap(tmp_path, capsys):
 
     class _Args:
         only = None; workload = None; package = None; status = None
-        remote = True
 
     with patch("subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(
             returncode=0, stdout=json.dumps(progress_data),
         )
-        _cmd_status(_Args(), tmp_path / "progress.json",
+        _cmd_status(_Args(), tmp_path,
                     setup_config={"namespace": "sim2real-ns"})
 
     out = capsys.readouterr().out
     assert "wl-smoke-baseline" in out
 
-def test_status_fallback_to_configmap_when_no_local(tmp_path, capsys):
-    """status reads ConfigMap when local progress.json doesn't exist."""
+def test_status_reads_configmap_when_no_local_file(tmp_path, capsys):
+    """status reads ConfigMap even when local progress.json doesn't exist."""
     from unittest.mock import patch, MagicMock
     from pipeline.deploy import _cmd_status
 
@@ -1741,14 +1734,14 @@ def test_status_fallback_to_configmap_when_no_local(tmp_path, capsys):
 
     class _Args:
         only = None; workload = None; package = None; status = None
-        remote = False
 
-    missing_path = tmp_path / "nonexistent" / "progress.json"
+    run_dir = tmp_path / "nonexistent-run"
+    run_dir.mkdir()
     with patch("subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(
             returncode=0, stdout=json.dumps(progress_data),
         )
-        _cmd_status(_Args(), missing_path,
+        _cmd_status(_Args(), run_dir,
                     setup_config={"namespace": "sim2real-ns"})
 
     out = capsys.readouterr().out
@@ -1761,25 +1754,24 @@ def test_status_no_configmap_no_local_reports_no_run(tmp_path, capsys):
 
     class _Args:
         only = None; workload = None; package = None; status = None
-        remote = True
 
     with patch("subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(
             returncode=1, stdout="",
             stderr='Error from server (NotFound): configmaps "sim2real-progress" not found',
         )
-        _cmd_status(_Args(), tmp_path / "missing.json",
+        _cmd_status(_Args(), tmp_path,
                     setup_config={"namespace": "sim2real-ns"})
 
     out = capsys.readouterr().out
     assert "0 pairs" in out
 
-def test_status_remote_no_namespace_warns(tmp_path, capsys):
-    """--remote with no namespace configured warns and falls back to local."""
+def test_status_no_namespace_uses_local_only(tmp_path, capsys):
+    """status with no namespace configured reads only local progress.json."""
     from pipeline.deploy import _cmd_status
 
-    progress_path = tmp_path / "progress.json"
-    progress_path.write_text(json.dumps({
+    run_dir = tmp_path
+    (run_dir / "progress.json").write_text(json.dumps({
         "wl-smoke-baseline": {
             "workload": "wl-smoke", "package": "baseline",
             "status": "done", "namespace": None, "retries": 0,
@@ -1788,13 +1780,11 @@ def test_status_remote_no_namespace_warns(tmp_path, capsys):
 
     class _Args:
         only = None; workload = None; package = None; status = None
-        remote = True
 
-    _cmd_status(_Args(), progress_path, setup_config={})
+    _cmd_status(_Args(), run_dir, setup_config={})
 
-    captured = capsys.readouterr()
-    assert "--remote requested but no namespace" in captured.err
-    assert "wl-smoke-baseline" in captured.out
+    out = capsys.readouterr().out
+    assert "wl-smoke-baseline" in out
 
 
 # ── _configmap_namespace helper ──────────────────────────────────────────────
@@ -1892,16 +1882,16 @@ def test_cmd_reset_creates_composite_store_when_namespace_available(monkeypatch,
     assert "LocalProgressStore" in secondary_types
 
 
-# ── --remote with existing local file ────────────────────────────────────────
-
-def test_status_remote_prefers_configmap_over_existing_local(tmp_path, capsys):
-    """--remote reads from ConfigMap even when local progress.json exists."""
+def test_status_always_uses_composite_store(tmp_path, capsys):
+    """status always uses CompositeProgressStore with CM primary."""
     from unittest.mock import patch, MagicMock
     from pipeline.deploy import _cmd_status
 
     local_data = {"wl-local-baseline": {"workload": "wl-local", "package": "baseline",
                                         "status": "done", "namespace": None, "retries": 0}}
-    progress_path = tmp_path / "progress.json"
+    run_dir = tmp_path / "runs" / "test-run"
+    run_dir.mkdir(parents=True)
+    progress_path = run_dir / "progress.json"
     progress_path.write_text(json.dumps(local_data))
 
     remote_data = {"wl-remote-baseline": {"workload": "wl-remote", "package": "baseline",
@@ -1909,11 +1899,10 @@ def test_status_remote_prefers_configmap_over_existing_local(tmp_path, capsys):
 
     class _Args:
         only = None; workload = None; package = None; status = None
-        remote = True
 
     with patch("subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps(remote_data))
-        _cmd_status(_Args(), progress_path, setup_config={"namespace": "sim2real-ns"})
+        _cmd_status(_Args(), run_dir, setup_config={"namespace": "sim2real-ns"})
 
     out = capsys.readouterr().out
     assert "wl-remote-baseline" in out

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -1785,6 +1785,29 @@ def test_status_no_namespace_uses_local_only(tmp_path, capsys):
     out = capsys.readouterr().out
     assert "wl-smoke-baseline" in out
 
+def test_status_cm_failure_falls_back_to_local(tmp_path, capsys):
+    """When CM primary raises, status falls back to local progress.json."""
+    from unittest.mock import patch, MagicMock
+    from pipeline.deploy import _cmd_status
+
+    run_dir = tmp_path / "runs" / "test-run"
+    run_dir.mkdir(parents=True)
+
+    local_data = {"wl-local-baseline": {"workload": "wl-local", "package": "baseline",
+                                        "status": "done", "namespace": None, "retries": 0}}
+    (run_dir / "progress.json").write_text(json.dumps(local_data))
+
+    class _Args:
+        only = None; workload = None; package = None; status = None
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=1, stderr="Unable to connect to the server: dial tcp: no such host")
+        _cmd_status(_Args(), run_dir, setup_config={"namespace": "sim2real-ns"})
+
+    out = capsys.readouterr().out
+    assert "wl-local-baseline" in out
+
 
 # ── _configmap_namespace helper ──────────────────────────────────────────────
 
@@ -1815,7 +1838,7 @@ def test_configmap_namespace_empty():
 def test_cmd_run_creates_composite_store_when_namespace_available(monkeypatch, tmp_path):
     """_cmd_run creates CompositeProgressStore with ConfigMap as primary."""
     import pipeline.deploy as mod
-    from pipeline.lib.progress import CompositeProgressStore
+    from pipeline.lib.progress import CompositeProgressStore, ConfigMapProgressStore
 
     stores_created = []
     _original_init = CompositeProgressStore.__init__
@@ -1825,6 +1848,8 @@ def test_cmd_run_creates_composite_store_when_namespace_available(monkeypatch, t
         _original_init(self, primary, *secondaries)
 
     monkeypatch.setattr(CompositeProgressStore, "__init__", track)
+    monkeypatch.setattr(ConfigMapProgressStore, "load", lambda self: {})
+    monkeypatch.setattr(ConfigMapProgressStore, "save", lambda self, data: None)
     monkeypatch.setattr(mod, "_resolve_epp_action", lambda *a: "skip")
     monkeypatch.setattr(mod, "_load_pairs", lambda d: {})
 

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -1689,7 +1689,6 @@ def test_init_progress_per_pair_heterogeneous_cost(tmp_path):
 
 def test_status_parser_has_no_remote_flag():
     """status subcommand does NOT accept --remote (flag removed)."""
-    import argparse as _argparse
     from pipeline.deploy import build_parser
     parser = build_parser()
     with pytest.raises(SystemExit):

--- a/pipeline/tests/test_deploy_standalone.py
+++ b/pipeline/tests/test_deploy_standalone.py
@@ -39,12 +39,12 @@ def test_main_works_without_transfer_yaml(tmp_path, monkeypatch):
 
     status_called = []
 
-    def mock_status(args, progress_path, setup_config=None):
-        status_called.append(progress_path)
+    def mock_status(args, run_dir, setup_config=None):
+        status_called.append(run_dir)
 
     with patch.object(deploy, "_cmd_status", mock_status):
         with patch.object(deploy, "_load_setup_config", return_value={"current_run": "test-run", "namespace": "ns-0"}):
             deploy.main()
 
     assert len(status_called) == 1
-    assert status_called[0] == run_dir / "progress.json"
+    assert status_called[0] == run_dir


### PR DESCRIPTION
## Summary

Closes #149
Related to #148

- **`collect`**: Replace raw `json.loads(progress.json)` with `CompositeProgressStore(cm, local)`, matching reset/wipe. Collect now works after remote orchestrator runs where no local `progress.json` exists.
- **`status`**: Rewrite to always use `CompositeProgressStore(cm, local)`. Remove the `--remote` flag (clean break — it's no longer needed when CM is always consulted first).
- **`run`**: Flip store order from `CompositeProgressStore(local, cm)` to `CompositeProgressStore(cm, local)`, making ConfigMap authoritative during orchestration.

All five subcommands (`collect`, `status`, `run`, `reset`, `wipe`) now use the same pattern: ConfigMap primary, local secondary.

## Reviewer attention

- **`--remote` flag on `status` is removed** (clean break, not deprecated). The `--remote` flag on `run` (submit orchestrator as in-cluster Job) is unchanged.
- **`_cmd_status` signature changed** from `progress_path: Path` to `run_dir: Path`. The dispatch site and test mocks are updated.
- **`_cmd_run` with CM-primary** means Kubernetes API failures during active orchestration are now fatal (primary store failures propagate per `CompositeProgressStore` semantics). This is intentional — the alternative (`--remote` flag on every subcommand) was error-prone.

## Test plan

- [x] 704 tests pass (`python -m pytest pipeline/ .claude/skills/sim2real-analyze/tests/ .claude/skills/sim2real-translate/tests/ -v`)
- [x] Lint clean (`ruff check pipeline/ --select F`)
- [x] All 5 subcommands verified via `grep -n CompositeProgressStore pipeline/deploy.py` — all use `(cm_store, local_store)` order
- [ ] Manual: run `deploy.py status` / `deploy.py collect` after a remote orchestrator run to confirm CM data is read