### PR TITLE
refactor: eliminate local progress.json — ConfigMap as sole progress store

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,8 +91,7 @@ All artifacts live under `<experiment-root>/workspace/` (gitignored). When no `-
 | `runs/<run>/cluster/pipelinerun-*.yaml` | `prepare.py` Phase 4 | `deploy.py run` |
 | `runs/<run>/run_summary.md` | `prepare.py` Phase 5 | human review |
 | `runs/<run>/results/{phase}/` | `deploy.py collect` | `/sim2real-analyze` skill, `deploy.py wipe` |
-| ConfigMap `sim2real-progress` | `deploy.py run`, `deploy.py reset` | All `deploy.py` subcommands (primary) |
-| `runs/<run>/progress.json` | `deploy.py run`, `deploy.py wipe` | All `deploy.py` subcommands (fallback) |
+| ConfigMap `sim2real-progress` | `deploy.py run`, `deploy.py reset` | All `deploy.py` subcommands |
 | `runs/<run>/plans/<phase>/<workload>/` | `deploy.py run` | workload tasks |
 | `context/{scenario}/{hash}.md` | `prepare.py` Phase 2 | `prepare.py` Phase 2 (cache) |
 

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -144,7 +144,7 @@ python pipeline/deploy.py wipe  [flags]     # delete local results and reset pai
 python pipeline/deploy.py pairs   [flags]   # list available pair keys, workloads, and packages
 ```
 
-**`deploy.py run`** — assigns `(workload, package)` pairs to free namespace slots, polls for completion, and retries pairs that time out. Reads progress from the ConfigMap (primary) or local file (fallback) to resume interrupted runs. Use `deploy.py collect` to pull results off-cluster after runs complete.
+**`deploy.py run`** — assigns `(workload, package)` pairs to free namespace slots, polls for completion, and retries pairs that time out. Reads progress from the `sim2real-progress` ConfigMap to resume interrupted runs. Requires a configured namespace. Use `deploy.py collect` to pull results off-cluster after runs complete.
 
 | Flag | Default | Description |
 |------|---------|-------------|

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -172,7 +172,7 @@ python pipeline/deploy.py pairs   [flags]   # list available pair keys, workload
 
 **Remote mode** — `deploy.py run --remote` submits the orchestrator as a Kubernetes Job (`sim2real-orchestrator`) instead of running locally. The launcher builds the EPP image locally, packs workspace files into a ConfigMap, applies the Job, and waits for the pod to reach Running. Use `stop` to cancel, `status` to check progress, and `collect` to pull results after completion. Requires `orchestrator_image` in `setup_config.json`.
 
-**`deploy.py status`** — prints the current state of all pairs. Always reads from the `sim2real-progress` ConfigMap first (primary), falling back to the local `progress.json` if the ConfigMap is empty or the namespace is not configured.
+**`deploy.py status`** — prints the current state of all pairs. Reads from the `sim2real-progress` ConfigMap. Requires a configured namespace.
 
 | Flag | Description |
 |------|-------------|
@@ -192,7 +192,7 @@ python pipeline/deploy.py pairs   [flags]   # list available pair keys, workload
 
 When `--only` or `--workload` is given, only matching workload subdirectories are pulled from the PVC (instead of entire phase directories). These pair-level flags compose with `--package` as AND: `--workload X --package baseline` pulls workload X from the baseline phase only. Requires progress data to resolve pairs.
 
-**`deploy.py stop`** — deletes the `sim2real-orchestrator` Kubernetes Job (with cascading pod deletion) in the primary namespace. Only meaningful when the orchestrator runs as an in-cluster Job. Does not touch `progress.json` — pair state is left as-is. If no remote orchestrator Job exists, prints a message and returns. Use `reset` separately to clear failed/stalled pair state.
+**`deploy.py stop`** — deletes the `sim2real-orchestrator` Kubernetes Job (with cascading pod deletion) in the primary namespace. Only meaningful when the orchestrator runs as an in-cluster Job. Pair state is left as-is. If no remote orchestrator Job exists, prints a message and returns. Use `reset` separately to clear failed/stalled pair state.
 
 **`deploy.py reset`** — removes cluster resources (PipelineRuns, Helm releases) for all non-pending pairs. Failed/running/timed-out pairs are reset to `pending` so they can be re-dispatched. Done pairs stay `done` — only their PipelineRun is deleted to free cluster resources.
 
@@ -206,7 +206,7 @@ When `--only` or `--workload` is given, only matching workload subdirectories ar
 
 **Safety:** Results in `workspace/runs/<run>/results/` are preserved — only cluster resources are removed. For `done` pairs, only the PipelineRun is deleted (Tekton already tore down Helm releases).
 
-**`deploy.py wipe`** — deletes local results (`results/<package>/<workload>/`) for non-pending pairs and resets their status to `pending` in `progress.json`. Use when reusing a run name and stale results from prior executions need to be cleared before re-executing. Pending pairs are skipped (nothing to wipe). Empty package directories are cleaned up automatically.
+**`deploy.py wipe`** — deletes local results (`results/<package>/<workload>/`) for non-pending pairs and resets their status to `pending` in the ConfigMap. Use when reusing a run name and stale results from prior executions need to be cleared before re-executing. Pending pairs are skipped (nothing to wipe). Empty package directories are cleaned up automatically.
 
 | Flag | Description |
 |------|-------------|
@@ -218,7 +218,7 @@ When `--only` or `--workload` is given, only matching workload subdirectories ar
 
 **Interaction with `collect`:** Wiping resets pair status to `pending`, which makes any PVC data unreachable via `collect` (collect only pulls `done` pairs). Re-executing the pairs writes fresh data to the PVC.
 
-**`deploy.py pairs`** — lists available pair keys, workloads, and packages by scanning `cluster/pipelinerun-*.yaml`. Works without `progress.json`.
+**`deploy.py pairs`** — lists available pair keys, workloads, and packages by scanning `cluster/pipelinerun-*.yaml`.
 
 | Flag | Description |
 |------|-------------|
@@ -332,14 +332,13 @@ All paths are relative to the repo root and validated at Phase 1.
 
 ## Parallel Pool Execution
 
-`setup.py --namespaces NS1,NS2,...` provisions N namespace slots, each bootstrapped identically. `prepare.py` generates one shared Tekton Pipeline plus one PipelineRun per `(workload, package)` pair. `deploy.py run` orchestrates execution by assigning pairs to free slots, polling for completion, and retrying on timeout. Use `deploy.py collect` to pull results off-cluster. `deploy.py status` reads progress from the ConfigMap (primary) or local file (fallback).
+`setup.py --namespaces NS1,NS2,...` provisions N namespace slots, each bootstrapped identically. `prepare.py` generates one shared Tekton Pipeline plus one PipelineRun per `(workload, package)` pair. `deploy.py run` orchestrates execution by assigning pairs to free slots, polling for completion, and retrying on timeout. Use `deploy.py collect` to pull results off-cluster. `deploy.py status` reads progress from the ConfigMap.
 
 | Artifact | Written by | Read by |
 |----------|-----------|---------|
-| ConfigMap `sim2real-progress` | `deploy.py run`, `deploy.py reset` | All subcommands (primary) |
-| `runs/<run>/progress.json` | `deploy.py run` | All subcommands (fallback) |
+| ConfigMap `sim2real-progress` | `deploy.py run`, `deploy.py reset` | All subcommands |
 
-The orchestrator writes progress to both the `sim2real-progress` ConfigMap and the local file on every poll cycle. All subcommands (`status`, `collect`, `run`, `reset`, `wipe`) read from the ConfigMap first, falling back to the local file when the ConfigMap is empty or the namespace is not configured.
+All subcommands (`status`, `collect`, `run`, `reset`, `wipe`) use the `sim2real-progress` ConfigMap as the sole progress store. A configured namespace is required.
 
 ---
 

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -230,33 +230,16 @@ def _delete_pipelinerun(pr_name: str, namespace: str) -> None:
 def _cmd_status(args, run_dir: Path,
                 setup_config: dict | None = None) -> None:
     """Print a snapshot table of all (workload, package) pair statuses."""
-    from pipeline.lib.progress import (
-        LocalProgressStore, ConfigMapProgressStore, CompositeProgressStore,
-    )
-    progress_path = run_dir / "progress.json"
-    local_store = LocalProgressStore(progress_path)
+    from pipeline.lib.progress import ConfigMapProgressStore
     primary_ns = _configmap_namespace(setup_config)
-    if primary_ns:
-        cm_store = ConfigMapProgressStore(primary_ns)
-        store = CompositeProgressStore(cm_store, local_store)
-    else:
-        store = local_store
-
-    try:
-        progress = store.load()
-    except (ValueError, RuntimeError, OSError) as exc:
-        warn(f"Failed to load progress from primary store: {exc}")
-        try:
-            progress = local_store.load()
-        except (ValueError, RuntimeError, OSError):
-            progress = {}
-        if progress:
-            warn("Using local progress data as fallback")
-        else:
-            warn("No local fallback available")
+    if not primary_ns:
+        err("No namespace configured. Run setup.py first.")
+        sys.exit(1)
+    store = ConfigMapProgressStore(primary_ns)
+    progress = store.load()
 
     if not progress:
