### PR TITLE
fix: restore incremental collect lost when PR #147 merged

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -502,17 +502,21 @@ def _probe_remote_mtimes(pod_name: str, phase_path: str, namespace: str) -> dict
         if result.returncode != 0:
             warn(f"mtime probe failed (rc={result.returncode}): "
                  f"{result.stderr.strip()} — falling back to full copy")
+        else:
+            info(f"mtime probe: no trace_data.csv found in {phase_path}")
         return {}
     if result.stderr.strip():
         warn(f"mtime probe had errors: {result.stderr.strip()}")
     mtimes: dict[str, float] = {}
     for line in result.stdout.strip().splitlines():
         parts = line.split(None, 1)
-        if len(parts) == 2:
-            try:
-                mtimes[Path(parts[1]).parent.name] = float(parts[0])
-            except (ValueError, IndexError):
-                warn(f"mtime probe: unparseable line: {line!r}")
+        if len(parts) != 2:
+            warn(f"mtime probe: unparseable line: {line!r}")
+            continue
+        try:
+            mtimes[Path(parts[1]).parent.name] = float(parts[0])
+        except ValueError:
+            warn(f"mtime probe: unparseable line: {line!r}")
     return mtimes
 
 
@@ -522,7 +526,8 @@ def _is_up_to_date(local_csv: Path, remote_mtime: "float | None") -> bool:
         return False
     try:
         return local_csv.exists() and local_csv.stat().st_mtime >= remote_mtime
-    except OSError:
+    except OSError as exc:
+        warn(f"stat failed for {local_csv}: {exc} — will re-download")
         return False
 
 
@@ -538,8 +543,9 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
 
     When *workload* is set, only that workload's subdirectory is copied for
     each phase (used by scoped ``collect --only/--workload``).
-    When *workload* is None (default), the entire phase directory is copied
-    (used by unscoped ``deploy.py collect`` for bulk collection).
+    When *workload* is None (default), workloads are discovered via ``ls`` and
+    copied individually, skipping those whose local ``trace_data.csv`` is
+    already up to date (used by unscoped ``deploy.py collect``).
 
     When *skip_logs* is True, only trace files are copied (skipping vLLM and
     EPP log files which typically account for the bulk of the data).
@@ -703,17 +709,6 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
                     if result.returncode != 0:
                         phase_errors.append(f"{wl_name}: {result.stderr.strip()}")
                 errors[phase] = RuntimeError("; ".join(phase_errors)) if phase_errors else None
