### PR TITLE
feat: generalize deploy build to ensure images for all scenarios

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -112,10 +112,10 @@ Phase state is tracked per-run in `workspace/runs/<run>/.state.json`. Delete it 
 
 ## deploy.py
 
-Builds the EPP image and orchestrates PipelineRun execution across namespace slots. Operates independently of `transfer.yaml` — driven by workspace files and `setup_config.json`.
+Ensures all scenario images exist and orchestrates PipelineRun execution across namespace slots. Operates independently of `transfer.yaml` — driven by workspace files and `setup_config.json`.
 
 ```bash
-python pipeline/deploy.py {run|status|collect|stop|reset|wipe|pairs} [flags]
+python pipeline/deploy.py {build|run|status|collect|stop|reset|wipe|pairs} [flags]
 ```
 
 Common flags (all subcommands):
@@ -124,18 +124,21 @@ Common flags (all subcommands):
 |------|---------|-------|
 | `--run NAME` | from `setup_config.json` | override active run |
 | `--experiment-root PATH` | cwd | path to experiment repo |
-| `--skip-build-epp` | false | reuse `epp_image` from `run_metadata.json` |
+| `--skip-build` | false | skip image build pre-flight |
+
+**Image build** — `deploy.py build` (called implicitly as pre-flight by `deploy.py run`) iterates over all resolved scenarios in `cluster/`, collects unique `images.inferenceScheduler` refs, and builds any that are stale. Baseline images are tagged by the component directory's HEAD SHA (8 chars); treatment images by the run name. Source hash comparison skips builds when the image is already current.
 
 **Pair discovery** — `deploy.py run` discovers `pipelinerun-*.yaml` files at the `cluster/` root. Each file's pair key is derived as `wl-` + filename stem minus the `pipelinerun-` prefix.
 
 **Collection phases** — `deploy.py collect` derives valid phases dynamically from progress data (packages with status `done`). Falls back to `[baseline, treatment]` when no progress exists. Use `--package` to filter, or `--package experiment` to collect all known phases.
 