-        suffix = " (no progress data)" if not progress_path.exists() else ""
+        suffix = " (no progress data)"
         filters_given = any([
             getattr(args, "only", None) is not None,
             getattr(args, "workload", None) is not None,
@@ -726,30 +709,18 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
 
     run_name = run_dir.name
 
-    # Derive known phases from CompositeProgressStore (CM primary, local fallback)
-    from pipeline.lib.progress import (
-        LocalProgressStore, ConfigMapProgressStore, CompositeProgressStore,
-    )
-    progress_path = run_dir / "progress.json"
-    local_store = LocalProgressStore(progress_path)
+    # Derive known phases from ConfigMap
+    from pipeline.lib.progress import ConfigMapProgressStore
     primary_ns = _configmap_namespace(setup_config)
-    if primary_ns:
-        cm_store = ConfigMapProgressStore(primary_ns)
-        store = CompositeProgressStore(cm_store, local_store)
-    else:
-        store = local_store
+    if not primary_ns:
+        err("No namespace configured. Run setup.py first.")
+        sys.exit(1)
+    store = ConfigMapProgressStore(primary_ns)
     try:
         progress = store.load() or None
-    except (ValueError, RuntimeError, OSError) as exc:
-        warn(f"Failed to load progress from primary store: {exc}")
-        try:
-            progress = local_store.load() or None
-        except (ValueError, RuntimeError, OSError):
-            progress = None
-        if progress:
-            warn("Using local progress data as fallback")
-        else:
-            warn("No local fallback available — falling back to default phases")
+    except (ValueError, RuntimeError) as exc:
+        warn(f"Failed to load progress: {exc}")
+        progress = None
 
     # ── Pair-level scoping (--only / --workload) ──────────────────────────
     scope_only = getattr(args, "only", None)
@@ -865,9 +836,9 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
         if not known_phases:
             cluster_dir = run_dir / "cluster"
             known_phases = _discover_phases(cluster_dir)
-            if progress is None and not progress_path.exists():
+            if progress is None:
                 warn(f"No progress data found — discovered phases from cluster/: {known_phases}")
-            elif progress is not None:
+            else:
                 warn(f"No done phases in progress — discovered from cluster/: {known_phases}")
 
         if args.package:
@@ -1232,7 +1203,7 @@ def _reconcile_on_resume(progress: dict, discovered: dict) -> None:
 
     - running pairs: check PipelineRun status on cluster and update accordingly
     - unrecognized statuses (e.g. 'collecting' or 'collect-failed' from a
-      pre-#120 progress.json): reset to pending so they are re-dispatched.
+      pre-#120 progress data): reset to pending so they are re-dispatched.
       This is safe because both historical statuses imply the PipelineRun
       already succeeded.
     """
@@ -1357,9 +1328,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
     """Orchestrate parallel pool execution across namespace slots."""
     import datetime as _dt
     import tempfile as _tmp
-    from pipeline.lib.progress import (
-        LocalProgressStore, ConfigMapProgressStore, CompositeProgressStore,
-    )
+    from pipeline.lib.progress import ConfigMapProgressStore
     from pipeline.lib.backoff import BackoffController
     from pipeline.lib.capacity import (
         probe_free_gpus, derive_gpu_resource_type, load_defaults
@@ -1384,14 +1353,10 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
     max_pending_stalls = getattr(args, "max_pending_stalls", 10)
 
     cluster_dir = run_dir / "cluster"
-    progress_path = run_dir / "progress.json"
-    local_store = LocalProgressStore(progress_path)
     primary_ns = _configmap_namespace(setup_config, namespaces)
-    if primary_ns:
-        cm_store = ConfigMapProgressStore(primary_ns)
-        store = CompositeProgressStore(cm_store, local_store)
-    else:
-        store = local_store
+    if not primary_ns:
+        err("No namespace configured."); sys.exit(1)
+    store = ConfigMapProgressStore(primary_ns)
 
     # Derive GPU resource type from baseline scenario
     # CLI --gpu-resource-type overrides auto-derivation when explicitly set
@@ -1712,27 +1677,20 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
             counts[v["status"]] = counts.get(v["status"], 0) + 1
     print()
     ok("Run complete: " + "  ".join(f"{v} {k}" for k, v in sorted(counts.items())))
-    if primary_ns:
-        print(f"  Progress: ConfigMap {ConfigMapProgressStore.CONFIGMAP_NAME} in {primary_ns}")
-    else:
-        print(f"  Progress: {progress_path}")
+    print(f"  Progress: ConfigMap {ConfigMapProgressStore.CONFIGMAP_NAME} in {primary_ns}")
     print()
 
 
-def _cmd_reset(args, progress_path: Path, discovered: dict,
+def _cmd_reset(args, run_dir: Path, discovered: dict,
                namespaces: list[str] | None = None,
                setup_config: dict | None = None) -> None:
     """Tear down cluster resources for all non-pending pairs."""
-    from pipeline.lib.progress import (
-        LocalProgressStore, ConfigMapProgressStore, CompositeProgressStore,
-    )
-    local_store = LocalProgressStore(progress_path)
+    from pipeline.lib.progress import ConfigMapProgressStore
     primary_ns = _configmap_namespace(setup_config, namespaces)
-    if primary_ns:
-        cm_store = ConfigMapProgressStore(primary_ns)
-        store = CompositeProgressStore(cm_store, local_store)
-    else:
-        store = local_store
+    if not primary_ns:
+        err("No namespace configured. Run setup.py first.")
+        sys.exit(1)
+    store = ConfigMapProgressStore(primary_ns)
     progress = store.load()
 
     if not progress:
@@ -1780,17 +1738,12 @@ def _cmd_reset(args, progress_path: Path, discovered: dict,
 def _cmd_wipe(args, run_dir: Path,
               setup_config: dict | None = None) -> None:
     """Delete local results and reset wiped pairs to pending."""
-    from pipeline.lib.progress import (
-        LocalProgressStore, ConfigMapProgressStore, CompositeProgressStore,
-    )
-    progress_path = run_dir / "progress.json"
-    local_store = LocalProgressStore(progress_path)
+    from pipeline.lib.progress import ConfigMapProgressStore
     primary_ns = _configmap_namespace(setup_config)
-    if primary_ns:
-        cm_store = ConfigMapProgressStore(primary_ns)
-        store = CompositeProgressStore(cm_store, local_store)
-    else:
-        store = local_store
+    if not primary_ns:
+        err("No namespace configured. Run setup.py first.")
+        sys.exit(1)
+    store = ConfigMapProgressStore(primary_ns)
     progress = store.load()
 
     if not progress:
@@ -2256,14 +2209,13 @@ def main():
     elif cmd == "collect":
         _cmd_collect(args, run_dir, setup_config)
     elif cmd == "reset":
-        progress_path = run_dir / "progress.json"
         cluster_dir = run_dir / "cluster"
         discovered = _load_pairs(cluster_dir)
         namespaces = [ns for ns in (setup_config.get("namespaces") or
                       [setup_config.get("namespace", "")]) if ns]
         if not namespaces:
             warn("No namespaces in setup_config — PipelineRun deletion for done pairs may be incomplete")
-        _cmd_reset(args, progress_path, discovered,
+        _cmd_reset(args, run_dir, discovered,
                    namespaces=namespaces or None,
                    setup_config=setup_config)
     elif cmd == "wipe":

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -236,7 +236,11 @@ def _cmd_status(args, run_dir: Path,
         err("No namespace configured. Run setup.py first.")
         sys.exit(1)
     store = ConfigMapProgressStore(primary_ns)
-    progress = store.load()
+    try:
+        progress = store.load()
+    except (ValueError, RuntimeError) as exc:
+        err(f"Failed to load progress: {exc}")
+        progress = {}
 
     if not progress:
         suffix = " (no progress data)"
@@ -1355,7 +1359,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
     cluster_dir = run_dir / "cluster"
     primary_ns = _configmap_namespace(setup_config, namespaces)
     if not primary_ns:
-        err("No namespace configured."); sys.exit(1)
+        err("No namespace configured. Run setup.py first."); sys.exit(1)
     store = ConfigMapProgressStore(primary_ns)
 
     # Derive GPU resource type from baseline scenario

--- a/pipeline/lib/progress.py
+++ b/pipeline/lib/progress.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
-import tempfile
 from abc import ABC, abstractmethod
-from pathlib import Path
 
 
 class ProgressStore(ABC):
@@ -16,30 +14,6 @@ class ProgressStore(ABC):
     @abstractmethod
     def save(self, data: dict) -> None:
         """Atomically persist the full dict."""
-
-
-class LocalProgressStore(ProgressStore):
-    def __init__(self, path: Path) -> None:
-        self._path = Path(path)
-
-    def load(self) -> dict:
-        if not self._path.exists():
-            return {}
-        try:
-            return json.loads(self._path.read_text())
-        except json.JSONDecodeError as exc:
-            raise ValueError(f"Corrupt progress file: {self._path}") from exc
-
-    def save(self, data: dict) -> None:
-        self._path.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp = tempfile.mkstemp(dir=self._path.parent, suffix=".tmp")
-        try:
-            with open(fd, "w") as f:
-                json.dump(data, f, indent=2)
-            Path(tmp).replace(self._path)
-        except BaseException:
-            Path(tmp).unlink(missing_ok=True)
-            raise
 
 
 class ConfigMapProgressStore(ProgressStore):
@@ -99,37 +73,3 @@ class ConfigMapProgressStore(ProgressStore):
                 f"Failed to update ConfigMap {self.CONFIGMAP_NAME}: "
                 f"{result.stderr.strip()}"
             )
-
-
-class CompositeProgressStore(ProgressStore):
-    """Write to all stores; read from the first that returns data.
-
-    Primary store failures propagate. Secondary store failures (both
-    save and load) print a warning to stderr but do not raise.
-    """
-
-    def __init__(self, primary: ProgressStore, *secondaries: ProgressStore) -> None:
-        self._primary = primary
-        self._secondaries = secondaries
-
-    def load(self) -> dict:
-        data = self._primary.load()
-        if data:
-            return data
-        for store in self._secondaries:
-            try:
-                data = store.load()
-                if data:
-                    return data
-            except (ValueError, RuntimeError, OSError) as exc:
-                print(f"[WARN] Secondary store load failed: {exc}", file=sys.stderr)
-                continue
-        return {}
-
-    def save(self, data: dict) -> None:
-        self._primary.save(data)
-        for store in self._secondaries:
-            try:
-                store.save(data)
-            except (ValueError, RuntimeError, OSError) as exc:
-                print(f"[WARN] {type(store).__name__} save failed: {exc}", file=sys.stderr)

--- a/pipeline/lib/progress.py
+++ b/pipeline/lib/progress.py
@@ -27,12 +27,15 @@ class ConfigMapProgressStore(ProgressStore):
         self._namespace = namespace
 
     def load(self) -> dict:
-        result = subprocess.run(
-            ["kubectl", "get", "configmap", self.CONFIGMAP_NAME,
-             "-n", self._namespace,
-             "-o", f"jsonpath={{.data.{self.DATA_KEY}}}"],
-            check=False, text=True, capture_output=True,
-        )
+        try:
+            result = subprocess.run(
+                ["kubectl", "get", "configmap", self.CONFIGMAP_NAME,
+                 "-n", self._namespace,
+                 "-o", f"jsonpath={{.data.{self.DATA_KEY}}}"],
+                check=False, text=True, capture_output=True,
+            )
+        except OSError as exc:
+            raise RuntimeError(f"kubectl not available: {exc}") from exc
         if result.returncode != 0:
             if "(NotFound)" in result.stderr:
                 return {}
@@ -62,11 +65,16 @@ class ConfigMapProgressStore(ProgressStore):
                 self.DATA_KEY: json.dumps(data, indent=2),
             },
         }
-        result = subprocess.run(
-            ["kubectl", "apply", "-f", "-"],
-            input=json.dumps(cm),
-            check=False, text=True, capture_output=True,
-        )
+        try:
+            result = subprocess.run(
+                ["kubectl", "apply", "-f", "-"],
+                input=json.dumps(cm),
+                check=False, text=True, capture_output=True,
+            )
+        except OSError as exc:
+            raise RuntimeError(
+                f"Failed to update ConfigMap {self.CONFIGMAP_NAME}: {exc}"
+            ) from exc
         if result.returncode != 0:
             raise RuntimeError(
                 f"Failed to update ConfigMap {self.CONFIGMAP_NAME}: "

--- a/pipeline/lib/progress.py
+++ b/pipeline/lib/progress.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 import json
 import subprocess
-import sys
 from abc import ABC, abstractmethod
 
 

--- a/pipeline/monitor.py
+++ b/pipeline/monitor.py
@@ -24,7 +24,7 @@ from pipeline.lib.health import (
     RemediationTracker, get_pods, get_events, get_pod_logs,
     delete_pod, describe_pod, triage_pod,
 )
-from pipeline.lib.progress import LocalProgressStore
+from pipeline.lib.progress import ConfigMapProgressStore
 
 # ── Color helpers (mirrors deploy.py) ────────────────────────────────────────
 _tty = sys.stdout.isatty()
@@ -345,7 +345,15 @@ def main() -> None:
 
     report = HealthReport(run_dir / "health_report.md")
     tracker = RemediationTracker()
-    store = LocalProgressStore(run_dir / "progress.json")
+
+    ns = setup_config.get("namespace", "")
+    if not ns:
+        ns_list = setup_config.get("namespaces", [])
+        ns = ns_list[0] if ns_list else ""
+    if not ns:
+        err("No namespace configured in setup_config.json. Run setup.py first.")
+        sys.exit(1)
+    store = ConfigMapProgressStore(ns)
 
     info(f"Monitoring run '{run_name}' (interval: {args.interval}s)")
     info(f"Report: {run_dir}/health_report.md")
@@ -357,8 +365,8 @@ def main() -> None:
     while True:
         try:
             progress = store.load()
-        except ValueError as exc:
-            warn(f"progress.json unreadable ({exc}) — retrying next interval")
+        except (ValueError, RuntimeError) as exc:
+            warn(f"ConfigMap unreadable ({exc}) — retrying next interval")
             time.sleep(args.interval)
             continue
         if not _work_remaining(progress):

--- a/pipeline/tests/test_deploy_collect.py
+++ b/pipeline/tests/test_deploy_collect.py
@@ -6,24 +6,27 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
-
-def _write_progress(run_dir, entries):
-    """Helper to write a progress.json file in run_dir."""
-    run_dir.mkdir(parents=True, exist_ok=True)
-    (run_dir / "progress.json").write_text(json.dumps(entries))
+from pipeline.lib.progress import ConfigMapProgressStore
 
 
-def test_collect_with_progress_default(tmp_path):
-    """Without --package, collect uses all unique packages from progress.json."""
+def _mock_cm(monkeypatch, data):
+    """Monkeypatch ConfigMapProgressStore to return *data* on load and no-op on save."""
+    monkeypatch.setattr(ConfigMapProgressStore, "load", lambda self: data)
+    monkeypatch.setattr(ConfigMapProgressStore, "save", lambda self, d: None)
+
+
+def test_collect_with_progress_default(tmp_path, monkeypatch):
+    """Without --package, collect uses all unique packages from progress."""
     from pipeline import deploy
 
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
-    _write_progress(run_dir, {
+    data = {
         "wl-smoke-baseline": {"workload": "wl-smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
         "wl-smoke-treatment": {"workload": "wl-smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
         "wl-load-baseline": {"workload": "wl-load", "package": "baseline", "status": "pending"},
-    })
+    }
+    _mock_cm(monkeypatch, data)
 
     class Args:
         package = None
@@ -41,13 +44,13 @@ def test_collect_with_progress_default(tmp_path):
     assert collected_phases == ["baseline", "treatment"]
 
 
-def test_collect_fallback_no_progress(tmp_path):
-    """Without --package and no progress.json, discovers phases from cluster/ with warning."""
+def test_collect_fallback_no_progress(tmp_path, monkeypatch):
+    """Without --package and empty progress, discovers phases from cluster/ with warning."""
     from pipeline import deploy
 
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
-    # No progress.json written
+    _mock_cm(monkeypatch, {})
 
     class Args:
         package = None
@@ -67,16 +70,17 @@ def test_collect_fallback_no_progress(tmp_path):
     mock_warn.assert_called()
 
 
-def test_collect_single_package_from_progress(tmp_path):
+def test_collect_single_package_from_progress(tmp_path, monkeypatch):
     """With --package treatment and progress containing it, collects only treatment."""
     from pipeline import deploy
 
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
-    _write_progress(run_dir, {
+    data = {
         "wl-smoke-baseline": {"workload": "wl-smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
         "wl-smoke-treatment": {"workload": "wl-smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
-    })
+    }
+    _mock_cm(monkeypatch, data)
 
     class Args:
         package = ["treatment"]
@@ -94,17 +98,18 @@ def test_collect_single_package_from_progress(tmp_path):
     assert collected_phases == ["treatment"]
 
 
-def test_collect_experiment_expands_to_all_progress_phases(tmp_path):
+def test_collect_experiment_expands_to_all_progress_phases(tmp_path, monkeypatch):
     """With --package experiment, expands to all known phases from progress."""
     from pipeline import deploy
 
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
-    _write_progress(run_dir, {
+    data = {
         "wl-smoke-baseline": {"workload": "wl-smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
         "wl-smoke-treatment": {"workload": "wl-smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
         "wl-smoke-canary": {"workload": "wl-smoke", "package": "canary", "status": "done", "completed_namespace": "ns-0"},
-    })
+    }
+    _mock_cm(monkeypatch, data)
 
     class Args:
         package = ["experiment"]
@@ -123,16 +128,17 @@ def test_collect_experiment_expands_to_all_progress_phases(tmp_path):
     assert collected_phases == ["baseline", "canary", "treatment"]
 
 
-def test_collect_unknown_package_exits(tmp_path):
+def test_collect_unknown_package_exits(tmp_path, monkeypatch):
     """With --package foo (not in progress), collect exits with error."""
     from pipeline import deploy
 
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
-    _write_progress(run_dir, {
+    data = {
         "wl-smoke-baseline": {"workload": "wl-smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
         "wl-smoke-treatment": {"workload": "wl-smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
-    })
+    }
+    _mock_cm(monkeypatch, data)
 
     class Args:
         package = ["foo"]
@@ -142,16 +148,17 @@ def test_collect_unknown_package_exits(tmp_path):
         deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
 
 
-def test_collect_custom_package_in_progress(tmp_path):
+def test_collect_custom_package_in_progress(tmp_path, monkeypatch):
     """With --package canary where canary IS in progress, succeeds."""
     from pipeline import deploy
 
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
-    _write_progress(run_dir, {
+    data = {
         "wl-smoke-baseline": {"workload": "wl-smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
         "wl-smoke-canary": {"workload": "wl-smoke", "package": "canary", "status": "done", "completed_namespace": "ns-0"},
-    })
+    }
+    _mock_cm(monkeypatch, data)
 
     class Args:
         package = ["canary"]
@@ -169,13 +176,18 @@ def test_collect_custom_package_in_progress(tmp_path):
     assert collected_phases == ["canary"]
 
 
-def test_collect_corrupt_progress_warns_and_falls_back(tmp_path, capsys):
-    """Corrupt progress.json warns with correct message and falls back to default phases."""
+def test_collect_corrupt_configmap_raises(tmp_path, monkeypatch):
+    """ValueError from ConfigMap with invalid JSON propagates."""
     from pipeline import deploy
 
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     run_dir.mkdir(parents=True)
-    (run_dir / "progress.json").write_text("{invalid json")
+
+    def _raise_on_load(self):
+        raise ValueError("Corrupt ConfigMap sim2real-progress in ns-0")
+
+    monkeypatch.setattr(ConfigMapProgressStore, "load", _raise_on_load)
+    monkeypatch.setattr(ConfigMapProgressStore, "save", lambda self, d: None)
 
     class Args:
         package = None
@@ -187,29 +199,27 @@ def test_collect_corrupt_progress_warns_and_falls_back(tmp_path, capsys):
         collected_phases.extend(phases)
         return {p: None for p in phases}
 
-    # CM primary returns empty (ConfigMap not found), local secondary has corrupt JSON.
+    # The ValueError is caught by _cmd_collect and treated as no progress
     with patch.object(deploy, "_extract_phases_from_pvc", mock_extract), \
-         patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(
-            returncode=1, stderr="Error from server (NotFound): configmaps \"sim2real-progress\" not found")
+         patch.object(deploy, "warn") as mock_warn:
         deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
 
     assert collected_phases == ["baseline", "treatment"]
-    captured = capsys.readouterr()
-    assert "Corrupt" in captured.err
+    assert any("Corrupt" in str(c) or "Failed" in str(c) for c in mock_warn.call_args_list)
 
 
-def test_collect_only_done_phases(tmp_path):
+def test_collect_only_done_phases(tmp_path, monkeypatch):
     """Only phases with status done are included."""
     from pipeline import deploy
 
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
-    _write_progress(run_dir, {
+    data = {
         "wl-a-baseline": {"workload": "wl-a", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
         "wl-a-treatment": {"workload": "wl-a", "package": "treatment", "status": "pending"},
         "wl-a-canary": {"workload": "wl-a", "package": "canary", "status": "done", "completed_namespace": "ns-0"},
-    })
+    }
+    _mock_cm(monkeypatch, data)
 
     class Args:
         package = None
@@ -228,16 +238,17 @@ def test_collect_only_done_phases(tmp_path):
     assert sorted(collected_phases) == ["baseline", "canary"]
 
 
-def test_collect_missing_package_key_skipped(tmp_path):
+def test_collect_missing_package_key_skipped(tmp_path, monkeypatch):
     """Progress entries without a 'package' key are gracefully skipped."""
     from pipeline import deploy
 
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
-    _write_progress(run_dir, {
+    data = {
         "wl-a-baseline": {"workload": "wl-a", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
         "wl-b-broken": {"workload": "wl-b", "status": "done"},
-    })
+    }
+    _mock_cm(monkeypatch, data)
 
     class Args:
         package = None
@@ -255,17 +266,18 @@ def test_collect_missing_package_key_skipped(tmp_path):
     assert collected_phases == ["baseline"]
 
 
-def test_collect_with_multi_baseline_progress(tmp_path):
-    """Collect discovers arbitrary phase names from progress.json."""
+def test_collect_with_multi_baseline_progress(tmp_path, monkeypatch):
+    """Collect discovers arbitrary phase names from progress."""
     from pipeline import deploy
 
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
-    _write_progress(run_dir, {
+    data = {
         "wl-smoke-b1": {"workload": "wl-smoke", "package": "b1", "status": "done", "completed_namespace": "ns-0"},
         "wl-smoke-b2": {"workload": "wl-smoke", "package": "b2", "status": "done", "completed_namespace": "ns-0"},
         "wl-smoke-ac1": {"workload": "wl-smoke", "package": "ac1", "status": "done", "completed_namespace": "ns-0"},
-    })
+    }
+    _mock_cm(monkeypatch, data)
 
     class Args:
         package = None
@@ -283,8 +295,8 @@ def test_collect_with_multi_baseline_progress(tmp_path):
     assert collected_phases == ["ac1", "b1", "b2"]
 
 
-def test_collect_fallback_discovers_from_pipelinerun_files(tmp_path):
-    """Without progress.json, falls back to discovering phases from pipelinerun YAMLs."""
+def test_collect_fallback_discovers_from_pipelinerun_files(tmp_path, monkeypatch):
+    """Without progress data, falls back to discovering phases from pipelinerun YAMLs."""
     from pipeline import deploy
 
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
@@ -292,6 +304,7 @@ def test_collect_fallback_discovers_from_pipelinerun_files(tmp_path):
     cluster_dir.mkdir(parents=True)
     (cluster_dir / "pipelinerun-wl-smoke-b1.yaml").write_text("apiVersion: tekton.dev/v1")
     (cluster_dir / "pipelinerun-wl-smoke-b2.yaml").write_text("apiVersion: tekton.dev/v1")
+    _mock_cm(monkeypatch, {})
 
     class Args:
         package = None
@@ -309,18 +322,19 @@ def test_collect_fallback_discovers_from_pipelinerun_files(tmp_path):
     assert collected_phases == ["b1", "b2"]
 
 
-def test_collect_with_workload_scope(tmp_path):
+def test_collect_with_workload_scope(tmp_path, monkeypatch):
     """--workload scopes extraction to matching workloads only."""
     from pipeline import deploy
 
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
-    _write_progress(run_dir, {
+    data = {
         "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
         "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
         "wl-load-baseline": {"workload": "load", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
         "wl-load-treatment": {"workload": "load", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
-    })
+    }
+    _mock_cm(monkeypatch, data)
 
     class Args:
         only = None
@@ -342,17 +356,18 @@ def test_collect_with_workload_scope(tmp_path):
     assert sorted(extract_calls[0]["phases"]) == ["baseline", "treatment"]
 
 
-def test_collect_with_only_scope(tmp_path):
+def test_collect_with_only_scope(tmp_path, monkeypatch):
     """--only scopes extraction to one pair's workload and package."""
     from pipeline import deploy
 
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
-    _write_progress(run_dir, {
+    data = {
         "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
         "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
         "wl-load-baseline": {"workload": "load", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
-    })
+    }
+    _mock_cm(monkeypatch, data)
 
     class Args:
         only = "wl-smoke-baseline"
@@ -374,15 +389,16 @@ def test_collect_with_only_scope(tmp_path):
     assert extract_calls[0]["phases"] == ["baseline"]
 
 
-def test_collect_only_without_prefix(tmp_path):
+def test_collect_only_without_prefix(tmp_path, monkeypatch):
     """--only resolves wl- prefix automatically."""
     from pipeline import deploy
 
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
-    _write_progress(run_dir, {
+    data = {
         "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
-    })
+    }
+    _mock_cm(monkeypatch, data)
 
     class Args:
         only = "smoke-baseline"
@@ -403,17 +419,18 @@ def test_collect_only_without_prefix(tmp_path):
     assert extract_calls[0]["workload"] == "smoke"
 
 
-def test_collect_workload_with_package_filter(tmp_path):
+def test_collect_workload_with_package_filter(tmp_path, monkeypatch):
     """--workload + --package compose: workload scopes within specified phases."""
     from pipeline import deploy
 
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
-    _write_progress(run_dir, {
+    data = {
         "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
         "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
         "wl-load-baseline": {"workload": "load", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
-    })
+    }
+    _mock_cm(monkeypatch, data)
 
     class Args:
         only = None
@@ -435,15 +452,16 @@ def test_collect_workload_with_package_filter(tmp_path):
     assert extract_calls[0]["phases"] == ["baseline"]
 
 
-def test_collect_workload_no_match_exits(tmp_path):
+def test_collect_workload_no_match_exits(tmp_path, monkeypatch):
     """--workload with no matching pairs exits with error."""
     from pipeline import deploy
 
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
-    _write_progress(run_dir, {
+    data = {
         "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
-    })
+    }
+    _mock_cm(monkeypatch, data)
 
     class Args:
         only = None
@@ -455,16 +473,17 @@ def test_collect_workload_no_match_exits(tmp_path):
         deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
 
 
-def test_collect_warns_nondone_scoped_pairs(tmp_path):
+def test_collect_warns_nondone_scoped_pairs(tmp_path, monkeypatch):
     """When scoped pairs include non-done entries, warn but continue with done ones."""
     from pipeline import deploy
 
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
-    _write_progress(run_dir, {
+    data = {
         "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
         "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "running"},
-    })
+    }
+    _mock_cm(monkeypatch, data)
 
     class Args:
         only = None
@@ -487,16 +506,17 @@ def test_collect_warns_nondone_scoped_pairs(tmp_path):
     assert any("running" in str(c) for c in mock_warn.call_args_list)
 
 
-def test_collect_unscoped_unchanged(tmp_path):
+def test_collect_unscoped_unchanged(tmp_path, monkeypatch):
     """Without --only/--workload, collect behaves exactly as before (no workload param)."""
     from pipeline import deploy
 
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
-    _write_progress(run_dir, {
+    data = {
         "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
         "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
-    })
+    }
+    _mock_cm(monkeypatch, data)
 
     class Args:
         only = None
@@ -518,12 +538,13 @@ def test_collect_unscoped_unchanged(tmp_path):
     assert sorted(extract_calls[0]["phases"]) == ["baseline", "treatment"]
 
 
-def test_collect_scoped_without_progress_exits(tmp_path):
-    """--workload without progress.json exits with error."""
+def test_collect_scoped_without_progress_exits(tmp_path, monkeypatch):
+    """--workload without progress data exits with error."""
     from pipeline import deploy
 
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     run_dir.mkdir(parents=True)
+    _mock_cm(monkeypatch, {})
 
     class Args:
         only = None
@@ -535,16 +556,17 @@ def test_collect_scoped_without_progress_exits(tmp_path):
         deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
 
 
-def test_collect_scoped_all_nondone_no_extraction(tmp_path):
+def test_collect_scoped_all_nondone_no_extraction(tmp_path, monkeypatch):
     """When all scoped pairs are non-done, no extraction is attempted and summary prints 0/0."""
     from pipeline import deploy
 
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
-    _write_progress(run_dir, {
+    data = {
         "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "running"},
         "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "pending"},
-    })
+    }
+    _mock_cm(monkeypatch, data)
 
     class Args:
         only = None
@@ -566,15 +588,16 @@ def test_collect_scoped_all_nondone_no_extraction(tmp_path):
     assert any("running" in str(c) or "pending" in str(c) for c in mock_warn.call_args_list)
 
 
-def test_collect_scoped_runtime_error(tmp_path):
+def test_collect_scoped_runtime_error(tmp_path, monkeypatch):
     """RuntimeError from extractor pod is caught and reported."""
     from pipeline import deploy
 
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
-    _write_progress(run_dir, {
+    data = {
         "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
-    })
+    }
+    _mock_cm(monkeypatch, data)
 
     class Args:
         only = None
@@ -592,16 +615,17 @@ def test_collect_scoped_runtime_error(tmp_path):
     assert any("pod failed" in str(c) for c in mock_warn.call_args_list)
 
 
-def test_collect_scoped_per_phase_failure(tmp_path):
+def test_collect_scoped_per_phase_failure(tmp_path, monkeypatch):
     """Per-phase extraction failure in scoped path populates failed list."""
     from pipeline import deploy
 
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
-    _write_progress(run_dir, {
+    data = {
         "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
         "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
-    })
+    }
+    _mock_cm(monkeypatch, data)
 
     class Args:
         only = None
@@ -622,17 +646,18 @@ def test_collect_scoped_per_phase_failure(tmp_path):
     assert any("tar failed" in str(c) for c in mock_warn.call_args_list)
 
 
-def test_collect_only_takes_precedence_over_workload(tmp_path):
+def test_collect_only_takes_precedence_over_workload(tmp_path, monkeypatch):
     """When both --only and --workload are given, --only takes precedence."""
     from pipeline import deploy
 
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
-    _write_progress(run_dir, {
+    data = {
         "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
         "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
         "wl-load-baseline": {"workload": "load", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
-    })
+    }
+    _mock_cm(monkeypatch, data)
 
     class Args:
         only = "wl-smoke-baseline"
@@ -654,18 +679,19 @@ def test_collect_only_takes_precedence_over_workload(tmp_path):
     assert extract_calls[0]["phases"] == ["baseline"]
 
 
-def test_collect_unscoped_multi_namespace_dispatch(tmp_path):
+def test_collect_unscoped_multi_namespace_dispatch(tmp_path, monkeypatch):
     """Unscoped collect dispatches one extract call per distinct completed_namespace."""
     from pipeline import deploy
 
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
-    (run_dir / "progress.json").write_text(json.dumps({
+    data = {
         "wl-smoke-baseline":   {"workload": "smoke", "package": "baseline",  "status": "done", "completed_namespace": "ns-0"},
         "wl-smoke-treatment":  {"workload": "smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
         "wl-load-baseline":    {"workload": "load",  "package": "baseline",  "status": "done", "completed_namespace": "ns-1"},
         "wl-load-treatment":   {"workload": "load",  "package": "treatment", "status": "done", "completed_namespace": "ns-1"},
-    }))
+    }
+    _mock_cm(monkeypatch, data)
 
     class Args:
         package = None
@@ -689,16 +715,17 @@ def test_collect_unscoped_multi_namespace_dispatch(tmp_path):
     assert all(c["workload"] is None for c in extract_calls)
 
 
-def test_collect_unscoped_missing_completed_namespace_warns_and_skips(tmp_path):
+def test_collect_unscoped_missing_completed_namespace_warns_and_skips(tmp_path, monkeypatch):
     """Done entries without completed_namespace emit a warning and are skipped."""
     from pipeline import deploy
 
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
-    (run_dir / "progress.json").write_text(json.dumps({
+    data = {
         "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done"},
         "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "done"},
-    }))
+    }
+    _mock_cm(monkeypatch, data)
 
     class Args:
         package = None
@@ -720,18 +747,19 @@ def test_collect_unscoped_missing_completed_namespace_warns_and_skips(tmp_path):
     assert any("completed_namespace" in w for w in warnings)
 
 
-def test_collect_scoped_multi_namespace_dispatch(tmp_path):
+def test_collect_scoped_multi_namespace_dispatch(tmp_path, monkeypatch):
     """Scoped collect uses each workload's completed_namespace, not primary."""
     from pipeline import deploy
 
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
-    (run_dir / "progress.json").write_text(json.dumps({
+    data = {
         "wl-smoke-baseline":  {"workload": "smoke", "package": "baseline",  "status": "done", "completed_namespace": "ns-0"},
         "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
         "wl-load-baseline":   {"workload": "load",  "package": "baseline",  "status": "done", "completed_namespace": "ns-1"},
         "wl-load-treatment":  {"workload": "load",  "package": "treatment", "status": "done", "completed_namespace": "ns-1"},
-    }))
+    }
+    _mock_cm(monkeypatch, data)
 
     class Args:
         only = None
@@ -755,16 +783,17 @@ def test_collect_scoped_multi_namespace_dispatch(tmp_path):
     assert sorted(extract_calls[0]["phases"]) == ["baseline", "treatment"]
 
 
-def test_collect_scoped_missing_completed_namespace_warns_and_skips(tmp_path):
+def test_collect_scoped_missing_completed_namespace_warns_and_skips(tmp_path, monkeypatch):
     """Scoped collect warns and skips workloads whose done pairs lack completed_namespace."""
     from pipeline import deploy
 
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
-    (run_dir / "progress.json").write_text(json.dumps({
+    data = {
         "wl-smoke-baseline":  {"workload": "smoke", "package": "baseline",  "status": "done"},
         "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "done"},
-    }))
+    }
+    _mock_cm(monkeypatch, data)
 
     class Args:
         only = None
@@ -787,8 +816,8 @@ def test_collect_scoped_missing_completed_namespace_warns_and_skips(tmp_path):
     assert any("completed_namespace" in w for w in warnings)
 
 
-def test_collect_reads_from_configmap_when_no_local_file(tmp_path):
-    """collect uses CompositeProgressStore to read from ConfigMap when no local file."""
+def test_collect_reads_from_configmap(tmp_path, monkeypatch):
+    """collect reads progress from ConfigMapProgressStore."""
     from pipeline import deploy
 
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
@@ -798,6 +827,7 @@ def test_collect_reads_from_configmap_when_no_local_file(tmp_path):
         "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
         "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
     }
+    _mock_cm(monkeypatch, cm_data)
 
     class Args:
         package = None
@@ -809,75 +839,12 @@ def test_collect_reads_from_configmap_when_no_local_file(tmp_path):
         extract_calls.append({"phases": phases, "workload": workload})
         return {p: None for p in phases}
 
-    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract), \
-         patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps(cm_data))
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
         deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
 
     assert len(extract_calls) == 1
     assert sorted(extract_calls[0]["phases"]) == ["baseline", "treatment"]
 
-
-def test_collect_cm_failure_falls_back_to_local(tmp_path):
-    """When CM primary raises RuntimeError, collect falls back to local progress.json."""
-    from pipeline import deploy
-
-    run_dir = tmp_path / "workspace" / "runs" / "test-run"
-    (run_dir / "cluster").mkdir(parents=True)
-    _write_progress(run_dir, {
-        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
-        "wl-smoke-treatment": {"workload": "smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
-    })
-
-    class Args:
-        package = None
-        skip_logs = False
-
-    extract_calls = []
-
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None):
-        extract_calls.append({"phases": phases, "workload": workload})
-        return {p: None for p in phases}
-
-    # CM primary raises RuntimeError (cluster unreachable)
-    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract), \
-         patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(
-            returncode=1, stderr="Unable to connect to the server: dial tcp: lookup cluster: no such host")
-        deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
-
-    assert len(extract_calls) == 1
-    assert sorted(extract_calls[0]["phases"]) == ["baseline", "treatment"]
-
-
-def test_collect_cm_failure_no_local_falls_back_to_discovery(tmp_path):
-    """When CM primary raises and no local file, collect falls back to phase discovery."""
-    from pipeline import deploy
-
-    run_dir = tmp_path / "workspace" / "runs" / "test-run"
-    cluster_dir = run_dir / "cluster"
-    cluster_dir.mkdir(parents=True)
-    (cluster_dir / "pipelinerun-wl-smoke-baseline.yaml").write_text("apiVersion: tekton.dev/v1")
-    (cluster_dir / "pipelinerun-wl-smoke-treatment.yaml").write_text("apiVersion: tekton.dev/v1")
-
-    class Args:
-        package = None
-        skip_logs = False
-
-    extract_calls = []
-
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None):
-        extract_calls.append(phases)
-        return {p: None for p in phases}
-
-    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract), \
-         patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(
-            returncode=1, stderr="Unable to connect to the server: dial tcp: lookup cluster: no such host")
-        deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
-
-    assert len(extract_calls) == 1
-    assert sorted(extract_calls[0]) == ["baseline", "treatment"]
 
 
 # ── Incremental collect helpers ──────────────────────────────────────────────

