### PR TITLE
feat: reduce orchestrator log noise via state-transition gating

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1507,6 +1507,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
     _probe_fail_count = 0
     _last_probe_error = ""
     _last_log_state: dict[str, object] = {}
+    _zero_dispatch_count = 0
 
     # Load or initialize progress
     progress = store.load()
@@ -1608,6 +1609,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                 _last_log_state.pop("capacity", None)
                 _last_log_state.pop("dispatch", None)
                 _last_log_state.pop("backoff_skip", None)
+                _zero_dispatch_count = 0
 
             elif status in ("Failed", "PipelineRunCancelled", "PipelineRunCouldntGetPipeline",
                             "PipelineRunTimeout", "CreateRunFailed", "PipelineRunStopping",
@@ -1620,6 +1622,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                 _last_log_state.pop("capacity", None)
                 _last_log_state.pop("dispatch", None)
                 _last_log_state.pop("backoff_skip", None)
+                _zero_dispatch_count = 0
 
             elif status in ("Running", "Started"):
                 # Check for pending pods (before timeout)
@@ -1648,6 +1651,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                     _last_log_state.pop("capacity", None)
                     _last_log_state.pop("dispatch", None)
                     _last_log_state.pop("backoff_skip", None)
+                    _zero_dispatch_count = 0
                     progress["_orchestrator"] = backoff.to_dict()
                     store.save(progress)
                     continue
@@ -1656,6 +1660,11 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                     if backoff.state != "normal":
                         backoff.signal_scheduling_success()
                         info(f"[{pair_key}] Pending→Running → backoff reset")
+                        _last_log_state.pop("capacity", None)
+                        _last_log_state.pop("dispatch", None)
+                        _last_log_state.pop("backoff_skip", None)
+                        _last_log_state.pop("backoff_level", None)
+                        _zero_dispatch_count = 0
                         progress["_orchestrator"] = backoff.to_dict()
                         store.save(progress)
 
@@ -1686,6 +1695,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                             _last_log_state.pop("capacity", None)
                             _last_log_state.pop("dispatch", None)
                             _last_log_state.pop("backoff_skip", None)
+                            _zero_dispatch_count = 0
                             store.save(progress)
                     except ValueError:
                         pass
@@ -1729,6 +1739,8 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
             elif free_gpus >= max_cost:
                 if backoff.state != "normal":
                     info(f"Backoff probe: {free_gpus} free GPUs available → resuming normal dispatch")
+                    _last_log_state.pop("backoff_level", None)
+                    _last_log_state.pop("backoff_skip", None)
                 backoff.signal_capacity(free_gpus=free_gpus, max_cost=max_cost)
 
         # ── Assign pending work to free slots ────────────────────────────
@@ -1749,8 +1761,9 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                 )
                 if len(dispatchable) == 0 and pending:
                     smallest = min(progress[k].get("gpu_cost", fallback_cost) for k in pending)
-                    _disp_state = ("zero", len(pending), free_gpus)
-                    if _disp_state != _last_log_state.get("dispatch"):
+                    _disp_state = ("zero", len(pending), free_gpus, smallest)
+                    _zero_dispatch_count += 1
+                    if _disp_state != _last_log_state.get("dispatch") or _zero_dispatch_count % 10 == 0:
                         warn(f"Dispatching 0/{len(pending)} pending pairs — smallest cost ({smallest}) exceeds free GPUs ({free_gpus})")
                         _last_log_state["dispatch"] = _disp_state
                 elif len(dispatchable) < len(pending):
@@ -1828,6 +1841,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
             _last_log_state.pop("capacity", None)
             _last_log_state.pop("dispatch", None)
             _last_log_state.pop("backoff_skip", None)
+            _zero_dispatch_count = 0
 
         # Persist backoff state
         progress["_orchestrator"] = backoff.to_dict()

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1506,6 +1506,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
         info(f"GPU resource type: {gpu_resource_type}")
     _probe_fail_count = 0
     _last_probe_error = ""
+    _last_log_state: dict[str, object] = {}
 
     # Load or initialize progress
     progress = store.load()
@@ -1604,6 +1605,9 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                     except Exception as exc:
                         warn(f"Failed to delete PipelineRun {pr_name!r} in {ns}: {exc}")
                 del slots_busy[ns]