-**`--skip-build-epp`** — skips the image build; use when resubmitting after a failed PipelineRun without changing the scorer.
+**`--skip-build`** — skips the image build; use when resubmitting after a failed PipelineRun without changing the scorer.
 
 **Subcommands:**
 
 ```bash
-python pipeline/deploy.py run     [flags]   # orchestrate parallel pool execution across namespace slots
+python pipeline/deploy.py build   [flags]   # ensure all scenario images exist (pre-flight for run)
+python pipeline/deploy.py run     [flags]   # ensure images + orchestrate parallel pool execution
 python pipeline/deploy.py status            # show progress snapshot of all (workload, package) pairs
 python pipeline/deploy.py collect [flags]     # pull results from the cluster PVC
 python pipeline/deploy.py stop               # stop the remote orchestrator Job

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -115,10 +115,12 @@ def _load_setup_config() -> dict:
 def _cmd_build(run_dir: Path, namespace: str, skip_build: bool) -> str:
     """Ensure all required scenario images exist. Returns 'built', 'skip', or 'current'.
 
-    This is the 'deploy build' logic. Called implicitly by 'deploy run' as pre-flight.
+    Iterates over resolved scenarios in cluster/, extracts image refs,
+    and builds any that are stale (source hash mismatch).
     """
     from pipeline.lib.ensure_image import (
-        compute_source_hash, image_needs_build, save_source_hash,
+        collect_scenario_images, compute_source_hash,
+        image_needs_build, save_source_hash,
     )
 
     run_meta_path = run_dir / "run_metadata.json"
@@ -157,38 +159,80 @@ def _cmd_build(run_dir: Path, namespace: str, skip_build: bool) -> str:
         err(f"Component source directory not found: {source_dir}")
         sys.exit(1)
 
-    # Treatment image: tagged by run name
-    treatment_ref = f"{registry}/{repo_name}:{run_name}"
+    # Collect all unique image refs from resolved scenarios
+    cluster_dir = run_dir / "cluster"
+    scenario_images = collect_scenario_images(cluster_dir)
 
-    if not image_needs_build(run_dir, treatment_ref, source_dir):
-        ok(f"Treatment image current (hash unchanged): {treatment_ref}")
+    if not scenario_images:
+        # Fallback: use the treatment ref from metadata (backward compat)
+        treatment_ref = f"{registry}/{repo_name}:{run_name}"
+        scenario_images = [{"image_ref": treatment_ref, "package": "treatment"}]
+
+    # Determine which images need building
+    to_build = []
+    for img_info in scenario_images:
+        ref = img_info["image_ref"]
+        if image_needs_build(run_dir, ref, source_dir):
+            to_build.append(img_info)
+        else:
+            ok(f"Image current (hash unchanged): {ref}")
+
+    if not to_build:
         return "current"
 
-    info(f"Building treatment image: {treatment_ref}")
+    # Load translation output for source toggle (if available)
+    translation_output_path = run_dir / "translation_output.json"
+    translation_output = None
+    if translation_output_path.exists():
+        translation_output = json.loads(translation_output_path.read_text())
+
     build_script = REPO_ROOT / "pipeline" / "scripts" / "build-epp.sh"
     if not build_script.exists():
         err(f"build-epp.sh not found at {build_script.relative_to(REPO_ROOT)}")
         sys.exit(1)
 
-    result = run(
-        ["bash", str(build_script),
-         "--run-dir", str(run_dir),
-         "--run-name", run_name,
-         "--namespace", namespace,
-         "--image-ref", treatment_ref,
-         "--source-dir", str(source_dir)],
-        check=False,
-        cwd=REPO_ROOT,
-    )
-    if result.returncode != 0:
-        err("Image build failed — see output above")
-        sys.exit(1)
+    # Treatment ref for comparison (to distinguish baseline from treatment builds)
+    treatment_ref = f"{registry}/{repo_name}:{run_name}"
+    generated_dir = run_dir / "generated"
 
-    # Record source hash after successful build
-    current_hash = compute_source_hash(source_dir)
-    save_source_hash(run_dir, treatment_ref, current_hash)
-    ok(f"Image built and hash recorded: {treatment_ref}")
-    return "built"
+    built_any = False
+    for img_info in to_build:
+        ref = img_info["image_ref"]
+        is_treatment = (ref == treatment_ref)
+
+        # Source toggle: ensure working tree is in correct state for baseline builds
+        if translation_output and not is_treatment:
+            from pipeline.lib.source_toggle import restore_baseline
+            info(f"Restoring baseline state for: {ref}")
+            restore_baseline(source_dir, translation_output)
+
+        info(f"Building image: {ref}")
+        result = run(
+            ["bash", str(build_script),
+             "--run-dir", str(run_dir),
+             "--run-name", run_name,
+             "--namespace", namespace,
+             "--image-ref", ref,
+             "--source-dir", str(source_dir)],
+            check=False,
+            cwd=REPO_ROOT,
+        )
+
+        # Restore treatment state after baseline build
+        if translation_output and not is_treatment:
+            from pipeline.lib.source_toggle import restore_treatment
+            restore_treatment(source_dir, generated_dir, translation_output)
+
+        if result.returncode != 0:
+            err(f"Image build failed for {ref} — see output above")
+            sys.exit(1)
+
+        current_hash = compute_source_hash(source_dir)
+        save_source_hash(run_dir, ref, current_hash)
+        ok(f"Image built and hash recorded: {ref}")
+        built_any = True
+
+    return "built" if built_any else "current"
 
 
 # ── PipelineRun helpers ──────────────────────────────────────────────────────

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -164,7 +164,9 @@ def _cmd_build(run_dir: Path, namespace: str, skip_build: bool) -> str:
     scenario_images = collect_scenario_images(cluster_dir)
 
     if not scenario_images:
-        # Fallback: use the treatment ref from metadata (backward compat)
+        if cluster_dir.exists() and any(cluster_dir.glob("*.yaml")):
+            warn("cluster/ has scenario files but no images.inferenceScheduler found — "
+                 "falling back to treatment image only")
         treatment_ref = f"{registry}/{repo_name}:{run_name}"
         scenario_images = [{"image_ref": treatment_ref, "package": "treatment"}]
 
@@ -184,7 +186,11 @@ def _cmd_build(run_dir: Path, namespace: str, skip_build: bool) -> str:
     translation_output_path = run_dir / "translation_output.json"
     translation_output = None
     if translation_output_path.exists():
-        translation_output = json.loads(translation_output_path.read_text())
+        try:
+            translation_output = json.loads(translation_output_path.read_text())
+        except json.JSONDecodeError as e:
+            err(f"translation_output.json is not valid JSON: {e}. Re-run /sim2real-translate.")
+            sys.exit(1)
 
     build_script = REPO_ROOT / "pipeline" / "scripts" / "build-epp.sh"
     if not build_script.exists():
@@ -204,7 +210,11 @@ def _cmd_build(run_dir: Path, namespace: str, skip_build: bool) -> str:
         if translation_output and not is_treatment:
             from pipeline.lib.source_toggle import restore_baseline
             info(f"Restoring baseline state for: {ref}")
-            restore_baseline(source_dir, translation_output)
+            try:
+                restore_baseline(source_dir, translation_output)
+            except (subprocess.CalledProcessError, OSError) as exc:
+                err(f"Failed to restore baseline state in {source_dir}: {exc}")
+                sys.exit(1)
 
         info(f"Building image: {ref}")
         result = run(
@@ -221,7 +231,13 @@ def _cmd_build(run_dir: Path, namespace: str, skip_build: bool) -> str:
         # Restore treatment state after baseline build
         if translation_output and not is_treatment:
             from pipeline.lib.source_toggle import restore_treatment
-            restore_treatment(source_dir, generated_dir, translation_output)
+            try:
+                restore_treatment(source_dir, generated_dir, translation_output)
+            except (OSError, FileNotFoundError) as exc:
+                err(f"Failed to restore treatment state in {source_dir}: {exc}\n"
+                    f"  Working tree may be in baseline state. To recover:\n"
+                    f"  cd {source_dir} && git checkout -- .")
+                sys.exit(1)
 
         if result.returncode != 0:
             err(f"Image build failed for {ref} — see output above")
@@ -2354,7 +2370,7 @@ def main():
                    workloads_only=args.workloads_only,
                    packages_only=args.packages_only)
     else:
-        err("No subcommand specified. Use: deploy.py run | status | collect | stop | reset | wipe | pairs")
+        err("No subcommand specified. Use: deploy.py build | run | status | collect | stop | reset | wipe | pairs")
         sys.exit(1)
 
 

--- a/pipeline/lib/ensure_image.py
+++ b/pipeline/lib/ensure_image.py
@@ -4,6 +4,8 @@ import os
 import subprocess
 from pathlib import Path
 
+import yaml
+
 
 def compute_source_hash(source_dir: Path) -> str:
     """Return the HEAD commit hash of the git repo at source_dir."""
@@ -43,3 +45,47 @@ def image_needs_build(run_dir: Path, image_ref: str, source_dir: Path) -> bool:
     except subprocess.CalledProcessError:
         return True
     return current != stored
+
+
+def compute_baseline_ref(registry_repo: str, source_dir: Path) -> str:
+    """Return the baseline image ref tagged by the 8-char HEAD SHA of source_dir."""
+    sha = compute_source_hash(source_dir)
+    return f"{registry_repo}:{sha[:8]}"
+
+
+def collect_scenario_images(cluster_dir: Path) -> list[dict]:
+    """Extract unique image refs from resolved scenario YAMLs in cluster/.
+
+    Returns list of dicts: {"image_ref": "repo:tag", "package": "filename_stem"}
+    Skips pipelinerun-*.yaml files.
+    """
+    if not cluster_dir.exists():
+        return []
+
+    seen: set[str] = set()
+    results: list[dict] = []
+
+    for yaml_path in sorted(cluster_dir.glob("*.yaml")):
+        if yaml_path.name.startswith("pipelinerun-"):
+            continue
+        try:
+            data = yaml.safe_load(yaml_path.read_text()) or {}
+        except (OSError, yaml.YAMLError):
+            continue
+
+        for entry in data.get("scenario", []):
+            images = entry.get("images", {})
+            sched = images.get("inferenceScheduler")
+            if not sched:
+                continue
+            repo = sched.get("repository", "")
+            tag = sched.get("tag", "")
+            if not repo or not tag:
+                continue
+            ref = f"{repo}:{tag}"
+            if ref in seen:
+                continue
+            seen.add(ref)
+            results.append({"image_ref": ref, "package": yaml_path.stem})
+
+    return results

--- a/pipeline/lib/ensure_image.py
+++ b/pipeline/lib/ensure_image.py
@@ -70,7 +70,9 @@ def collect_scenario_images(cluster_dir: Path) -> list[dict]:
             continue
         try:
             data = yaml.safe_load(yaml_path.read_text()) or {}
-        except (OSError, yaml.YAMLError):
+        except (OSError, yaml.YAMLError) as exc:
+            import warnings
+            warnings.warn(f"Skipping unreadable scenario file {yaml_path.name}: {exc}")
             continue
 
         for entry in data.get("scenario", []):

--- a/pipeline/lib/epp.py
+++ b/pipeline/lib/epp.py
@@ -19,3 +19,21 @@ def inject_epp_image(scenario_dict: dict, registry: str, repo_name: str, tag: st
     for entry in scenario_list:
         entry.setdefault("images", {})["inferenceScheduler"] = epp_img
     return True
+
+
+def inject_image_ref(scenario_dict: dict, repository: str, tag: str) -> bool:
+    """Inject inferenceScheduler image into all scenario entries.
+
+    Returns True if injection occurred, False if skipped (no scenarios).
+    """
+    scenario_list = scenario_dict.get("scenario", [])
+    if not scenario_list:
+        return False
+    img = {
+        "repository": repository,
+        "tag": tag,
+        "pullPolicy": "Always",
+    }
+    for entry in scenario_list:
+        entry.setdefault("images", {})["inferenceScheduler"] = img
+    return True

--- a/pipeline/lib/epp.py
+++ b/pipeline/lib/epp.py
@@ -1,4 +1,4 @@
-"""EPP image injection for treatment scenarios."""
+"""EPP image injection utilities."""
 
 
 def inject_epp_image(scenario_dict: dict, registry: str, repo_name: str, tag: str) -> bool:

--- a/pipeline/prepare.py
+++ b/pipeline/prepare.py
@@ -438,7 +438,7 @@ def _phase_assembly(args, state: StateMachine, manifest: dict, run_dir: Path,
         err(str(e))
         sys.exit(1)
 
-    # 4b.5: Inject EPP image into algorithm packages (only when translation occurred)
+    # 4b.5: Inject EPP images into packages (only when translation occurred)
     if translation_happened:
         meta_path = run_dir / "run_metadata.json"
         if not meta_path.exists():
@@ -463,6 +463,22 @@ def _phase_assembly(args, state: StateMachine, manifest: dict, run_dir: Path,
                 else:
                     err(f"{pkg.name} has no 'scenario' entries — EPP image cannot be injected.")
                     sys.exit(1)
+
+        # Inject baseline EPP image into baseline packages
+        component_path = manifest.get("component", {}).get("path", "")
+        if component_path:
+            comp_dir = EXPERIMENT_ROOT / component_path
+            if comp_dir.exists() and (comp_dir / ".git").exists():
+                from pipeline.lib.ensure_image import compute_source_hash
+                baseline_tag = compute_source_hash(comp_dir)[:8]
+                from pipeline.lib.epp import inject_image_ref
+                for pkg in packages:
+                    if pkg.kind == "baseline":
+                        injected = inject_image_ref(
+                            pkg.resolved, f"{registry}/{repo_name}", baseline_tag
+                        )
+                        if injected:
+                            ok(f"Baseline EPP image: {registry}/{repo_name}:{baseline_tag} → {pkg.name}")
 
     # 4b.6: Inject huggingface.secretName into all packages
     setup_config = _load_setup_config()

--- a/pipeline/prepare.py
+++ b/pipeline/prepare.py
@@ -479,6 +479,10 @@ def _phase_assembly(args, state: StateMachine, manifest: dict, run_dir: Path,
                         )
                         if injected:
                             ok(f"Baseline EPP image: {registry}/{repo_name}:{baseline_tag} → {pkg.name}")
+            else:
+                info(f"Skipping baseline EPP injection: {component_path} not found or not a git repo")
+        else:
+            info("Skipping baseline EPP injection: no component.path in manifest")
 
     # 4b.6: Inject huggingface.secretName into all packages
     setup_config = _load_setup_config()

--- a/pipeline/tests/test_deploy_build.py
+++ b/pipeline/tests/test_deploy_build.py
@@ -1,7 +1,6 @@
 """Tests for deploy build subcommand."""
 import json
 import subprocess
-from pathlib import Path
 
 import pytest
 import yaml

--- a/pipeline/tests/test_deploy_build.py
+++ b/pipeline/tests/test_deploy_build.py
@@ -1,5 +1,11 @@
 """Tests for deploy build subcommand."""
+import json
+import subprocess
+from pathlib import Path
+
 import pytest
+import yaml
+
 from pipeline.deploy import build_parser
 
 
@@ -29,3 +35,105 @@ def test_run_parser_no_skip_build_epp():
     parser = build_parser()
     with pytest.raises(SystemExit):
         parser.parse_args(["run", "--skip-build-epp"])
+
+
+class TestCmdBuildScenarioIteration:
+    """Integration tests for multi-scenario image build logic."""
+
+    def _make_cluster(self, tmp_path, scenarios: dict):
+        """Create cluster/ dir with named scenario YAML files."""
+        cluster_dir = tmp_path / "cluster"
+        cluster_dir.mkdir()
+        for name, content in scenarios.items():
+            (cluster_dir / f"{name}.yaml").write_text(yaml.dump(content))
+        return cluster_dir
+
+    def test_collects_both_baseline_and_treatment_refs(self, tmp_path):
+        from pipeline.lib.ensure_image import collect_scenario_images
+
+        cluster_dir = self._make_cluster(tmp_path, {
+            "base1": {"scenario": [{"name": "s", "images": {
+                "inferenceScheduler": {"repository": "ghcr.io/org/sched", "tag": "abc12345"}
+            }}]},
+            "algo1": {"scenario": [{"name": "s", "images": {
+                "inferenceScheduler": {"repository": "ghcr.io/org/sched", "tag": "r1"}
+            }}]},
+        })
+        images = collect_scenario_images(cluster_dir)
+        refs = {i["image_ref"] for i in images}
+        assert "ghcr.io/org/sched:abc12345" in refs
+        assert "ghcr.io/org/sched:r1" in refs
+        assert len(refs) == 2
+
+    def test_deduplicates_shared_baseline_image(self, tmp_path):
+        """Multiple baselines sharing the same image are deduplicated."""
+        from pipeline.lib.ensure_image import collect_scenario_images
+
+        cluster_dir = self._make_cluster(tmp_path, {
+            "base1": {"scenario": [{"name": "s", "images": {
+                "inferenceScheduler": {"repository": "ghcr.io/org/sched", "tag": "abc12345"}
+            }}]},
+            "base2": {"scenario": [{"name": "s", "images": {
+                "inferenceScheduler": {"repository": "ghcr.io/org/sched", "tag": "abc12345"}
+            }}]},
+        })
+        images = collect_scenario_images(cluster_dir)
+        assert len(images) == 1
+
+    def test_skipped_when_hash_matches(self, tmp_path):
+        """Images with matching source hashes are reported as current."""
+        from pipeline.lib.ensure_image import compute_source_hash, image_needs_build
+
+        src = tmp_path / "src"
+        src.mkdir()
+        subprocess.run(["git", "init", str(src)], check=True, capture_output=True)
+        subprocess.run(["git", "-C", str(src), "config", "user.email", "t@t"], check=True, capture_output=True)
+        subprocess.run(["git", "-C", str(src), "config", "user.name", "T"], check=True, capture_output=True)
+        (src / "f.txt").write_text("x")
+        subprocess.run(["git", "-C", str(src), "add", "."], check=True, capture_output=True)
+        subprocess.run(["git", "-C", str(src), "commit", "-m", "i"], check=True, capture_output=True)
+
+        run_dir = tmp_path / "run"
+        run_dir.mkdir()
+        current = compute_source_hash(src)
+        meta = {"version": 1, "stages": {}, "source_hashes": {"ghcr.io/org/sched:abc12345": current}}
+        (run_dir / "run_metadata.json").write_text(json.dumps(meta))
+
+        assert image_needs_build(run_dir, "ghcr.io/org/sched:abc12345", src) is False
+
+    def test_needs_build_when_no_stored_hash(self, tmp_path):
+        """Images with no stored hash need building."""
+        from pipeline.lib.ensure_image import image_needs_build
+
+        src = tmp_path / "src"
+        src.mkdir()
+        subprocess.run(["git", "init", str(src)], check=True, capture_output=True)
+        subprocess.run(["git", "-C", str(src), "config", "user.email", "t@t"], check=True, capture_output=True)
+        subprocess.run(["git", "-C", str(src), "config", "user.name", "T"], check=True, capture_output=True)
+        (src / "f.txt").write_text("x")
+        subprocess.run(["git", "-C", str(src), "add", "."], check=True, capture_output=True)
+        subprocess.run(["git", "-C", str(src), "commit", "-m", "i"], check=True, capture_output=True)
+
+        run_dir = tmp_path / "run"
+        run_dir.mkdir()
+        (run_dir / "run_metadata.json").write_text(json.dumps({"version": 1, "stages": {}}))
+
+        assert image_needs_build(run_dir, "ghcr.io/org/sched:abc12345", src) is True
+
+    def test_treatment_ref_identified_correctly(self, tmp_path):
+        """Treatment ref matches {registry}/{repo_name}:{run_name} pattern."""
+        from pipeline.lib.ensure_image import collect_scenario_images
+
+        registry = "ghcr.io/org"
+        repo_name = "sched"
+        run_name = "r1"
+        treatment_ref = f"{registry}/{repo_name}:{run_name}"
+        assert treatment_ref == "ghcr.io/org/sched:r1"
+
+        cluster_dir = self._make_cluster(tmp_path, {
+            "algo1": {"scenario": [{"name": "s", "images": {
+                "inferenceScheduler": {"repository": "ghcr.io/org/sched", "tag": "r1"}
+            }}]},
+        })
+        images = collect_scenario_images(cluster_dir)
+        assert images[0]["image_ref"] == treatment_ref

--- a/pipeline/tests/test_ensure_image.py
+++ b/pipeline/tests/test_ensure_image.py
@@ -4,6 +4,7 @@ import subprocess
 from pathlib import Path
 
 from pipeline.lib.ensure_image import (
+    compute_baseline_ref,
     compute_source_hash,
     image_needs_build,
     load_source_hashes,
@@ -93,3 +94,18 @@ class TestImageNeedsBuild:
         meta = {"version": 1, "stages": {}, "source_hashes": {"img:tag": "stale_hash"}}
         (tmp_path / "run_metadata.json").write_text(json.dumps(meta))
         assert image_needs_build(tmp_path, "img:tag", src) is True
+
+
+class TestComputeBaselineRef:
+    def test_returns_short_sha_tag(self, tmp_path):
+        _init_git_repo(tmp_path)
+        full_hash = compute_source_hash(tmp_path)
+        result = compute_baseline_ref("ghcr.io/org/scheduler", tmp_path)
+        assert result == f"ghcr.io/org/scheduler:{full_hash[:8]}"
+
+    def test_uses_8_char_prefix(self, tmp_path):
+        _init_git_repo(tmp_path)
+        result = compute_baseline_ref("ghcr.io/org/scheduler", tmp_path)
+        tag = result.split(":")[-1]
+        assert len(tag) == 8
+        assert all(c in "0123456789abcdef" for c in tag)

--- a/pipeline/tests/test_ensure_image.py
+++ b/pipeline/tests/test_ensure_image.py
@@ -1,9 +1,11 @@
 """Tests for pipeline/lib/ensure_image.py."""
 import json
 import subprocess
+import yaml
 from pathlib import Path
 
 from pipeline.lib.ensure_image import (
+    collect_scenario_images,
     compute_baseline_ref,
     compute_source_hash,
     image_needs_build,
@@ -109,3 +111,65 @@ class TestComputeBaselineRef:
         tag = result.split(":")[-1]
         assert len(tag) == 8
         assert all(c in "0123456789abcdef" for c in tag)
+
+
+class TestCollectScenarioImages:
+    def test_extracts_images_from_scenarios(self, tmp_path):
+        cluster_dir = tmp_path / "cluster"
+        cluster_dir.mkdir()
+        baseline = {
+            "scenario": [{"name": "s1", "images": {
+                "inferenceScheduler": {"repository": "ghcr.io/org/scheduler", "tag": "abc1234"}
+            }}]
+        }
+        (cluster_dir / "base1.yaml").write_text(yaml.dump(baseline))
+        algo = {
+            "scenario": [{"name": "s1", "images": {
+                "inferenceScheduler": {"repository": "ghcr.io/org/scheduler", "tag": "r1"}
+            }}]
+        }
+        (cluster_dir / "algo1.yaml").write_text(yaml.dump(algo))
+
+        result = collect_scenario_images(cluster_dir)
+        refs = {r["image_ref"] for r in result}
+        assert "ghcr.io/org/scheduler:abc1234" in refs
+        assert "ghcr.io/org/scheduler:r1" in refs
+
+    def test_deduplicates_identical_refs(self, tmp_path):
+        cluster_dir = tmp_path / "cluster"
+        cluster_dir.mkdir()
+        scenario = {
+            "scenario": [{"name": "s1", "images": {
+                "inferenceScheduler": {"repository": "ghcr.io/org/sched", "tag": "v1"}
+            }}]
+        }
+        (cluster_dir / "base1.yaml").write_text(yaml.dump(scenario))
+        (cluster_dir / "base2.yaml").write_text(yaml.dump(scenario))
+
+        result = collect_scenario_images(cluster_dir)
+        assert len(result) == 1
+
+    def test_skips_pipelinerun_files(self, tmp_path):
+        cluster_dir = tmp_path / "cluster"
+        cluster_dir.mkdir()
+        pr = {"scenario": [{"name": "s", "images": {
+            "inferenceScheduler": {"repository": "r", "tag": "t"}
+        }}]}
+        (cluster_dir / "pipelinerun-wl1-base.yaml").write_text(yaml.dump(pr))
+
+        result = collect_scenario_images(cluster_dir)
+        assert result == []
+
+    def test_skips_scenarios_without_images(self, tmp_path):
+        cluster_dir = tmp_path / "cluster"
+        cluster_dir.mkdir()
+        scenario = {"scenario": [{"name": "s1"}]}
+        (cluster_dir / "base1.yaml").write_text(yaml.dump(scenario))
+
+        result = collect_scenario_images(cluster_dir)
+        assert result == []
+
+    def test_empty_cluster_dir(self, tmp_path):
+        cluster_dir = tmp_path / "cluster"
+        cluster_dir.mkdir()
+        assert collect_scenario_images(cluster_dir) == []

--- a/pipeline/tests/test_epp.py
+++ b/pipeline/tests/test_epp.py
@@ -3,7 +3,7 @@
 import yaml
 
 from pipeline.lib.assemble import assemble_scenarios
-from pipeline.lib.epp import inject_epp_image
+from pipeline.lib.epp import inject_epp_image, inject_image_ref
 from pipeline.lib.tekton import make_pipelinerun_scenario
 
 
@@ -86,6 +86,31 @@ class TestInjectEppImage:
         inject_epp_image(scenario, "reg.io", "epp", "v2")
         assert scenario["scenario"][0]["images"]["vllm"] == {"repository": "vllm-r", "tag": "vllm-t"}
         assert scenario["scenario"][0]["images"]["inferenceScheduler"]["tag"] == "v2"
+
+
+class TestInjectImageRef:
+    def test_injects_complete_ref(self):
+        scenario = {"scenario": [{"name": "s1"}]}
+        result = inject_image_ref(scenario, "ghcr.io/org/scheduler", "abc12345")
+        assert result is True
+        img = scenario["scenario"][0]["images"]["inferenceScheduler"]
+        assert img["repository"] == "ghcr.io/org/scheduler"
+        assert img["tag"] == "abc12345"
+        assert img["pullPolicy"] == "Always"
+
+    def test_returns_false_for_empty_scenario(self):
+        scenario = {"scenario": []}
+        assert inject_image_ref(scenario, "r", "t") is False
+
+    def test_returns_false_for_missing_scenario_key(self):
+        scenario = {}
+        assert inject_image_ref(scenario, "r", "t") is False
+
+    def test_preserves_existing_images(self):
+        scenario = {"scenario": [{"name": "s1", "images": {"vllm": {"repository": "vllm-r", "tag": "vllm-t"}}}]}
+        inject_image_ref(scenario, "ghcr.io/org/scheduler", "tag1")
+        assert scenario["scenario"][0]["images"]["vllm"] == {"repository": "vllm-r", "tag": "vllm-t"}
+        assert scenario["scenario"][0]["images"]["inferenceScheduler"]["tag"] == "tag1"
 
 
 def _write(path, data):


### PR DESCRIPTION
## Summary

Closes #187 (Phase 2)

- `_cmd_build` now iterates over all resolved scenarios in `cluster/`, extracting unique `images.inferenceScheduler` refs via `collect_scenario_images`
- For each unique image ref, checks source hash staleness and builds only if needed
- **Source toggle**: for non-treatment (baseline) images, restores baseline state before building and restores treatment state after
- `prepare.py` Phase 4 now injects baseline EPP image refs (tagged by component HEAD short SHA) into baseline packages
- Backward compatible: falls back to single treatment ref if no scenario files exist in `cluster/`

## Key design decisions

- **Baseline tag = 8-char HEAD SHA**: Since translation only modifies working-tree files (no commits), HEAD is the same for baseline and treatment. The baseline image tag is deterministic from the component state.
- **Source toggle in `_cmd_build` only**: The toggle is needed at build time (to ensure the working tree matches what we're building). At prepare time, we only need the SHA for tagging — no toggle required.
- **Treatment ref detection**: `{registry}/{repo_name}:{run_name}` is the treatment pattern. Any other ref triggers the baseline toggle path.

## New modules/functions

| Location | Function | Purpose |
|----------|----------|---------|
| `pipeline/lib/ensure_image.py` | `collect_scenario_images` | Scan cluster/ YAMLs, extract unique image refs |
| `pipeline/lib/ensure_image.py` | `compute_baseline_ref` | Format baseline image ref with 8-char SHA tag |
| `pipeline/lib/epp.py` | `inject_image_ref` | Inject pre-computed repo+tag into scenarios |

## Test plan

- [x] `TestCollectScenarioImages` — 5 tests covering extraction, deduplication, pipelinerun skipping
- [x] `TestComputeBaselineRef` — 2 tests verifying 8-char SHA tagging
- [x] `TestInjectImageRef` — 4 tests for baseline injection
- [x] `TestCmdBuildScenarioIteration` — 5 integration tests for the full iteration path
- [x] All 700 pipeline tests pass
- [x] Lint clean (ruff --select F)

## Reviewer attention

- The source toggle in `_cmd_build` (lines 204-224) assumes `translation_output.json` lists ALL files that differ between baseline and treatment states. If indirect/generated files ever enter the picture (lockfiles, vendored deps), this assumption will need revisiting.
- Baseline image builds only happen when the registry check shows the hash has changed. On first run, both baseline and treatment will be built.