-                result = run(
-                    ["kubectl", "cp",
-                     f"{namespace}/{pod_name}:/data/{run_name}/{phase}/",
-                     str(dest_dir), "--retries=3"],
-                    check=False, capture=True,
-                )
-                if result.returncode != 0:
-                    errors[phase] = RuntimeError(
-                        f"kubectl cp failed: {result.stderr.strip()}")
-                else:
-                    errors[phase] = None
     finally:
         run(["kubectl", "delete", "pod", pod_name, "-n", namespace,
              "--ignore-not-found", "--force", "--grace-period=0"],

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -485,6 +485,41 @@ def _fmt_size(b: int) -> str:
     return f"{b / (1 << 10):.0f} KB"
 
 
+def _probe_remote_mtimes(pod_name: str, phase_path: str, namespace: str) -> dict[str, float]:
+    """Return {workload_name: mtime_epoch} for workloads that have trace_data.csv.
+
+    Uses a single kubectl exec to stat all trace_data.csv files in the phase
+    directory.  Returns empty dict on probe failure — callers should fall back
+    to full copy in that case.
+    """
+    result = run(
+        ["kubectl", "exec", pod_name, f"-n={namespace}", "--", "sh", "-c",
+         f"find {phase_path} -name 'trace_data.csv'"
+         " -exec stat -c '%Y %n' {} \\; 2>/dev/null"],
+        check=False, capture=True,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        return {}
+    mtimes: dict[str, float] = {}
+    for line in result.stdout.strip().splitlines():
+        parts = line.split(None, 1)
+        if len(parts) == 2:
+            try:
+                mtimes[Path(parts[1]).parent.name] = float(parts[0])
+            except (ValueError, IndexError):
+                pass
+    return mtimes
+
+
+def _is_up_to_date(local_csv: Path, remote_mtime: "float | None") -> bool:
+    """Return True if local trace_data.csv is at least as new as the remote copy."""
+    return (
+        remote_mtime is not None
+        and local_csv.exists()
+        and local_csv.stat().st_mtime >= remote_mtime
+    )
+
+
 def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
                               run_dir: Path,
                               skip_logs: bool = False,
@@ -561,12 +596,17 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
             dest_dir = run_dir / "results" / phase
             dest_dir.mkdir(parents=True, exist_ok=True)
 
+            remote_mtimes = _probe_remote_mtimes(
+                pod_name, f"/data/{run_name}/{phase}", namespace)
+
             if skip_logs:
                 # Selective copy: trace files + epp_logs via kubectl cp per
                 # workload; skips vLLM server_logs which dominate data volume.
                 # BusyBox tar doesn't handle large streaming well, so use cp.
                 if workload:
                     wl_names = [workload]
+                elif remote_mtimes:
+                    wl_names = list(remote_mtimes.keys())
                 else:
                     list_result = run(
                         ["kubectl", "exec", pod_name, f"-n={namespace}", "--",
@@ -581,6 +621,10 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
                     wl_names = list_result.stdout.strip().split() if list_result.stdout.strip() else []
                 phase_errors = []
                 for wl_name in wl_names:
+                    if _is_up_to_date(dest_dir / wl_name / "trace_data.csv",
+                                      remote_mtimes.get(wl_name)):
+                        info(f"[{phase}/{wl_name}] up to date — skipping")
+                        continue
                     wl_dest = dest_dir / wl_name
                     wl_dest.mkdir(parents=True, exist_ok=True)
                     # Copy trace files
@@ -603,19 +647,41 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
                 else:
                     errors[phase] = None
             elif workload:
-                wl_dest = dest_dir / workload
-                wl_dest.mkdir(parents=True, exist_ok=True)
-                result = run(
-                    ["kubectl", "cp",
-                     f"{namespace}/{pod_name}:/data/{run_name}/{phase}/{workload}/",
-                     str(wl_dest), "--retries=3"],
-                    check=False, capture=True,
-                )
-                if result.returncode != 0:
-                    errors[phase] = RuntimeError(
-                        f"kubectl cp failed: {result.stderr.strip()}")
-                else:
+                if _is_up_to_date(dest_dir / workload / "trace_data.csv",
+                                  remote_mtimes.get(workload)):
+                    info(f"[{phase}/{workload}] up to date — skipping")
                     errors[phase] = None
+                else:
+                    wl_dest = dest_dir / workload
+                    wl_dest.mkdir(parents=True, exist_ok=True)
+                    result = run(
+                        ["kubectl", "cp",
+                         f"{namespace}/{pod_name}:/data/{run_name}/{phase}/{workload}/",
+                         str(wl_dest), "--retries=3"],
+                        check=False, capture=True,
+                    )
+                    if result.returncode != 0:
+                        errors[phase] = RuntimeError(
+                            f"kubectl cp failed: {result.stderr.strip()}")
+                    else:
+                        errors[phase] = None
+            elif remote_mtimes:
+                phase_errors = []
+                for wl_name, remote_mtime in remote_mtimes.items():
+                    if _is_up_to_date(dest_dir / wl_name / "trace_data.csv", remote_mtime):
+                        info(f"[{phase}/{wl_name}] up to date — skipping")
+                        continue
+                    wl_dest = dest_dir / wl_name
+                    wl_dest.mkdir(parents=True, exist_ok=True)
+                    result = run(
+                        ["kubectl", "cp",
+                         f"{namespace}/{pod_name}:/data/{run_name}/{phase}/{wl_name}/",
+                         str(wl_dest), "--retries=3"],
+                        check=False, capture=True,
+                    )
+                    if result.returncode != 0:
+                        phase_errors.append(f"{wl_name}: {result.stderr.strip()}")
+                errors[phase] = RuntimeError("; ".join(phase_errors)) if phase_errors else None
             else:
                 result = run(
                     ["kubectl", "cp",

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -495,11 +495,16 @@ def _probe_remote_mtimes(pod_name: str, phase_path: str, namespace: str) -> dict
     result = run(
         ["kubectl", "exec", pod_name, f"-n={namespace}", "--", "sh", "-c",
          f"find {phase_path} -name 'trace_data.csv'"
-         " -exec stat -c '%Y %n' {} \\; 2>/dev/null"],
+         " -exec stat -c '%Y %n' {} \\;"],
         check=False, capture=True,
     )
     if result.returncode != 0 or not result.stdout.strip():
+        if result.returncode != 0:
+            warn(f"mtime probe failed (rc={result.returncode}): "
+                 f"{result.stderr.strip()} — falling back to full copy")
         return {}
+    if result.stderr.strip():
+        warn(f"mtime probe had errors: {result.stderr.strip()}")
     mtimes: dict[str, float] = {}
     for line in result.stdout.strip().splitlines():
         parts = line.split(None, 1)
@@ -507,17 +512,18 @@ def _probe_remote_mtimes(pod_name: str, phase_path: str, namespace: str) -> dict
             try:
                 mtimes[Path(parts[1]).parent.name] = float(parts[0])
             except (ValueError, IndexError):
-                pass
+                warn(f"mtime probe: unparseable line: {line!r}")
     return mtimes
 
 
 def _is_up_to_date(local_csv: Path, remote_mtime: "float | None") -> bool:
     """Return True if local trace_data.csv is at least as new as the remote copy."""
-    return (
-        remote_mtime is not None
-        and local_csv.exists()
-        and local_csv.stat().st_mtime >= remote_mtime
-    )
+    if remote_mtime is None:
+        return False
+    try:
+        return local_csv.exists() and local_csv.stat().st_mtime >= remote_mtime
+    except OSError:
+        return False
 
 
 def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
@@ -605,8 +611,6 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
                 # BusyBox tar doesn't handle large streaming well, so use cp.
                 if workload:
                     wl_names = [workload]
-                elif remote_mtimes:
-                    wl_names = list(remote_mtimes.keys())
                 else:
                     list_result = run(
                         ["kubectl", "exec", pod_name, f"-n={namespace}", "--",
@@ -665,10 +669,27 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
                             f"kubectl cp failed: {result.stderr.strip()}")
                     else:
                         errors[phase] = None
-            elif remote_mtimes:
+            else:
+                # Unscoped full copy: discover workloads via ls, skip
+                # up-to-date ones using remote_mtimes when available.
+                list_result = run(
+                    ["kubectl", "exec", pod_name, f"-n={namespace}", "--",
+                     "sh", "-c",
+                     f"ls /data/{run_name}/{phase}/"],
+                    check=False, capture=True,
+                )
+                if list_result.returncode != 0:
+                    errors[phase] = RuntimeError(
+                        f"failed to list workloads: {list_result.stderr.strip()}")
+                    continue
+                wl_names = list_result.stdout.strip().split() if list_result.stdout.strip() else []
+                if not wl_names:
+                    errors[phase] = None
+                    continue
                 phase_errors = []
-                for wl_name, remote_mtime in remote_mtimes.items():
-                    if _is_up_to_date(dest_dir / wl_name / "trace_data.csv", remote_mtime):
+                for wl_name in wl_names:
+                    if _is_up_to_date(dest_dir / wl_name / "trace_data.csv",
+                                      remote_mtimes.get(wl_name)):
                         info(f"[{phase}/{wl_name}] up to date — skipping")
                         continue
                     wl_dest = dest_dir / wl_name
@@ -682,7 +703,6 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
                     if result.returncode != 0:
                         phase_errors.append(f"{wl_name}: {result.stderr.strip()}")
                 errors[phase] = RuntimeError("; ".join(phase_errors)) if phase_errors else None
-            else:
                 result = run(
                     ["kubectl", "cp",
                      f"{namespace}/{pod_name}:/data/{run_name}/{phase}/",

--- a/pipeline/tests/test_deploy_collect.py
+++ b/pipeline/tests/test_deploy_collect.py
@@ -877,3 +877,75 @@ def test_collect_cm_failure_no_local_falls_back_to_discovery(tmp_path):
 
     assert len(extract_calls) == 1
     assert sorted(extract_calls[0]) == ["baseline", "treatment"]
+
+
+# ── Incremental collect helpers ──────────────────────────────────────────────
+
+def test_probe_remote_mtimes_parses_output():
+    """_probe_remote_mtimes parses stat output into {workload: mtime} dict."""
+    from pipeline.deploy import _probe_remote_mtimes
+
+    stat_output = (
+        "1715800000 /data/run1/baseline/wl-smoke/trace_data.csv\n"
+        "1715800100 /data/run1/baseline/wl-load/trace_data.csv\n"
+    )
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout=stat_output)
+        result = _probe_remote_mtimes("pod", "/data/run1/baseline", "ns-0")
+
+    assert result == {"wl-smoke": 1715800000.0, "wl-load": 1715800100.0}
+
+
+def test_probe_remote_mtimes_returns_empty_on_failure():
+    """_probe_remote_mtimes returns {} when kubectl exec fails."""
+    from pipeline.deploy import _probe_remote_mtimes
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=1, stdout="")
+        result = _probe_remote_mtimes("pod", "/data/run1/baseline", "ns-0")
+
+    assert result == {}
+
+
+def test_is_up_to_date_true_when_local_newer(tmp_path):
+    """_is_up_to_date returns True when local file is at least as new as remote."""
+    from pipeline.deploy import _is_up_to_date
+
+    local_csv = tmp_path / "trace_data.csv"
+    local_csv.write_text("data")
+    local_mtime = local_csv.stat().st_mtime
+
+    assert _is_up_to_date(local_csv, local_mtime - 100) is True
+    assert _is_up_to_date(local_csv, local_mtime) is True
+
+
+def test_is_up_to_date_false_when_no_local(tmp_path):
+    """_is_up_to_date returns False when local file does not exist."""
+    from pipeline.deploy import _is_up_to_date
+
+    assert _is_up_to_date(tmp_path / "trace_data.csv", 1715800000.0) is False
+
+
+def test_is_up_to_date_false_when_remote_newer(tmp_path):
+    """_is_up_to_date returns False when remote mtime is newer than local."""
+    from pipeline.deploy import _is_up_to_date
+    import os
+
+    local_csv = tmp_path / "trace_data.csv"
+    local_csv.write_text("data")
+    old_time = 1000000000.0
+    os.utime(local_csv, (old_time, old_time))
+
+    assert _is_up_to_date(local_csv, old_time + 100) is False
+
+
+def test_is_up_to_date_false_when_remote_mtime_none(tmp_path):
+    """_is_up_to_date returns False when remote_mtime is None."""
+    from pipeline.deploy import _is_up_to_date
+
+    local_csv = tmp_path / "trace_data.csv"
+    local_csv.write_text("data")
+
+    assert _is_up_to_date(local_csv, None) is False

--- a/pipeline/tests/test_deploy_collect.py
+++ b/pipeline/tests/test_deploy_collect.py
@@ -913,6 +913,20 @@ def test_probe_remote_mtimes_returns_empty_on_failure():
     assert any("mtime probe failed" in str(c) for c in mock_warn.call_args_list)
 
 
+def test_probe_remote_mtimes_logs_info_on_empty_stdout():
+    """_probe_remote_mtimes logs info when find succeeds but finds nothing."""
+    from pipeline import deploy
+    from pipeline.deploy import _probe_remote_mtimes
+
+    with patch("subprocess.run") as mock_run, \
+         patch.object(deploy, "info") as mock_info:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        result = _probe_remote_mtimes("pod", "/data/run1/baseline", "ns-0")
+
+    assert result == {}
+    assert any("no trace_data.csv" in str(c) for c in mock_info.call_args_list)
+
+
 def test_probe_remote_mtimes_warns_on_stderr():
     """_probe_remote_mtimes warns when stderr has content but command succeeds."""
     from pipeline import deploy
@@ -932,11 +946,28 @@ def test_probe_remote_mtimes_warns_on_stderr():
 
 
 def test_probe_remote_mtimes_warns_on_unparseable_line():
-    """_probe_remote_mtimes warns per unparseable line."""
+    """_probe_remote_mtimes warns when float() fails on the mtime token."""
     from pipeline import deploy
     from pipeline.deploy import _probe_remote_mtimes
 
-    stat_output = "garbage line\n1715800000 /data/run1/baseline/wl-smoke/trace_data.csv\n"
+    stat_output = "garbage /data/run1/baseline/wl-bad/trace_data.csv\n1715800000 /data/run1/baseline/wl-smoke/trace_data.csv\n"
+
+    with patch("subprocess.run") as mock_run, \
+         patch.object(deploy, "warn") as mock_warn:
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout=stat_output, stderr="")
+        result = _probe_remote_mtimes("pod", "/data/run1/baseline", "ns-0")
+
+    assert result == {"wl-smoke": 1715800000.0}
+    assert any("unparseable" in str(c) for c in mock_warn.call_args_list)
+
+
+def test_probe_remote_mtimes_warns_on_single_token_line():
+    """_probe_remote_mtimes warns on lines with fewer than 2 tokens."""
+    from pipeline import deploy
+    from pipeline.deploy import _probe_remote_mtimes
+
+    stat_output = "onlyone\n1715800000 /data/run1/baseline/wl-smoke/trace_data.csv\n"
 
     with patch("subprocess.run") as mock_run, \
          patch.object(deploy, "warn") as mock_warn:
@@ -991,11 +1022,15 @@ def test_is_up_to_date_false_when_remote_mtime_none(tmp_path):
 
 
 def test_is_up_to_date_false_on_os_error(tmp_path):
-    """_is_up_to_date returns False (re-download) when stat raises OSError."""
+    """_is_up_to_date returns False and warns when stat raises OSError."""
+    from pipeline import deploy
     from pipeline.deploy import _is_up_to_date
 
     local_csv = tmp_path / "trace_data.csv"
     local_csv.write_text("data")
 
-    with patch.object(Path, "stat", side_effect=OSError("permission denied")):
+    with patch.object(Path, "stat", side_effect=OSError("permission denied")), \
+         patch.object(deploy, "warn") as mock_warn:
         assert _is_up_to_date(local_csv, 1715800000.0) is False
+
+    assert any("stat failed" in str(c) for c in mock_warn.call_args_list)

--- a/pipeline/tests/test_deploy_collect.py
+++ b/pipeline/tests/test_deploy_collect.py
@@ -1,6 +1,7 @@
 """Tests for deploy.py _cmd_collect phase selection logic."""
 
 import json
+from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -892,21 +893,59 @@ def test_probe_remote_mtimes_parses_output():
 
     with patch("subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(
-            returncode=0, stdout=stat_output)
+            returncode=0, stdout=stat_output, stderr="")
         result = _probe_remote_mtimes("pod", "/data/run1/baseline", "ns-0")
 
     assert result == {"wl-smoke": 1715800000.0, "wl-load": 1715800100.0}
 
 
 def test_probe_remote_mtimes_returns_empty_on_failure():
-    """_probe_remote_mtimes returns {} when kubectl exec fails."""
+    """_probe_remote_mtimes returns {} and warns when kubectl exec fails."""
+    from pipeline import deploy
     from pipeline.deploy import _probe_remote_mtimes
 
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(returncode=1, stdout="")
+    with patch("subprocess.run") as mock_run, \
+         patch.object(deploy, "warn") as mock_warn:
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="exec failed")
         result = _probe_remote_mtimes("pod", "/data/run1/baseline", "ns-0")
 
     assert result == {}
+    assert any("mtime probe failed" in str(c) for c in mock_warn.call_args_list)
+
+
+def test_probe_remote_mtimes_warns_on_stderr():
+    """_probe_remote_mtimes warns when stderr has content but command succeeds."""
+    from pipeline import deploy
+    from pipeline.deploy import _probe_remote_mtimes
+
+    stat_output = "1715800000 /data/run1/baseline/wl-smoke/trace_data.csv\n"
+
+    with patch("subprocess.run") as mock_run, \
+         patch.object(deploy, "warn") as mock_warn:
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout=stat_output,
+            stderr="stat: /data/run1/baseline/wl-broken/trace_data.csv: No such file")
+        result = _probe_remote_mtimes("pod", "/data/run1/baseline", "ns-0")
+
+    assert result == {"wl-smoke": 1715800000.0}
+    assert any("mtime probe had errors" in str(c) for c in mock_warn.call_args_list)
+
+
+def test_probe_remote_mtimes_warns_on_unparseable_line():
+    """_probe_remote_mtimes warns per unparseable line."""
+    from pipeline import deploy
+    from pipeline.deploy import _probe_remote_mtimes
+
+    stat_output = "garbage line\n1715800000 /data/run1/baseline/wl-smoke/trace_data.csv\n"
+
+    with patch("subprocess.run") as mock_run, \
+         patch.object(deploy, "warn") as mock_warn:
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout=stat_output, stderr="")
+        result = _probe_remote_mtimes("pod", "/data/run1/baseline", "ns-0")
+
+    assert result == {"wl-smoke": 1715800000.0}
+    assert any("unparseable" in str(c) for c in mock_warn.call_args_list)
 
 
 def test_is_up_to_date_true_when_local_newer(tmp_path):
@@ -949,3 +988,14 @@ def test_is_up_to_date_false_when_remote_mtime_none(tmp_path):
     local_csv.write_text("data")
 
     assert _is_up_to_date(local_csv, None) is False
+
+
+def test_is_up_to_date_false_on_os_error(tmp_path):
+    """_is_up_to_date returns False (re-download) when stat raises OSError."""
+    from pipeline.deploy import _is_up_to_date
+
+    local_csv = tmp_path / "trace_data.csv"
+    local_csv.write_text("data")
+
+    with patch.object(Path, "stat", side_effect=OSError("permission denied")):
+        assert _is_up_to_date(local_csv, 1715800000.0) is False


### PR DESCRIPTION
## Summary

- PR #147 (namespace-aware collect) was branched before `c49277c` (incremental collect via mtime probing) and silently overwrote it on merge — `_probe_remote_mtimes` and `_is_up_to_date` were dropped
- Re-integrates both helpers into the current namespace-aware `_extract_phases_from_pvc` so repeated `deploy.py collect` invocations skip workloads whose local `trace_data.csv` is already current
- Falls back to full-phase copy when the remote mtime probe fails (e.g. empty phase dir)

## Test plan

- [x] All 36 collect tests pass (`pytest pipeline/tests/test_deploy_collect.py -v`)
- [x] Full suite passes (713 tests)
- [x] Lint clean (`ruff check pipeline/ --select F`)
- [ ] Manual: run `deploy.py collect` twice — second run should print "up to date — skipping" for all workloads and not re-download files