### PR TITLE
feat(deploy): add build subcommand with source hash staleness detection

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-"""sim2real deploy — Build EPP, orchestrate runs, collect results.
+"""sim2real deploy — Ensure images, orchestrate runs, collect results.
 
 Subcommands:
-  run      Build EPP image, submit PipelineRuns
+  build    Ensure all scenario images exist (pre-flight for run)
+  run      Ensure images + submit PipelineRuns
   status   Show progress of all (workload, package) pairs
   collect  Pull results from cluster for completed phases
   stop     Stop the remote orchestrator Job
@@ -2123,13 +2124,14 @@ def _cmd_run_remote(args, run_dir: "Path", setup_config: dict) -> None:
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="deploy.py",
-        description="sim2real deploy — Build EPP, orchestrate runs, collect results",
+        description="sim2real deploy — Ensure images, orchestrate runs, collect results",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  python pipeline/deploy.py run                        # Build EPP + orchestrate all pairs
+  python pipeline/deploy.py build                      # Ensure all scenario images exist
+  python pipeline/deploy.py run                        # Ensure images + orchestrate all pairs
   python pipeline/deploy.py run --remote               # Submit orchestrator as in-cluster Job
-  python pipeline/deploy.py run --skip-build            # Orchestrate without image build
+  python pipeline/deploy.py run --skip-build           # Orchestrate without image build
   python pipeline/deploy.py status                     # Show progress snapshot
   python pipeline/deploy.py collect                    # Pull results for completed phases
   python pipeline/deploy.py collect --skip-logs        # Collect traces only (skip large logs)

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -109,41 +109,58 @@ def _load_setup_config() -> dict:
     return {}
 
 
-# ── EPP build decision ─────────────────────────────────────────────────────────
+# ── Image build ───────────────────────────────────────────────────────────────
 
-def _resolve_epp_action(run_dir: Path, skip_build_epp: bool) -> str:
-    """Determine EPP build action based on run metadata.
+def _cmd_build(run_dir: Path, namespace: str, skip_build: bool) -> str:
+    """Ensure all required scenario images exist. Returns 'built', 'skip', or 'current'.
 
