### PR TITLE
fix: remove pending-status filter from deploy wipe

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -143,7 +143,7 @@ python pipeline/deploy.py status            # show progress snapshot of all (wor
 python pipeline/deploy.py collect [flags]     # pull results from the cluster PVC
 python pipeline/deploy.py stop               # stop the remote orchestrator Job
 python pipeline/deploy.py reset [flags]     # reset all non-pending pairs to pending (with cluster cleanup)
-python pipeline/deploy.py wipe  [flags]     # delete local result files for non-pending pairs
+python pipeline/deploy.py wipe  [flags]     # delete local result files for pairs in scope
 python pipeline/deploy.py pairs   [flags]   # list available pair keys, workloads, and packages
 ```
 
@@ -212,7 +212,7 @@ When `--only` or `--workload` is given, only matching workload subdirectories ar
 
 **Safety:** Results in `workspace/runs/<run>/results/` are preserved — only cluster resources and ConfigMap status are affected.
 
-**`deploy.py wipe`** — deletes local result files (`results/<package>/<workload>/`) for non-pending pairs. Does **not** modify pair status in the ConfigMap. Pending pairs are skipped (nothing to wipe). Empty package directories are cleaned up automatically.
+**`deploy.py wipe`** — deletes local result files (`results/<package>/<workload>/`) for all pairs in scope. Does **not** modify pair status in the ConfigMap. Pairs with no results on disk are skipped. Empty package directories are cleaned up automatically.
 
 | Flag | Description |
 |------|-------------|
@@ -222,7 +222,7 @@ When `--only` or `--workload` is given, only matching workload subdirectories ar
 | `--dry-run` | Print what would be wiped without acting |
 | `--yes` / `-y` | Skip confirmation prompt |
 
-**Re-running wiped pairs:** `wipe` only removes files; to re-dispatch, follow with `reset` to move pairs back to `pending`.
+**Re-running wiped pairs:** `wipe` only removes files. To re-dispatch wiped pairs, use `reset` to move them back to `pending`.
 
 **`deploy.py pairs`** — lists available pair keys, workloads, and packages by scanning `cluster/pipelinerun-*.yaml`.
 

--- a/pipeline/completions.zsh
+++ b/pipeline/completions.zsh
@@ -60,7 +60,7 @@ _sim2real_deploy() {
                 'collect:Pull results for completed packages'
                 'stop:Stop the remote orchestrator Job'
                 'reset:Tear down cluster resources for all non-pending pairs'
-                'wipe:Delete local results and reset pairs to pending'
+                'wipe:Delete local result files for pairs in scope'
                 'pairs:List available pair keys, workloads, and packages'
             )
             _describe 'subcommand' subcommands

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1872,7 +1872,7 @@ def _cmd_reset(args, run_dir: Path, discovered: dict,
 
 def _cmd_wipe(args, run_dir: Path,
               setup_config: dict | None = None) -> None:
-    """Delete local result files for non-pending pairs."""
+    """Delete local result files for pairs in scope."""
     from pipeline.lib.progress import ConfigMapProgressStore
     primary_ns = _configmap_namespace(setup_config)
     if not primary_ns:
@@ -1887,18 +1887,11 @@ def _cmd_wipe(args, run_dir: Path,
 
     _scope = _resolve_scope(progress, args)
 
-    actionable = {k for k in _scope
-                  if progress[k].get("status") not in (None, "pending")}
-
-    if not actionable:
-        info("No pairs need wiping (all pending)")
-        return
-
     total_pairs = sum(1 for k in progress if _is_pair_key(k))
     results_dir = run_dir / "results"
 
     targets = []
-    for key in sorted(actionable):
+    for key in sorted(_scope):
         entry = progress[key]
         pkg = entry.get("package", "")
         wl = entry.get("workload", "")
@@ -1908,7 +1901,7 @@ def _cmd_wipe(args, run_dir: Path,
         target_dir = results_dir / pkg / wl
         targets.append((key, pkg, wl, target_dir))
 
-    info(f"Scope: {len(actionable)}/{total_pairs} pairs"
+    info(f"Scope: {len(_scope)}/{total_pairs} pairs"
          + (" [DRY-RUN]" if args.dry_run else ""))
 
     if args.dry_run:

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -8,7 +8,7 @@ Subcommands:
   collect  Pull results from cluster for completed phases
   stop     Stop the remote orchestrator Job
   reset    Reset all non-pending pairs to pending (with cluster cleanup)
-  wipe     Delete local result files for non-pending pairs
+  wipe     Delete local result files for pairs in scope
   pairs    List available pair keys, workloads, and packages
 """
 
@@ -2272,7 +2272,7 @@ Examples:
     reset_p.add_argument("--dry-run",  action="store_true", dest="dry_run",
                          help="Print what would be reset without doing it")
 
-    wipe_p = sub.add_parser("wipe", help="Delete local result files for non-pending pairs")
+    wipe_p = sub.add_parser("wipe", help="Delete local result files for pairs in scope")
     wipe_p.add_argument("--only",     metavar="PAIR",  help="Scope to one specific pair key (wl- prefix optional)")
     wipe_p.add_argument("--workload", metavar="NAME",  help="Scope to pairs matching this workload")
     wipe_p.add_argument("--package",  metavar="NAME",  help="Scope to pairs matching this package")

--- a/pipeline/tests/test_deploy_wipe.py
+++ b/pipeline/tests/test_deploy_wipe.py
@@ -32,7 +32,7 @@ def _setup_results(run_dir: Path) -> None:
 
 
 def test_wipe_all_deletes_results(tmp_path, monkeypatch):
-    """Unscoped wipe deletes results for non-pending pairs without resetting status."""
+    """Unscoped wipe deletes results for all pairs regardless of status."""
     import pipeline.deploy as mod
 
     run_dir = tmp_path / "run1"
@@ -45,13 +45,12 @@ def test_wipe_all_deletes_results(tmp_path, monkeypatch):
 
     mod._cmd_wipe(_Args(), run_dir, setup_config={"namespace": "ns-0"})
 
-    # Non-pending workload dirs deleted
+    # All pairs wiped regardless of status (including pending)
     assert not (run_dir / "results" / "baseline" / "wl-smoke").exists()
     assert not (run_dir / "results" / "baseline" / "wl-heavy").exists()
+    assert not (run_dir / "results" / "baseline" / "wl-load").exists()
     assert not (run_dir / "results" / "treatment" / "wl-smoke").exists()
     assert not (run_dir / "results" / "treatment" / "wl-load").exists()
-    # Pending pair's dir survives
-    assert (run_dir / "results" / "baseline" / "wl-load").exists()
 
 
 def test_wipe_scoped_by_workload(tmp_path, monkeypatch):
@@ -134,8 +133,8 @@ def test_wipe_dry_run_does_not_delete(tmp_path, monkeypatch, capsys):
     assert "DRY-RUN" in captured.out + captured.err
 
 
-def test_wipe_skips_pending_pairs(tmp_path, monkeypatch, capsys):
-    """Pending pairs are skipped (nothing to wipe)."""
+def test_wipe_includes_pending_pairs(tmp_path, monkeypatch):
+    """Pending pairs with results on disk are wiped like any other pair."""
     import pipeline.deploy as mod
 
     run_dir = tmp_path / "run1"
@@ -145,14 +144,16 @@ def test_wipe_skips_pending_pairs(tmp_path, monkeypatch, capsys):
                           "namespace": None, "retries": 0, "pending_stalls": 0, "pending_since": None},
     }
     _mock_cm(monkeypatch, progress)
+    d = run_dir / "results" / "baseline" / "wl-a"
+    d.mkdir(parents=True)
+    (d / "trace.csv").write_text("data")
 
     class _Args:
         only = None; workload = None; package = None; dry_run = False; yes = True
 
     mod._cmd_wipe(_Args(), run_dir, setup_config={"namespace": "ns-0"})
 
-    captured = capsys.readouterr()
-    assert "no pairs need wiping" in (captured.out + captured.err).lower()
+    assert not (run_dir / "results" / "baseline" / "wl-a").exists()
 
 
 def test_wipe_no_progress_reports_nothing(tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
## Summary

- Removes the status-based pre-filter from `_cmd_wipe` that prevented wiping pairs in `pending` status
- After `reset` + `collect` cycles, pairs return to `pending` but result files remain on disk — wipe now correctly cleans them up
- Updates tests and README to reflect the new behavior

This was a vestige of pre-#168 behavior when wipe also reset ConfigMap status. Now that wipe only deletes files (#168), filtering by status contradicts separation of concerns.

## Test plan

- [x] All 700 pipeline tests pass
- [x] Lint clean (`ruff check pipeline/ --select F`)
- [x] `test_wipe_includes_pending_pairs` verifies pending-status pairs are now wiped
- [x] `test_wipe_all_deletes_results` updated to assert all pairs (including pending) are cleaned

Closes #194
Closes #155