### PR TITLE
feat: add --preserve-pipelineruns flag to deploy.py run

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -154,6 +154,7 @@ python pipeline/deploy.py pairs   [flags]   # list available pair keys, workload
 | `--package NAME` | — | Scope execution to pairs matching this package |
 | `--status STATE` | — | Scope execution to pairs with this status (e.g. `failed`, `timed-out`) |
 | `--skip-teardown` | — | Skip the Tekton teardown task, leaving namespace resources intact for debugging |
+| `--preserve-pipelineruns` | — | Do not delete PipelineRun objects after completion (keeps TaskRun logs for debugging) |
 | `--force` | — | Reset non-pending pairs to `pending`, cleaning cluster resources (PipelineRuns + Helm) for pairs with assigned namespaces |
 | `--max-retries N` | 2 | Max retries for timed-out pairs |
 | `--poll-interval N` | 30 | Seconds between status polls |
@@ -169,7 +170,7 @@ python pipeline/deploy.py pairs   [flags]   # list available pair keys, workload
 
 **Pair statuses:** `pending` → `running` → `done`. Failure paths: `running` → `failed` (hard failure or non-recoverable pending), `running` → `timed-out` (4h timeout exceeded), `running` → `pending` (recoverable early reclaim, repeats up to `--max-pending-stalls` times) → `stalled`.
 
-**Auto-cleanup** — when a PipelineRun succeeds, the orchestrator deletes the PipelineRun CR from the cluster. Failed PipelineRuns are left in place for debugging (`kubectl describe`, pod logs). Use `reset` to remove them when done. Note: `--skip-teardown` only suppresses the Tekton `llmdbenchmark-teardown` task (Helm-level resource cleanup); PipelineRun CR deletion by the orchestrator is unaffected.
+**Auto-cleanup** — when a PipelineRun succeeds, the orchestrator deletes the PipelineRun CR from the cluster. Failed PipelineRuns are left in place for debugging (`kubectl describe`, pod logs). Use `reset` to remove them when done. Note: `--skip-teardown` only suppresses the Tekton `llmdbenchmark-teardown` task (Helm-level resource cleanup); PipelineRun CR deletion by the orchestrator is unaffected. Use `--preserve-pipelineruns` to suppress PipelineRun CR deletion on success — useful for debugging steps that fail silently (e.g., `set +e` scripts that exit 0 despite internal errors).
 
 **Remote mode** — `deploy.py run --remote` submits the orchestrator as a Kubernetes Job (`sim2real-orchestrator`) instead of running locally. The launcher builds the EPP image locally, packs workspace files into a ConfigMap, applies the Job, and waits for the pod to reach Running. Use `stop` to cancel, `status` to check progress, and `collect` to pull results after completion. Requires `orchestrator_image` in `setup_config.json`.
 

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1240,7 +1240,8 @@ def _check_slot_ready(namespace: str, hf_secret_name: str = "hf-secret") -> tupl
     return len(failures) == 0, failures
 
 