--- a/pipeline/tests/test_deploy_collect.py
+++ b/pipeline/tests/test_deploy_collect.py
@@ -11,7 +11,8 @@ from pipeline.lib.progress import ConfigMapProgressStore
 
 def _mock_cm(monkeypatch, data):
     """Monkeypatch ConfigMapProgressStore to return *data* on load and no-op on save."""
-    monkeypatch.setattr(ConfigMapProgressStore, "load", lambda self: data)
+    monkeypatch.setattr(ConfigMapProgressStore, "load",
+                        lambda self: json.loads(json.dumps(data)))
     monkeypatch.setattr(ConfigMapProgressStore, "save", lambda self, d: None)
 
 

--- a/pipeline/tests/test_deploy_reset.py
+++ b/pipeline/tests/test_deploy_reset.py
@@ -1,6 +1,6 @@
 """Tests for deploy.py reset subcommand and _reset_pair helper."""
 
-import json
+from pipeline.lib.progress import ConfigMapProgressStore
 
 
 _PROGRESS = {
@@ -18,6 +18,24 @@ _DISCOVERED = {
     "wl-load-treatment":  {"pr_name": "treatment-load-run1",  "workload": "wl-load",  "package": "treatment"},
     "wl-heavy-baseline":  {"pr_name": "baseline-heavy-run1",  "workload": "wl-heavy", "package": "baseline"},
 }
+
+
+def _mock_cm(monkeypatch, data, capture_saves=None):
+    """Monkeypatch ConfigMapProgressStore to return a deep copy of *data* on load.
+
+    If *capture_saves* is a dict, saves are captured into it.
+    Otherwise saves are no-ops.
+    """
+    import json as _json
+    monkeypatch.setattr(ConfigMapProgressStore, "load",
+                        lambda self: _json.loads(_json.dumps(data)))
+    if capture_saves is not None:
+        def _save(self, d):
+            capture_saves.clear()
+            capture_saves.update(d)
+        monkeypatch.setattr(ConfigMapProgressStore, "save", _save)
+    else:
+        monkeypatch.setattr(ConfigMapProgressStore, "save", lambda self, d: None)
 
 
 def test_reset_pair_failed_deletes_pr_and_helm(monkeypatch):
@@ -190,8 +208,8 @@ def test_cmd_reset_continues_on_exception(tmp_path, monkeypatch, capsys):
         "wl-b-baseline": {"workload": "wl-b", "package": "baseline", "status": "failed",
                           "namespace": "sim2real-1", "retries": 0},
     }
