### PR TITLE
feat: add --skip-teardown flag to deploy.py run

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -153,7 +153,7 @@ python pipeline/deploy.py pairs   [flags]   # list available pair keys, workload
 | `--workload NAME` | — | Scope execution to pairs matching this workload |
 | `--package NAME` | — | Scope execution to pairs matching this package |
 | `--status STATE` | — | Scope execution to pairs with this status (e.g. `failed`, `timed-out`) |
-| `--skip-teardown` | — | Skip teardown after PipelineRun completes, leaving namespace intact for debugging |
+| `--skip-teardown` | — | Skip the Tekton teardown task, leaving namespace resources intact for debugging |
 | `--force` | — | Reset non-pending pairs to `pending`, cleaning cluster resources (PipelineRuns + Helm) for pairs with assigned namespaces |
 | `--max-retries N` | 2 | Max retries for timed-out pairs |
 | `--poll-interval N` | 30 | Seconds between status polls |
@@ -169,7 +169,7 @@ python pipeline/deploy.py pairs   [flags]   # list available pair keys, workload
 
 **Pair statuses:** `pending` → `running` → `done`. Failure paths: `running` → `failed` (hard failure or non-recoverable pending), `running` → `timed-out` (4h timeout exceeded), `running` → `pending` (recoverable early reclaim, repeats up to `--max-pending-stalls` times) → `stalled`.
 
-**Auto-cleanup** — when a PipelineRun succeeds, the orchestrator deletes the PipelineRun CR from the cluster. Failed PipelineRuns are left in place for debugging (`kubectl describe`, pod logs). Use `reset` to remove them when done.
+**Auto-cleanup** — when a PipelineRun succeeds, the orchestrator deletes the PipelineRun CR from the cluster. Failed PipelineRuns are left in place for debugging (`kubectl describe`, pod logs). Use `reset` to remove them when done. Note: `--skip-teardown` only suppresses the Tekton `llmdbenchmark-teardown` task (Helm-level resource cleanup); PipelineRun CR deletion by the orchestrator is unaffected.
 
 **Remote mode** — `deploy.py run --remote` submits the orchestrator as a Kubernetes Job (`sim2real-orchestrator`) instead of running locally. The launcher builds the EPP image locally, packs workspace files into a ConfigMap, applies the Job, and waits for the pod to reach Running. Use `stop` to cancel, `status` to check progress, and `collect` to pull results after completion. Requires `orchestrator_image` in `setup_config.json`.
 

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -153,6 +153,7 @@ python pipeline/deploy.py pairs   [flags]   # list available pair keys, workload
 | `--workload NAME` | — | Scope execution to pairs matching this workload |
 | `--package NAME` | — | Scope execution to pairs matching this package |
 | `--status STATE` | — | Scope execution to pairs with this status (e.g. `failed`, `timed-out`) |
+| `--skip-teardown` | — | Skip teardown after PipelineRun completes, leaving namespace intact for debugging |
 | `--force` | — | Reset non-pending pairs to `pending`, cleaning cluster resources (PipelineRuns + Helm) for pairs with assigned namespaces |
 | `--max-retries N` | 2 | Max retries for timed-out pairs |
 | `--poll-interval N` | 30 | Seconds between status polls |

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1637,7 +1637,8 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                     param["value"] = ns
 
             if getattr(args, "skip_teardown", False):
-                params = pr_data.get("spec", {}).get("params", [])
+                spec = pr_data.get("spec") or {}
+                params = spec.setdefault("params", [])
                 for param in params:
                     if param["name"] == "skipTeardown":
                         param["value"] = "true"

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1637,8 +1637,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                     param["value"] = ns
 
             if getattr(args, "skip_teardown", False):
-                spec = pr_data.get("spec") or {}
-                params = spec.setdefault("params", [])
+                params = pr_data.setdefault("spec", {}).setdefault("params", [])
                 for param in params:
                     if param["name"] == "skipTeardown":
                         param["value"] = "true"

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1636,6 +1636,15 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                 if param["name"] == "namespace":
                     param["value"] = ns
 
+            if getattr(args, "skip_teardown", False):
+                params = pr_data.get("spec", {}).get("params", [])
+                for param in params:
+                    if param["name"] == "skipTeardown":
+                        param["value"] = "true"
+                        break
+                else:
+                    params.append({"name": "skipTeardown", "value": "true"})
+
             tf_path = None
             try:
                 with _tmp.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as tf:
@@ -1884,6 +1893,8 @@ def _collect_run_flags(args) -> list[str]:
             flags.extend([f"--{name}", str(val)])
     if getattr(args, "force"):
         flags.append("--force")
