### PR TITLE
feat: parallelize deploy collect across namespace slots

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -949,7 +949,6 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
         else:
             phases_to_collect = list(known_phases)
 
-        step(1, "Collecting Results")
         collected = []
         failed = []
         collected_pairs: list[str] = []
@@ -990,24 +989,28 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
                     and pentry.get("completed_namespace")
                 )
 
+                ns_items = sorted(ns_phase_map.items())
+                if len(ns_items) > 1:
+                    step(1, f"Collecting Results ({len(ns_items)} slots in parallel)")
+                else:
+                    step(1, "Collecting Results")
+
                 for key in missing_ns_keys:
                     warn(f"{key}: completed_namespace missing — skipping (re-run the workload with a newer orchestrator to collect results)")
-                for ns, ns_phases in sorted(ns_phase_map.items()):
-                    pairs_in_ns = ns_pair_map.get(ns, set())
-                    try:
-                        errors = _extract_phases_from_pvc(
-                            sorted(ns_phases), run_name, ns, run_dir,
-                            skip_logs=skip_logs)
-                    except RuntimeError as e:
-                        warn(f"Extractor pod failed in {ns}: {e}")
-                        for p in ns_phases:
+
+                def _process_slot_result(ns, pairs_in_ns, result):
+                    """Process extraction result for one namespace slot."""
+                    if isinstance(result, Exception):
+                        warn(f"Extractor pod failed in {ns}: {result}")
+                        ns_phases_local = ns_phase_map[ns]
+                        for p in ns_phases_local:
                             if p not in failed:
                                 failed.append(p)
                             for pkg, wl in sorted(pairs_in_ns):
                                 if pkg == p:
                                     failed_pairs.append(f"{p}/{wl}")
                     else:
-                        for phase, exc in errors.items():
+                        for phase, exc in result.items():
                             wls_for_phase = sorted(
                                 wl for pkg, wl in pairs_in_ns if pkg == phase)
                             if exc is None:
@@ -1022,8 +1025,42 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
                                     failed_pairs.append(f"{phase}/{wl}")
                                 if phase not in failed:
                                     failed.append(phase)
+
+                if len(ns_items) > 1:
+                    import concurrent.futures
+
+                    def _extract_one_slot(ns, ns_phases):
+                        pairs_in_ns = ns_pair_map.get(ns, set())
+                        try:
+                            errors = _extract_phases_from_pvc(
+                                sorted(ns_phases), run_name, ns, run_dir,
+                                skip_logs=skip_logs)
+                        except RuntimeError as e:
+                            return (ns, pairs_in_ns, e)
+                        return (ns, pairs_in_ns, errors)
+
+                    with concurrent.futures.ThreadPoolExecutor(max_workers=len(ns_items)) as executor:
+                        futures = {
+                            executor.submit(_extract_one_slot, ns, ns_phases): ns
+                            for ns, ns_phases in ns_items
+                        }
+                        for future in concurrent.futures.as_completed(futures):
+                            ns, pairs_in_ns, result = future.result()
+                            _process_slot_result(ns, pairs_in_ns, result)
+                else:
+                    for ns, ns_phases in ns_items:
+                        pairs_in_ns = ns_pair_map.get(ns, set())
+                        try:
+                            errors = _extract_phases_from_pvc(
+                                sorted(ns_phases), run_name, ns, run_dir,
+                                skip_logs=skip_logs)
+                        except RuntimeError as e:
+                            _process_slot_result(ns, pairs_in_ns, e)
+                        else:
+                            _process_slot_result(ns, pairs_in_ns, errors)
             else:
                 # No progress data — fallback to primary namespace.
+                step(1, "Collecting Results")
                 total_pairs = len(phases_to_collect)
                 try:
                     errors = _extract_phases_from_pvc(

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1035,7 +1035,7 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
                             errors = _extract_phases_from_pvc(
                                 sorted(ns_phases), run_name, ns, run_dir,
                                 skip_logs=skip_logs)
-                        except RuntimeError as e:
+                        except Exception as e:
                             return (ns, pairs_in_ns, e)
                         return (ns, pairs_in_ns, errors)
 
@@ -1045,7 +1045,12 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
                             for ns, ns_phases in ns_items
                         }
                         for future in concurrent.futures.as_completed(futures):
-                            ns, pairs_in_ns, result = future.result()
+                            try:
+                                ns, pairs_in_ns, result = future.result()
+                            except Exception as e:
+                                ns = futures[future]
+                                pairs_in_ns = ns_pair_map.get(ns, set())
+                                result = e
                             _process_slot_result(ns, pairs_in_ns, result)
                 else:
                     for ns, ns_phases in ns_items:

--- a/pipeline/tests/test_deploy_collect.py
+++ b/pipeline/tests/test_deploy_collect.py
@@ -1277,3 +1277,64 @@ def test_collect_unscoped_parallel_step_header(tmp_path, monkeypatch, capsys):
 
     out = capsys.readouterr().out
     assert "2 slots in parallel" in out
+
+
+def test_collect_unscoped_parallel_non_runtime_error(tmp_path, monkeypatch, capsys):
+    """Non-RuntimeError from one slot doesn't crash the loop — other slots still succeed."""
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    data = {
+        "wl-smoke-baseline":   {"workload": "smoke", "package": "baseline",  "status": "done", "completed_namespace": "ns-0"},
+        "wl-smoke-treatment":  {"workload": "smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
+        "wl-load-baseline":    {"workload": "load",  "package": "baseline",  "status": "done", "completed_namespace": "ns-1"},
+        "wl-load-treatment":   {"workload": "load",  "package": "treatment", "status": "done", "completed_namespace": "ns-1"},
+    }
+    _mock_cm(monkeypatch, data)
+
+    class Args:
+        package = None
+        skip_logs = False
+
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None):
+        if namespace == "ns-1":
+            raise OSError("kubectl binary not found")
+        return {p: None for p in phases}
+
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
+        deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
+
+    out = capsys.readouterr().out
+    assert "baseline/smoke" in out
+    assert "treatment/smoke" in out
+    assert "2/" in out
+
+
+def test_collect_unscoped_parallel_all_slots_fail(tmp_path, monkeypatch, capsys):
+    """All slots failing produces correct summary with zero collected."""
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    data = {
+        "wl-smoke-baseline":   {"workload": "smoke", "package": "baseline",  "status": "done", "completed_namespace": "ns-0"},
+        "wl-smoke-treatment":  {"workload": "smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
+        "wl-load-baseline":    {"workload": "load",  "package": "baseline",  "status": "done", "completed_namespace": "ns-1"},
+        "wl-load-treatment":   {"workload": "load",  "package": "treatment", "status": "done", "completed_namespace": "ns-1"},
+    }
+    _mock_cm(monkeypatch, data)
+
+    class Args:
+        package = None
+        skip_logs = False
+
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None):
+        raise RuntimeError(f"pod failed in {namespace}")
+
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
+        deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
+
+    out = capsys.readouterr().out
+    assert "0/" in out
+    assert "Failed:" in out