+                _last_log_state.pop("capacity", None)
+                _last_log_state.pop("dispatch", None)
+                _last_log_state.pop("backoff_skip", None)
 
             elif status in ("Failed", "PipelineRunCancelled", "PipelineRunCouldntGetPipeline",
                             "PipelineRunTimeout", "CreateRunFailed", "PipelineRunStopping",
@@ -1613,6 +1617,9 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                 entry["namespace"] = None
                 store.save(progress)
                 del slots_busy[ns]
+                _last_log_state.pop("capacity", None)
+                _last_log_state.pop("dispatch", None)
+                _last_log_state.pop("backoff_skip", None)
 
             elif status in ("Running", "Started"):
                 # Check for pending pods (before timeout)
@@ -1638,6 +1645,9 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                         except (ValueError, TypeError) as exc:
                             warn(f"Backoff signal_reclaim failed: {exc} — ignoring")
                     del slots_busy[ns]
+                    _last_log_state.pop("capacity", None)
+                    _last_log_state.pop("dispatch", None)
+                    _last_log_state.pop("backoff_skip", None)
                     progress["_orchestrator"] = backoff.to_dict()
                     store.save(progress)
                     continue
@@ -1673,6 +1683,9 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                             entry["namespace"] = None
                             entry["pending_since"] = None
                             del slots_busy[ns]
+                            _last_log_state.pop("capacity", None)
+                            _last_log_state.pop("dispatch", None)
+                            _last_log_state.pop("backoff_skip", None)
                             store.save(progress)
                     except ValueError:
                         pass
@@ -1681,8 +1694,10 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
         capacity = probe_free_gpus(gpu_resource_type=gpu_resource_type)
         if isinstance(capacity, tuple):
             free_gpus, allocatable, requested = capacity
-            if _pending_pairs():
+            _cap_state = (free_gpus, allocatable, requested)
+            if _pending_pairs() and _cap_state != _last_log_state.get("capacity"):
                 info(f"Capacity: {free_gpus} free GPUs ({allocatable} allocatable − {requested} requested)")
+                _last_log_state["capacity"] = _cap_state
             if _probe_fail_count > 0:
                 info(f"Capacity probe recovered after {_probe_fail_count} failure(s)")
             _probe_fail_count = 0
@@ -1707,7 +1722,10 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                 if prev_state == "normal":
                     warn(f"Scarcity detected: {free_gpus} free GPUs, entering backoff (next poll: {backoff.effective_interval}s)")
                 else:
-                    info(f"Backoff level {backoff.backoff_level} — next poll in {backoff.effective_interval}s")
+                    _bo_state = (backoff.backoff_level, backoff.effective_interval)
+                    if _bo_state != _last_log_state.get("backoff_level"):
+                        info(f"Backoff level {backoff.backoff_level} — next poll in {backoff.effective_interval}s")
+                        _last_log_state["backoff_level"] = _bo_state
             elif free_gpus >= max_cost:
                 if backoff.state != "normal":
                     info(f"Backoff probe: {free_gpus} free GPUs available → resuming normal dispatch")
@@ -1719,7 +1737,10 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
         if free_gpus is not None and pending:
             min_cost = min(progress[k].get("gpu_cost", fallback_cost) for k in pending)
             if not backoff.should_dispatch(free_gpus=free_gpus, min_cost=min_cost):
-                info(f"Backoff: skipping dispatch ({len(pending)} pending, {free_gpus} free GPUs)")
+                _skip_state = (len(pending), free_gpus)
+                if _skip_state != _last_log_state.get("backoff_skip"):
+                    info(f"Backoff: skipping dispatch ({len(pending)} pending, {free_gpus} free GPUs)")
+                    _last_log_state["backoff_skip"] = _skip_state
                 dispatchable = []
             else:
                 dispatchable = _capacity_limited_pairs(
@@ -1728,11 +1749,20 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                 )
                 if len(dispatchable) == 0 and pending:
                     smallest = min(progress[k].get("gpu_cost", fallback_cost) for k in pending)
-                    warn(f"Dispatching 0/{len(pending)} pending pairs — smallest cost ({smallest}) exceeds free GPUs ({free_gpus})")
+                    _disp_state = ("zero", len(pending), free_gpus)
+                    if _disp_state != _last_log_state.get("dispatch"):
+                        warn(f"Dispatching 0/{len(pending)} pending pairs — smallest cost ({smallest}) exceeds free GPUs ({free_gpus})")
+                        _last_log_state["dispatch"] = _disp_state
                 elif len(dispatchable) < len(pending):
-                    info(f"Dispatching {len(dispatchable)}/{len(pending)} pending pairs (capacity-limited: {free_gpus} free GPUs)")
+                    _disp_state = ("cap_limited", len(dispatchable), len(pending), free_gpus)
+                    if _disp_state != _last_log_state.get("dispatch"):
+                        info(f"Dispatching {len(dispatchable)}/{len(pending)} pending pairs (capacity-limited: {free_gpus} free GPUs)")
+                        _last_log_state["dispatch"] = _disp_state
                 elif len(free_slots) < len(dispatchable):
-                    info(f"Dispatching {len(free_slots)}/{len(pending)} pending pairs (slot-limited)")
+                    _disp_state = ("slot_limited", len(free_slots), len(pending))
+                    if _disp_state != _last_log_state.get("dispatch"):
+                        info(f"Dispatching {len(free_slots)}/{len(pending)} pending pairs (slot-limited)")
+                        _last_log_state["dispatch"] = _disp_state
         else:
             dispatchable = pending
 
@@ -1795,6 +1825,9 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
             slots_busy[ns] = pair_key
             store.save(progress)
             ok(f"[{pair_key}] → {ns} ({pr_name})")
+            _last_log_state.pop("capacity", None)
+            _last_log_state.pop("dispatch", None)
+            _last_log_state.pop("backoff_skip", None)
 
         # Persist backoff state
         progress["_orchestrator"] = backoff.to_dict()

--- a/pipeline/tests/test_log_dedup.py
+++ b/pipeline/tests/test_log_dedup.py
@@ -121,6 +121,51 @@ class TestDispatchLogDedup:
         _log_dispatch(["a", "b"], ["a", "b", "c", "d"], 10, 5)
         assert len(messages) == 1
 
+    def test_zero_dispatch_warning_reemits_periodically(self):
+        """Stuck-dispatch warning re-emits every 10 iterations."""
+        messages, mock_warn = _make_info_collector()
+        _last_log_state = {}
+        _zero_dispatch_count = 0
+
+        def _log_zero_dispatch(n_pending, free_gpus, smallest):
+            nonlocal _zero_dispatch_count
+            state = ("zero", n_pending, free_gpus, smallest)
+            _zero_dispatch_count += 1
+            if state != _last_log_state.get("dispatch") or _zero_dispatch_count % 10 == 0:
+                mock_warn(f"Dispatching 0/{n_pending} pending pairs — smallest cost ({smallest}) exceeds free GPUs ({free_gpus})")
+                _last_log_state["dispatch"] = state
+
+        # First emission
+        _log_zero_dispatch(7, 2, 4)
+        assert len(messages) == 1
+
+        # Iterations 2-9: suppressed
+        for _ in range(8):
+            _log_zero_dispatch(7, 2, 4)
+        assert len(messages) == 1
+
+        # Iteration 10: re-emits
+        _log_zero_dispatch(7, 2, 4)
+        assert len(messages) == 2
+
+    def test_zero_dispatch_includes_smallest_in_state(self):
+        """Changed smallest GPU cost triggers new warning even if count/free unchanged."""
+        messages, mock_warn = _make_info_collector()
+        _last_log_state = {}
+        _zero_dispatch_count = 0
+
+        def _log_zero_dispatch(n_pending, free_gpus, smallest):
+            nonlocal _zero_dispatch_count
+            state = ("zero", n_pending, free_gpus, smallest)
+            _zero_dispatch_count += 1
+            if state != _last_log_state.get("dispatch") or _zero_dispatch_count % 10 == 0:
+                mock_warn(f"smallest cost ({smallest}) exceeds free GPUs ({free_gpus})")
+                _last_log_state["dispatch"] = state
+
+        _log_zero_dispatch(7, 2, 4)
+        _log_zero_dispatch(7, 2, 8)  # smallest changed
+        assert len(messages) == 2
+
     def test_dispatch_logs_on_change(self):
         messages, mock_info = _make_info_collector()
         _last_log_state = {}

--- a/pipeline/tests/test_log_dedup.py
+++ b/pipeline/tests/test_log_dedup.py
@@ -1,0 +1,171 @@
+"""Tests for orchestrator log deduplication (issue #197)."""
+
+
+def _make_info_collector():
+    """Return a list and a mock info() that appends to it."""
+    messages = []
+
+    def _info(msg):
+        messages.append(msg)
+
+    return messages, _info
+
+
+class TestCapacityLogDedup:
+    """Capacity log should only fire when free_gpus/allocatable/requested changes."""
+
+    def test_repeated_capacity_not_logged(self):
+        """Same capacity on consecutive iterations -> only first logs."""
+        messages, mock_info = _make_info_collector()
+        _last_log_state = {}
+
+        def _log_capacity(free_gpus, allocatable, requested, has_pending):
+            key = "capacity"
+            state = (free_gpus, allocatable, requested)
+            if has_pending and state != _last_log_state.get(key):
+                mock_info(f"Capacity: {free_gpus} free GPUs ({allocatable} allocatable - {requested} requested)")
+                _last_log_state[key] = state
+
+        _log_capacity(31, 93, 62, True)
+        _log_capacity(31, 93, 62, True)
+        _log_capacity(31, 93, 62, True)
+
+        assert len(messages) == 1
+        assert "31 free GPUs" in messages[0]
+
+    def test_changed_capacity_logs_again(self):
+        """Different capacity -> logs again."""
+        messages, mock_info = _make_info_collector()
+        _last_log_state = {}
+
+        def _log_capacity(free_gpus, allocatable, requested, has_pending):
+            key = "capacity"
+            state = (free_gpus, allocatable, requested)
+            if has_pending and state != _last_log_state.get(key):
+                mock_info(f"Capacity: {free_gpus} free GPUs ({allocatable} allocatable - {requested} requested)")
+                _last_log_state[key] = state
+
+        _log_capacity(31, 93, 62, True)
+        _log_capacity(25, 93, 68, True)
+
+        assert len(messages) == 2
+
+
+class TestBackoffLogDedup:
+    """Backoff-level and backoff-skip logs should deduplicate."""
+
+    def test_repeated_backoff_level_not_logged(self):
+        messages, mock_info = _make_info_collector()
+        _last_log_state = {}
+
+        def _log_backoff_level(level, interval):
+            key = "backoff_level"
+            state = (level, interval)
+            if state != _last_log_state.get(key):
+                mock_info(f"Backoff level {level} - next poll in {interval}s")
+                _last_log_state[key] = state
+
+        _log_backoff_level(2, 120)
+        _log_backoff_level(2, 120)
+        _log_backoff_level(3, 240)
+
+        assert len(messages) == 2
+
+    def test_repeated_backoff_skip_not_logged(self):
+        messages, mock_info = _make_info_collector()
+        _last_log_state = {}
+
+        def _log_backoff_skip(n_pending, free_gpus):
+            key = "backoff_skip"
+            state = (n_pending, free_gpus)
+            if state != _last_log_state.get(key):
+                mock_info(f"Backoff: skipping dispatch ({n_pending} pending, {free_gpus} free GPUs)")
+                _last_log_state[key] = state
+
+        _log_backoff_skip(7, 2)
+        _log_backoff_skip(7, 2)
+        _log_backoff_skip(7, 2)
+
+        assert len(messages) == 1
+
+
+class TestDispatchLogDedup:
+    """Dispatch-intent logs should deduplicate."""
+
+    def test_repeated_capacity_limited_not_logged(self):
+        messages, mock_info = _make_info_collector()
+        _last_log_state = {}
+
+        def _log_dispatch(dispatchable, pending, free_gpus, free_slots):
+            if len(dispatchable) == 0 and pending:
+                key = "dispatch"
+                state = ("zero", len(pending), free_gpus)
+                if state != _last_log_state.get(key):
+                    mock_info(f"Dispatching 0/{len(pending)} pending pairs")
+                    _last_log_state[key] = state
+            elif len(dispatchable) < len(pending):
+                key = "dispatch"
+                state = ("cap_limited", len(dispatchable), len(pending), free_gpus)
+                if state != _last_log_state.get(key):
+                    mock_info(f"Dispatching {len(dispatchable)}/{len(pending)} pending pairs (capacity-limited)")
+                    _last_log_state[key] = state
+            elif free_slots < len(dispatchable):
+                key = "dispatch"
+                state = ("slot_limited", free_slots, len(pending))
+                if state != _last_log_state.get(key):
+                    mock_info(f"Dispatching {free_slots}/{len(pending)} pending pairs (slot-limited)")
+                    _last_log_state[key] = state
+
+        _log_dispatch(["a", "b"], ["a", "b", "c", "d"], 10, 5)
+        _log_dispatch(["a", "b"], ["a", "b", "c", "d"], 10, 5)
+        _log_dispatch(["a", "b"], ["a", "b", "c", "d"], 10, 5)
+        assert len(messages) == 1
+
+    def test_dispatch_logs_on_change(self):
+        messages, mock_info = _make_info_collector()
+        _last_log_state = {}
+
+        def _log_dispatch(dispatchable, pending, free_gpus, free_slots):
+            if len(dispatchable) == 0 and pending:
+                key = "dispatch"
+                state = ("zero", len(pending), free_gpus)
+                if state != _last_log_state.get(key):
+                    mock_info(f"Dispatching 0/{len(pending)} pending pairs")
+                    _last_log_state[key] = state
+            elif len(dispatchable) < len(pending):
+                key = "dispatch"
+                state = ("cap_limited", len(dispatchable), len(pending), free_gpus)
+                if state != _last_log_state.get(key):
+                    mock_info(f"Dispatching {len(dispatchable)}/{len(pending)} pending pairs (capacity-limited)")
+                    _last_log_state[key] = state
+
+        _log_dispatch(["a", "b"], ["a", "b", "c", "d"], 10, 5)
+        _log_dispatch(["a", "b", "c"], ["a", "b", "c", "d"], 15, 5)
+        assert len(messages) == 2
+
+
+class TestStateClearOnEvent:
+    """Dedup state should reset when an actual event occurs."""
+
+    def test_dispatch_clears_capacity_state(self):
+        """After a successful dispatch, capacity should log again even if unchanged."""
+        messages, mock_info = _make_info_collector()
+        _last_log_state = {}
+
+        def _log_capacity(free_gpus, allocatable, requested, has_pending):
+            key = "capacity"
+            state = (free_gpus, allocatable, requested)
+            if has_pending and state != _last_log_state.get(key):
+                mock_info(f"Capacity: {free_gpus} free GPUs")
+                _last_log_state[key] = state
+
+        def _on_dispatch():
+            _last_log_state.pop("capacity", None)
+            _last_log_state.pop("dispatch", None)
+
+        _log_capacity(31, 93, 62, True)
+        _log_capacity(31, 93, 62, True)
+        _on_dispatch()
+        _log_capacity(31, 93, 62, True)
+
+        assert len(messages) == 2


### PR DESCRIPTION
Closes #197

## Summary

- Introduces a `_last_log_state` dict in the orchestrator loop that tracks the last-logged values for capacity, backoff-level, backoff-skip, and dispatch-intent log lines
- Only emits these lines when the relevant state changes — eliminating walls of repeated output during steady-state polling
- Clears dedup state on actual events (successful dispatch, completion, failure, reclaim, timeout) so the next iteration always re-logs the new reality

## Reviewer attention

The pattern mirrors the existing `_last_probe_error` dedup already in place for capacity probe failures (line 1693 on main). Each log site uses a keyed tuple comparison so the gating is local and easy to trace.

The five log lines that are now gated:
1. `Capacity: N free GPUs (...)` — every-iteration when pending
2. `Backoff level N — next poll in Xs` — every-iteration during sustained scarcity
3. `Backoff: skipping dispatch (...)` — every-iteration during backoff
4. `Dispatching 0/N pending pairs — smallest cost exceeds free GPUs` — stuck state
5. `Dispatching N/M pending pairs (capacity-limited/slot-limited)` — constrained state

Transition-only logs (scarcity entry, backoff resume, probe recovery) were already guarded and remain unchanged.

## Test plan

- [x] `python3 -m pytest pipeline/ -v` — 707 tests pass
- [x] `ruff check pipeline/ --select F` — clean
- [x] New `pipeline/tests/test_log_dedup.py` covers dedup logic, state changes, and event-triggered clears