+    if getattr(args, "skip_teardown", False):
+        flags.append("--skip-teardown")
     _defaults = {
         "max_retries": 2,
         "poll_interval": 30,
@@ -2122,6 +2133,8 @@ Examples:
     run_p.add_argument("--status",       metavar="STATE", help="Scope execution to pairs with this status (e.g. failed, timed-out)")
     run_p.add_argument("--force",        action="store_true",
                        help="Reset non-pending pairs to pending, cleaning cluster resources for pairs with assigned namespaces")
+    run_p.add_argument("--skip-teardown", action="store_true", dest="skip_teardown",
+                       help="Skip teardown after PipelineRun completes (keeps namespace intact for debugging)")
     run_p.add_argument("--max-retries",  type=int, default=2, dest="max_retries",
                        help="Max retries for timed-out pairs [2]")
     run_p.add_argument("--poll-interval", type=int, default=30, dest="poll_interval",

--- a/pipeline/pipeline.yaml
+++ b/pipeline/pipeline.yaml
@@ -30,6 +30,9 @@ spec:
       type: string
     - name: model
       type: string
+    - name: skipTeardown
+      type: string
+      default: "false"
   workspaces:
     - name: source
     - name: data-storage
@@ -113,6 +116,10 @@ spec:
 
   finally:
     - name: llmdbenchmark-teardown
+      when:
+        - input: "$(params.skipTeardown)"
+          operator: notin
+          values: ["true"]
       taskRef:
         name: llmdbenchmark-teardown
       workspaces:

--- a/pipeline/tests/test_deploy_remote.py
+++ b/pipeline/tests/test_deploy_remote.py
@@ -82,6 +82,46 @@ def test_run_parser_skip_teardown_default_false():
     assert args.skip_teardown is False
 
 
+# ── skip-teardown param injection tests ────────────────────────────────────
+
+def _inject_skip_teardown(pr_data):
+    """Simulate the injection logic from deploy.py _cmd_run."""
+    params = pr_data.setdefault("spec", {}).setdefault("params", [])
+    for param in params:
+        if param["name"] == "skipTeardown":
+            param["value"] = "true"
+            break
+    else:
+        params.append({"name": "skipTeardown", "value": "true"})
+    return pr_data
+
+
+def test_skip_teardown_injection_appends_new_param():
+    pr_data = {"spec": {"params": [{"name": "namespace", "value": "ns1"}]}}
+    _inject_skip_teardown(pr_data)
+    names = {p["name"]: p["value"] for p in pr_data["spec"]["params"]}
+    assert names["skipTeardown"] == "true"
+    assert names["namespace"] == "ns1"
+
+
+def test_skip_teardown_injection_updates_existing_param():
+    pr_data = {"spec": {"params": [{"name": "skipTeardown", "value": "false"}]}}
+    _inject_skip_teardown(pr_data)
+    assert pr_data["spec"]["params"][0]["value"] == "true"
+
+
+def test_skip_teardown_injection_missing_spec():
+    pr_data = {}
+    _inject_skip_teardown(pr_data)
+    assert pr_data["spec"]["params"] == [{"name": "skipTeardown", "value": "true"}]
+
+
+def test_skip_teardown_injection_missing_params():
+    pr_data = {"spec": {}}
+    _inject_skip_teardown(pr_data)
+    assert pr_data["spec"]["params"] == [{"name": "skipTeardown", "value": "true"}]
+
+
 # ── _check_existing_job tests ──────────────────────────────────────────────
 
 def test_check_existing_job_active(monkeypatch):

--- a/pipeline/tests/test_deploy_remote.py
+++ b/pipeline/tests/test_deploy_remote.py
@@ -11,12 +11,14 @@ import pipeline.deploy as mod
 
 def _make_run_args(*, remote=False, workload=None, only=None, package=None,
                    status=None, force=False, skip_build_epp=False,
+                   skip_teardown=False,
                    max_retries=2, poll_interval=30, gpu_resource_type=None,
                    default_gpu_cost=1, pending_threshold=600,
                    max_pending_stalls=10, max_backoff=600):
     return argparse.Namespace(
         remote=remote, workload=workload, only=only, package=package,
         status=status, force=force, skip_build_epp=skip_build_epp,
+        skip_teardown=skip_teardown,
         max_retries=max_retries, poll_interval=poll_interval,
         gpu_resource_type=gpu_resource_type, default_gpu_cost=default_gpu_cost,
         pending_threshold=pending_threshold, max_pending_stalls=max_pending_stalls,
@@ -56,6 +58,28 @@ def test_collect_run_flags_force():
 def test_collect_run_flags_non_default_retries():
     args = _make_run_args(max_retries=5)
     assert mod._collect_run_flags(args) == ["--max-retries", "5"]
+
+
+def test_collect_run_flags_skip_teardown():
+    args = _make_run_args(skip_teardown=True)
+    assert "--skip-teardown" in mod._collect_run_flags(args)
+
+
+def test_collect_run_flags_skip_teardown_absent_by_default():
+    args = _make_run_args()
+    assert "--skip-teardown" not in mod._collect_run_flags(args)
+
+
+# ── skip-teardown parser tests ─────────────────────────────────────────────
+
+def test_run_parser_skip_teardown_flag():
+    args = mod.build_parser().parse_args(["run", "--skip-teardown"])
+    assert args.skip_teardown is True
+
+
+def test_run_parser_skip_teardown_default_false():
+    args = mod.build_parser().parse_args(["run"])
+    assert args.skip_teardown is False
 
 
 # ── _check_existing_job tests ──────────────────────────────────────────────


### PR DESCRIPTION
Closes #160

## Summary

- Add `skipTeardown` pipeline param (default `"false"`) and a `when` clause on the teardown finally task in `pipeline.yaml`
- Add `--skip-teardown` flag to `deploy.py run` argument parser
- Inject `skipTeardown=true` into PipelineRun params at apply time when the flag is set (same pattern as the existing namespace override)
- Wire the flag through `_collect_run_flags()` for `--remote` mode

## Reviewer notes

- Requires `setup.py` re-run to apply the updated Pipeline definition to the cluster
- The `when` clause uses `notin ["true"]` so the default (`"false"`) and omitted param both result in normal teardown behavior
- The injection uses `for/else` to handle both cases: updating an existing `skipTeardown` param (if one were ever baked in at assemble time) and appending a new one (the normal case)