### PR TITLE
fix: signal backoff reset on actual Pending→Running transition

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1539,6 +1539,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
 
             elif status in ("Running", "Started"):
                 # Check for pending pods (before timeout)
+                had_pending = entry.get("pending_since") is not None
                 try:
                     reclaimed = _handle_pending_pods(
                         pr_name=pr_name, namespace=ns, entry=entry,
@@ -1563,6 +1564,13 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                     progress["_orchestrator"] = backoff.to_dict()
                     store.save(progress)
                     continue
+
+                if had_pending and entry.get("pending_since") is None:
+                    if backoff.state != "normal":
+                        backoff.signal_scheduling_success()
+                        info(f"[{pair_key}] Pending→Running → backoff reset")
+                        progress["_orchestrator"] = backoff.to_dict()
+                        store.save(progress)
 
                 # Check for timeout
                 ts_result = run(
@@ -1710,9 +1718,6 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
             slots_busy[ns] = pair_key
             store.save(progress)
             ok(f"[{pair_key}] → {ns} ({pr_name})")
-            if backoff.state != "normal":
-                backoff.signal_scheduling_success()
-                info("Scheduling success → backoff reset")
 
         # Persist backoff state
         progress["_orchestrator"] = backoff.to_dict()

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -1250,6 +1250,114 @@ def test_early_reclaim_pods_running_clears_pending_since(monkeypatch):
     assert entry["pending_since"] is None
 
 
+def test_pending_to_running_signals_backoff_reset(monkeypatch):
+    """When pods transition Pending→Running, caller should signal backoff reset."""
+    import json
+    import pipeline.deploy as mod
+    from pipeline.lib.backoff import BackoffController
+
+    pods_json_running = {
+        "items": [{
+            "status": {
+                "phase": "Running",
+                "conditions": [{"type": "Ready", "status": "True"}],
+            },
+        }],
+    }
+
+    entry = {
+        "workload": "wl-smoke", "package": "baseline", "status": "running",
+        "namespace": "sim2real-0", "retries": 0, "gpu_cost": 1,
+        "pending_stalls": 0,
+        "pending_since": "2026-05-09T12:00:00+00:00",
+    }
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = json.dumps(pods_json_running)
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    bc = BackoffController(base_interval=30, max_backoff=600)
+    bc.signal_scarcity(free_gpus=0, min_cost=8)
+    assert bc.state == "backing_off"
+
+    had_pending = entry.get("pending_since") is not None
+    reclaimed = mod._handle_pending_pods(
+        pr_name="baseline-smoke-run1",
+        namespace="sim2real-0",
+        entry=entry,
+        pending_threshold=600,
+        max_pending_stalls=10,
+    )
+
+    assert reclaimed is False
+    assert entry["pending_since"] is None
+    assert had_pending is True
+
+    # This mirrors the logic now in deploy.py's orchestrator loop
+    if had_pending and entry.get("pending_since") is None and not reclaimed:
+        bc.signal_scheduling_success()
+
+    assert bc.state == "normal"
+    assert bc.backoff_level == 0
+
+
+def test_no_backoff_signal_when_never_pending(monkeypatch):
+    """Pods that were never pending should NOT trigger backoff reset."""
+    import json
+    import pipeline.deploy as mod
+    from pipeline.lib.backoff import BackoffController
+
+    pods_json_running = {
+        "items": [{
+            "status": {
+                "phase": "Running",
+                "conditions": [{"type": "Ready", "status": "True"}],
+            },
+        }],
+    }
+
+    entry = {
+        "workload": "wl-smoke", "package": "baseline", "status": "running",
+        "namespace": "sim2real-0", "retries": 0, "gpu_cost": 1,
+        "pending_stalls": 0,
+        "pending_since": None,
+    }
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = json.dumps(pods_json_running)
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    bc = BackoffController(base_interval=30, max_backoff=600)
+    bc.signal_scarcity(free_gpus=0, min_cost=8)
+    assert bc.state == "backing_off"
+
+    had_pending = entry.get("pending_since") is not None
+    reclaimed = mod._handle_pending_pods(
+        pr_name="baseline-smoke-run1",
+        namespace="sim2real-0",
+        entry=entry,
+        pending_threshold=600,
+        max_pending_stalls=10,
+    )
+
+    assert reclaimed is False
+    assert had_pending is False
+
+    # Caller logic: no signal because had_pending is False
+    if had_pending and entry.get("pending_since") is None and not reclaimed:
+        bc.signal_scheduling_success()
+
+    assert bc.state == "backing_off"  # Unchanged
+
+
 def test_early_reclaim_malformed_pending_since_resets_timer(monkeypatch, capsys):
     """Malformed pending_since resets timer instead of crashing."""
     import json


### PR DESCRIPTION
Closes #86

## Summary

- Removed the premature `signal_scheduling_success()` call at PipelineRun submission time (`kubectl apply` succeeding is not evidence that pods scheduled)
- Added detection of the actual Pending→Running transition in the orchestrator loop: capture `pending_since` before calling `_handle_pending_pods`, then check if it was cleared without a reclaim — that's the real scheduling success signal
- Added two tests: one verifying the transition triggers a backoff reset, one verifying that pods that were never pending do not trigger it

## Design choice

Rather than passing the `BackoffController` into `_handle_pending_pods` (coupling a pod-checking utility to orchestrator state), the caller observes the entry's `pending_since` field before and after the call. This keeps `_handle_pending_pods` focused on pod classification with zero signature changes.

## Test plan

- [x] `test_pending_to_running_signals_backoff_reset` — verifies backoff resets when pods transition Pending→Running
- [x] `test_no_backoff_signal_when_never_pending` — verifies no spurious reset when pods were never pending
- [x] All 662 existing tests pass, lint clean