-    progress_path = tmp_path / "progress.json"
-    progress_path.write_text(json.dumps(progress))
+    saved_data = {}
+    _mock_cm(monkeypatch, progress, capture_saves=saved_data)
 
     call_count = []
 
@@ -206,17 +224,20 @@ def test_cmd_reset_continues_on_exception(tmp_path, monkeypatch, capsys):
 
     monkeypatch.setattr(mod, "_reset_pair", exploding_reset)
 
+    run_dir = tmp_path / "runs" / "test-run"
+    run_dir.mkdir(parents=True)
+
     class _Args:
         only = None; workload = None; package = None; status = None; dry_run = False
 
-    mod._cmd_reset(_Args(), progress_path, _DISCOVERED)
+    mod._cmd_reset(_Args(), run_dir, _DISCOVERED,
+                   setup_config={"namespace": "sim2real-ns"})
 
     # Both pairs should have been attempted
     assert "wl-a-baseline" in call_count
     assert "wl-b-baseline" in call_count
     # Progress should still be saved (wl-b was reset)
-    saved = json.loads(progress_path.read_text())
-    assert saved["wl-b-baseline"]["status"] == "pending"
+    assert saved_data["wl-b-baseline"]["status"] == "pending"
 
 
 def test_reset_pair_done_deletes_pr_without_state_reset(monkeypatch):
@@ -256,17 +277,20 @@ def test_cmd_reset_skips_pending_only(tmp_path, monkeypatch, capsys):
     """reset acts on all non-pending pairs, including done."""
     import pipeline.deploy as mod
 
-    progress_path = tmp_path / "progress.json"
-    progress_path.write_text(json.dumps(_PROGRESS))
+    _mock_cm(monkeypatch, _PROGRESS)
 
     cleaned = []
     monkeypatch.setattr(mod, "_reset_pair",
                         lambda k, e, d, dry_run=False, namespaces=None: cleaned.append(k) or True)
 
+    run_dir = tmp_path / "runs" / "test-run"
+    run_dir.mkdir(parents=True)
+
     class _Args:
         only = None; workload = None; package = None; status = None; dry_run = False
 
-    mod._cmd_reset(_Args(), progress_path, _DISCOVERED)
+    mod._cmd_reset(_Args(), run_dir, _DISCOVERED,
+                   setup_config={"namespace": "sim2real-ns"})
 
     # pending (wl-load-baseline) should be skipped
     assert "wl-load-baseline" not in cleaned
@@ -281,48 +305,53 @@ def test_cmd_reset_respects_only_filter(tmp_path, monkeypatch, capsys):
     """--only scopes reset to a single pair."""
     import pipeline.deploy as mod
 
-    progress_path = tmp_path / "progress.json"
-    progress_path.write_text(json.dumps(_PROGRESS))
+    _mock_cm(monkeypatch, _PROGRESS)
 
     cleaned = []
     monkeypatch.setattr(mod, "_reset_pair",
                         lambda k, e, d, dry_run=False, namespaces=None: cleaned.append(k) or True)
 
+    run_dir = tmp_path / "runs" / "test-run"
+    run_dir.mkdir(parents=True)
+
     class _Args:
         only = "wl-heavy-baseline"; workload = None; package = None; status = None; dry_run = False
 
-    mod._cmd_reset(_Args(), progress_path, _DISCOVERED)
+    mod._cmd_reset(_Args(), run_dir, _DISCOVERED,
+                   setup_config={"namespace": "sim2real-ns"})
 
     assert cleaned == ["wl-heavy-baseline"]
 
 
 def test_cmd_reset_dry_run_does_not_save(tmp_path, monkeypatch, capsys):
-    """--dry-run does not mutate progress.json."""
+    """--dry-run does not persist to ConfigMap."""
     import pipeline.deploy as mod
 
-    progress_path = tmp_path / "progress.json"
-    progress_path.write_text(json.dumps(_PROGRESS))
+    saved_data = {}
+    _mock_cm(monkeypatch, _PROGRESS, capture_saves=saved_data)
 
     monkeypatch.setattr(mod, "_reset_pair",
                         lambda k, e, d, dry_run=False, namespaces=None: True)
 
+    run_dir = tmp_path / "runs" / "test-run"
+    run_dir.mkdir(parents=True)
+
     class _Args:
         only = None; workload = None; package = None; status = None; dry_run = True
 
-    mod._cmd_reset(_Args(), progress_path, _DISCOVERED)
+    mod._cmd_reset(_Args(), run_dir, _DISCOVERED,
+                   setup_config={"namespace": "sim2real-ns"})
 
-    # Progress should not be modified
-    saved = json.loads(progress_path.read_text())
-    assert saved == _PROGRESS
+    # Progress should not be saved (capture_saves stays empty)
+    assert saved_data == {}
 
 
 def test_cmd_reset_saves_progress_on_success(tmp_path, monkeypatch, capsys):
-    """After reset, progress.json is updated with reset entries."""
+    """After reset, progress is saved via ConfigMapProgressStore."""
     import pipeline.deploy as mod
-    from pipeline.lib.progress import ConfigMapProgressStore
 
-    progress_path = tmp_path / "progress.json"
-    progress_path.write_text(json.dumps(_PROGRESS))
+    saved_data = {}
+    _mock_cm(monkeypatch, _PROGRESS, capture_saves=saved_data)
 
     def fake_run(cmd, *, check=True, capture=False, cwd=None):
         class _R:
@@ -335,25 +364,25 @@ def test_cmd_reset_saves_progress_on_success(tmp_path, monkeypatch, capsys):
 
     monkeypatch.setattr(mod, "run", fake_run)
     monkeypatch.setattr(mod, "_cancel_and_delete_pipelinerun", fake_cancel)
-    monkeypatch.setattr(ConfigMapProgressStore, "load",
-                        lambda self: json.loads(progress_path.read_text()))
-    monkeypatch.setattr(ConfigMapProgressStore, "save", lambda self, data: None)
+
+    run_dir = tmp_path / "runs" / "test-run"
+    run_dir.mkdir(parents=True)
 
     class _Args:
         only = None; workload = None; package = None; status = None; dry_run = False
 
-    mod._cmd_reset(_Args(), progress_path, _DISCOVERED,
-                   namespaces=["sim2real-0", "sim2real-1", "sim2real-2"])
+    mod._cmd_reset(_Args(), run_dir, _DISCOVERED,
+                   namespaces=["sim2real-0", "sim2real-1", "sim2real-2"],
+                   setup_config={"namespace": "sim2real-ns"})
 
-    saved = json.loads(progress_path.read_text())
     # Non-done pairs reset to pending
-    assert saved["wl-smoke-treatment"]["status"] == "pending"
-    assert saved["wl-load-treatment"]["status"] == "pending"
-    assert saved["wl-heavy-baseline"]["status"] == "pending"
+    assert saved_data["wl-smoke-treatment"]["status"] == "pending"
+    assert saved_data["wl-load-treatment"]["status"] == "pending"
+    assert saved_data["wl-heavy-baseline"]["status"] == "pending"
     # Done pair stays done (PipelineRun deleted but state preserved)
-    assert saved["wl-smoke-baseline"]["status"] == "done"
+    assert saved_data["wl-smoke-baseline"]["status"] == "done"
     # Pending pair unchanged
-    assert saved["wl-load-baseline"]["status"] == "pending"
+    assert saved_data["wl-load-baseline"]["status"] == "pending"
 
 
 def test_force_reset_calls_reset_for_non_pending_non_done(monkeypatch):
@@ -455,18 +484,21 @@ def test_force_reset_continues_on_exception(monkeypatch):
     assert progress["wl-b-baseline"]["status"] == "pending"
 
 
-def test_cmd_reset_aborts_on_filter_mismatch(tmp_path, capsys):
+def test_cmd_reset_aborts_on_filter_mismatch(tmp_path, monkeypatch, capsys):
     """reset exits with error when --only doesn't match any pair."""
     import pipeline.deploy as mod
 
-    progress_path = tmp_path / "progress.json"
-    progress_path.write_text(json.dumps(_PROGRESS))
+    _mock_cm(monkeypatch, _PROGRESS)
+
+    run_dir = tmp_path / "runs" / "test-run"
+    run_dir.mkdir(parents=True)
 
     class _Args:
         only = "nonexistent"; workload = None; package = None; status = None; dry_run = False
 
     with __import__("pytest").raises(SystemExit) as exc_info:
-        mod._cmd_reset(_Args(), progress_path, _DISCOVERED)
+        mod._cmd_reset(_Args(), run_dir, _DISCOVERED,
+                       setup_config={"namespace": "sim2real-ns"})
     assert exc_info.value.code == 1
     captured = capsys.readouterr()
     assert "No pairs matched" in captured.out + captured.err

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -4,6 +4,8 @@ import json
 import pytest
 from unittest.mock import patch
 