-    Returns one of: "build", "skip", "error:<message>"
+    This is the 'deploy build' logic. Called implicitly by 'deploy run' as pre-flight.
     """
+    from pipeline.lib.ensure_image import (
+        compute_source_hash, image_needs_build, save_source_hash,
+    )
+
     run_meta_path = run_dir / "run_metadata.json"
     if not run_meta_path.exists():
-        return "error:run_metadata.json not found — run setup.py first."
+        err("run_metadata.json not found — run setup.py first.")
+        sys.exit(1)
     try:
         run_meta = json.loads(run_meta_path.read_text())
     except json.JSONDecodeError as e:
-        return f"error:run_metadata.json is not valid JSON: {e}. Re-run setup.py."
+        err(f"run_metadata.json is not valid JSON: {e}. Re-run setup.py.")
+        sys.exit(1)
 
     component_image = run_meta.get("component_image")
-    if component_image is None:
-        return "skip"
     if not component_image:
-        return "error:component_image is empty in run_metadata.json. Re-run setup.py with a valid --registry."
-    if skip_build_epp:
+        info("No component_image in run metadata — skipping image build")
         return "skip"
-    return "build"
 
+    if skip_build:
+        info("--skip-build: skipping image build")
+        return "skip"
 
-# ── EPP Image build ─────────────────────────────────────────────────────────
+    step(1, "Ensure Images")
 
-def _build_epp_image(run_dir: Path, run_name: str, namespace: str) -> str:
-    """Build EPP image on-cluster. Returns the full image reference."""
-    step(1, "Build EPP Image")
+    registry = run_meta.get("registry", "")
+    repo_name = run_meta.get("repo_name", "llm-d-inference-scheduler")
+    run_name = run_dir.name
+    source_dir = EXPERIMENT_ROOT / repo_name
 
-    # Locate build-epp.sh
+    if not source_dir.exists():
+        err(f"Component source directory not found: {source_dir}")
+        sys.exit(1)
+
+    # Treatment image: tagged by run name
+    treatment_ref = f"{registry}/{repo_name}:{run_name}"
+
+    if not image_needs_build(run_dir, treatment_ref, source_dir):
+        ok(f"Treatment image current (hash unchanged): {treatment_ref}")
+        return "current"
+
+    info(f"Building treatment image: {treatment_ref}")
     build_script = REPO_ROOT / "pipeline" / "scripts" / "build-epp.sh"
     if not build_script.exists():
-        err(f"build-epp.sh not found at {build_script.relative_to(REPO_ROOT)} — ensure pipeline/scripts/build-epp.sh is present in the repo")
+        err(f"build-epp.sh not found at {build_script.relative_to(REPO_ROOT)}")
         sys.exit(1)
 
     result = run(
@@ -151,25 +168,20 @@ def _build_epp_image(run_dir: Path, run_name: str, namespace: str) -> str:
          "--run-dir", str(run_dir),
          "--run-name", run_name,
          "--namespace", namespace,
-         "--experiment-root", str(EXPERIMENT_ROOT)],
+         "--image-ref", treatment_ref,
+         "--source-dir", str(source_dir)],
         check=False,
         cwd=REPO_ROOT,
     )
     if result.returncode != 0:
-        err("EPP build failed — see output above")
+        err("Image build failed — see output above")
         sys.exit(1)
 
-    # Read image reference from run_metadata.json
-    meta_path = run_dir / "run_metadata.json"
-    if meta_path.exists():
-        meta = json.loads(meta_path.read_text())
-        full_image = meta.get("component_image", "")
-        if full_image:
-            ok(f"EPP image: {full_image}")
-            return full_image
-
-    err("EPP build completed but component_image not set in run_metadata.json")
-    sys.exit(1)
+    # Record source hash after successful build
+    current_hash = compute_source_hash(source_dir)
+    save_source_hash(run_dir, treatment_ref, current_hash)
+    ok(f"Image built and hash recorded: {treatment_ref}")
+    return "built"
 
 
 # ── PipelineRun helpers ──────────────────────────────────────────────────────
@@ -1382,14 +1394,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
     if not namespaces or not namespaces[0]:
         err("No namespaces configured. Run setup.py with --namespaces."); sys.exit(1)
 
-    # Decide whether to build EPP image
-    epp_action = _resolve_epp_action(run_dir, args.skip_build_epp)
-    if epp_action.startswith("error:"):
-        err(epp_action[len("error:"):]); sys.exit(1)
-    elif epp_action == "skip":
-        info("No component_image in run metadata — skipping EPP build")
-    else:
-        _build_epp_image(run_dir, run_dir.name, namespaces[0])
+    _cmd_build(run_dir, namespace=namespaces[0], skip_build=args.skip_build)
 
     max_retries = getattr(args, "max_retries", 2)
     poll_interval = getattr(args, "poll_interval", 30)
@@ -2069,13 +2074,7 @@ def _cmd_run_remote(args, run_dir: "Path", setup_config: dict) -> None:
             err(f"Failed to delete completed Job: {detail}")
             sys.exit(1)
 
-    epp_action = _resolve_epp_action(run_dir, args.skip_build_epp)
-    if epp_action.startswith("error:"):
-        err(epp_action[len("error:"):]); sys.exit(1)
-    elif epp_action == "skip":
-        info("No component_image in run metadata — skipping EPP build")
-    else:
-        _build_epp_image(run_dir, run_dir.name, namespace)
+    _cmd_build(run_dir, namespace=namespace, skip_build=args.skip_build)
 
     workspace_dir = EXPERIMENT_ROOT / "workspace"
     run_name = run_dir.name
@@ -2130,7 +2129,7 @@ def build_parser() -> argparse.ArgumentParser:
 Examples:
   python pipeline/deploy.py run                        # Build EPP + orchestrate all pairs
   python pipeline/deploy.py run --remote               # Submit orchestrator as in-cluster Job
-  python pipeline/deploy.py run --skip-build-epp       # Orchestrate without EPP build
+  python pipeline/deploy.py run --skip-build            # Orchestrate without image build
   python pipeline/deploy.py status                     # Show progress snapshot
   python pipeline/deploy.py collect                    # Pull results for completed phases
   python pipeline/deploy.py collect --skip-logs        # Collect traces only (skip large logs)
@@ -2166,11 +2165,15 @@ Examples:
     status_p.add_argument("--package",  metavar="NAME",  help="Scope to pairs matching this package")
     status_p.add_argument("--status",   metavar="STATE", help="Scope to pairs with this status (e.g. running, done, failed)")
 
+    build_p = sub.add_parser("build", help="Ensure all scenario images exist (pre-flight for run)")
+    build_p.add_argument("--skip-build", action="store_true", dest="skip_build",
+                         help="Skip image build entirely")
+
     run_p = sub.add_parser("run", help="Orchestrate parallel pool execution")
     run_p.add_argument("--remote", action="store_true", default=False,
                        help="Submit orchestrator as in-cluster Job instead of running locally")
-    run_p.add_argument("--skip-build-epp", action="store_true", dest="skip_build_epp",
-                       help="Skip EPP image build")
+    run_p.add_argument("--skip-build", action="store_true", dest="skip_build",
+                       help="Skip image build")
     run_p.add_argument("--only",         metavar="PAIR",  help="Scope execution to one specific pair key (wl- prefix optional)")
     run_p.add_argument("--workload",     metavar="NAME",  help="Scope execution to pairs matching this workload")
     run_p.add_argument("--package",      metavar="NAME",  help="Scope execution to pairs matching this package")
@@ -2263,6 +2266,14 @@ def main():
     if not run_dir.exists():
         err(f"Run directory not found: {run_dir}")
         sys.exit(1)
+
+    if cmd == "build":
+        namespaces = setup_config.get("namespaces") or [setup_config.get("namespace", "")]
+        if not namespaces or not namespaces[0]:
+            err("No namespaces configured. Run setup.py with --namespaces."); sys.exit(1)
+        _cmd_build(run_dir, namespace=namespaces[0],
+                   skip_build=getattr(args, "skip_build", False))
+        return
 
     if cmd == "run":
         if getattr(args, "remote", False):

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -132,9 +132,12 @@ def _cmd_build(run_dir: Path, namespace: str, skip_build: bool) -> str:
         sys.exit(1)
 
     component_image = run_meta.get("component_image")
-    if not component_image:
+    if component_image is None:
         info("No component_image in run metadata — skipping image build")
         return "skip"
+    if not component_image:
+        err("component_image is empty in run_metadata.json — re-run setup.py with a valid --registry.")
+        sys.exit(1)
 
     if skip_build:
         info("--skip-build: skipping image build")
@@ -143,6 +146,9 @@ def _cmd_build(run_dir: Path, namespace: str, skip_build: bool) -> str:
     step(1, "Ensure Images")
 
     registry = run_meta.get("registry", "")
+    if not registry:
+        err("registry is empty in run_metadata.json — re-run setup.py with a valid --registry.")
+        sys.exit(1)
     repo_name = run_meta.get("repo_name", "llm-d-inference-scheduler")
     run_name = run_dir.name
     source_dir = EXPERIMENT_ROOT / repo_name

--- a/pipeline/lib/ensure_image.py
+++ b/pipeline/lib/ensure_image.py
@@ -1,0 +1,39 @@
+"""Ensure container images exist: source hash comparison and build dispatch."""
+import json
+import subprocess
+from pathlib import Path
+
+
+def compute_source_hash(source_dir: Path) -> str:
+    """Return the HEAD commit hash of the git repo at source_dir."""
+    result = subprocess.run(
+        ["git", "-C", str(source_dir), "rev-parse", "HEAD"],
+        capture_output=True, text=True, check=True,
+    )
+    return result.stdout.strip()
+
+
+def load_source_hashes(run_dir: Path) -> dict[str, str]:
+    """Load source_hashes dict from run_metadata.json. Returns {} if absent."""
+    meta_path = run_dir / "run_metadata.json"
+    if not meta_path.exists():
+        return {}
+    meta = json.loads(meta_path.read_text())
+    return meta.get("source_hashes", {})
+
+
+def save_source_hash(run_dir: Path, image_ref: str, source_hash: str) -> None:
+    """Persist a source hash for an image ref in run_metadata.json."""
+    meta_path = run_dir / "run_metadata.json"
+    meta = json.loads(meta_path.read_text())
+    meta.setdefault("source_hashes", {})[image_ref] = source_hash
+    meta_path.write_text(json.dumps(meta, indent=2))
+
+
+def image_needs_build(run_dir: Path, image_ref: str, source_dir: Path) -> bool:
+    """Return True if the image should be (re)built based on source hash comparison."""
+    stored = load_source_hashes(run_dir).get(image_ref)
+    if stored is None:
+        return True
+    current = compute_source_hash(source_dir)
+    return current != stored

--- a/pipeline/lib/ensure_image.py
+++ b/pipeline/lib/ensure_image.py
@@ -1,5 +1,6 @@
 """Ensure container images exist: source hash comparison and build dispatch."""
 import json
+import os
 import subprocess
 from pathlib import Path
 
@@ -27,7 +28,9 @@ def save_source_hash(run_dir: Path, image_ref: str, source_hash: str) -> None:
     meta_path = run_dir / "run_metadata.json"
     meta = json.loads(meta_path.read_text())
     meta.setdefault("source_hashes", {})[image_ref] = source_hash
-    meta_path.write_text(json.dumps(meta, indent=2))
+    tmp_path = meta_path.with_suffix(".json.tmp")
+    tmp_path.write_text(json.dumps(meta, indent=2))
+    os.replace(tmp_path, meta_path)
 
 
 def image_needs_build(run_dir: Path, image_ref: str, source_dir: Path) -> bool:
@@ -35,5 +38,8 @@ def image_needs_build(run_dir: Path, image_ref: str, source_dir: Path) -> bool:
     stored = load_source_hashes(run_dir).get(image_ref)
     if stored is None:
         return True
-    current = compute_source_hash(source_dir)
+    try:
+        current = compute_source_hash(source_dir)
+    except subprocess.CalledProcessError:
+        return True
     return current != stored

--- a/pipeline/lib/remote.py
+++ b/pipeline/lib/remote.py
@@ -71,7 +71,7 @@ def build_orchestrator_job(
     args = [
         "--experiment-root", MOUNT_BASE,
         "--run", run_name,
-        "run", "--skip-build-epp",
+        "run", "--skip-build",
     ] + run_flags
 
     return {

--- a/pipeline/lib/source_toggle.py
+++ b/pipeline/lib/source_toggle.py
@@ -1,0 +1,43 @@
+"""Toggle component directory between baseline and treatment states."""
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def restore_baseline(component_dir: Path, translation_output: dict) -> None:
+    """Restore component_dir to its pre-translation (baseline) state.
+
+    - Deletes files listed in translation_output["files_created"]
+    - Runs git checkout on files listed in translation_output["files_modified"]
+    """
+    for rel_path in translation_output.get("files_created", []):
+        target = component_dir / rel_path
+        if target.exists():
+            target.unlink()
+
+    modified = translation_output.get("files_modified", [])
+    if modified:
+        subprocess.run(
+            ["git", "-C", str(component_dir), "checkout", "--"] + modified,
+            check=True, capture_output=True,
+        )
+
+
+def restore_treatment(
+    component_dir: Path,
+    generated_dir: Path,
+    translation_output: dict,
+) -> None:
+    """Restore component_dir to its post-translation (treatment) state.
+
+    Copies files from generated_dir back to their relative paths in component_dir.
+    """
+    all_files = (
+        translation_output.get("files_created", [])
+        + translation_output.get("files_modified", [])
+    )
+    for rel_path in all_files:
+        src = generated_dir / Path(rel_path).name
+        dst = component_dir / rel_path
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dst)

--- a/pipeline/scripts/build-epp.sh
+++ b/pipeline/scripts/build-epp.sh
@@ -3,8 +3,10 @@ set -euo pipefail
 
 # ── Build EPP image on Kubernetes cluster ──────────────────────────
 # Usage: build-epp.sh --run-dir <path> --run-name <name> --namespace <ns>
+#          [--image-ref <ref>] [--source-dir <path>] [--experiment-root <path>]
 #
-# Reads registry/repo from run_metadata.json (created by /sim2real-setup).
+# When --image-ref and --source-dir are provided, uses them directly.
+# Otherwise reads registry/repo from run_metadata.json (created by /sim2real-setup).
 # Requires registry-secret in the namespace for push credentials.
 
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'

--- a/pipeline/scripts/build-epp.sh
+++ b/pipeline/scripts/build-epp.sh
@@ -23,6 +23,8 @@ RUN_DIR=""
 RUN_NAME=""
 NAMESPACE=""
 EXPERIMENT_ROOT=""
+IMAGE_REF=""
+SOURCE_DIR=""
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -30,6 +32,8 @@ while [[ $# -gt 0 ]]; do
     --run-name)         RUN_NAME="$2"; shift 2 ;;
     --namespace)        NAMESPACE="$2"; shift 2 ;;
     --experiment-root)  EXPERIMENT_ROOT="$2"; shift 2 ;;
+    --image-ref)        IMAGE_REF="$2"; shift 2 ;;
+    --source-dir)       SOURCE_DIR="$2"; shift 2 ;;
     *) err "Unknown arg: $1"; exit 1 ;;
   esac
 done
@@ -44,19 +48,28 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SIM2REAL_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 SCHEDULER_ROOT="${EXPERIMENT_ROOT:-${SIM2REAL_ROOT}}"
 
-# ── Step 1: Read metadata ─────────────────────────────────────────
-info "Reading run metadata..."
+# ── Step 1: Resolve image ref and source dir ─────────────────────
+info "Resolving build parameters..."
 METADATA="${RUN_DIR}/run_metadata.json"
-if [ ! -f "${METADATA}" ]; then
-  err "run_metadata.json not found at ${METADATA}"
-  exit 1
+
+if [ -n "${IMAGE_REF}" ] && [ -n "${SOURCE_DIR}" ]; then
+  FULL_IMAGE="${IMAGE_REF}"
+  SCHEDULER_DIR="${SOURCE_DIR}"
+else
+  # Fallback: derive from run_metadata.json (backward compat)
+  if [ ! -f "${METADATA}" ]; then
+    err "run_metadata.json not found at ${METADATA}"
+    exit 1
+  fi
+  REGISTRY_HUB=$(python3 -c "import json; print(json.load(open('${METADATA}'))['registry'])")
+  REPO_NAME=$(python3 -c "import json; print(json.load(open('${METADATA}')).get('repo_name','llm-d-inference-scheduler'))")
+  FULL_IMAGE="${REGISTRY_HUB}/${REPO_NAME}:${RUN_NAME}"
+  SCHEDULER_DIR="${SCHEDULER_ROOT}/${REPO_NAME}"
 fi
 
-REGISTRY_HUB=$(python3 -c "import json; print(json.load(open('${METADATA}'))['registry'])")
-REPO_NAME=$(python3 -c "import json; print(json.load(open('${METADATA}')).get('repo_name','llm-d-inference-scheduler'))")
-FULL_IMAGE="${REGISTRY_HUB}/${REPO_NAME}:${RUN_NAME}"
-SCHEDULER_DIR="${SCHEDULER_ROOT}/${REPO_NAME}"
+DIR_BASENAME=$(basename "${SCHEDULER_DIR}")
 info "Target image: ${FULL_IMAGE}"
+info "Source dir: ${SCHEDULER_DIR}"
 
 # ── Step 2: Check registry secret ─────────────────────────────────
 info "Checking registry-secret..."
@@ -78,7 +91,7 @@ fi
 ok "registry-secret found"
 
 # ── Step 3: Copy source to cluster ─────────────────────────────────
-info "Copying ${REPO_NAME} source to cluster..."
+info "Copying ${DIR_BASENAME} source to cluster..."
 
 # Clean up any leftover pod from a previous run
 kubectl delete pod source-copy -n "${NAMESPACE}" --ignore-not-found --force --grace-period=0 2>/dev/null || true
@@ -102,7 +115,7 @@ kubectl exec source-copy -n "${NAMESPACE}" -- sh -c "rm -rf /workspace/source/${
 
 info "Uploading source (this may take a minute)..."
 kubectl exec source-copy -n "${NAMESPACE}" -- mkdir -p "/workspace/source/${RUN_NAME}"
-kubectl cp "${SCHEDULER_DIR}/" "${NAMESPACE}/source-copy:/workspace/source/${RUN_NAME}/${REPO_NAME}"
+kubectl cp "${SCHEDULER_DIR}/" "${NAMESPACE}/source-copy:/workspace/source/${RUN_NAME}/${DIR_BASENAME}"
 ok "Source uploaded"
 
 kubectl delete pod source-copy --namespace "${NAMESPACE}" --force --grace-period=0 2>/dev/null || true
@@ -131,9 +144,9 @@ spec:
         - build
         - --frontend=dockerfile.v0
         - --local
-        - context=/workspace/source/${RUN_NAME}/${REPO_NAME}
+        - context=/workspace/source/${RUN_NAME}/${DIR_BASENAME}
         - --local
-        - dockerfile=/workspace/source/${RUN_NAME}/${REPO_NAME}
+        - dockerfile=/workspace/source/${RUN_NAME}/${DIR_BASENAME}
         - --opt
         - filename=Dockerfile.epp
         - --opt
@@ -174,13 +187,15 @@ fi
 kubectl delete pod "${BUILD_POD}" -n "${NAMESPACE}" --ignore-not-found --force --grace-period=0 2>/dev/null || true
 
 # ── Step 7: Update metadata ───────────────────────────────────────
-python3 -c "
+if [ -z "${IMAGE_REF}" ] && [ -f "${METADATA}" ]; then
+  python3 -c "
 import json
 m = json.load(open('${METADATA}'))
 m['stages']['deploy']['last_completed_step'] = 'build_epp'
 m['epp_image'] = '${FULL_IMAGE}'
 json.dump(m, open('${METADATA}', 'w'), indent=2)
 "
+fi
 
 # ── Done ───────────────────────────────────────────────────────────
 echo

--- a/pipeline/tests/test_deploy_build.py
+++ b/pipeline/tests/test_deploy_build.py
@@ -1,0 +1,31 @@
+"""Tests for deploy build subcommand."""
+import pytest
+from pipeline.deploy import build_parser
+
+
+def test_build_parser_exists():
+    """build subcommand is registered."""
+    parser = build_parser()
+    args = parser.parse_args(["build"])
+    assert args.command == "build"
+
+
+def test_build_parser_skip_flag():
+    """build subcommand has --skip-build flag."""
+    parser = build_parser()
+    args = parser.parse_args(["build", "--skip-build"])
+    assert args.skip_build is True
+
+
+def test_run_parser_skip_build_flag():
+    """run subcommand has --skip-build (not --skip-build-epp)."""
+    parser = build_parser()
+    args = parser.parse_args(["run", "--skip-build"])
+    assert args.skip_build is True
+
+
+def test_run_parser_no_skip_build_epp():
+    """--skip-build-epp is no longer accepted."""
+    parser = build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["run", "--skip-build-epp"])

--- a/pipeline/tests/test_deploy_remote.py
+++ b/pipeline/tests/test_deploy_remote.py
@@ -10,14 +10,14 @@ import pipeline.deploy as mod
 
 
 def _make_run_args(*, remote=False, workload=None, only=None, package=None,
-                   status=None, force=False, skip_build_epp=False,
+                   status=None, force=False, skip_build=False,
                    skip_teardown=False,
                    max_retries=2, poll_interval=30, gpu_resource_type=None,
                    default_gpu_cost=1, pending_threshold=600,
                    max_pending_stalls=10, max_backoff=600):
     return argparse.Namespace(
         remote=remote, workload=workload, only=only, package=package,
-        status=status, force=force, skip_build_epp=skip_build_epp,
+        status=status, force=force, skip_build=skip_build,
         skip_teardown=skip_teardown,
         max_retries=max_retries, poll_interval=poll_interval,
         gpu_resource_type=gpu_resource_type, default_gpu_cost=default_gpu_cost,
@@ -302,9 +302,9 @@ def test_run_remote_refuses_when_active(monkeypatch, tmp_path):
     run_dir = _setup_run_dir(tmp_path)
     monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)
     monkeypatch.setattr(mod, "_check_existing_job", lambda ns: "active")
-    monkeypatch.setattr(mod, "_resolve_epp_action", lambda *a: "skip")
+    monkeypatch.setattr(mod, "_cmd_build", lambda *a, **kw: "skip")
 
-    args = _make_run_args(remote=True, skip_build_epp=True)
+    args = _make_run_args(remote=True, skip_build=True)
     setup_config = {"namespaces": ["ns"], "orchestrator_image": "img:latest"}
 
     with pytest.raises(SystemExit) as exc_info:
@@ -316,7 +316,7 @@ def test_run_remote_deletes_completed_job(monkeypatch, tmp_path):
     run_dir = _setup_run_dir(tmp_path)
     monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)
     monkeypatch.setattr(mod, "_check_existing_job", lambda ns: "completed")
-    monkeypatch.setattr(mod, "_resolve_epp_action", lambda *a: "skip")
+    monkeypatch.setattr(mod, "_cmd_build", lambda *a, **kw: "skip")
     monkeypatch.setattr(mod, "_wait_for_job_pod", lambda *a, **kw: None)
 
     calls = []
@@ -332,7 +332,7 @@ def test_run_remote_deletes_completed_job(monkeypatch, tmp_path):
     monkeypatch.setattr(mod, "run", fake_run)
 
     with patch("subprocess.run", side_effect=_mock_subprocess_ok):
-        args = _make_run_args(remote=True, skip_build_epp=True)
+        args = _make_run_args(remote=True, skip_build=True)
         setup_config = {"namespaces": ["ns"], "orchestrator_image": "img:latest"}
         mod._cmd_run_remote(args, run_dir, setup_config)
 
@@ -346,7 +346,7 @@ def test_run_remote_completed_delete_failure_exits(monkeypatch, tmp_path, capsys
     run_dir = _setup_run_dir(tmp_path)
     monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)
     monkeypatch.setattr(mod, "_check_existing_job", lambda ns: "completed")
-    monkeypatch.setattr(mod, "_resolve_epp_action", lambda *a: "skip")
+    monkeypatch.setattr(mod, "_cmd_build", lambda *a, **kw: "skip")
 
     def fake_run(cmd, *, check=True, capture=False, cwd=None):
         class _R:
@@ -357,7 +357,7 @@ def test_run_remote_completed_delete_failure_exits(monkeypatch, tmp_path, capsys
 
     monkeypatch.setattr(mod, "run", fake_run)
 
-    args = _make_run_args(remote=True, skip_build_epp=True)
+    args = _make_run_args(remote=True, skip_build=True)
     setup_config = {"namespaces": ["ns"], "orchestrator_image": "img:latest"}
 
     with pytest.raises(SystemExit) as exc_info:
@@ -370,7 +370,7 @@ def test_run_remote_creates_configmap_and_job(monkeypatch, tmp_path):
     run_dir = _setup_run_dir(tmp_path)
     monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)
     monkeypatch.setattr(mod, "_check_existing_job", lambda ns: None)
-    monkeypatch.setattr(mod, "_resolve_epp_action", lambda *a: "skip")
+    monkeypatch.setattr(mod, "_cmd_build", lambda *a, **kw: "skip")
     monkeypatch.setattr(mod, "_wait_for_job_pod", lambda *a, **kw: None)
 
     apply_inputs = []
@@ -381,7 +381,7 @@ def test_run_remote_creates_configmap_and_job(monkeypatch, tmp_path):
         return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
 
     with patch("subprocess.run", side_effect=fake_subprocess_run):
-        args = _make_run_args(remote=True, skip_build_epp=True)
+        args = _make_run_args(remote=True, skip_build=True)
         setup_config = {"namespaces": ["ns"], "orchestrator_image": "img:latest"}
         mod._cmd_run_remote(args, run_dir, setup_config)
 
@@ -395,7 +395,7 @@ def test_run_remote_job_uses_initcontainer_and_emptydir(monkeypatch, tmp_path):
     run_dir = _setup_run_dir(tmp_path)
     monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)
     monkeypatch.setattr(mod, "_check_existing_job", lambda ns: None)
-    monkeypatch.setattr(mod, "_resolve_epp_action", lambda *a: "skip")
+    monkeypatch.setattr(mod, "_cmd_build", lambda *a, **kw: "skip")
     monkeypatch.setattr(mod, "_wait_for_job_pod", lambda *a, **kw: None)
 
     apply_inputs = []
@@ -406,7 +406,7 @@ def test_run_remote_job_uses_initcontainer_and_emptydir(monkeypatch, tmp_path):
         return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
 
     with patch("subprocess.run", side_effect=fake_subprocess_run):
-        args = _make_run_args(remote=True, skip_build_epp=True)
+        args = _make_run_args(remote=True, skip_build=True)
         setup_config = {"namespaces": ["ns"], "orchestrator_image": "img:latest"}
         mod._cmd_run_remote(args, run_dir, setup_config)
 
@@ -426,7 +426,7 @@ def test_run_remote_passes_scoping_flags(monkeypatch, tmp_path):
     run_dir = _setup_run_dir(tmp_path)
     monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)
     monkeypatch.setattr(mod, "_check_existing_job", lambda ns: None)
-    monkeypatch.setattr(mod, "_resolve_epp_action", lambda *a: "skip")
+    monkeypatch.setattr(mod, "_cmd_build", lambda *a, **kw: "skip")
     monkeypatch.setattr(mod, "_wait_for_job_pod", lambda *a, **kw: None)
 
     apply_inputs = []
@@ -437,7 +437,7 @@ def test_run_remote_passes_scoping_flags(monkeypatch, tmp_path):
         return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
 
     with patch("subprocess.run", side_effect=fake_subprocess_run):
-        args = _make_run_args(remote=True, skip_build_epp=True, workload="wl-smoke")
+        args = _make_run_args(remote=True, skip_build=True, workload="wl-smoke")
         setup_config = {"namespaces": ["ns"], "orchestrator_image": "img:latest"}
         mod._cmd_run_remote(args, run_dir, setup_config)
 
@@ -451,7 +451,7 @@ def test_run_remote_no_image_exits(monkeypatch, tmp_path):
     run_dir = _setup_run_dir(tmp_path)
     monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)
 
-    args = _make_run_args(remote=True, skip_build_epp=True)
+    args = _make_run_args(remote=True, skip_build=True)
     setup_config = {"namespaces": ["ns"]}
 
     with pytest.raises(SystemExit) as exc_info:
@@ -464,13 +464,13 @@ def test_run_remote_configmap_apply_failure_exits(monkeypatch, tmp_path, capsys)
     run_dir = _setup_run_dir(tmp_path)
     monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)
     monkeypatch.setattr(mod, "_check_existing_job", lambda ns: None)
-    monkeypatch.setattr(mod, "_resolve_epp_action", lambda *a: "skip")
+    monkeypatch.setattr(mod, "_cmd_build", lambda *a, **kw: "skip")
 
     def fake_subprocess_run(cmd, *, input=None, text=True, check=False, capture_output=True, **kw):
         return type("R", (), {"returncode": 1, "stdout": "", "stderr": "forbidden"})()
 
     with patch("subprocess.run", side_effect=fake_subprocess_run):
-        args = _make_run_args(remote=True, skip_build_epp=True)
+        args = _make_run_args(remote=True, skip_build=True)
         setup_config = {"namespaces": ["ns"], "orchestrator_image": "img:latest"}
         with pytest.raises(SystemExit) as exc_info:
             mod._cmd_run_remote(args, run_dir, setup_config)

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -1574,56 +1574,31 @@ def test_status_empty_pairs_only_orchestrator(tmp_path, capsys, monkeypatch):
     assert "0 pairs" in out
 
 
-# ── EPP build decision (_resolve_epp_action) ──────────────────────────────────
+# ── Image build decision (_cmd_build) ──────────────────────────────────────────
 
-def test_epp_action_missing_metadata(tmp_path):
-    """Missing run_metadata.json → error."""
-    from pipeline.deploy import _resolve_epp_action
-    result = _resolve_epp_action(tmp_path, skip_build_epp=False)
-    assert result.startswith("error:")
-    assert "run_metadata.json not found" in result
-
-
-def test_epp_action_malformed_json(tmp_path):
-    """Corrupt run_metadata.json → error."""
-    from pipeline.deploy import _resolve_epp_action
-    (tmp_path / "run_metadata.json").write_text("{bad json")
-    result = _resolve_epp_action(tmp_path, skip_build_epp=False)
-    assert result.startswith("error:")
-    assert "not valid JSON" in result
+def test_cmd_build_missing_metadata(tmp_path):
+    """Missing run_metadata.json → sys.exit."""
+    from pipeline.deploy import _cmd_build
+    with pytest.raises(SystemExit):
+        _cmd_build(tmp_path, namespace="ns", skip_build=False)
 
 
-def test_epp_action_no_component_image(tmp_path):
+def test_cmd_build_no_component_image(tmp_path, capsys):
     """component_image absent → skip."""
-    from pipeline.deploy import _resolve_epp_action
+    from pipeline.deploy import _cmd_build
     (tmp_path / "run_metadata.json").write_text(json.dumps({"registry": "quay.io/me"}))
-    result = _resolve_epp_action(tmp_path, skip_build_epp=False)
+    result = _cmd_build(tmp_path, namespace="ns", skip_build=False)
     assert result == "skip"
 
 
-def test_epp_action_empty_component_image(tmp_path):
-    """component_image is empty string → error (misconfigured setup)."""
-    from pipeline.deploy import _resolve_epp_action
-    (tmp_path / "run_metadata.json").write_text(json.dumps({"component_image": ""}))
-    result = _resolve_epp_action(tmp_path, skip_build_epp=False)
-    assert result.startswith("error:")
-    assert "empty" in result
-
-
-def test_epp_action_skip_build_flag(tmp_path):
-    """component_image present + --skip-build-epp → skip."""
-    from pipeline.deploy import _resolve_epp_action
-    (tmp_path / "run_metadata.json").write_text(json.dumps({"component_image": "quay.io/me/sched:run1"}))
-    result = _resolve_epp_action(tmp_path, skip_build_epp=True)
+def test_cmd_build_skip_flag(tmp_path, capsys):
+    """--skip-build returns skip."""
+    from pipeline.deploy import _cmd_build
+    (tmp_path / "run_metadata.json").write_text(
+        json.dumps({"component_image": "quay.io/me/sched:r1", "registry": "quay.io/me", "repo_name": "sched"})
+    )
+    result = _cmd_build(tmp_path, namespace="ns", skip_build=True)
     assert result == "skip"
-
-
-def test_epp_action_build(tmp_path):
-    """component_image present, no skip flag → build."""
-    from pipeline.deploy import _resolve_epp_action
-    (tmp_path / "run_metadata.json").write_text(json.dumps({"component_image": "quay.io/me/sched:run1"}))
-    result = _resolve_epp_action(tmp_path, skip_build_epp=False)
-    assert result == "build"
 
 
 # ── _check_slot_ready hf_secret_name parameter ──────────────────────────────
@@ -1941,7 +1916,7 @@ def test_cmd_run_uses_configmap_store(monkeypatch, tmp_path):
     import pipeline.deploy as mod
 
     _mock_cm(monkeypatch, {})
-    monkeypatch.setattr(mod, "_resolve_epp_action", lambda *a: "skip")
+    monkeypatch.setattr(mod, "_cmd_build", lambda *a, **kw: "skip")
     monkeypatch.setattr(mod, "_load_pairs", lambda d: {})
 
     run_dir = tmp_path / "runs" / "test-run"
@@ -1950,7 +1925,7 @@ def test_cmd_run_uses_configmap_store(monkeypatch, tmp_path):
     (run_dir / "cluster").mkdir()
 
     args = argparse.Namespace(
-        skip_build_epp=True, only=None, workload=None, package=None,
+        skip_build=True, only=None, workload=None, package=None,
         status=None, force=False, max_retries=2, poll_interval=30,
         gpu_resource_type=None, default_gpu_cost=1,
         pending_threshold=600, max_pending_stalls=10, max_backoff=600,

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -1591,6 +1591,14 @@ def test_cmd_build_no_component_image(tmp_path, capsys):
     assert result == "skip"
 
 
+def test_cmd_build_empty_component_image(tmp_path):
+    """component_image is empty string → sys.exit (misconfigured setup)."""
+    from pipeline.deploy import _cmd_build
+    (tmp_path / "run_metadata.json").write_text(json.dumps({"component_image": ""}))
+    with pytest.raises(SystemExit):
+        _cmd_build(tmp_path, namespace="ns", skip_build=False)
+
+
 def test_cmd_build_skip_flag(tmp_path, capsys):
     """--skip-build returns skip."""
     from pipeline.deploy import _cmd_build

--- a/pipeline/tests/test_ensure_image.py
+++ b/pipeline/tests/test_ensure_image.py
@@ -1,0 +1,95 @@
+"""Tests for pipeline/lib/ensure_image.py."""
+import json
+import subprocess
+from pathlib import Path
+
+from pipeline.lib.ensure_image import (
+    compute_source_hash,
+    image_needs_build,
+    load_source_hashes,
+    save_source_hash,
+)
+
+
+def _init_git_repo(path: Path) -> None:
+    """Create a git repo with an initial commit."""
+    subprocess.run(["git", "init", str(path)], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.email", "test@test.com"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.name", "Test"], check=True, capture_output=True)
+    (path / "file.txt").write_text("hello")
+    subprocess.run(["git", "-C", str(path), "add", "."], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(path), "commit", "-m", "init"], check=True, capture_output=True)
+
+
+class TestComputeSourceHash:
+    def test_returns_40_char_hex(self, tmp_path):
+        _init_git_repo(tmp_path)
+        result = compute_source_hash(tmp_path)
+        assert len(result) == 40
+        assert all(c in "0123456789abcdef" for c in result)
+
+    def test_changes_on_new_commit(self, tmp_path):
+        _init_git_repo(tmp_path)
+        hash1 = compute_source_hash(tmp_path)
+        (tmp_path / "file.txt").write_text("changed")
+        subprocess.run(["git", "-C", str(tmp_path), "add", "."], check=True, capture_output=True)
+        subprocess.run(["git", "-C", str(tmp_path), "commit", "-m", "edit"], check=True, capture_output=True)
+        hash2 = compute_source_hash(tmp_path)
+        assert hash1 != hash2
+
+
+class TestLoadSourceHashes:
+    def test_returns_empty_when_no_file(self, tmp_path):
+        assert load_source_hashes(tmp_path) == {}
+
+    def test_returns_empty_when_no_key(self, tmp_path):
+        (tmp_path / "run_metadata.json").write_text(json.dumps({"version": 1, "stages": {}}))
+        assert load_source_hashes(tmp_path) == {}
+
+    def test_returns_stored_hashes(self, tmp_path):
+        meta = {"version": 1, "stages": {}, "source_hashes": {"img:tag": "abc123"}}
+        (tmp_path / "run_metadata.json").write_text(json.dumps(meta))
+        assert load_source_hashes(tmp_path) == {"img:tag": "abc123"}
+
+
+class TestSaveSourceHash:
+    def test_creates_key(self, tmp_path):
+        meta = {"version": 1, "stages": {}}
+        (tmp_path / "run_metadata.json").write_text(json.dumps(meta))
+        save_source_hash(tmp_path, "ghcr.io/me/repo:v1", "deadbeef" * 5)
+        loaded = json.loads((tmp_path / "run_metadata.json").read_text())
+        assert loaded["source_hashes"]["ghcr.io/me/repo:v1"] == "deadbeef" * 5
+
+    def test_preserves_existing_hashes(self, tmp_path):
+        meta = {"version": 1, "stages": {}, "source_hashes": {"old:ref": "aaa"}}
+        (tmp_path / "run_metadata.json").write_text(json.dumps(meta))
+        save_source_hash(tmp_path, "new:ref", "bbb")
+        loaded = json.loads((tmp_path / "run_metadata.json").read_text())
+        assert loaded["source_hashes"]["old:ref"] == "aaa"
+        assert loaded["source_hashes"]["new:ref"] == "bbb"
+
+
+class TestImageNeedsBuild:
+    def test_needs_build_when_no_stored_hash(self, tmp_path):
+        (tmp_path / "run_metadata.json").write_text(json.dumps({"version": 1, "stages": {}}))
+        src = tmp_path / "src"
+        src.mkdir()
+        _init_git_repo(src)
+        assert image_needs_build(tmp_path, "img:tag", src) is True
+
+    def test_no_build_when_hash_matches(self, tmp_path):
+        src = tmp_path / "src"
+        src.mkdir()
+        _init_git_repo(src)
+        current_hash = compute_source_hash(src)
+        meta = {"version": 1, "stages": {}, "source_hashes": {"img:tag": current_hash}}
+        (tmp_path / "run_metadata.json").write_text(json.dumps(meta))
+        assert image_needs_build(tmp_path, "img:tag", src) is False
+
+    def test_needs_build_when_hash_differs(self, tmp_path):
+        src = tmp_path / "src"
+        src.mkdir()
+        _init_git_repo(src)
+        meta = {"version": 1, "stages": {}, "source_hashes": {"img:tag": "stale_hash"}}
+        (tmp_path / "run_metadata.json").write_text(json.dumps(meta))
+        assert image_needs_build(tmp_path, "img:tag", src) is True

--- a/pipeline/tests/test_remote.py
+++ b/pipeline/tests/test_remote.py
@@ -190,7 +190,7 @@ def test_job_structure():
     args = container["args"]
     assert "--experiment-root" in args
     assert "run" in args
-    assert "--skip-build-epp" in args
+    assert "--skip-build" in args
     assert "--dry-run" in args
 
 

--- a/pipeline/tests/test_source_toggle.py
+++ b/pipeline/tests/test_source_toggle.py
@@ -1,0 +1,172 @@
+"""Tests for pipeline/lib/source_toggle.py."""
+import subprocess
+from pathlib import Path
+
+from pipeline.lib.source_toggle import restore_baseline, restore_treatment
+
+
+def _init_repo(path: Path) -> None:
+    """Create a git repo with an initial commit."""
+    subprocess.run(["git", "init", str(path)], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.email", "t@t"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.name", "T"], check=True, capture_output=True)
+    (path / "base.txt").write_text("original")
+    subprocess.run(["git", "-C", str(path), "add", "."], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(path), "commit", "-m", "init"], check=True, capture_output=True)
+
+
+class TestRestoreBaseline:
+    def test_removes_created_files(self, tmp_path):
+        component_dir = tmp_path / "component"
+        component_dir.mkdir()
+        _init_repo(component_dir)
+
+        (component_dir / "pkg").mkdir()
+        (component_dir / "pkg" / "scorer.go").write_text("generated")
+
+        translation_output = {
+            "files_created": ["pkg/scorer.go"],
+            "files_modified": [],
+        }
+
+        restore_baseline(component_dir, translation_output)
+        assert not (component_dir / "pkg" / "scorer.go").exists()
+
+    def test_restores_modified_files_to_git_state(self, tmp_path):
+        component_dir = tmp_path / "component"
+        component_dir.mkdir()
+        _init_repo(component_dir)
+
+        (component_dir / "base.txt").write_text("modified by translation")
+
+        translation_output = {
+            "files_created": [],
+            "files_modified": ["base.txt"],
+        }
+
+        restore_baseline(component_dir, translation_output)
+        assert (component_dir / "base.txt").read_text() == "original"
+
+    def test_handles_both_created_and_modified(self, tmp_path):
+        component_dir = tmp_path / "component"
+        component_dir.mkdir()
+        _init_repo(component_dir)
+
+        (component_dir / "new_file.go").write_text("new")
+        (component_dir / "base.txt").write_text("changed")
+
+        translation_output = {
+            "files_created": ["new_file.go"],
+            "files_modified": ["base.txt"],
+        }
+
+        restore_baseline(component_dir, translation_output)
+        assert not (component_dir / "new_file.go").exists()
+        assert (component_dir / "base.txt").read_text() == "original"
+
+    def test_skips_missing_created_files(self, tmp_path):
+        component_dir = tmp_path / "component"
+        component_dir.mkdir()
+        _init_repo(component_dir)
+
+        translation_output = {
+            "files_created": ["nonexistent.go"],
+            "files_modified": [],
+        }
+
+        restore_baseline(component_dir, translation_output)  # should not raise
+
+    def test_noop_with_empty_lists(self, tmp_path):
+        component_dir = tmp_path / "component"
+        component_dir.mkdir()
+        _init_repo(component_dir)
+
+        translation_output = {"files_created": [], "files_modified": []}
+        restore_baseline(component_dir, translation_output)
+        assert (component_dir / "base.txt").read_text() == "original"
+
+
+class TestRestoreTreatment:
+    def test_copies_created_files(self, tmp_path):
+        component_dir = tmp_path / "component"
+        component_dir.mkdir()
+        _init_repo(component_dir)
+
+        generated_dir = tmp_path / "generated"
+        generated_dir.mkdir()
+        (generated_dir / "scorer.go").write_text("generated content")
+
+        translation_output = {
+            "files_created": ["pkg/scorer.go"],
+            "files_modified": [],
+        }
+
+        restore_treatment(component_dir, generated_dir, translation_output)
+        assert (component_dir / "pkg" / "scorer.go").read_text() == "generated content"
+
+    def test_copies_modified_files(self, tmp_path):
+        component_dir = tmp_path / "component"
+        component_dir.mkdir()
+        _init_repo(component_dir)
+
+        generated_dir = tmp_path / "generated"
+        generated_dir.mkdir()
+        (generated_dir / "base.txt").write_text("treatment version")
+
+        translation_output = {
+            "files_created": [],
+            "files_modified": ["base.txt"],
+        }
+
+        restore_treatment(component_dir, generated_dir, translation_output)
+        assert (component_dir / "base.txt").read_text() == "treatment version"
+
+    def test_creates_parent_directories(self, tmp_path):
+        component_dir = tmp_path / "component"
+        component_dir.mkdir()
+        _init_repo(component_dir)
+
+        generated_dir = tmp_path / "generated"
+        generated_dir.mkdir()
+        (generated_dir / "deep.go").write_text("deep file")
+
+        translation_output = {
+            "files_created": ["a/b/c/deep.go"],
+            "files_modified": [],
+        }
+
+        restore_treatment(component_dir, generated_dir, translation_output)
+        assert (component_dir / "a" / "b" / "c" / "deep.go").read_text() == "deep file"
+
+
+class TestRoundTrip:
+    def test_baseline_then_treatment_restores_state(self, tmp_path):
+        """Full round-trip: start with treatment state, restore baseline, restore treatment."""
+        component_dir = tmp_path / "component"
+        component_dir.mkdir()
+        _init_repo(component_dir)
+
+        generated_dir = tmp_path / "generated"
+        generated_dir.mkdir()
+        (generated_dir / "scorer.go").write_text("generated scorer")
+        (generated_dir / "base.txt").write_text("modified base")
+
+        translation_output = {
+            "files_created": ["pkg/scorer.go"],
+            "files_modified": ["base.txt"],
+        }
+
+        # Start in treatment state
+        restore_treatment(component_dir, generated_dir, translation_output)
+        assert (component_dir / "pkg" / "scorer.go").exists()
+        assert (component_dir / "base.txt").read_text() == "modified base"
+
+        # Restore to baseline
+        restore_baseline(component_dir, translation_output)
+        assert not (component_dir / "pkg" / "scorer.go").exists()
+        assert (component_dir / "base.txt").read_text() == "original"
+
+        # Restore back to treatment
+        restore_treatment(component_dir, generated_dir, translation_output)
+        assert (component_dir / "pkg" / "scorer.go").read_text() == "generated scorer"
+        assert (component_dir / "base.txt").read_text() == "modified base"


### PR DESCRIPTION
## Summary

- Adds a `deploy build` subcommand that ensures all required scenario images exist before dispatching PipelineRuns
- Introduces source hash staleness detection: images are only rebuilt when the component source directory has changed (by comparing git HEAD hash against a stored hash in `run_metadata.json`)
- Refactors `build-epp.sh` to accept explicit `--image-ref` and `--source-dir` parameters (also fixes #185 — hardcoded directory name)
- Renames `--skip-build-epp` to `--skip-build` across the CLI

Closes #187

## Changes

| File | What |
|------|------|
| `pipeline/lib/ensure_image.py` (new) | Source hash computation, persistence, and staleness check |
| `pipeline/lib/source_toggle.py` (new) | Toggle component dir between baseline/treatment states (Phase 2 prep) |
| `pipeline/scripts/build-epp.sh` | Accepts `--image-ref` + `--source-dir`; uses basename for PVC paths |
| `pipeline/deploy.py` | Replaces `_resolve_epp_action`/`_build_epp_image` with `_cmd_build`; adds `build` subcommand |
| `pipeline/lib/remote.py` | `--skip-build-epp` → `--skip-build` in orchestrator Job args |
| `pipeline/tests/test_ensure_image.py` (new) | 10 tests for source hash module |
| `pipeline/tests/test_source_toggle.py` (new) | 9 tests for directory toggle module |
| `pipeline/tests/test_deploy_build.py` (new) | 4 tests for CLI parser |
| `pipeline/tests/test_deploy_run.py` | Updated: old `_resolve_epp_action` tests replaced with `_cmd_build` tests |
| `pipeline/tests/test_deploy_remote.py` | Updated: `skip_build_epp` → `skip_build` |
| `pipeline/tests/test_remote.py` | Updated assertion for renamed flag |

## Reviewer notes

- **Phase 1 scope**: Only the treatment `inferenceScheduler` image is handled. The `source_toggle.py` module is available for Phase 2 (baseline image building with directory toggle) but not yet wired into `_cmd_build`.
- **No `--force` flag**: Source hash detection handles staleness automatically. If the source changes, the hash changes, and rebuild triggers. Registry corruption is rare enough to handle manually (delete tag, re-run).
- **Idempotent**: If `deploy build` is interrupted, re-running picks up cleanly — the registry check detects the missing image and rebuilds.
- **Backward compat**: `build-epp.sh` still works without the new flags (falls back to `run_metadata.json` derivation).

## Test plan

- [x] All 750 tests pass (`python3 -m pytest pipeline/ .claude/skills/ -v`)
- [x] Lint clean (`ruff check pipeline/ .claude/skills/ --select F`)
- [x] `deploy.py build --help` shows the new subcommand
- [x] `deploy.py run --skip-build` works (old `--skip-build-epp` rejected)
- [ ] End-to-end: run `deploy build` against a cluster with a real experiment repo