### PR TITLE
fix: build-epp uses repo_name from metadata + update submodule

### DIFF
--- a/.claude/skills/sim2real-check/SKILL.md
+++ b/.claude/skills/sim2real-check/SKILL.md
@@ -1,5 +1,4 @@
 ---
-name: sim2real-check
 description: Validate a sim2real translation bundle against its simulation bundle. Checks workloads, configs, signals, policies, and runtime health.
 ---
 
@@ -77,10 +76,11 @@ Run ALL checks below.
 For each workload in the real bundle, find the matching sim workload YAML in `<sim>/workloads/`.
 
 **1a. Arrival Rate (QPS)**
+- **Intended QPS**: compute from `trace_data.csv` `arrival_time_us` column: `num_requests / (max - min arrival)`. This is the rate the load generator *scheduled* requests at.
+- **Actual QPS**: compute from `trace_data.csv` `send_time_us` column: `num_requests / (max - min send_time)`. This is the rate requests were *actually sent* to the server. If actual QPS << intended QPS, the load generator hit a concurrency ceiling and requests queued client-side.
 - From sim: `aggregate_rate` in workload YAML
-- From real: compute from `trace_data.csv` arrival_time_us column: `num_requests / (max - min arrival)`
-- Tolerance: within 5%
-- Show: table with expected rate, actual rate, % difference
+- Tolerance: intended QPS within 5% of sim spec. If actual QPS is more than 5% below intended QPS, emit WARN — this means the load generator couldn't keep up with the schedule (likely concurrency ceiling or server backpressure), so the server saw less load than intended and results are not comparable to simulation.
+- Show: table with sim spec rate, intended QPS, actual QPS — all three columns so the reader can spot concurrency bottlenecks
 
 **1b. SLO Class Distribution**
 - From sim: each client's `rate_fraction`
@@ -245,11 +245,13 @@ Parse each server log's startup lines. Verify `non-default args` match expected 
 Extract: model, TP size, max_model_len, gpu_memory_utilization, enable_prefix_caching, max_num_seqs, max_num_batched_tokens.
 - Show: extracted values from log vs expected
 
-**5b. Instance Health**
-- Count requests per instance: group `trace_data.csv` by some proxy (or count server log files that show activity)
-- Check for even distribution (for random/round-robin routing): no instance should get <10% or >40% of total (for 4 instances, expect ~25% each)
+**5b. Instance Health & Request Distribution**
+- Count `/completions` requests per instance by grepping each server log file in `server_logs/` for `/completions` (or `/chat/completions` if chat API). This is the authoritative per-instance request count — `trace_data.csv` does not have an instance identifier column.
+- Compute total served requests (sum across instances), per-instance percentage, and spread (max-min as % of average).
+- Check for even distribution (for random/round-robin routing): no instance should get <10% or >40% of total (for 4 instances, expect ~25% each). Spread should be < 10%.
+- Compare total served vs total sent (from trace_data.csv row count) — the difference is requests shed by admission before reaching any instance.
 - Flag any instance that appears unhealthy (no requests, errors in logs)
-- Show: table with instance name, request count, percentage, health status
+- Show: table with instance name, `/completions` request count, percentage of total served, and a summary row with total served vs total sent and spread %
 
 **5c. Prefix Hit Ratio**
 If `enable_prefix_caching=True`, grep server logs for prefix cache hit metrics.

--- a/pipeline/scripts/build-epp.sh
+++ b/pipeline/scripts/build-epp.sh
@@ -42,9 +42,7 @@ fi
 # ── Find repo root ─────────────────────────────────────────────────
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SIM2REAL_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-# llm-d-inference-scheduler lives in the experiment repo, not the framework.
 SCHEDULER_ROOT="${EXPERIMENT_ROOT:-${SIM2REAL_ROOT}}"
-SCHEDULER_DIR="${SCHEDULER_ROOT}/llm-d-inference-scheduler"
 
 # ── Step 1: Read metadata ─────────────────────────────────────────
 info "Reading run metadata..."
@@ -57,6 +55,7 @@ fi
 REGISTRY_HUB=$(python3 -c "import json; print(json.load(open('${METADATA}'))['registry'])")
 REPO_NAME=$(python3 -c "import json; print(json.load(open('${METADATA}')).get('repo_name','llm-d-inference-scheduler'))")
 FULL_IMAGE="${REGISTRY_HUB}/${REPO_NAME}:${RUN_NAME}"
+SCHEDULER_DIR="${SCHEDULER_ROOT}/${REPO_NAME}"
 info "Target image: ${FULL_IMAGE}"
 
 # ── Step 2: Check registry secret ─────────────────────────────────
@@ -79,7 +78,7 @@ fi
 ok "registry-secret found"
 
 # ── Step 3: Copy source to cluster ─────────────────────────────────
-info "Copying llm-d-inference-scheduler source to cluster..."
+info "Copying ${REPO_NAME} source to cluster..."
 
 # Clean up any leftover pod from a previous run
 kubectl delete pod source-copy -n "${NAMESPACE}" --ignore-not-found --force --grace-period=0 2>/dev/null || true
@@ -103,7 +102,7 @@ kubectl exec source-copy -n "${NAMESPACE}" -- sh -c "rm -rf /workspace/source/${
 
 info "Uploading source (this may take a minute)..."
 kubectl exec source-copy -n "${NAMESPACE}" -- mkdir -p "/workspace/source/${RUN_NAME}"
-kubectl cp "${SCHEDULER_DIR}/" "${NAMESPACE}/source-copy:/workspace/source/${RUN_NAME}/llm-d-inference-scheduler"
+kubectl cp "${SCHEDULER_DIR}/" "${NAMESPACE}/source-copy:/workspace/source/${RUN_NAME}/${REPO_NAME}"
 ok "Source uploaded"
 
 kubectl delete pod source-copy --namespace "${NAMESPACE}" --force --grace-period=0 2>/dev/null || true
@@ -132,9 +131,9 @@ spec:
         - build
         - --frontend=dockerfile.v0
         - --local
-        - context=/workspace/source/${RUN_NAME}/llm-d-inference-scheduler
+        - context=/workspace/source/${RUN_NAME}/${REPO_NAME}
         - --local
-        - dockerfile=/workspace/source/${RUN_NAME}/llm-d-inference-scheduler
+        - dockerfile=/workspace/source/${RUN_NAME}/${REPO_NAME}
         - --opt
         - filename=Dockerfile.epp
         - --opt


### PR DESCRIPTION
Closes #185

## Summary

- **build-epp.sh**: Use `repo_name` from `run_metadata.json` instead of hardcoded `llm-d-inference-scheduler` for the component directory path. Experiments using a different component repo (e.g. `llm-d-router`) now work correctly.
- **tektonc-data-collection submodule**: Updated to latest main (39a9827), picking up:
  - Correct EPP pod discovery label (`inferencepool` instead of `app.kubernetes.io/managed-by=inferencepool`)
  - Verbose standup output for debugging

## Test plan

- [x] Verified `deploy.py run` with `--experiment-root` pointing to an experiment using `llm-d-router` as the component repo
- [x] EPP pod log collection uses correct label selector