+from pipeline.lib.progress import ConfigMapProgressStore
+
 
 _PROGRESS = {
     "wl-smoke-baseline":   {"workload": "wl-smoke",  "package": "baseline",   "status": "done",      "namespace": "sim2real-0", "retries": 0},
@@ -15,10 +17,15 @@ _PROGRESS = {
 }
 
 
-def test_status_output_contains_all_pairs(tmp_path, capsys):
+def _mock_cm(monkeypatch, data):
+    """Monkeypatch ConfigMapProgressStore to return *data* on load and no-op on save."""
+    monkeypatch.setattr(ConfigMapProgressStore, "load", lambda self: data)
+    monkeypatch.setattr(ConfigMapProgressStore, "save", lambda self, d: None)
+
+
+def test_status_output_contains_all_pairs(tmp_path, capsys, monkeypatch):
     from pipeline.deploy import _cmd_status
-    run_dir = tmp_path
-    (run_dir / "progress.json").write_text(json.dumps(_PROGRESS))
+    _mock_cm(monkeypatch, _PROGRESS)
 
     class _Args:
         only = None
@@ -27,17 +34,16 @@ def test_status_output_contains_all_pairs(tmp_path, capsys):
         status = None
         live = False
 
-    _cmd_status(_Args(), run_dir)
+    _cmd_status(_Args(), tmp_path, setup_config={"namespace": "sim2real-ns"})
     out = capsys.readouterr().out
     for key in _PROGRESS:
         if not key.startswith("_"):
             assert key in out
 
 
-def test_status_filter_by_workload(tmp_path, capsys):
+def test_status_filter_by_workload(tmp_path, capsys, monkeypatch):
     from pipeline.deploy import _cmd_status
-    run_dir = tmp_path
-    (run_dir / "progress.json").write_text(json.dumps(_PROGRESS))
+    _mock_cm(monkeypatch, _PROGRESS)
 
     class _Args:
         only = None
@@ -46,17 +52,16 @@ def test_status_filter_by_workload(tmp_path, capsys):
         status = None
         live = False
 
-    _cmd_status(_Args(), run_dir)
+    _cmd_status(_Args(), tmp_path, setup_config={"namespace": "sim2real-ns"})
     out = capsys.readouterr().out
     assert "wl-smoke-baseline" in out
     assert "wl-smoke-treatment" in out
     assert "wl-load-baseline" not in out
 
 
-def test_status_filter_by_package(tmp_path, capsys):
+def test_status_filter_by_package(tmp_path, capsys, monkeypatch):
     from pipeline.deploy import _cmd_status
-    run_dir = tmp_path
-    (run_dir / "progress.json").write_text(json.dumps(_PROGRESS))
+    _mock_cm(monkeypatch, _PROGRESS)
 
     class _Args:
         only = None
@@ -65,17 +70,16 @@ def test_status_filter_by_package(tmp_path, capsys):
         status = None
         live = False
 
-    _cmd_status(_Args(), run_dir)
+    _cmd_status(_Args(), tmp_path, setup_config={"namespace": "sim2real-ns"})
     out = capsys.readouterr().out
     assert "wl-smoke-treatment" in out
     assert "wl-load-treatment" in out
     assert "wl-smoke-baseline" not in out
 
 
-def test_status_summary_line(tmp_path, capsys):
+def test_status_summary_line(tmp_path, capsys, monkeypatch):
     from pipeline.deploy import _cmd_status
-    run_dir = tmp_path
-    (run_dir / "progress.json").write_text(json.dumps(_PROGRESS))
+    _mock_cm(monkeypatch, _PROGRESS)
 
     class _Args:
         only = None
@@ -84,7 +88,7 @@ def test_status_summary_line(tmp_path, capsys):
         status = None
         live = False
 
-    _cmd_status(_Args(), run_dir)
+    _cmd_status(_Args(), tmp_path, setup_config={"namespace": "sim2real-ns"})
     out = capsys.readouterr().out
     assert "5 pairs" in out
     assert "1 done" in out
@@ -92,8 +96,9 @@ def test_status_summary_line(tmp_path, capsys):
     assert "1 pending" in out
 
 
-def test_status_missing_progress_file(tmp_path, capsys):
+def test_status_missing_progress_file(tmp_path, capsys, monkeypatch):
     from pipeline.deploy import _cmd_status
+    _mock_cm(monkeypatch, {})
 
     class _Args:
         only = None
@@ -102,69 +107,65 @@ def test_status_missing_progress_file(tmp_path, capsys):
         status = None
         live = False
 
-    _cmd_status(_Args(), tmp_path / "missing-run-dir")
+    _cmd_status(_Args(), tmp_path / "missing-run-dir",
+                setup_config={"namespace": "sim2real-ns"})
     out = capsys.readouterr().out
     assert "0 pairs" in out
 
 
-def test_status_filter_by_only(tmp_path, capsys):
+def test_status_filter_by_only(tmp_path, capsys, monkeypatch):
     """status subcommand supports --only filter."""
     from pipeline.deploy import _cmd_status
-    run_dir = tmp_path
-    (run_dir / "progress.json").write_text(json.dumps(_PROGRESS))
+    _mock_cm(monkeypatch, _PROGRESS)
 
     class _Args:
         only = "wl-smoke-baseline"; workload = None; package = None; status = None; live = False
 
-    _cmd_status(_Args(), run_dir)
+    _cmd_status(_Args(), tmp_path, setup_config={"namespace": "sim2real-ns"})
     out = capsys.readouterr().out
     assert "wl-smoke-baseline" in out
     assert "wl-load-baseline" not in out
 
 
-def test_status_filter_by_status(tmp_path, capsys):
+def test_status_filter_by_status(tmp_path, capsys, monkeypatch):
     """status subcommand supports --status filter."""
     from pipeline.deploy import _cmd_status
-    run_dir = tmp_path
-    (run_dir / "progress.json").write_text(json.dumps(_PROGRESS))
+    _mock_cm(monkeypatch, _PROGRESS)
 
     class _Args:
         only = None; workload = None; package = None; status = "running"; live = False
 
-    _cmd_status(_Args(), run_dir)
+    _cmd_status(_Args(), tmp_path, setup_config={"namespace": "sim2real-ns"})
     out = capsys.readouterr().out
     assert "wl-smoke-treatment" in out
     assert "wl-load-baseline" not in out
 
 
-def test_status_mismatch_shows_valid_values(tmp_path, capsys):
+def test_status_mismatch_shows_valid_values(tmp_path, capsys, monkeypatch):
     """status subcommand shows valid values on filter mismatch."""
-    import pytest
     from pipeline.deploy import _cmd_status
-    run_dir = tmp_path
-    (run_dir / "progress.json").write_text(json.dumps(_PROGRESS))
+    _mock_cm(monkeypatch, _PROGRESS)
 
     class _Args:
         only = None; workload = "nonexistent"; package = None; status = None; live = False
 
     with pytest.raises(SystemExit) as exc_info:
-        _cmd_status(_Args(), run_dir)
+        _cmd_status(_Args(), tmp_path, setup_config={"namespace": "sim2real-ns"})
     assert exc_info.value.code == 1
     captured = capsys.readouterr().err
     assert "No pairs matched" in captured
     assert "wl-smoke" in captured
 
 
-def test_status_empty_progress_with_filters(tmp_path, capsys):
+def test_status_empty_progress_with_filters(tmp_path, capsys, monkeypatch):
     """status with empty progress and active filters warns filters are ignored."""
     from pipeline.deploy import _cmd_status
-    run_dir = tmp_path
-    (run_dir / "progress.json").write_text("{}")
+    _mock_cm(monkeypatch, {})
 
     class _Args:
         only = None; workload = "foo"; package = None; status = None; live = False
 
-    _cmd_status(_Args(), run_dir)
+    _cmd_status(_Args(), tmp_path, setup_config={"namespace": "sim2real-ns"})
     out = capsys.readouterr().out
     assert "0 pairs" in out
     assert "filters ignored" in out
@@ -1335,18 +1336,17 @@ def test_early_reclaim_json_decode_error_warns(monkeypatch, capsys):
     assert "invalid JSON" in err
 
 
-def test_status_ignores_orchestrator_metadata_as_pair(tmp_path, capsys):
+def test_status_ignores_orchestrator_metadata_as_pair(tmp_path, capsys, monkeypatch):
     """_orchestrator key should not appear as a pair row in status output."""
     progress = {
         "wl-foo-baseline": {"workload": "foo", "package": "baseline", "status": "running", "namespace": "ns-1", "retries": 0},
         "_orchestrator": {"state": "backing_off", "backoff_level": 2, "last_probe_free_gpus": 0},
     }
-    run_dir = tmp_path
-    (run_dir / "progress.json").write_text(json.dumps(progress))
+    _mock_cm(monkeypatch, progress)
 
     from pipeline.deploy import _cmd_status
     args = argparse.Namespace(only=None, workload=None, package=None, status=None)
-    _cmd_status(args, run_dir)
+    _cmd_status(args, tmp_path, setup_config={"namespace": "sim2real-ns"})
     out = capsys.readouterr().out
     assert "wl-foo-baseline" in out
     lines = out.strip().split("\n")
@@ -1355,35 +1355,33 @@ def test_status_ignores_orchestrator_metadata_as_pair(tmp_path, capsys):
         assert not line.strip().startswith("_orchestrator")
 
 
-def test_status_shows_orchestrator_state_backing_off(tmp_path, capsys):
+def test_status_shows_orchestrator_state_backing_off(tmp_path, capsys, monkeypatch):
     """deploy.py status should show backoff state when _orchestrator is present."""
     progress = {
         "wl-foo-baseline": {"workload": "foo", "package": "baseline", "status": "running", "namespace": "ns-1", "retries": 0},
         "_orchestrator": {"state": "backing_off", "backoff_level": 2, "last_probe_free_gpus": 0, "last_scarcity_time": "2026-05-08T14:32:00+00:00"},
     }
-    run_dir = tmp_path
-    (run_dir / "progress.json").write_text(json.dumps(progress))
+    _mock_cm(monkeypatch, progress)
 
     from pipeline.deploy import _cmd_status
     args = argparse.Namespace(only=None, workload=None, package=None, status=None)
-    _cmd_status(args, run_dir)
+    _cmd_status(args, tmp_path, setup_config={"namespace": "sim2real-ns"})
     out = capsys.readouterr().out
     assert "backing_off" in out
     assert "level 2" in out
 
 
-def test_status_no_orchestrator_section_when_normal(tmp_path, capsys):
+def test_status_no_orchestrator_section_when_normal(tmp_path, capsys, monkeypatch):
     """deploy.py status should not show orchestrator section when state is normal."""
     progress = {
         "wl-foo-baseline": {"workload": "foo", "package": "baseline", "status": "running", "namespace": "ns-1", "retries": 0},
         "_orchestrator": {"state": "normal", "backoff_level": 0, "last_probe_free_gpus": 8},
     }
-    run_dir = tmp_path
-    (run_dir / "progress.json").write_text(json.dumps(progress))
+    _mock_cm(monkeypatch, progress)
 
     from pipeline.deploy import _cmd_status
     args = argparse.Namespace(only=None, workload=None, package=None, status=None)
-    _cmd_status(args, run_dir)
+    _cmd_status(args, tmp_path, setup_config={"namespace": "sim2real-ns"})
     out = capsys.readouterr().out
     assert "backing_off" not in out
 
@@ -1413,16 +1411,16 @@ def test_report_filter_mismatch_excludes_orchestrator(tmp_path, capsys):
     assert "_orchestrator" not in err_out
 
 
-def test_status_empty_pairs_only_orchestrator(tmp_path, capsys):
+def test_status_empty_pairs_only_orchestrator(tmp_path, capsys, monkeypatch):
     """deploy.py status should handle progress with only _orchestrator (no pairs)."""
     progress = {
         "_orchestrator": {"state": "backing_off", "backoff_level": 3, "last_probe_free_gpus": 0},
     }
-    run_dir = tmp_path
-    (run_dir / "progress.json").write_text(json.dumps(progress))
+    _mock_cm(monkeypatch, progress)
+
     from pipeline.deploy import _cmd_status
     args = argparse.Namespace(only=None, workload=None, package=None, status=None)
-    _cmd_status(args, run_dir)
+    _cmd_status(args, tmp_path, setup_config={"namespace": "sim2real-ns"})
     out = capsys.readouterr().out
     assert "0 pairs" in out
 
@@ -1685,7 +1683,7 @@ def test_init_progress_per_pair_heterogeneous_cost(tmp_path):
     assert progress["wl-b-treatment"]["gpu_cost"] == 2
 
 
-# ── status ConfigMap / composite store behavior ───────────────────────────────
+# ── status ConfigMap behavior ───────────────────────────────────────────────
 
 def test_status_parser_has_no_remote_flag():
     """status subcommand does NOT accept --remote (flag removed)."""
@@ -1694,9 +1692,8 @@ def test_status_parser_has_no_remote_flag():
     with pytest.raises(SystemExit):
         parser.parse_args(["status", "--remote"])
 
-def test_status_reads_configmap_when_namespace_configured(tmp_path, capsys):
-    """status reads from ConfigMap (CM primary) when namespace is configured."""
-    from unittest.mock import patch, MagicMock
+def test_status_reads_configmap_when_namespace_configured(tmp_path, capsys, monkeypatch):
+    """status reads from ConfigMap when namespace is configured."""
     from pipeline.deploy import _cmd_status
 
     progress_data = {
@@ -1705,23 +1702,19 @@ def test_status_reads_configmap_when_namespace_configured(tmp_path, capsys):
             "status": "running", "namespace": "sim2real-0", "retries": 0,
         },
     }
+    _mock_cm(monkeypatch, progress_data)
 
     class _Args:
         only = None; workload = None; package = None; status = None
 
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(
-            returncode=0, stdout=json.dumps(progress_data),
-        )
-        _cmd_status(_Args(), tmp_path,
-                    setup_config={"namespace": "sim2real-ns"})
+    _cmd_status(_Args(), tmp_path,
+                setup_config={"namespace": "sim2real-ns"})
 
     out = capsys.readouterr().out
     assert "wl-smoke-baseline" in out
 
-def test_status_reads_configmap_when_no_local_file(tmp_path, capsys):
-    """status reads ConfigMap even when local progress.json doesn't exist."""
-    from unittest.mock import patch, MagicMock
+def test_status_reads_configmap_when_no_local_file(tmp_path, capsys, monkeypatch):
+    """status reads ConfigMap even when no local file exists."""
     from pipeline.deploy import _cmd_status
 
     progress_data = {
@@ -1730,83 +1723,42 @@ def test_status_reads_configmap_when_no_local_file(tmp_path, capsys):
             "status": "done", "namespace": None, "retries": 0,
         },
     }
+    _mock_cm(monkeypatch, progress_data)
 
     class _Args:
         only = None; workload = None; package = None; status = None
 
     run_dir = tmp_path / "nonexistent-run"
     run_dir.mkdir()
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(
-            returncode=0, stdout=json.dumps(progress_data),
-        )
-        _cmd_status(_Args(), run_dir,
-                    setup_config={"namespace": "sim2real-ns"})
+    _cmd_status(_Args(), run_dir,
+                setup_config={"namespace": "sim2real-ns"})
 
     out = capsys.readouterr().out
     assert "wl-smoke-baseline" in out
 