-def _reconcile_on_resume(progress: dict, discovered: dict) -> None:
+def _reconcile_on_resume(progress: dict, discovered: dict, *,
+                         preserve_pipelineruns: bool = False) -> None:
     """Reconcile pair statuses against cluster state when resuming an interrupted run.
 
     - running pairs: check PipelineRun status on cluster and update accordingly
@@ -1267,10 +1268,11 @@ def _reconcile_on_resume(progress: dict, discovered: dict) -> None:
                     entry["status"] = "done"
                     entry["pending_since"] = None
                     entry["completed_namespace"] = ns
-                    try:
-                        _delete_pipelinerun(pr_name, ns)
-                    except Exception as exc:
-                        warn(f"Failed to delete PipelineRun {pr_name!r} in {ns}: {exc}")
+                    if not preserve_pipelineruns:
+                        try:
+                            _delete_pipelinerun(pr_name, ns)
+                        except Exception as exc:
+                            warn(f"Failed to delete PipelineRun {pr_name!r} in {ns}: {exc}")
                     entry["namespace"] = None
                 elif actual in ("Failed", "PipelineRunCancelled",
                                "PipelineRunCouldntGetPipeline",
@@ -1481,7 +1483,9 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
             info("--force: no non-pending pairs found in scope — nothing reset")
         store.save(progress)
 
-    _reconcile_on_resume(progress, discovered)
+    preserve_pipelineruns = getattr(args, "preserve_pipelineruns", False)
+    _reconcile_on_resume(progress, discovered,
+                         preserve_pipelineruns=preserve_pipelineruns)
     store.save(progress)
 
     # Track which namespace is assigned to which pair
@@ -1522,10 +1526,11 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                 entry["completed_namespace"] = ns
                 entry["namespace"] = None
                 store.save(progress)
-                try:
-                    _delete_pipelinerun(pr_name, ns)
-                except Exception as exc:
-                    warn(f"Failed to delete PipelineRun {pr_name!r} in {ns}: {exc}")
+                if not preserve_pipelineruns:
+                    try:
+                        _delete_pipelinerun(pr_name, ns)
+                    except Exception as exc:
+                        warn(f"Failed to delete PipelineRun {pr_name!r} in {ns}: {exc}")
                 del slots_busy[ns]
 
             elif status in ("Failed", "PipelineRunCancelled", "PipelineRunCouldntGetPipeline",
@@ -1927,6 +1932,8 @@ def _collect_run_flags(args) -> list[str]:
         flags.append("--force")
     if getattr(args, "skip_teardown", False):
         flags.append("--skip-teardown")
+    if getattr(args, "preserve_pipelineruns", False):
+        flags.append("--preserve-pipelineruns")
     _defaults = {
         "max_retries": 2,
         "poll_interval": 30,
@@ -2167,6 +2174,8 @@ Examples:
                        help="Reset non-pending pairs to pending, cleaning cluster resources for pairs with assigned namespaces")
     run_p.add_argument("--skip-teardown", action="store_true", dest="skip_teardown",
                        help="Skip teardown after PipelineRun completes (keeps namespace intact for debugging)")
+    run_p.add_argument("--preserve-pipelineruns", action="store_true", dest="preserve_pipelineruns",
+                       help="Do not delete PipelineRun objects after completion (keeps TaskRun logs for debugging)")
     run_p.add_argument("--max-retries",  type=int, default=2, dest="max_retries",
                        help="Max retries for timed-out pairs [2]")
     run_p.add_argument("--poll-interval", type=int, default=30, dest="poll_interval",

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -546,6 +546,27 @@ def test_reconcile_succeeded_deletes_pipelinerun(monkeypatch):
     assert deleted == [("baseline-smoke-run1", "sim2real-0")]
 
 
+def test_reconcile_preserve_pipelineruns_skips_deletion(monkeypatch):
+    """With preserve_pipelineruns=True, _delete_pipelinerun is not called."""
+    import pipeline.deploy as mod
+
+    monkeypatch.setattr(mod, "_check_pipelinerun_status", lambda pr, ns: "Succeeded")
+    deleted = []
+    monkeypatch.setattr(mod, "_delete_pipelinerun",
+                        lambda pr, ns: deleted.append((pr, ns)))
+
+    progress = {
+        "wl-smoke-baseline": {
+            "workload": "wl-smoke", "package": "baseline",
+            "status": "running", "namespace": "sim2real-0",
+            "pending_since": "2026-01-01T00:00:00Z",
+        }
+    }
+    mod._reconcile_on_resume(progress, _DISCOVERED, preserve_pipelineruns=True)
+    assert progress["wl-smoke-baseline"]["status"] == "done"
+    assert deleted == []
+
+
 def test_reconcile_succeeded_delete_failure_nonfatal(monkeypatch, capsys):
     """If _delete_pipelinerun raises, the pair still transitions to done."""
     import pipeline.deploy as mod


### PR DESCRIPTION
## Summary

- Adds `--preserve-pipelineruns` flag to `deploy.py run` that suppresses deletion of PipelineRun objects after completion
- Guards both deletion sites: the main run loop (success path) and `_reconcile_on_resume` (resume path)
- Forwards the flag in the `--remote` path

Closes #179

## Reviewer attention

The pre-apply deletion at line 1688 (`kubectl delete pipelinerun ... --ignore-not-found`) is intentionally NOT guarded — that clears a stale prior run before re-applying the same pair, which is necessary for correct dispatch. `--preserve-pipelineruns` only preserves runs that reach terminal state during the current execution.

## Test plan

- [x] New test: `test_reconcile_preserve_pipelineruns_skips_deletion` verifies the flag suppresses deletion in `_reconcile_on_resume`
- [x] All 661 existing tests pass
- [x] Lint clean (`ruff check pipeline/ --select F`)