### PR TITLE
fix: accept Tekton 'Completed' reason as PipelineRun success

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1257,7 +1257,7 @@ def _reconcile_on_resume(progress: dict, discovered: dict) -> None:
                 except Exception as exc:
                     warn(f"[{key}] failed to check PipelineRun status: {exc}")
                     continue
-                if actual == "Succeeded":
+                if actual in ("Succeeded", "Completed"):
                     entry["status"] = "done"
                     entry["pending_since"] = None
                     entry["completed_namespace"] = ns
@@ -1510,8 +1510,8 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
 
             status = _check_pipelinerun_status(pr_name, ns) if pr_name else "Unknown"
 
-            if status == "Succeeded":
-                ok(f"[{pair_key}] Succeeded → done")
+            if status in ("Succeeded", "Completed"):
+                ok(f"[{pair_key}] {status} → done")
                 entry["status"] = "done"
                 entry["completed_namespace"] = ns
                 entry["namespace"] = None

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -446,6 +446,27 @@ def test_reconcile_succeeded_sets_done_and_frees_namespace(monkeypatch):
     assert progress["wl-smoke-baseline"]["pending_since"] is None
 
 
+def test_reconcile_completed_sets_done_and_frees_namespace(monkeypatch):
+    """Tekton v0.44+ returns 'Completed' for success — treat same as 'Succeeded'."""
+    import pipeline.deploy as mod
+
+    monkeypatch.setattr(mod, "_check_pipelinerun_status", lambda pr, ns: "Completed")
+    monkeypatch.setattr(mod, "_delete_pipelinerun", lambda pr, ns: None)
+
+    progress = {
+        "wl-smoke-baseline": {
+            "workload": "wl-smoke", "package": "baseline",
+            "status": "running", "namespace": "sim2real-0",
+            "pending_since": "2026-01-01T00:00:00Z",
+        }
+    }
+    mod._reconcile_on_resume(progress, _DISCOVERED)
+    assert progress["wl-smoke-baseline"]["status"] == "done"
+    assert progress["wl-smoke-baseline"]["namespace"] is None
+    assert progress["wl-smoke-baseline"]["completed_namespace"] == "sim2real-0"
+    assert progress["wl-smoke-baseline"]["pending_since"] is None
+
+
 def test_reconcile_on_resume_sets_completed_namespace_on_success(monkeypatch):
     """In _reconcile_on_resume, when a running pair's PipelineRun Succeeds, completed_namespace is recorded before namespace is cleared."""
     import pipeline.deploy as mod


### PR DESCRIPTION
## Summary

- Tekton Pipelines v0.44+ returns `"Completed"` (not `"Succeeded"`) as `.status.conditions[0].reason` for successful PipelineRuns
- The orchestrator poll loop and `_reconcile_on_resume` now accept either `"Succeeded"` or `"Completed"` as success
- Without this fix, completed PipelineRuns stay stuck as "running" indefinitely

Closes #164

## Changes

- `pipeline/deploy.py:1260` — reconcile-on-resume: `== "Succeeded"` → `in ("Succeeded", "Completed")`
- `pipeline/deploy.py:1513` — poll loop: same change, plus log message uses actual status value
- `pipeline/tests/test_deploy_run.py` — new test `test_reconcile_completed_sets_done_and_frees_namespace`

## Test plan

- [x] New test verifies `"Completed"` triggers done transition in reconcile path
- [x] All 655 existing tests pass
- [x] Lint clean (`ruff check pipeline/ --select F`)