-def test_status_no_configmap_no_local_reports_no_run(tmp_path, capsys):
-    """No local file and no ConfigMap reports '0 pairs'."""
-    from unittest.mock import patch, MagicMock
+def test_status_no_configmap_no_local_reports_no_run(tmp_path, capsys, monkeypatch):
+    """No ConfigMap data reports '0 pairs'."""
     from pipeline.deploy import _cmd_status
+    _mock_cm(monkeypatch, {})
 
     class _Args:
         only = None; workload = None; package = None; status = None
 
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(
-            returncode=1, stdout="",
-            stderr='Error from server (NotFound): configmaps "sim2real-progress" not found',
-        )
-        _cmd_status(_Args(), tmp_path,
-                    setup_config={"namespace": "sim2real-ns"})
+    _cmd_status(_Args(), tmp_path,
+                setup_config={"namespace": "sim2real-ns"})
 
     out = capsys.readouterr().out
     assert "0 pairs" in out
 
-def test_status_no_namespace_uses_local_only(tmp_path, capsys):
-    """status with no namespace configured reads only local progress.json."""
+def test_status_no_namespace_exits_with_error(tmp_path, capsys):
+    """status with no namespace configured exits with error."""
     from pipeline.deploy import _cmd_status
-
-    run_dir = tmp_path
-    (run_dir / "progress.json").write_text(json.dumps({
-        "wl-smoke-baseline": {
-            "workload": "wl-smoke", "package": "baseline",
-            "status": "done", "namespace": None, "retries": 0,
-        },
-    }))
 
     class _Args:
         only = None; workload = None; package = None; status = None
 
-    _cmd_status(_Args(), run_dir, setup_config={})
-
-    out = capsys.readouterr().out
-    assert "wl-smoke-baseline" in out
-
-def test_status_cm_failure_falls_back_to_local(tmp_path, capsys):
-    """When CM primary raises, status falls back to local progress.json."""
-    from unittest.mock import patch, MagicMock
-    from pipeline.deploy import _cmd_status
-
-    run_dir = tmp_path / "runs" / "test-run"
-    run_dir.mkdir(parents=True)
-
-    local_data = {"wl-local-baseline": {"workload": "wl-local", "package": "baseline",
-                                        "status": "done", "namespace": None, "retries": 0}}
-    (run_dir / "progress.json").write_text(json.dumps(local_data))
-
-    class _Args:
-        only = None; workload = None; package = None; status = None
-
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(
-            returncode=1, stderr="Unable to connect to the server: dial tcp: no such host")
-        _cmd_status(_Args(), run_dir, setup_config={"namespace": "sim2real-ns"})
-
-    out = capsys.readouterr().out
-    assert "wl-local-baseline" in out
+    with pytest.raises(SystemExit):
+        _cmd_status(_Args(), tmp_path, setup_config={})
 
 
 # ── _configmap_namespace helper ──────────────────────────────────────────────
@@ -1833,23 +1785,13 @@ def test_configmap_namespace_empty():
     assert _configmap_namespace(None) == ""
 
 
-# ── Composite store wiring in _cmd_run / _cmd_reset ─────────────────────────
+# ── ConfigMapProgressStore wiring in _cmd_run / _cmd_reset ─────────────────
 
-def test_cmd_run_creates_composite_store_when_namespace_available(monkeypatch, tmp_path):
-    """_cmd_run creates CompositeProgressStore with ConfigMap as primary."""
+def test_cmd_run_uses_configmap_store(monkeypatch, tmp_path):
+    """_cmd_run uses ConfigMapProgressStore directly (not CompositeProgressStore)."""
     import pipeline.deploy as mod
-    from pipeline.lib.progress import CompositeProgressStore, ConfigMapProgressStore
 
-    stores_created = []
-    _original_init = CompositeProgressStore.__init__
-
-    def track(self, primary, *secondaries):
-        stores_created.append((type(primary).__name__, [type(s).__name__ for s in secondaries]))
-        _original_init(self, primary, *secondaries)
-
-    monkeypatch.setattr(CompositeProgressStore, "__init__", track)
-    monkeypatch.setattr(ConfigMapProgressStore, "load", lambda self: {})
-    monkeypatch.setattr(ConfigMapProgressStore, "save", lambda self, data: None)
+    _mock_cm(monkeypatch, {})
     monkeypatch.setattr(mod, "_resolve_epp_action", lambda *a: "skip")
     monkeypatch.setattr(mod, "_load_pairs", lambda d: {})
 
