### PR TITLE
fix: add helm CLI to orchestrator image

### DIFF
--- a/.github/workflows/orchestrator-image.yml
+++ b/.github/workflows/orchestrator-image.yml
@@ -57,6 +57,7 @@ jobs:
         run: |
           docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} --help
           docker run --rm --entrypoint kubectl ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} version --client
+          docker run --rm --entrypoint helm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} version --short
           docker run --rm --entrypoint python ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} -c "from pipeline.lib import assemble, backoff, capacity, context_builder, epp, health, manifest, pod_pending, progress, run_manager, state_machine, tekton, values; print('OK')"
 
       - name: Push

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
     install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
     rm kubectl kubectl.sha256 && \
     HELM_VERSION=$(curl -fsSL https://api.github.com/repos/helm/helm/releases/latest | grep '"tag_name"' | sed 's/.*"v\(.*\)".*/\1/') && \
+    test -n "$HELM_VERSION" || { echo "ERROR: failed to determine helm version"; exit 1; } && \
     curl -fLO "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz" && \
     curl -fLO "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz.sha256sum" && \
     sha256sum --check "helm-v${HELM_VERSION}-linux-amd64.tar.gz.sha256sum" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,13 @@ RUN apt-get update && \
     echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check && \
     install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
     rm kubectl kubectl.sha256 && \
+    HELM_VERSION=$(curl -fsSL https://api.github.com/repos/helm/helm/releases/latest | grep '"tag_name"' | sed 's/.*"v\(.*\)".*/\1/') && \
+    curl -fLO "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz" && \
+    curl -fLO "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz.sha256sum" && \
+    sha256sum --check "helm-v${HELM_VERSION}-linux-amd64.tar.gz.sha256sum" && \
+    tar -xzf "helm-v${HELM_VERSION}-linux-amd64.tar.gz" linux-amd64/helm && \
+    install -o root -g root -m 0755 linux-amd64/helm /usr/local/bin/helm && \
+    rm -rf "helm-v${HELM_VERSION}-linux-amd64.tar.gz" "helm-v${HELM_VERSION}-linux-amd64.tar.gz.sha256sum" linux-amd64 && \
     apt-get purge -y curl && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Closes #182

## Summary

- Added `helm` CLI installation to the orchestrator `Dockerfile` alongside `kubectl`, with SHA-256 checksum verification
- Added `helm version --short` to the CI smoke test so missing tools are caught before the image ships

## Context

`deploy.py` invokes `helm` for `--force` reset (uninstalling helm releases) and slot cleanup (removing orphaned releases). The orchestrator image only had `kubectl`, causing `[Errno 2] No such file or directory: 'helm'` when running remotely.

## Reviewer notes

- Helm version is fetched dynamically from the GitHub releases API at build time (same pattern as kubectl)
- The `.sha256sum` file is used directly with `sha256sum --check` — this is the official verification method from the Helm project
- Everything stays in one RUN layer to avoid inflating image size