### PR TITLE
fix: collect-results discovers pods by type instead of modelLabel

### DIFF
--- a/pipeline/pipeline.yaml
+++ b/pipeline/pipeline.yaml
@@ -109,8 +109,6 @@ spec:
         - name: data
           workspace: data-storage
       params:
-        - name: modelLabel
-          value: "sim2real-$(params.experimentId)"
         - name: resultsDir
           value: "$(params.runName)/$(params.phase)/$(params.workloadName)"
         - name: namespace

--- a/pipeline/tests/test_pipeline_yaml.py
+++ b/pipeline/tests/test_pipeline_yaml.py
@@ -1,0 +1,34 @@
+"""Tests for pipeline.yaml structural correctness."""
+import yaml
+from pathlib import Path
+
+PIPELINE_YAML = Path(__file__).resolve().parents[2] / "pipeline" / "pipeline.yaml"
+
+
+class TestCollectResultsParams:
+    """collect-results task invocation uses correct params."""
+
+    def _get_collect_results_task(self):
+        pipeline = yaml.safe_load(PIPELINE_YAML.read_text())
+        tasks = pipeline["spec"]["tasks"]
+        cr = [t for t in tasks if t["name"] == "collect-results"]
+        assert len(cr) == 1, "Expected exactly one collect-results task"
+        return cr[0]
+
+    def test_no_model_label_param(self):
+        """modelLabel should not be passed to collect-results."""
+        task = self._get_collect_results_task()
+        param_names = [p["name"] for p in task["params"]]
+        assert "modelLabel" not in param_names
+
+    def test_has_namespace_param(self):
+        """collect-results must receive a namespace param."""
+        task = self._get_collect_results_task()
+        param_names = [p["name"] for p in task["params"]]
+        assert "namespace" in param_names
+
+    def test_has_results_dir_param(self):
+        """collect-results must receive a resultsDir param."""
+        task = self._get_collect_results_task()
+        param_names = [p["name"] for p in task["params"]]
+        assert "resultsDir" in param_names


### PR DESCRIPTION
## Summary

- Removes the stale `modelLabel` param from the `collect-results` task invocation in `pipeline/pipeline.yaml`
- Rewrites `collect-results.yaml` to discover pods using stable Helm chart labels instead of the broken hash-based `modelLabel`
- Adds prefill log collection (previously missing — only decode was collected)
- Adds a structural test validating the pipeline.yaml params

Closes #170

## Design Decision

Option C from the issue discussion: discover by pod type. Relies on the one-model-stack-per-namespace invariant enforced by `deploy.py` slot allocation.

| Pod type | Old selector | New selector |
|----------|-------------|--------------|
| vLLM decode | `llm-d.ai/model=${MODEL_LABEL}` | `llm-d.ai/role=decode` |
| vLLM prefill | (not collected) | `llm-d.ai/role=prefill` |
| EPP | grep on `${MODEL_LABEL}-gaie` prefix | `app.kubernetes.io/managed-by=inferencepool` |

## Reviewer Attention

- **Submodule commit**: `tektonc-data-collection` is updated with a new commit that rewrites `collect-results.yaml`. The submodule pointer is bumped in this PR.
- **EPP label**: Uses `app.kubernetes.io/managed-by=inferencepool` — verify this label is applied by the inferencepool chart version currently deployed.
- **Assumption**: One model stack per namespace. If this invariant changes, these generic selectors would collect logs from all stacks indiscriminately.

## Test plan

- [x] `ruff check pipeline/ --select F` — passes
- [x] `python -m pytest pipeline/ -v` — 660 tests pass
- [ ] Deploy a PipelineRun on cluster and verify `server_logs/` and `epp_logs/` directories are populated in results