@@ -1869,67 +1811,43 @@ def test_cmd_run_creates_composite_store_when_namespace_available(monkeypatch, t
     with pytest.raises(SystemExit):
         mod._cmd_run(args, run_dir, setup)
 
-    assert len(stores_created) == 1
-    primary_type, secondary_types = stores_created[0]
-    assert primary_type == "ConfigMapProgressStore"
-    assert "LocalProgressStore" in secondary_types
+    # If we got this far without ImportError on CompositeProgressStore, the
+    # subcommand is using ConfigMapProgressStore directly (since
+    # CompositeProgressStore no longer exists).
 
-def test_cmd_reset_creates_composite_store_when_namespace_available(monkeypatch, tmp_path):
-    """_cmd_reset creates CompositeProgressStore with ConfigMap as primary."""
+def test_cmd_reset_uses_configmap_store(monkeypatch, tmp_path):
+    """_cmd_reset uses ConfigMapProgressStore directly."""
     import pipeline.deploy as mod
-    from pipeline.lib.progress import CompositeProgressStore, ConfigMapProgressStore
 
-    stores_created = []
-    _original_init = CompositeProgressStore.__init__
-
-    def track(self, primary, *secondaries):
-        stores_created.append((type(primary).__name__, [type(s).__name__ for s in secondaries]))
-        _original_init(self, primary, *secondaries)
-
-    monkeypatch.setattr(CompositeProgressStore, "__init__", track)
-    monkeypatch.setattr(ConfigMapProgressStore, "load", lambda self: {})
-    monkeypatch.setattr(ConfigMapProgressStore, "save", lambda self, data: None)
-
-    progress_path = tmp_path / "progress.json"
-    progress_path.write_text(json.dumps({
+    progress_data = {
         "wl-a-baseline": {"workload": "wl-a", "package": "baseline",
                           "status": "done", "namespace": None, "retries": 0},
-    }))
+    }
+    _mock_cm(monkeypatch, progress_data)
+
+    run_dir = tmp_path / "runs" / "test-run"
+    run_dir.mkdir(parents=True)
 
     args = argparse.Namespace(only=None, workload=None, package=None,
                               status=None, dry_run=False)
-    mod._cmd_reset(args, progress_path, {},
+    # Note: _cmd_reset now takes run_dir, not progress_path
+    mod._cmd_reset(args, run_dir, {},
                    namespaces=["sim2real-ns"],
                    setup_config={"namespace": "sim2real-ns"})
 
-    assert len(stores_created) == 1
-    primary_type, secondary_types = stores_created[0]
-    assert primary_type == "ConfigMapProgressStore"
-    assert "LocalProgressStore" in secondary_types
 
-
-def test_status_always_uses_composite_store(tmp_path, capsys):
-    """status always uses CompositeProgressStore with CM primary."""
-    from unittest.mock import patch, MagicMock
+def test_status_uses_configmap_directly(tmp_path, capsys, monkeypatch):
+    """status uses ConfigMapProgressStore directly (CM data appears in output)."""
     from pipeline.deploy import _cmd_status
-
-    local_data = {"wl-local-baseline": {"workload": "wl-local", "package": "baseline",
-                                        "status": "done", "namespace": None, "retries": 0}}
-    run_dir = tmp_path / "runs" / "test-run"
-    run_dir.mkdir(parents=True)
-    progress_path = run_dir / "progress.json"
-    progress_path.write_text(json.dumps(local_data))
 
     remote_data = {"wl-remote-baseline": {"workload": "wl-remote", "package": "baseline",
                                           "status": "running", "namespace": "ns-0", "retries": 0}}
+    _mock_cm(monkeypatch, remote_data)
 
     class _Args:
         only = None; workload = None; package = None; status = None
 
-    with patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps(remote_data))
-        _cmd_status(_Args(), run_dir, setup_config={"namespace": "sim2real-ns"})
+    _cmd_status(_Args(), tmp_path, setup_config={"namespace": "sim2real-ns"})
 
     out = capsys.readouterr().out
     assert "wl-remote-baseline" in out
-    assert "wl-local-baseline" not in out

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -1788,7 +1788,7 @@ def test_configmap_namespace_empty():
 # ── ConfigMapProgressStore wiring in _cmd_run / _cmd_reset ─────────────────
 
 def test_cmd_run_uses_configmap_store(monkeypatch, tmp_path):
-    """_cmd_run uses ConfigMapProgressStore directly (not CompositeProgressStore)."""
+    """_cmd_run uses ConfigMapProgressStore directly."""
     import pipeline.deploy as mod
 
     _mock_cm(monkeypatch, {})
@@ -1811,9 +1811,6 @@ def test_cmd_run_uses_configmap_store(monkeypatch, tmp_path):
     with pytest.raises(SystemExit):
         mod._cmd_run(args, run_dir, setup)
 
-    # If we got this far without ImportError on CompositeProgressStore, the
-    # subcommand is using ConfigMapProgressStore directly (since
-    # CompositeProgressStore no longer exists).
 
 def test_cmd_reset_uses_configmap_store(monkeypatch, tmp_path):
     """_cmd_reset uses ConfigMapProgressStore directly."""

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -1713,8 +1713,8 @@ def test_status_reads_configmap_when_namespace_configured(tmp_path, capsys, monk
     out = capsys.readouterr().out
     assert "wl-smoke-baseline" in out
 
-def test_status_reads_configmap_when_no_local_file(tmp_path, capsys, monkeypatch):
-    """status reads ConfigMap even when no local file exists."""
+def test_status_reads_from_configmap(tmp_path, capsys, monkeypatch):
+    """status reads progress from ConfigMap."""
     from pipeline.deploy import _cmd_status
 
     progress_data = {
@@ -1736,8 +1736,8 @@ def test_status_reads_configmap_when_no_local_file(tmp_path, capsys, monkeypatch
     out = capsys.readouterr().out
     assert "wl-smoke-baseline" in out
 
-def test_status_no_configmap_no_local_reports_no_run(tmp_path, capsys, monkeypatch):
-    """No ConfigMap data reports '0 pairs'."""
+def test_status_empty_configmap_reports_no_run(tmp_path, capsys, monkeypatch):
+    """Empty ConfigMap reports '0 pairs'."""
     from pipeline.deploy import _cmd_status
     _mock_cm(monkeypatch, {})
 

--- a/pipeline/tests/test_deploy_standalone.py
+++ b/pipeline/tests/test_deploy_standalone.py
@@ -3,6 +3,8 @@
 import json
 from unittest.mock import patch
 
+from pipeline.lib.progress import ConfigMapProgressStore
+
 
 def test_build_parser_no_manifest_flag():
     """build_parser() does NOT expose a --manifest argument."""
@@ -24,12 +26,15 @@ def test_main_works_without_transfer_yaml(tmp_path, monkeypatch):
     # Set up minimal workspace structure
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     run_dir.mkdir(parents=True)
-    progress = {"wl-a-baseline": {"workload": "wl-a", "package": "baseline", "status": "pending", "namespace": None, "retries": 0}}
-    (run_dir / "progress.json").write_text(json.dumps(progress))
 
     # setup_config.json with current_run
     ws = tmp_path / "workspace"
     (ws / "setup_config.json").write_text(json.dumps({"current_run": "test-run", "namespace": "ns-0"}))
+
+    # Mock ConfigMapProgressStore to return progress data
+    progress = {"wl-a-baseline": {"workload": "wl-a", "package": "baseline", "status": "pending", "namespace": None, "retries": 0}}
+    monkeypatch.setattr(ConfigMapProgressStore, "load", lambda self: progress)
+    monkeypatch.setattr(ConfigMapProgressStore, "save", lambda self, d: None)
 
     # Patch sys.argv to simulate CLI invocation
     monkeypatch.setattr("sys.argv", ["deploy.py", "--experiment-root", str(tmp_path), "status"])

--- a/pipeline/tests/test_deploy_wipe.py
+++ b/pipeline/tests/test_deploy_wipe.py
@@ -3,6 +3,8 @@
 import json
 from pathlib import Path
 
+from pipeline.lib.progress import ConfigMapProgressStore
+
 
 _PROGRESS = {
     "wl-smoke-baseline":   {"workload": "wl-smoke",  "package": "baseline",  "status": "done",      "namespace": "sim2real-0", "retries": 0, "pending_stalls": 0, "pending_since": None},
@@ -11,6 +13,23 @@ _PROGRESS = {
     "wl-load-treatment":   {"workload": "wl-load",   "package": "treatment", "status": "failed",    "namespace": "sim2real-2", "retries": 1, "pending_stalls": 2, "pending_since": "2026-05-14T10:00:00Z"},
     "wl-heavy-baseline":   {"workload": "wl-heavy",  "package": "baseline",  "status": "timed-out", "namespace": "sim2real-0", "retries": 1, "pending_stalls": 3, "pending_since": "2026-05-14T11:00:00Z"},
 }
+
+
+def _mock_cm(monkeypatch, data, capture_saves=None):
+    """Monkeypatch ConfigMapProgressStore to return a deep copy of *data* on load.
+
+    If *capture_saves* is a dict, saves are captured into it.
+    Otherwise saves are no-ops.
+    """
+    monkeypatch.setattr(ConfigMapProgressStore, "load",
+                        lambda self: json.loads(json.dumps(data)))
+    if capture_saves is not None:
+        def _save(self, d):
+            capture_saves.clear()
+            capture_saves.update(d)
+        monkeypatch.setattr(ConfigMapProgressStore, "save", _save)
+    else:
+        monkeypatch.setattr(ConfigMapProgressStore, "save", lambda self, d: None)
 
 
 def _assert_reset(entry: dict) -> None:
@@ -32,28 +51,27 @@ def _setup_results(run_dir: Path) -> None:
             (d / "trace_data.csv").write_text("data")
 
 
-def test_wipe_all_deletes_results_and_resets(tmp_path):
+def test_wipe_all_deletes_results_and_resets(tmp_path, monkeypatch):
     """Unscoped wipe deletes results for non-pending pairs and resets them."""
     import pipeline.deploy as mod
 
     run_dir = tmp_path / "run1"
     run_dir.mkdir()
-    progress_path = run_dir / "progress.json"
-    progress_path.write_text(json.dumps(_PROGRESS))
+    saved_data = {}
+    _mock_cm(monkeypatch, _PROGRESS, capture_saves=saved_data)
     _setup_results(run_dir)
 
     class _Args:
         only = None; workload = None; package = None; dry_run = False; yes = True
 
-    mod._cmd_wipe(_Args(), run_dir)
+    mod._cmd_wipe(_Args(), run_dir, setup_config={"namespace": "ns-0"})
 
-    saved = json.loads(progress_path.read_text())
-    _assert_reset(saved["wl-smoke-baseline"])
-    _assert_reset(saved["wl-smoke-treatment"])
-    _assert_reset(saved["wl-load-treatment"])
-    _assert_reset(saved["wl-heavy-baseline"])
+    _assert_reset(saved_data["wl-smoke-baseline"])
+    _assert_reset(saved_data["wl-smoke-treatment"])
+    _assert_reset(saved_data["wl-load-treatment"])
+    _assert_reset(saved_data["wl-heavy-baseline"])
     # Already-pending pair unchanged
-    assert saved["wl-load-baseline"]["status"] == "pending"
+    assert saved_data["wl-load-baseline"]["status"] == "pending"
     # Non-pending workload dirs deleted
     assert not (run_dir / "results" / "baseline" / "wl-smoke").exists()
     assert not (run_dir / "results" / "baseline" / "wl-heavy").exists()
@@ -63,27 +81,26 @@ def test_wipe_all_deletes_results_and_resets(tmp_path):
     assert (run_dir / "results" / "baseline" / "wl-load").exists()
 
 
-def test_wipe_scoped_by_workload(tmp_path):
+def test_wipe_scoped_by_workload(tmp_path, monkeypatch):
     """--workload scopes wipe to matching pairs only."""
     import pipeline.deploy as mod
 
     run_dir = tmp_path / "run1"
     run_dir.mkdir()
-    progress_path = run_dir / "progress.json"
-    progress_path.write_text(json.dumps(_PROGRESS))
+    saved_data = {}
+    _mock_cm(monkeypatch, _PROGRESS, capture_saves=saved_data)
     _setup_results(run_dir)
 
     class _Args:
         only = None; workload = "wl-smoke"; package = None; dry_run = False; yes = True
 
-    mod._cmd_wipe(_Args(), run_dir)
+    mod._cmd_wipe(_Args(), run_dir, setup_config={"namespace": "ns-0"})
 
-    saved = json.loads(progress_path.read_text())
-    _assert_reset(saved["wl-smoke-baseline"])
-    _assert_reset(saved["wl-smoke-treatment"])
+    _assert_reset(saved_data["wl-smoke-baseline"])
+    _assert_reset(saved_data["wl-smoke-treatment"])
     # Out-of-scope pairs unchanged
-    assert saved["wl-load-treatment"]["status"] == "failed"
-    assert saved["wl-heavy-baseline"]["status"] == "timed-out"
+    assert saved_data["wl-load-treatment"]["status"] == "failed"
+    assert saved_data["wl-heavy-baseline"]["status"] == "timed-out"
     # Only wl-smoke directories deleted
     assert not (run_dir / "results" / "baseline" / "wl-smoke").exists()
     assert not (run_dir / "results" / "treatment" / "wl-smoke").exists()
@@ -91,82 +108,79 @@ def test_wipe_scoped_by_workload(tmp_path):
     assert (run_dir / "results" / "baseline" / "wl-load").exists()
 
 
-def test_wipe_scoped_by_only(tmp_path):
+def test_wipe_scoped_by_only(tmp_path, monkeypatch):
     """--only scopes wipe to a single pair."""
     import pipeline.deploy as mod
 
     run_dir = tmp_path / "run1"
     run_dir.mkdir()
-    progress_path = run_dir / "progress.json"
-    progress_path.write_text(json.dumps(_PROGRESS))
+    saved_data = {}
+    _mock_cm(monkeypatch, _PROGRESS, capture_saves=saved_data)
     _setup_results(run_dir)
 
     class _Args:
         only = "wl-heavy-baseline"; workload = None; package = None; dry_run = False; yes = True
 
-    mod._cmd_wipe(_Args(), run_dir)
+    mod._cmd_wipe(_Args(), run_dir, setup_config={"namespace": "ns-0"})
 
-    saved = json.loads(progress_path.read_text())
-    _assert_reset(saved["wl-heavy-baseline"])
+    _assert_reset(saved_data["wl-heavy-baseline"])
     # Other pairs unchanged
-    assert saved["wl-smoke-baseline"]["status"] == "done"
+    assert saved_data["wl-smoke-baseline"]["status"] == "done"
     # Only wl-heavy/baseline deleted
     assert not (run_dir / "results" / "baseline" / "wl-heavy").exists()
     assert (run_dir / "results" / "baseline" / "wl-smoke").exists()
 
 
-def test_wipe_scoped_by_package(tmp_path):
+def test_wipe_scoped_by_package(tmp_path, monkeypatch):
     """--package scopes wipe to pairs matching that package."""
     import pipeline.deploy as mod
 
     run_dir = tmp_path / "run1"
     run_dir.mkdir()
-    progress_path = run_dir / "progress.json"
-    progress_path.write_text(json.dumps(_PROGRESS))
+    saved_data = {}
+    _mock_cm(monkeypatch, _PROGRESS, capture_saves=saved_data)
     _setup_results(run_dir)
 
     class _Args:
         only = None; workload = None; package = "treatment"; dry_run = False; yes = True
 
-    mod._cmd_wipe(_Args(), run_dir)
+    mod._cmd_wipe(_Args(), run_dir, setup_config={"namespace": "ns-0"})
 
-    saved = json.loads(progress_path.read_text())
-    _assert_reset(saved["wl-smoke-treatment"])
-    _assert_reset(saved["wl-load-treatment"])
+    _assert_reset(saved_data["wl-smoke-treatment"])
+    _assert_reset(saved_data["wl-load-treatment"])
     # Baseline pairs unchanged
-    assert saved["wl-smoke-baseline"]["status"] == "done"
-    assert saved["wl-heavy-baseline"]["status"] == "timed-out"
+    assert saved_data["wl-smoke-baseline"]["status"] == "done"
+    assert saved_data["wl-heavy-baseline"]["status"] == "timed-out"
     # Only treatment directories deleted
     assert not (run_dir / "results" / "treatment" / "wl-smoke").exists()
     assert (run_dir / "results" / "baseline" / "wl-smoke").exists()
 
 
-def test_wipe_dry_run_does_not_delete(tmp_path, capsys):
+def test_wipe_dry_run_does_not_delete(tmp_path, monkeypatch, capsys):
     """--dry-run prints what would be deleted but does not mutate anything."""
     import pipeline.deploy as mod
 
     run_dir = tmp_path / "run1"
     run_dir.mkdir()
-    progress_path = run_dir / "progress.json"
-    progress_path.write_text(json.dumps(_PROGRESS))
+    saved_data = {}
+    _mock_cm(monkeypatch, _PROGRESS, capture_saves=saved_data)
     _setup_results(run_dir)
 
     class _Args:
         only = None; workload = None; package = None; dry_run = True; yes = False
 
-    mod._cmd_wipe(_Args(), run_dir)
+    mod._cmd_wipe(_Args(), run_dir, setup_config={"namespace": "ns-0"})
 
     # Nothing deleted
     assert (run_dir / "results" / "baseline" / "wl-smoke").exists()
-    # Progress unchanged
-    saved = json.loads(progress_path.read_text())
-    assert saved == _PROGRESS
+    # Progress not saved (capture_saves stays empty)
+    assert saved_data == {}
     # DRY-RUN mentioned in output
     captured = capsys.readouterr()
     assert "DRY-RUN" in captured.out + captured.err
 
 
-def test_wipe_skips_pending_pairs(tmp_path, capsys):
+def test_wipe_skips_pending_pairs(tmp_path, monkeypatch, capsys):
     """Pending pairs are skipped (nothing to wipe)."""
     import pipeline.deploy as mod
 
@@ -176,32 +190,34 @@ def test_wipe_skips_pending_pairs(tmp_path, capsys):
         "wl-a-baseline": {"workload": "wl-a", "package": "baseline", "status": "pending",
                           "namespace": None, "retries": 0, "pending_stalls": 0, "pending_since": None},
     }
-    progress_path = run_dir / "progress.json"
-    progress_path.write_text(json.dumps(progress))
+    saved_data = {}
+    _mock_cm(monkeypatch, progress, capture_saves=saved_data)
 
     class _Args:
         only = None; workload = None; package = None; dry_run = False; yes = True
 
-    mod._cmd_wipe(_Args(), run_dir)
+    mod._cmd_wipe(_Args(), run_dir, setup_config={"namespace": "ns-0"})
 
-    saved = json.loads(progress_path.read_text())
-    assert saved["wl-a-baseline"]["status"] == "pending"
+    # Nothing wiped — all pending
+    # saved_data may or may not have been written; the important check is status
+    # The function should report "no pairs need wiping" and return early
 
 
-def test_wipe_no_progress_reports_nothing(tmp_path, capsys):
-    """When progress.json doesn't exist, wipe reports nothing to do."""
+def test_wipe_no_progress_reports_nothing(tmp_path, monkeypatch, capsys):
+    """When ConfigMap has no progress data, wipe reports nothing to do."""
     import pipeline.deploy as mod
 
     run_dir = tmp_path / "run1"
     run_dir.mkdir()
+    _mock_cm(monkeypatch, {})
 
     class _Args:
         only = None; workload = None; package = None; dry_run = False; yes = True
 
-    mod._cmd_wipe(_Args(), run_dir)
+    mod._cmd_wipe(_Args(), run_dir, setup_config={"namespace": "ns-0"})
 
     captured = capsys.readouterr()
-    assert "nothing to wipe" in (captured.out + captured.err).lower()
+    assert "nothing" in (captured.out + captured.err).lower()
 
 
 def test_wipe_confirmation_abort(tmp_path, monkeypatch, capsys):
@@ -210,8 +226,8 @@ def test_wipe_confirmation_abort(tmp_path, monkeypatch, capsys):
 
     run_dir = tmp_path / "run1"
     run_dir.mkdir()
-    progress_path = run_dir / "progress.json"
-    progress_path.write_text(json.dumps(_PROGRESS))
+    saved_data = {}
+    _mock_cm(monkeypatch, _PROGRESS, capture_saves=saved_data)
     _setup_results(run_dir)
 
     monkeypatch.setattr("builtins.input", lambda _: "n")
@@ -219,11 +235,10 @@ def test_wipe_confirmation_abort(tmp_path, monkeypatch, capsys):
     class _Args:
         only = None; workload = None; package = None; dry_run = False; yes = False
 
-    mod._cmd_wipe(_Args(), run_dir)
+    mod._cmd_wipe(_Args(), run_dir, setup_config={"namespace": "ns-0"})
 
     # Nothing changed
-    saved = json.loads(progress_path.read_text())
-    assert saved == _PROGRESS
+    assert saved_data == {}
     assert (run_dir / "results" / "baseline" / "wl-smoke").exists()
 
 
@@ -233,8 +248,8 @@ def test_wipe_confirmation_accept(tmp_path, monkeypatch):
 
     run_dir = tmp_path / "run1"
     run_dir.mkdir()
-    progress_path = run_dir / "progress.json"
-    progress_path.write_text(json.dumps(_PROGRESS))
+    saved_data = {}
+    _mock_cm(monkeypatch, _PROGRESS, capture_saves=saved_data)
     _setup_results(run_dir)
 
     monkeypatch.setattr("builtins.input", lambda _: "y")
@@ -242,10 +257,9 @@ def test_wipe_confirmation_accept(tmp_path, monkeypatch):
     class _Args:
         only = None; workload = None; package = None; dry_run = False; yes = False
 
-    mod._cmd_wipe(_Args(), run_dir)
+    mod._cmd_wipe(_Args(), run_dir, setup_config={"namespace": "ns-0"})
 
-    saved = json.loads(progress_path.read_text())
-    _assert_reset(saved["wl-smoke-baseline"])
+    _assert_reset(saved_data["wl-smoke-baseline"])
     assert not (run_dir / "results" / "baseline" / "wl-smoke").exists()
 
 
@@ -255,8 +269,8 @@ def test_wipe_eof_on_input_aborts(tmp_path, monkeypatch, capsys):
 
     run_dir = tmp_path / "run1"
     run_dir.mkdir()
-    progress_path = run_dir / "progress.json"
-    progress_path.write_text(json.dumps(_PROGRESS))
+    saved_data = {}
+    _mock_cm(monkeypatch, _PROGRESS, capture_saves=saved_data)
     _setup_results(run_dir)
 
     def raise_eof(_):
@@ -267,32 +281,30 @@ def test_wipe_eof_on_input_aborts(tmp_path, monkeypatch, capsys):
     class _Args:
         only = None; workload = None; package = None; dry_run = False; yes = False
 
-    mod._cmd_wipe(_Args(), run_dir)
+    mod._cmd_wipe(_Args(), run_dir, setup_config={"namespace": "ns-0"})
 
-    saved = json.loads(progress_path.read_text())
-    assert saved == _PROGRESS
+    assert saved_data == {}
     captured = capsys.readouterr()
     assert "--yes" in captured.out + captured.err
 
 
-def test_wipe_filter_mismatch_aborts(tmp_path, capsys):
+def test_wipe_filter_mismatch_aborts(tmp_path, monkeypatch, capsys):
     """--only with non-existent pair aborts with error."""
     import pipeline.deploy as mod
 
     run_dir = tmp_path / "run1"
     run_dir.mkdir()
-    progress_path = run_dir / "progress.json"
-    progress_path.write_text(json.dumps(_PROGRESS))
+    _mock_cm(monkeypatch, _PROGRESS)
 
     class _Args:
         only = "nonexistent"; workload = None; package = None; dry_run = False; yes = True
 
     with __import__("pytest").raises(SystemExit) as exc_info:
-        mod._cmd_wipe(_Args(), run_dir)
+        mod._cmd_wipe(_Args(), run_dir, setup_config={"namespace": "ns-0"})
     assert exc_info.value.code == 1
 
 
-def test_wipe_cleans_empty_parent_dirs(tmp_path):
+def test_wipe_cleans_empty_parent_dirs(tmp_path, monkeypatch):
     """After wiping all workloads under a package, the package dir is removed."""
     import pipeline.deploy as mod
 
@@ -302,8 +314,8 @@ def test_wipe_cleans_empty_parent_dirs(tmp_path):
         "wl-only-baseline": {"workload": "wl-only", "package": "baseline", "status": "done",
                              "namespace": None, "retries": 0, "pending_stalls": 0, "pending_since": None},
     }
-    progress_path = run_dir / "progress.json"
-    progress_path.write_text(json.dumps(progress))
+    saved_data = {}
+    _mock_cm(monkeypatch, progress, capture_saves=saved_data)
     d = run_dir / "results" / "baseline" / "wl-only"
     d.mkdir(parents=True)
     (d / "trace.csv").write_text("data")
@@ -311,12 +323,12 @@ def test_wipe_cleans_empty_parent_dirs(tmp_path):
     class _Args:
         only = None; workload = None; package = None; dry_run = False; yes = True
 
-    mod._cmd_wipe(_Args(), run_dir)
+    mod._cmd_wipe(_Args(), run_dir, setup_config={"namespace": "ns-0"})
 
     assert not (run_dir / "results" / "baseline").exists()
 
 
-def test_wipe_no_results_on_disk(tmp_path, capsys):
+def test_wipe_no_results_on_disk(tmp_path, monkeypatch, capsys):
     """Wipe succeeds even when results directories don't exist on disk."""
     import pipeline.deploy as mod
 
@@ -326,22 +338,21 @@ def test_wipe_no_results_on_disk(tmp_path, capsys):
         "wl-a-baseline": {"workload": "wl-a", "package": "baseline", "status": "done",
                           "namespace": None, "retries": 0, "pending_stalls": 0, "pending_since": None},
     }
-    progress_path = run_dir / "progress.json"
-    progress_path.write_text(json.dumps(progress))
+    saved_data = {}
+    _mock_cm(monkeypatch, progress, capture_saves=saved_data)
     # No results/ directory created
 
     class _Args:
         only = None; workload = None; package = None; dry_run = False; yes = True
 
-    mod._cmd_wipe(_Args(), run_dir)
+    mod._cmd_wipe(_Args(), run_dir, setup_config={"namespace": "ns-0"})
 
-    saved = json.loads(progress_path.read_text())
-    _assert_reset(saved["wl-a-baseline"])
+    _assert_reset(saved_data["wl-a-baseline"])
     captured = capsys.readouterr()
     assert "no results on disk" in (captured.out + captured.err).lower()
 
 
-def test_wipe_parent_not_removed_when_siblings_remain(tmp_path):
+def test_wipe_parent_not_removed_when_siblings_remain(tmp_path, monkeypatch):
     """Package dir is kept when out-of-scope workloads remain under it."""
     import pipeline.deploy as mod
 
@@ -353,8 +364,8 @@ def test_wipe_parent_not_removed_when_siblings_remain(tmp_path):
         "wl-b-baseline": {"workload": "wl-b", "package": "baseline", "status": "done",
                           "namespace": None, "retries": 0, "pending_stalls": 0, "pending_since": None},
     }
-    progress_path = run_dir / "progress.json"
-    progress_path.write_text(json.dumps(progress))
+    saved_data = {}
+    _mock_cm(monkeypatch, progress, capture_saves=saved_data)
     for wl in ("wl-a", "wl-b"):
         d = run_dir / "results" / "baseline" / wl
         d.mkdir(parents=True)
@@ -363,7 +374,7 @@ def test_wipe_parent_not_removed_when_siblings_remain(tmp_path):
     class _Args:
         only = "wl-a-baseline"; workload = None; package = None; dry_run = False; yes = True
 
-    mod._cmd_wipe(_Args(), run_dir)
+    mod._cmd_wipe(_Args(), run_dir, setup_config={"namespace": "ns-0"})
 
     # wl-a deleted, wl-b untouched, parent kept
     assert not (run_dir / "results" / "baseline" / "wl-a").exists()
@@ -384,8 +395,8 @@ def test_wipe_rmtree_failure_skips_pair(tmp_path, monkeypatch, capsys):
         "wl-b-baseline": {"workload": "wl-b", "package": "baseline", "status": "done",
                           "namespace": None, "retries": 0, "pending_stalls": 0, "pending_since": None},
     }
