### PR TITLE
fix: reset moves done pairs back to pending by default

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -139,7 +139,7 @@ python pipeline/deploy.py run     [flags]   # orchestrate parallel pool executio
 python pipeline/deploy.py status            # show progress snapshot of all (workload, package) pairs
 python pipeline/deploy.py collect [flags]     # pull results from the cluster PVC
 python pipeline/deploy.py stop               # stop the remote orchestrator Job
-python pipeline/deploy.py reset [flags]     # tear down cluster resources for failed/stalled pairs
+python pipeline/deploy.py reset [flags]     # reset all non-pending pairs to pending (with cluster cleanup)
 python pipeline/deploy.py wipe  [flags]     # delete local result files for non-pending pairs
 python pipeline/deploy.py pairs   [flags]   # list available pair keys, workloads, and packages
 ```
@@ -195,7 +195,7 @@ When `--only` or `--workload` is given, only matching workload subdirectories ar
 
 **`deploy.py stop`** — deletes the `sim2real-orchestrator` Kubernetes Job (with cascading pod deletion) in the primary namespace. Only meaningful when the orchestrator runs as an in-cluster Job. Pair state is left as-is. If no remote orchestrator Job exists, prints a message and returns. Use `reset` separately to clear failed/stalled pair state.
 
-**`deploy.py reset`** — removes cluster resources (PipelineRuns, Helm releases) for all non-pending pairs. Failed/running/timed-out pairs are reset to `pending` so they can be re-dispatched. Done pairs stay `done` — only their PipelineRun is deleted to free cluster resources.
+**`deploy.py reset`** — resets all non-pending pairs to `pending` and removes their cluster resources (PipelineRuns, Helm releases). This includes `done` pairs — use `--preserve-done-status` to clean up cluster resources for done pairs without re-queuing them.
 
 | Flag | Description |
 |------|-------------|
@@ -203,9 +203,10 @@ When `--only` or `--workload` is given, only matching workload subdirectories ar
 | `--workload NAME` | Scope reset to pairs matching this workload |
 | `--package NAME` | Scope reset to pairs matching this package |
 | `--status STATE` | Scope reset to pairs with this status |
+| `--preserve-done-status` | Keep done pairs' status unchanged (cluster cleanup only) |
 | `--dry-run` | Print what would be reset without acting |
 
-**Safety:** Results in `workspace/runs/<run>/results/` are preserved — only cluster resources are removed. For `done` pairs, only the PipelineRun is deleted (Tekton already tore down Helm releases).
+**Safety:** Results in `workspace/runs/<run>/results/` are preserved — only cluster resources and ConfigMap status are affected.
 
 **`deploy.py wipe`** — deletes local result files (`results/<package>/<workload>/`) for non-pending pairs. Does **not** modify pair status in the ConfigMap. Pending pairs are skipped (nothing to wipe). Empty package directories are cleaned up automatically.
 
@@ -217,7 +218,7 @@ When `--only` or `--workload` is given, only matching workload subdirectories ar
 | `--dry-run` | Print what would be wiped without acting |
 | `--yes` / `-y` | Skip confirmation prompt |
 
-**Re-running wiped pairs:** `wipe` only removes files; to re-dispatch, follow with `reset` to move pairs back to `pending`. Note: `reset` currently skips `done` pairs — see [#172](https://github.com/inference-sim/sim2real/issues/172) for enabling `reset` to handle all statuses.
+**Re-running wiped pairs:** `wipe` only removes files; to re-dispatch, follow with `reset` to move pairs back to `pending`.
 
 **`deploy.py pairs`** — lists available pair keys, workloads, and packages by scanning `cluster/pipelinerun-*.yaml`.
 

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -6,7 +6,7 @@ Subcommands:
   status   Show progress of all (workload, package) pairs
   collect  Pull results from cluster for completed phases
   stop     Stop the remote orchestrator Job
-  reset    Tear down cluster resources for all non-pending pairs
+  reset    Reset all non-pending pairs to pending (with cluster cleanup)
   wipe     Delete local result files for non-pending pairs
   pairs    List available pair keys, workloads, and packages
 """
@@ -989,12 +989,12 @@ def _uninstall_orphaned_helm(key: str, namespace: str) -> None:
 
 
 def _reset_pair(key: str, entry: dict, discovered: dict, *,
-                dry_run: bool = False, namespaces: list[str] | None = None) -> bool:
-    """Delete PipelineRun and Helm releases for a pair.
+                dry_run: bool = False, namespaces: list[str] | None = None,
+                preserve_done_status: bool = False) -> bool:
+    """Delete PipelineRun and Helm releases for a pair, then reset state to pending.
 
-    For non-done pairs: also resets state to pending.
-    For done pairs: deletes PipelineRun and uninstalls any orphaned Helm
-    releases found in completed_namespace.
+    For done pairs with preserve_done_status=True: cluster cleanup only,
+    status stays done.
 
     Returns True if reset was performed, False if it failed and state was NOT reset.
     """
@@ -1004,11 +1004,6 @@ def _reset_pair(key: str, entry: dict, discovered: dict, *,
 
     # No namespace and no pr_name — just reset state
     if not ns and not pr_name:
-        if not dry_run and not is_done:
-            entry["status"] = "pending"
-            entry["retries"] = 0
-            entry["pending_stalls"] = 0
-            entry["pending_since"] = None
         if is_done:
             completed_ns = entry.get("completed_namespace")
             if completed_ns:
@@ -1016,6 +1011,11 @@ def _reset_pair(key: str, entry: dict, discovered: dict, *,
                     info(f"[DRY-RUN] {key}: would check for orphaned helm releases in {completed_ns}")
                 else:
                     _uninstall_orphaned_helm(key, completed_ns)
+        if not dry_run and not (is_done and preserve_done_status):
+            entry["status"] = "pending"
+            entry["retries"] = 0
+            entry["pending_stalls"] = 0
+            entry["pending_since"] = None
         return True
 
     if dry_run:
@@ -1062,6 +1062,12 @@ def _reset_pair(key: str, entry: dict, discovered: dict, *,
         completed_ns = entry.get("completed_namespace")
         if completed_ns:
             _uninstall_orphaned_helm(key, completed_ns)
+        if not preserve_done_status:
+            entry["status"] = "pending"
+            entry["namespace"] = None
+            entry["retries"] = 0
+            entry["pending_stalls"] = 0
+            entry["pending_since"] = None
         return True
 
     if ns and not pr_deleted and pr_name:
@@ -1098,7 +1104,7 @@ def _reset_pair(key: str, entry: dict, discovered: dict, *,
 
 def _force_reset(progress: dict, scope: set, discovered: dict | None = None,
                  namespaces: list[str] | None = None) -> int:
-    """Reset non-pending, non-done pairs in scope to pending.
+    """Reset all non-pending pairs in scope to pending.
 
     Calls _reset_pair for cluster teardown when possible. Pairs where
     reset fails are skipped (not counted, state preserved).
@@ -1106,7 +1112,7 @@ def _force_reset(progress: dict, scope: set, discovered: dict | None = None,
     reset = 0
     for key in scope:
         entry = progress.get(key, {})
-        if entry.get("status") not in (None, "pending", "done"):
+        if entry.get("status") not in (None, "pending"):
             try:
                 if _reset_pair(key, entry, discovered or {},
                               namespaces=namespaces):
@@ -1729,7 +1735,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
 def _cmd_reset(args, run_dir: Path, discovered: dict,
                namespaces: list[str] | None = None,
                setup_config: dict | None = None) -> None:
-    """Tear down cluster resources for all non-pending pairs."""
+    """Reset all non-pending pairs to pending (with cluster cleanup)."""
     from pipeline.lib.progress import ConfigMapProgressStore
     primary_ns = _configmap_namespace(setup_config, namespaces)
     if not primary_ns:
@@ -1753,6 +1759,7 @@ def _cmd_reset(args, run_dir: Path, discovered: dict,
         return
 
     dry_run = getattr(args, "dry_run", False)
+    preserve_done = getattr(args, "preserve_done_status", False)
     total_pairs = sum(1 for k in progress if _is_pair_key(k))
     info(f"Scope: {len(actionable)}/{total_pairs} pairs"
          + (" [DRY-RUN]" if dry_run else ""))
@@ -1763,7 +1770,8 @@ def _cmd_reset(args, run_dir: Path, discovered: dict,
         entry = progress[key]
         try:
             if _reset_pair(key, entry, discovered, dry_run=dry_run,
-                          namespaces=namespaces):
+                          namespaces=namespaces,
+                          preserve_done_status=preserve_done):
                 cleaned += 1
             else:
                 errors += 1
@@ -2176,11 +2184,13 @@ Examples:
 
     sub.add_parser("stop", help="Stop the remote orchestrator Job")
 
-    reset_p = sub.add_parser("reset", help="Tear down cluster resources for all non-pending pairs")
+    reset_p = sub.add_parser("reset", help="Reset all non-pending pairs to pending (with cluster cleanup)")
     reset_p.add_argument("--only",     metavar="PAIR",  help="Scope to one specific pair key (wl- prefix optional)")
     reset_p.add_argument("--workload", metavar="NAME",  help="Scope to pairs matching this workload")
     reset_p.add_argument("--package",  metavar="NAME",  help="Scope to pairs matching this package")
     reset_p.add_argument("--status",   metavar="STATE", help="Scope to pairs with this status")
+    reset_p.add_argument("--preserve-done-status", action="store_true", dest="preserve_done_status",
+                         help="Keep done pairs' status unchanged (cluster cleanup only)")
     reset_p.add_argument("--dry-run",  action="store_true", dest="dry_run",
                          help="Print what would be reset without doing it")
 

--- a/pipeline/tests/test_deploy_reset.py
+++ b/pipeline/tests/test_deploy_reset.py
@@ -213,7 +213,7 @@ def test_cmd_reset_continues_on_exception(tmp_path, monkeypatch, capsys):
 
     call_count = []
 
-    def exploding_reset(key, entry, disc, dry_run=False, namespaces=None):
+    def exploding_reset(key, entry, disc, dry_run=False, namespaces=None, preserve_done_status=False):
         call_count.append(key)
         if key == "wl-a-baseline":
             raise RuntimeError("kubectl not found")
@@ -229,6 +229,7 @@ def test_cmd_reset_continues_on_exception(tmp_path, monkeypatch, capsys):
 
     class _Args:
         only = None; workload = None; package = None; status = None; dry_run = False
+        preserve_done_status = False
 
     mod._cmd_reset(_Args(), run_dir, _DISCOVERED,
                    setup_config={"namespace": "sim2real-ns"})
@@ -240,8 +241,8 @@ def test_cmd_reset_continues_on_exception(tmp_path, monkeypatch, capsys):
     assert saved_data["wl-b-baseline"]["status"] == "pending"
 
 
-def test_reset_pair_done_deletes_pr_without_state_reset(monkeypatch):
-    """Done pairs get PipelineRun deleted but stay in done state."""
+def test_reset_pair_done_resets_state_by_default(monkeypatch):
+    """Done pairs get PipelineRun deleted AND state reset to pending."""
     import pipeline.deploy as mod
 
     entry = {"workload": "wl-smoke", "package": "baseline", "status": "done",
@@ -261,16 +262,41 @@ def test_reset_pair_done_deletes_pr_without_state_reset(monkeypatch):
                              namespaces=["sim2real-0", "sim2real-1"])
 
     assert result is True
-    # State stays done
-    assert entry["status"] == "done"
+    # State reset to pending
+    assert entry["status"] == "pending"
+    assert entry["namespace"] is None
     # PipelineRun deleted across all namespace slots
     kubectl_deletes = [c for c in calls if "delete" in c and "pipelinerun" in c]
     assert len(kubectl_deletes) == 2
-    assert "sim2real-0" in kubectl_deletes[0]
-    assert "sim2real-1" in kubectl_deletes[1]
-    # No helm operations for done pairs
-    helm_calls = [c for c in calls if c[0] == "helm"]
-    assert helm_calls == []
+
+
+def test_reset_pair_done_preserves_status_with_flag(monkeypatch):
+    """Done pairs with preserve_done_status=True get cleanup but stay done."""
+    import pipeline.deploy as mod
+
+    entry = {"workload": "wl-smoke", "package": "baseline", "status": "done",
+             "namespace": None, "retries": 0}
+    calls = []
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        calls.append(cmd)
+        class _R:
+            returncode = 0
+            stdout = ""
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    result = mod._reset_pair("wl-smoke-baseline", entry, _DISCOVERED,
+                             namespaces=["sim2real-0", "sim2real-1"],
+                             preserve_done_status=True)
+
+    assert result is True
+    # State stays done
+    assert entry["status"] == "done"
+    # PipelineRun still deleted
+    kubectl_deletes = [c for c in calls if "delete" in c and "pipelinerun" in c]
+    assert len(kubectl_deletes) == 2
 
 
 def test_cmd_reset_skips_pending_only(tmp_path, monkeypatch, capsys):
@@ -281,13 +307,14 @@ def test_cmd_reset_skips_pending_only(tmp_path, monkeypatch, capsys):
 
     cleaned = []
     monkeypatch.setattr(mod, "_reset_pair",
-                        lambda k, e, d, dry_run=False, namespaces=None: cleaned.append(k) or True)
+                        lambda k, e, d, dry_run=False, namespaces=None, preserve_done_status=False: cleaned.append(k) or True)
 
     run_dir = tmp_path / "runs" / "test-run"
     run_dir.mkdir(parents=True)
 
     class _Args:
         only = None; workload = None; package = None; status = None; dry_run = False
+        preserve_done_status = False
 
     mod._cmd_reset(_Args(), run_dir, _DISCOVERED,
                    setup_config={"namespace": "sim2real-ns"})
@@ -309,13 +336,14 @@ def test_cmd_reset_respects_only_filter(tmp_path, monkeypatch, capsys):
 
     cleaned = []
     monkeypatch.setattr(mod, "_reset_pair",
-                        lambda k, e, d, dry_run=False, namespaces=None: cleaned.append(k) or True)
+                        lambda k, e, d, dry_run=False, namespaces=None, preserve_done_status=False: cleaned.append(k) or True)
 
     run_dir = tmp_path / "runs" / "test-run"
     run_dir.mkdir(parents=True)
 
     class _Args:
         only = "wl-heavy-baseline"; workload = None; package = None; status = None; dry_run = False
+        preserve_done_status = False
 
     mod._cmd_reset(_Args(), run_dir, _DISCOVERED,
                    setup_config={"namespace": "sim2real-ns"})
@@ -331,13 +359,14 @@ def test_cmd_reset_dry_run_does_not_save(tmp_path, monkeypatch, capsys):
     _mock_cm(monkeypatch, _PROGRESS, capture_saves=saved_data)
 
     monkeypatch.setattr(mod, "_reset_pair",
-                        lambda k, e, d, dry_run=False, namespaces=None: True)
+                        lambda k, e, d, dry_run=False, namespaces=None, preserve_done_status=False: True)
 
     run_dir = tmp_path / "runs" / "test-run"
     run_dir.mkdir(parents=True)
 
     class _Args:
         only = None; workload = None; package = None; status = None; dry_run = True
+        preserve_done_status = False
 
     mod._cmd_reset(_Args(), run_dir, _DISCOVERED,
                    setup_config={"namespace": "sim2real-ns"})
@@ -370,23 +399,23 @@ def test_cmd_reset_saves_progress_on_success(tmp_path, monkeypatch, capsys):
 
     class _Args:
         only = None; workload = None; package = None; status = None; dry_run = False
+        preserve_done_status = False
 
     mod._cmd_reset(_Args(), run_dir, _DISCOVERED,
                    namespaces=["sim2real-0", "sim2real-1", "sim2real-2"],
                    setup_config={"namespace": "sim2real-ns"})
 
-    # Non-done pairs reset to pending
+    # All non-pending pairs reset to pending (including done)
+    assert saved_data["wl-smoke-baseline"]["status"] == "pending"
     assert saved_data["wl-smoke-treatment"]["status"] == "pending"
     assert saved_data["wl-load-treatment"]["status"] == "pending"
     assert saved_data["wl-heavy-baseline"]["status"] == "pending"
-    # Done pair stays done (PipelineRun deleted but state preserved)
-    assert saved_data["wl-smoke-baseline"]["status"] == "done"
     # Pending pair unchanged
     assert saved_data["wl-load-baseline"]["status"] == "pending"
 
 
-def test_force_reset_calls_reset_for_non_pending_non_done(monkeypatch):
-    """_force_reset resets non-pending, non-done pairs via _reset_pair."""
+def test_force_reset_resets_all_non_pending_including_done(monkeypatch):
+    """_force_reset resets all non-pending pairs including done."""
     import pipeline.deploy as mod
 
     progress = {
@@ -421,14 +450,13 @@ def test_force_reset_calls_reset_for_non_pending_non_done(monkeypatch):
     n = mod._force_reset(progress, scope, discovered,
                          namespaces=["sim2real-0", "sim2real-1"])
 
-    # Pending and done should be skipped
+    # Only pending should be skipped
     assert "wl-a-treatment" not in cleaned
-    assert "wl-c-baseline" not in cleaned
-    # Failed and timed-out should be reset
+    # Failed, timed-out, AND done should all be reset
     assert "wl-a-baseline" in cleaned
     assert "wl-b-baseline" in cleaned
-    assert n == 2
-    assert progress["wl-c-baseline"]["status"] == "done"
+    assert "wl-c-baseline" in cleaned
+    assert n == 3
 
 
 def test_force_reset_skips_count_on_reset_failure(monkeypatch):
@@ -495,6 +523,7 @@ def test_cmd_reset_aborts_on_filter_mismatch(tmp_path, monkeypatch, capsys):
 
     class _Args:
         only = "nonexistent"; workload = None; package = None; status = None; dry_run = False
+        preserve_done_status = False
 
     with __import__("pytest").raises(SystemExit) as exc_info:
         mod._cmd_reset(_Args(), run_dir, _DISCOVERED,
@@ -525,7 +554,7 @@ def test_reset_pair_done_uninstalls_helm_in_completed_namespace(monkeypatch):
                              namespaces=["sim2real-0", "sim2real-1"])
 
     assert result is True
-    assert entry["status"] == "done"
+    assert entry["status"] == "pending"
 
     helm_lists = [c for c in calls if c[:2] == ["helm", "list"]]
     assert len(helm_lists) == 1
@@ -607,7 +636,7 @@ def test_reset_pair_done_helm_list_failure_warns(monkeypatch, capsys):
                              namespaces=["sim2real-0", "sim2real-1"])
 
     assert result is True
-    assert entry["status"] == "done"
+    assert entry["status"] == "pending"
     err = capsys.readouterr().err
     assert "helm list failed" in err
 
@@ -631,7 +660,7 @@ def test_reset_pair_done_helm_uninstall_failure_warns(monkeypatch, capsys):
                              namespaces=["sim2real-0", "sim2real-1"])
 
     assert result is True
-    assert entry["status"] == "done"
+    assert entry["status"] == "pending"
     err = capsys.readouterr().err
     assert "Failed to uninstall" in err
 

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -658,19 +658,18 @@ def _mock_run(monkeypatch):
     monkeypatch.setattr(mod, "run", fake_run)
 
 
-def test_force_reset_resets_non_pending_non_done_pairs(monkeypatch):
+def test_force_reset_resets_all_non_pending_pairs(monkeypatch):
     from pipeline.deploy import _force_reset
     _mock_run(monkeypatch)
     progress = dict(_PROGRESS)
     scope = set(progress.keys())
     n = _force_reset(progress, scope)
-    # running, timed-out, failed are reset; done and pending are skipped
-    assert n == 3
-    for key in ("wl-smoke-treatment", "wl-load-treatment", "wl-heavy-baseline"):
+    # running, timed-out, failed, AND done are reset; only pending is skipped
+    assert n == 4
+    for key in ("wl-smoke-baseline", "wl-smoke-treatment", "wl-load-treatment", "wl-heavy-baseline"):
         assert progress[key]["status"] == "pending"
         assert progress[key]["namespace"] is None
         assert progress[key]["retries"] == 0
-    assert progress["wl-smoke-baseline"]["status"] == "done"
 
 
 def test_force_reset_leaves_pending_pairs_unchanged(monkeypatch):


### PR DESCRIPTION
## Summary
- `reset` now resets ALL non-pending pairs including `done` to `pending` (with cluster cleanup)
- New `--preserve-done-status` flag provides the old behavior: cluster cleanup for done pairs without changing their status
- `run --force` (via `_force_reset`) also resets done pairs — no opt-out

Closes #172

## What changed

**`pipeline/deploy.py`:**
- `_reset_pair`: added `preserve_done_status` parameter. Both done-guards now check this flag — by default, done pairs get status reset to pending after cluster cleanup
- `_force_reset`: removed `"done"` from the exclusion filter
- `_cmd_reset`: reads `--preserve-done-status` from args, passes to `_reset_pair`
- Argparse: added `--preserve-done-status` flag
- Docstrings/help text updated

**`pipeline/README.md`:**
- Reset description rewritten to reflect new default
- `--preserve-done-status` documented in flag table
- Wipe "Re-running" note simplified (no more #172 caveat)

**Tests:**
- `test_reset_pair_done_resets_state_by_default` — verifies done→pending
- `test_reset_pair_done_preserves_status_with_flag` — verifies flag preserves done
- `test_force_reset_resets_all_non_pending_including_done` — verifies run --force behavior
- Existing done-pair helm tests updated to expect `pending` status after reset

## Reviewer attention
- **Breaking change**: `reset` without `--preserve-done-status` will now re-queue done pairs.