--- a/pipeline/tests/test_deploy_collect.py
+++ b/pipeline/tests/test_deploy_collect.py
@@ -1136,3 +1136,144 @@ def test_collect_unscoped_no_cross_product_on_slot_reuse(tmp_path, monkeypatch, 
     assert "baseline/smoke" in output
     assert "baseline/load" in output
     assert "treatment/smoke" in output
+
+
+# ── Parallel extraction tests ────────────────────────────────────────────────
+
+
+def test_collect_unscoped_parallel_multi_ns(tmp_path, monkeypatch):
+    """With multiple namespace slots, extraction runs via ThreadPoolExecutor."""
+    from pipeline import deploy
+    import concurrent.futures
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    data = {
+        "wl-smoke-baseline":   {"workload": "smoke", "package": "baseline",  "status": "done", "completed_namespace": "ns-0"},
+        "wl-smoke-treatment":  {"workload": "smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
+        "wl-load-baseline":    {"workload": "load",  "package": "baseline",  "status": "done", "completed_namespace": "ns-1"},
+        "wl-load-treatment":   {"workload": "load",  "package": "treatment", "status": "done", "completed_namespace": "ns-1"},
+        "wl-heavy-baseline":   {"workload": "heavy", "package": "baseline",  "status": "done", "completed_namespace": "ns-2"},
+        "wl-heavy-treatment":  {"workload": "heavy", "package": "treatment", "status": "done", "completed_namespace": "ns-2"},
+    }
+    _mock_cm(monkeypatch, data)
+
+    class Args:
+        package = None
+        skip_logs = False
+
+    extract_calls = []
+
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None):
+        extract_calls.append({"namespace": namespace, "phases": sorted(phases)})
+        return {p: None for p in phases}
+
+    executor_used = []
+    OrigExecutor = concurrent.futures.ThreadPoolExecutor
+
+    class TrackingExecutor(OrigExecutor):
+        def __init__(self, *a, **kw):
+            executor_used.append(True)
+            super().__init__(*a, **kw)
+
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract), \
+         patch("concurrent.futures.ThreadPoolExecutor", TrackingExecutor):
+        deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
+
+    assert len(extract_calls) == 3
+    ns_set = {c["namespace"] for c in extract_calls}
+    assert ns_set == {"ns-0", "ns-1", "ns-2"}
+    assert len(executor_used) == 1
+
+
+def test_collect_unscoped_single_ns_no_threading(tmp_path, monkeypatch):
+    """With a single namespace slot, extraction runs sequentially (no ThreadPoolExecutor)."""
+    from pipeline import deploy
+    import concurrent.futures
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    data = {
+        "wl-smoke-baseline":   {"workload": "smoke", "package": "baseline",  "status": "done", "completed_namespace": "ns-0"},
+        "wl-smoke-treatment":  {"workload": "smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
+    }
+    _mock_cm(monkeypatch, data)
+
+    class Args:
+        package = None
+        skip_logs = False
+
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None):
+        return {p: None for p in phases}
+
+    executor_used = []
+    OrigExecutor = concurrent.futures.ThreadPoolExecutor
+
+    class TrackingExecutor(OrigExecutor):
+        def __init__(self, *a, **kw):
+            executor_used.append(True)
+            super().__init__(*a, **kw)
+
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract), \
+         patch("concurrent.futures.ThreadPoolExecutor", TrackingExecutor):
+        deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
+
+    assert len(executor_used) == 0
+
+
+def test_collect_unscoped_parallel_one_slot_fails(tmp_path, monkeypatch, capsys):
+    """When one slot fails in parallel mode, other slots still succeed."""
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    data = {
+        "wl-smoke-baseline":   {"workload": "smoke", "package": "baseline",  "status": "done", "completed_namespace": "ns-0"},
+        "wl-smoke-treatment":  {"workload": "smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
+        "wl-load-baseline":    {"workload": "load",  "package": "baseline",  "status": "done", "completed_namespace": "ns-1"},
+        "wl-load-treatment":   {"workload": "load",  "package": "treatment", "status": "done", "completed_namespace": "ns-1"},
+    }
+    _mock_cm(monkeypatch, data)
+
+    class Args:
+        package = None
+        skip_logs = False
+
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None):
+        if namespace == "ns-1":
+            raise RuntimeError("pod not ready")
+        return {p: None for p in phases}
+
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
+        deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
+
+    out = capsys.readouterr().out
+    assert "baseline/smoke" in out
+    assert "treatment/smoke" in out
+    assert "2/" in out
+
+
+def test_collect_unscoped_parallel_step_header(tmp_path, monkeypatch, capsys):
+    """Step header announces slot count when multiple slots exist."""
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    data = {
+        "wl-smoke-baseline":   {"workload": "smoke", "package": "baseline",  "status": "done", "completed_namespace": "ns-0"},
+        "wl-load-baseline":    {"workload": "load",  "package": "baseline",  "status": "done", "completed_namespace": "ns-1"},
+    }
+    _mock_cm(monkeypatch, data)
+
+    class Args:
+        package = None
+        skip_logs = False
+
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None):
+        return {p: None for p in phases}
+
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
+        deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
+
+    out = capsys.readouterr().out
+    assert "2 slots in parallel" in out


### PR DESCRIPTION
Closes #200

## Summary

- Uses `concurrent.futures.ThreadPoolExecutor` to extract results from all namespace slots in parallel (one thread per slot)
- Falls back to sequential for single-slot case (avoids thread overhead)
- Step header announces slot count: `Collecting Results (3 slots in parallel)`
- Partial failures isolated: if one slot's extractor pod fails, other slots complete normally

## Design choices

**Post-join result processing:** Results from `as_completed()` are processed (OK/FAIL output + list aggregation) on the main thread after each future completes. This avoids needing locks on `collected`/`failed` lists or a print lock. Output order may vary by completion time — this is noted in the issue as acceptable.

**`_process_slot_result` helper:** Extracted the per-slot result handling (shared between parallel and sequential paths) into a nested function to avoid duplicating the OK/FAIL/list-append logic.

**No `_extract_phases_from_pvc` changes:** The function already operates on a single namespace with its own pod name — it's naturally thread-safe (no shared mutable state between calls from different namespaces).

## Reviewer attention

- The interactive size-probe prompt (>1GB warning) inside `_extract_phases_from_pvc` could race in parallel mode. Currently each thread would prompt independently — but in practice this is rare (the prompt only fires for >1GB data). A follow-up could move the size probe before parallel dispatch if needed.
- The scoped path (`--only`/`--workload`) still runs sequentially — it iterates per-workload rather than per-namespace, so parallelizing it is a different shape. Out of scope per the issue.

## Test plan

- [x] `python3 -m pytest pipeline/ -v` — 717 tests pass
- [x] `ruff check pipeline/ --select F` — clean
- [x] New tests verify: ThreadPoolExecutor used for multi-slot, not used for single-slot, partial failure handled, step header includes slot count