-    progress_path = run_dir / "progress.json"
-    progress_path.write_text(json.dumps(progress))
+    saved_data = {}
+    _mock_cm(monkeypatch, progress, capture_saves=saved_data)
     for wl in ("wl-a", "wl-b"):
         d = run_dir / "results" / "baseline" / wl
         d.mkdir(parents=True)
@@ -404,20 +415,19 @@ def test_wipe_rmtree_failure_skips_pair(tmp_path, monkeypatch, capsys):
         only = None; workload = None; package = None; dry_run = False; yes = True
 
     with __import__("pytest").raises(SystemExit) as exc_info:
-        mod._cmd_wipe(_Args(), run_dir)
+        mod._cmd_wipe(_Args(), run_dir, setup_config={"namespace": "ns-0"})
     assert exc_info.value.code == 1
 
-    saved = json.loads(progress_path.read_text())
     # wl-a: rmtree failed → status NOT reset
-    assert saved["wl-a-baseline"]["status"] == "done"
+    assert saved_data["wl-a-baseline"]["status"] == "done"
     # wl-b: succeeded → status reset
-    _assert_reset(saved["wl-b-baseline"])
+    _assert_reset(saved_data["wl-b-baseline"])
     # Error count in summary
     captured = capsys.readouterr()
     assert "1 failed" in captured.out + captured.err
 
 
-def test_wipe_warns_on_missing_package_workload(tmp_path, capsys):
+def test_wipe_warns_on_missing_package_workload(tmp_path, monkeypatch, capsys):
     """Entries missing package/workload fields emit a warning."""
     import pipeline.deploy as mod
 
@@ -429,17 +439,16 @@ def test_wipe_warns_on_missing_package_workload(tmp_path, capsys):
         "wl-ok-baseline": {"workload": "wl-ok", "package": "baseline", "status": "done",
                            "namespace": None, "retries": 0, "pending_stalls": 0, "pending_since": None},
     }
-    progress_path = run_dir / "progress.json"
-    progress_path.write_text(json.dumps(progress))
+    saved_data = {}
+    _mock_cm(monkeypatch, progress, capture_saves=saved_data)
 
     class _Args:
         only = None; workload = None; package = None; dry_run = False; yes = True
 
-    mod._cmd_wipe(_Args(), run_dir)
+    mod._cmd_wipe(_Args(), run_dir, setup_config={"namespace": "ns-0"})
 
-    saved = json.loads(progress_path.read_text())
-    _assert_reset(saved["wl-ok-baseline"])
+    _assert_reset(saved_data["wl-ok-baseline"])
     # Broken entry was skipped — status unchanged
-    assert saved["wl-broken"]["status"] == "done"
+    assert saved_data["wl-broken"]["status"] == "done"
     captured = capsys.readouterr()
     assert "missing package/workload" in (captured.out + captured.err).lower()

--- a/pipeline/tests/test_progress.py
+++ b/pipeline/tests/test_progress.py
@@ -2,46 +2,9 @@ import json
 import pytest
 from unittest.mock import patch, MagicMock
 from pipeline.lib.progress import (
-    LocalProgressStore,
     ConfigMapProgressStore,
-    CompositeProgressStore,
     ProgressStore,
 )
-
-def test_load_missing_returns_empty(tmp_path):
-    store = LocalProgressStore(tmp_path / "progress.json")
-    assert store.load() == {}
-
-def test_save_and_load_roundtrip(tmp_path):
-    store = LocalProgressStore(tmp_path / "progress.json")
-    data = {
-        "wl-smoke-baseline": {
-            "workload": "wl-smoke", "package": "baseline",
-            "status": "done", "namespace": "sim2real-0", "retries": 0,
-        }
-    }
-    store.save(data)
-    assert store.load() == data
-
-def test_save_is_atomic(tmp_path):
-    path = tmp_path / "progress.json"
-    store = LocalProgressStore(path)
-    store.save({"a": {"workload": "a", "package": "baseline", "status": "done", "namespace": "ns", "retries": 0}})
-    assert not (tmp_path / "progress.json.tmp").exists()
-    assert path.exists()
-
-def test_save_overwrites_existing(tmp_path):
-    store = LocalProgressStore(tmp_path / "progress.json")
-    store.save({"x": {"workload": "x", "package": "baseline", "status": "pending", "namespace": None, "retries": 0}})
-    store.save({"y": {"workload": "y", "package": "treatment", "status": "done", "namespace": "ns", "retries": 0}})
-    assert list(store.load().keys()) == ["y"]
-
-def test_load_corrupt_file_raises(tmp_path):
-    path = tmp_path / "progress.json"
-    path.write_text("{truncated")
-    store = LocalProgressStore(path)
-    with pytest.raises((json.JSONDecodeError, ValueError)):
-        store.load()
 
 
 # --- ConfigMapProgressStore tests ---
@@ -130,67 +93,3 @@ def test_configmap_save_failure_raises():
         store = ConfigMapProgressStore("sim2real-ns")
         with pytest.raises(RuntimeError, match="Failed to update ConfigMap"):
             store.save({"x": 1})
-
-
-# --- CompositeProgressStore tests ---
-
-def test_composite_save_writes_to_all_stores(tmp_path):
-    """save() writes to both primary and secondary stores."""
-    primary = LocalProgressStore(tmp_path / "a.json")
-    secondary = LocalProgressStore(tmp_path / "b.json")
-    store = CompositeProgressStore(primary, secondary)
-    data = {"wl-x": {"status": "done"}}
-    store.save(data)
-    assert primary.load() == data
-    assert secondary.load() == data
-
-def test_composite_load_returns_primary(tmp_path):
-    """load() returns data from primary when available."""
-    primary = LocalProgressStore(tmp_path / "a.json")
-    secondary = LocalProgressStore(tmp_path / "b.json")
-    primary.save({"from": "primary"})
-    secondary.save({"from": "secondary"})
-    store = CompositeProgressStore(primary, secondary)
-    assert store.load() == {"from": "primary"}
-
-def test_composite_load_falls_back_to_secondary(tmp_path):
-    """load() falls back to secondary when primary is empty."""
-    primary = LocalProgressStore(tmp_path / "a.json")
-    secondary = LocalProgressStore(tmp_path / "b.json")
-    secondary.save({"from": "secondary"})
-    store = CompositeProgressStore(primary, secondary)
-    assert store.load() == {"from": "secondary"}
-
-def test_composite_load_all_empty(tmp_path):
-    """load() returns {} when all stores are empty."""
-    primary = LocalProgressStore(tmp_path / "a.json")
-    secondary = LocalProgressStore(tmp_path / "b.json")
-    store = CompositeProgressStore(primary, secondary)
-    assert store.load() == {}
-
-def test_composite_secondary_save_failure_warns(tmp_path, capsys):
-    """Secondary store save failure warns but doesn't raise."""
-    primary = LocalProgressStore(tmp_path / "a.json")
-
-    class FailStore(ProgressStore):
-        def load(self): return {}
-        def save(self, data): raise RuntimeError("kubectl fail")
-
-    store = CompositeProgressStore(primary, FailStore())
-    store.save({"wl-x": {"status": "done"}})
-    assert primary.load() == {"wl-x": {"status": "done"}}
-    err_output = capsys.readouterr().err
-    assert "FailStore save failed" in err_output
-    assert "kubectl fail" in err_output
-
-def test_composite_secondary_load_failure_warns(tmp_path, capsys):
-    """Secondary store load failure warns and is skipped."""
-    primary = LocalProgressStore(tmp_path / "a.json")
-
-    class FailStore(ProgressStore):
-        def load(self): raise RuntimeError("boom")
-        def save(self, data): pass
-
-    store = CompositeProgressStore(primary, FailStore())
-    assert store.load() == {}
-    assert "boom" in capsys.readouterr().err

--- a/pipeline/tests/test_progress.py
+++ b/pipeline/tests/test_progress.py
@@ -1,9 +1,7 @@
-import json
 import pytest
 from unittest.mock import patch, MagicMock
 from pipeline.lib.progress import (
     ConfigMapProgressStore,
-    ProgressStore,
 )
 
 

--- a/pipeline/tests/test_progress.py
+++ b/pipeline/tests/test_progress.py
@@ -91,3 +91,17 @@ def test_configmap_save_failure_raises():
         store = ConfigMapProgressStore("sim2real-ns")
         with pytest.raises(RuntimeError, match="Failed to update ConfigMap"):
             store.save({"x": 1})
+
+def test_configmap_load_missing_kubectl_raises():
+    """load() wraps OSError (missing kubectl) as RuntimeError."""
+    with patch("subprocess.run", side_effect=FileNotFoundError("kubectl")):
+        store = ConfigMapProgressStore("sim2real-ns")
+        with pytest.raises(RuntimeError, match="kubectl not available"):
+            store.load()
+
+def test_configmap_save_missing_kubectl_raises():
+    """save() wraps OSError (missing kubectl) as RuntimeError."""
+    with patch("subprocess.run", side_effect=FileNotFoundError("kubectl")):
+        store = ConfigMapProgressStore("sim2real-ns")
+        with pytest.raises(RuntimeError, match="Failed to update ConfigMap"):
+            store.save({"x": 1})


### PR DESCRIPTION
Closes #148

## Summary

- **Delete `LocalProgressStore` and `CompositeProgressStore`** from `pipeline/lib/progress.py` — `ConfigMapProgressStore` is now the only implementation
- **All 5 deploy.py subcommands** (`status`, `collect`, `run`, `reset`, `wipe`) use `ConfigMapProgressStore` directly — no composite wrapping, no local fallback
- **All subcommands require a configured namespace** — exit with error if `_configmap_namespace()` returns empty (previously silently fell back to local file)
- **`monitor.py`** switched from `LocalProgressStore` to `ConfigMapProgressStore`
- **Net -280 lines** across 11 files

## Motivation

Every time a new feature was introduced (e.g. `completed_namespace` in #147, `--remote` in #143), the local `progress.json` path was inadvertently made primary or left inconsistent. This happened because `CompositeProgressStore` made both paths look equivalent to callers, and the "no namespace configured" fallback silently used the local file. A Kubernetes-only tool should not have a non-Kubernetes fallback — it masks configuration errors and creates a recurring class of bugs.

## Reviewer attention

- **`_cmd_reset` signature changed**: `progress_path: Path` → `run_dir: Path`. The dispatch site in `main()` is updated.
- **No namespace = hard error**: All subcommands now call `sys.exit(1)` if no namespace is configured. This is intentional — there's no valid deploy.py use case without a cluster.
- **Test migration**: All tests that wrote `progress.json` as fixture data now monkeypatch `ConfigMapProgressStore.load/save`. Tests for local-fallback behavior are deleted (the behavior no longer exists).

## Test plan

- [x] 693 tests pass (`python -m pytest pipeline/ .claude/skills/sim2real-analyze/tests/ .claude/skills/sim2real-translate/tests/ -v`)
- [x] Lint clean (`ruff check pipeline/ .claude/skills/ --select F`)
- [x] Zero remaining `progress.json` / `LocalProgressStore` / `CompositeProgressStore` references in `pipeline/` Python files