### PR TITLE
fix: add PYTHONUNBUFFERED=1 to orchestrator container

### DIFF
--- a/pipeline/lib/remote.py
+++ b/pipeline/lib/remote.py
@@ -98,6 +98,7 @@ def build_orchestrator_job(
                         "name": "orchestrator",
                         "image": image,
                         "args": args,
+                        "env": [{"name": "PYTHONUNBUFFERED", "value": "1"}],
                         "volumeMounts": [
                             {"name": "workspace", "mountPath": workspace_path},
                         ],

--- a/pipeline/tests/test_remote.py
+++ b/pipeline/tests/test_remote.py
@@ -194,6 +194,13 @@ def test_job_structure():
     assert "--dry-run" in args
 
 
+def test_job_orchestrator_unbuffered():
+    job = _build_job()
+    container = job["spec"]["template"]["spec"]["containers"][0]
+    env = {e["name"]: e["value"] for e in container["env"]}
+    assert env["PYTHONUNBUFFERED"] == "1"
+
+
 def test_job_workspace_is_writable_emptydir():
     """Orchestrator mounts a writable emptyDir at /data/workspace."""
     job = _build_job()


### PR DESCRIPTION
Closes #158

## Summary

- Add `PYTHONUNBUFFERED=1` env var to the orchestrator container spec in `pipeline/lib/remote.py`
- Add test asserting the env var is present

## Context

This fix was documented as completed in #145 (defect #4) but was never actually committed. Without it, Python buffers stdout in the orchestrator pod, so `kubectl logs -f` shows nothing until the job finishes.