### PR TITLE
feat: reset always cleans up helm releases for done pairs

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -999,6 +999,8 @@ def _reset_pair(key: str, entry: dict, discovered: dict, *,
         info(f"[DRY-RUN] {key}: would delete pipelinerun {pr_name or '(unknown)'} in {target}")
         if not is_done:
             info(f"[DRY-RUN] {key}: would uninstall all helm releases in {target}")
+        elif entry.get("completed_namespace"):
+            info(f"[DRY-RUN] {key}: would check for orphaned helm releases in {entry['completed_namespace']}")
         return True
 
     # Delete PipelineRun
@@ -1028,8 +1030,23 @@ def _reset_pair(key: str, entry: dict, discovered: dict, *,
     else:
         warn(f"{key}: no namespace and no namespace slots — cannot delete pipelinerun {pr_name}")
 
-    # For done pairs, Tekton finally task already tore down Helm releases
+    # For done pairs, Tekton finally task should have torn down Helm releases,
+    # but check completed_namespace for orphans in case teardown failed.
     if is_done:
+        completed_ns = entry.get("completed_namespace")
+        if completed_ns:
+            result = run(["helm", "list", "-n", completed_ns, "-q"],
+                         check=False, capture=True)
+            if result.returncode != 0:
+                warn(f"{key}: helm list failed in {completed_ns}")
+            elif result.stdout.strip():
+                for release in result.stdout.strip().splitlines():
+                    ur = run(["helm", "uninstall", release, "-n", completed_ns],
+                             check=False, capture=True)
+                    if ur.returncode == 0:
+                        ok(f"Uninstalled: {release} (ns: {completed_ns})")
+                    else:
+                        warn(f"Failed to uninstall {release} in {completed_ns}")
         return True
 
     if ns and not pr_deleted and pr_name:

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -972,12 +972,29 @@ def _load_pairs(cluster_dir: Path) -> dict:
     return pairs
 
 
+def _uninstall_orphaned_helm(key: str, namespace: str) -> None:
+    """Check a namespace for lingering helm releases and uninstall them."""
+    result = run(["helm", "list", "-n", namespace, "-q"],
+                 check=False, capture=True)
+    if result.returncode != 0:
+        warn(f"{key}: helm list failed in {namespace}")
+    elif result.stdout.strip():
+        for release in result.stdout.strip().splitlines():
+            ur = run(["helm", "uninstall", release, "-n", namespace],
+                     check=False, capture=True)
+            if ur.returncode == 0:
+                ok(f"Uninstalled: {release} (ns: {namespace})")
+            else:
+                warn(f"Failed to uninstall {release} in {namespace}")
+
+
 def _reset_pair(key: str, entry: dict, discovered: dict, *,
                 dry_run: bool = False, namespaces: list[str] | None = None) -> bool:
     """Delete PipelineRun and Helm releases for a pair.
 
     For non-done pairs: also resets state to pending.
-    For done pairs: deletes PipelineRun only (Helm already torn down by Tekton).
+    For done pairs: deletes PipelineRun and uninstalls any orphaned Helm
+    releases found in completed_namespace.
 
     Returns True if reset was performed, False if it failed and state was NOT reset.
     """
@@ -992,6 +1009,13 @@ def _reset_pair(key: str, entry: dict, discovered: dict, *,
             entry["retries"] = 0
             entry["pending_stalls"] = 0
             entry["pending_since"] = None
+        if is_done:
+            completed_ns = entry.get("completed_namespace")
+            if completed_ns:
+                if dry_run:
+                    info(f"[DRY-RUN] {key}: would check for orphaned helm releases in {completed_ns}")
+                else:
+                    _uninstall_orphaned_helm(key, completed_ns)
         return True
 
     if dry_run:
@@ -999,8 +1023,10 @@ def _reset_pair(key: str, entry: dict, discovered: dict, *,
         info(f"[DRY-RUN] {key}: would delete pipelinerun {pr_name or '(unknown)'} in {target}")
         if not is_done:
             info(f"[DRY-RUN] {key}: would uninstall all helm releases in {target}")
-        elif entry.get("completed_namespace"):
-            info(f"[DRY-RUN] {key}: would check for orphaned helm releases in {entry['completed_namespace']}")
+        else:
+            completed_ns = entry.get("completed_namespace")
+            if completed_ns:
+                info(f"[DRY-RUN] {key}: would check for orphaned helm releases in {completed_ns}")
         return True
 
     # Delete PipelineRun
@@ -1035,18 +1061,7 @@ def _reset_pair(key: str, entry: dict, discovered: dict, *,
     if is_done:
         completed_ns = entry.get("completed_namespace")
         if completed_ns:
-            result = run(["helm", "list", "-n", completed_ns, "-q"],
-                         check=False, capture=True)
-            if result.returncode != 0:
-                warn(f"{key}: helm list failed in {completed_ns}")
-            elif result.stdout.strip():
-                for release in result.stdout.strip().splitlines():
-                    ur = run(["helm", "uninstall", release, "-n", completed_ns],
-                             check=False, capture=True)
-                    if ur.returncode == 0:
-                        ok(f"Uninstalled: {release} (ns: {completed_ns})")
-                    else:
-                        warn(f"Failed to uninstall {release} in {completed_ns}")
+            _uninstall_orphaned_helm(key, completed_ns)
         return True
 
     if ns and not pr_deleted and pr_name:

--- a/pipeline/tests/test_deploy_reset.py
+++ b/pipeline/tests/test_deploy_reset.py
@@ -502,3 +502,87 @@ def test_cmd_reset_aborts_on_filter_mismatch(tmp_path, monkeypatch, capsys):
     assert exc_info.value.code == 1
     captured = capsys.readouterr()
     assert "No pairs matched" in captured.out + captured.err
+
+
+def test_reset_pair_done_uninstalls_helm_in_completed_namespace(monkeypatch):
+    """Done pairs get orphaned helm releases uninstalled in completed_namespace."""
+    import pipeline.deploy as mod
+
+    entry = {"workload": "wl-smoke", "package": "baseline", "status": "done",
+             "namespace": None, "completed_namespace": "sim2real-0", "retries": 0}
+    calls = []
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        calls.append(cmd)
+        class _R:
+            returncode = 0
+            stdout = "orphaned-release\n" if cmd[:2] == ["helm", "list"] else ""
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    result = mod._reset_pair("wl-smoke-baseline", entry, _DISCOVERED,
+                             namespaces=["sim2real-0", "sim2real-1"])
+
+    assert result is True
+    assert entry["status"] == "done"
+
+    helm_lists = [c for c in calls if c[:2] == ["helm", "list"]]
+    assert len(helm_lists) == 1
+    assert "-n" in helm_lists[0] and "sim2real-0" in helm_lists[0]
+
+    helm_uninstalls = [c for c in calls if c[:2] == ["helm", "uninstall"]]
+    assert len(helm_uninstalls) == 1
+    assert "orphaned-release" in helm_uninstalls[0]
+
+
+def test_reset_pair_done_no_completed_ns_skips_helm(monkeypatch):
+    """Done pairs without completed_namespace skip helm cleanup gracefully."""
+    import pipeline.deploy as mod
+
+    entry = {"workload": "wl-smoke", "package": "baseline", "status": "done",
+             "namespace": None, "retries": 0}
+    calls = []
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        calls.append(cmd)
+        class _R:
+            returncode = 0
+            stdout = ""
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    result = mod._reset_pair("wl-smoke-baseline", entry, _DISCOVERED,
+                             namespaces=["sim2real-0", "sim2real-1"])
+
+    assert result is True
+    helm_calls = [c for c in calls if c[0] == "helm"]
+    assert helm_calls == []
+
+
+def test_reset_pair_done_no_releases_is_noop(monkeypatch):
+    """Done pairs with no helm releases found skip uninstall."""
+    import pipeline.deploy as mod
+
+    entry = {"workload": "wl-smoke", "package": "baseline", "status": "done",
+             "namespace": None, "completed_namespace": "sim2real-0", "retries": 0}
+    calls = []
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        calls.append(cmd)
+        class _R:
+            returncode = 0
+            stdout = ""
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    result = mod._reset_pair("wl-smoke-baseline", entry, _DISCOVERED,
+                             namespaces=["sim2real-0", "sim2real-1"])
+
+    assert result is True
+    helm_lists = [c for c in calls if c[:2] == ["helm", "list"]]
+    assert len(helm_lists) == 1
+    helm_uninstalls = [c for c in calls if c[:2] == ["helm", "uninstall"]]
+    assert helm_uninstalls == []

--- a/pipeline/tests/test_deploy_reset.py
+++ b/pipeline/tests/test_deploy_reset.py
@@ -586,3 +586,79 @@ def test_reset_pair_done_no_releases_is_noop(monkeypatch):
     assert len(helm_lists) == 1
     helm_uninstalls = [c for c in calls if c[:2] == ["helm", "uninstall"]]
     assert helm_uninstalls == []
+
+
+def test_reset_pair_done_helm_list_failure_warns(monkeypatch, capsys):
+    """Done pair with helm list failure still returns True but warns."""
+    import pipeline.deploy as mod
+
+    entry = {"workload": "wl-smoke", "package": "baseline", "status": "done",
+             "namespace": None, "completed_namespace": "sim2real-0", "retries": 0}
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 1 if cmd[:2] == ["helm", "list"] else 0
+            stdout = ""
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    result = mod._reset_pair("wl-smoke-baseline", entry, _DISCOVERED,
+                             namespaces=["sim2real-0", "sim2real-1"])
+
+    assert result is True
+    assert entry["status"] == "done"
+    err = capsys.readouterr().err
+    assert "helm list failed" in err
+
+
+def test_reset_pair_done_helm_uninstall_failure_warns(monkeypatch, capsys):
+    """Done pair with helm uninstall failure still returns True but warns."""
+    import pipeline.deploy as mod
+
+    entry = {"workload": "wl-smoke", "package": "baseline", "status": "done",
+             "namespace": None, "completed_namespace": "sim2real-0", "retries": 0}
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 1 if cmd[:2] == ["helm", "uninstall"] else 0
+            stdout = "stuck-release\n" if cmd[:2] == ["helm", "list"] else ""
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    result = mod._reset_pair("wl-smoke-baseline", entry, _DISCOVERED,
+                             namespaces=["sim2real-0", "sim2real-1"])
+
+    assert result is True
+    assert entry["status"] == "done"
+    err = capsys.readouterr().err
+    assert "Failed to uninstall" in err
+
+
+def test_reset_pair_done_no_pr_name_still_cleans_helm(monkeypatch):
+    """Done pair with no pr_name in discovered still checks completed_namespace for orphans."""
+    import pipeline.deploy as mod
+
+    entry = {"workload": "wl-smoke", "package": "baseline", "status": "done",
+             "namespace": None, "completed_namespace": "sim2real-0", "retries": 0}
+    calls = []
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        calls.append(cmd)
+        class _R:
+            returncode = 0
+            stdout = "orphaned-release\n" if cmd[:2] == ["helm", "list"] else ""
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    # Empty discovered — simulates PipelineRun already deleted
+    result = mod._reset_pair("wl-smoke-baseline", entry, {})
+
+    assert result is True
+    helm_lists = [c for c in calls if c[:2] == ["helm", "list"]]
+    assert len(helm_lists) == 1
+    assert "sim2real-0" in helm_lists[0]
+    helm_uninstalls = [c for c in calls if c[:2] == ["helm", "uninstall"]]
+    assert len(helm_uninstalls) == 1


### PR DESCRIPTION
Closes #162

## Summary

- `_reset_pair` now unconditionally checks `completed_namespace` for lingering helm releases on done pairs
- If `helm list` finds releases in that namespace, they are uninstalled
- No new flags — reset just does the right thing

## Context

When a pair succeeds, `namespace` is cleared and `completed_namespace` is saved. Previously, `_reset_pair` skipped helm cleanup for done pairs entirely, trusting Tekton's finally-block teardown. If that teardown failed, releases were orphaned with no recovery path.

## Test plan

- [x] Done pair with `completed_namespace` containing releases → uninstalled
- [x] Done pair without `completed_namespace` → skipped gracefully  
- [x] Done pair with empty `helm list` → no uninstall attempted
- [x] All 651 existing tests pass
- [x] Lint clean (`ruff check pipeline/ --select F`)