### PR TITLE
fix: clear local workload dirs before kubectl cp in deploy collect

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -703,6 +703,9 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
                         continue
                     wl_dest = dest_dir / wl_name
                     wl_dest.mkdir(parents=True, exist_ok=True)
+                    for log_dir in (wl_dest / "server_logs", wl_dest / "epp_logs"):
+                        if log_dir.exists():
+                            shutil.rmtree(log_dir)
                     # Copy trace files
                     for fname in ("trace_data.csv", "trace_header.yaml", "epp_stream_done"):
                         src = f"{namespace}/{pod_name}:/data/{run_name}/{phase}/{wl_name}/{fname}"
@@ -729,6 +732,8 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
                     errors[phase] = None
                 else:
                     wl_dest = dest_dir / workload
+                    if wl_dest.exists():
+                        shutil.rmtree(wl_dest)
                     wl_dest.mkdir(parents=True, exist_ok=True)
                     result = run(
                         ["kubectl", "cp",
@@ -765,6 +770,8 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
                         info(f"[{phase}/{wl_name}] up to date — skipping")
                         continue
                     wl_dest = dest_dir / wl_name
+                    if wl_dest.exists():
+                        shutil.rmtree(wl_dest)
                     wl_dest.mkdir(parents=True, exist_ok=True)
                     result = run(
                         ["kubectl", "cp",

--- a/pipeline/tests/test_deploy_collect.py
+++ b/pipeline/tests/test_deploy_collect.py
@@ -1338,3 +1338,167 @@ def test_collect_unscoped_parallel_all_slots_fail(tmp_path, monkeypatch, capsys)
     out = capsys.readouterr().out
     assert "0/" in out
     assert "Failed:" in out
+
+
+# ── Stale file clearing tests ───────────────────────────────────────────────
+
+
+def test_collect_full_copy_clears_stale_files(tmp_path, monkeypatch):
+    """Full-copy path removes stale local files before kubectl cp."""
+    from pipeline import deploy
+    import subprocess
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    results_dir = run_dir / "results" / "baseline" / "wl-smoke"
+    results_dir.mkdir(parents=True)
+
+    stale_file = results_dir / "server_logs" / "stale.log"
+    stale_file.parent.mkdir(parents=True)
+    stale_file.write_text("stale")
+
+    data = {
+        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
+    }
+    _mock_cm(monkeypatch, data)
+
+    class Args:
+        package = None
+        skip_logs = False
+
+    def mock_run(cmd, **kwargs):
+        mock = MagicMock(returncode=0, stdout="", stderr="")
+        cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
+        if "exec" in cmd_str and "ls" in cmd_str:
+            mock.stdout = "wl-smoke"
+        if "exec" in cmd_str and "stat" in cmd_str:
+            mock.stdout = ""
+        return mock
+
+    monkeypatch.setattr(subprocess, "run", mock_run)
+
+    deploy._extract_phases_from_pvc(
+        ["baseline"], "test-run", "ns-0", run_dir, skip_logs=False)
+
+    assert not stale_file.exists()
+
+
+def test_collect_per_workload_clears_stale_files(tmp_path, monkeypatch):
+    """Per-workload (scoped) path removes stale local files before kubectl cp."""
+    from pipeline import deploy
+    import subprocess
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    results_dir = run_dir / "results" / "baseline" / "wl-smoke"
+    results_dir.mkdir(parents=True)
+
+    stale_file = results_dir / "server_logs" / "stale.log"
+    stale_file.parent.mkdir(parents=True)
+    stale_file.write_text("stale")
+
+    data = {
+        "wl-smoke-baseline": {"workload": "wl-smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
+    }
+    _mock_cm(monkeypatch, data)
+
+    def mock_run(cmd, **kwargs):
+        mock = MagicMock(returncode=0, stdout="", stderr="")
+        cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
+        if "exec" in cmd_str and "stat" in cmd_str:
+            mock.stdout = ""
+        return mock
+
+    monkeypatch.setattr(subprocess, "run", mock_run)
+
+    deploy._extract_phases_from_pvc(
+        ["baseline"], "test-run", "ns-0", run_dir,
+        skip_logs=False, workload="wl-smoke")
+
+    assert not stale_file.exists()
+
+
+def test_collect_skip_logs_clears_stale_log_dirs(tmp_path, monkeypatch):
+    """--skip-logs path removes stale server_logs/ and epp_logs/ before copying."""
+    from pipeline import deploy
+    import subprocess
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    results_dir = run_dir / "results" / "baseline" / "wl-smoke"
+    results_dir.mkdir(parents=True)
+
+    stale_server = results_dir / "server_logs" / "stale.log"
+    stale_server.parent.mkdir(parents=True)
+    stale_server.write_text("stale server log")
+
+    stale_epp = results_dir / "epp_logs" / "stale.log"
+    stale_epp.parent.mkdir(parents=True)
+    stale_epp.write_text("stale epp log")
+
+    data = {
+        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
+    }
+    _mock_cm(monkeypatch, data)
+
+    def mock_run(cmd, **kwargs):
+        mock = MagicMock(returncode=0, stdout="", stderr="")
+        cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
+        if "exec" in cmd_str and "ls" in cmd_str:
+            mock.stdout = "wl-smoke"
+        if "exec" in cmd_str and "stat" in cmd_str:
+            mock.stdout = ""
+        return mock
+
+    monkeypatch.setattr(subprocess, "run", mock_run)
+
+    deploy._extract_phases_from_pvc(
+        ["baseline"], "test-run", "ns-0", run_dir, skip_logs=True)
+
+    assert not stale_server.exists()
+    assert not (results_dir / "server_logs").exists()
+    assert not stale_epp.exists()
+
+
+def test_collect_idempotent_no_stale_accumulation(tmp_path, monkeypatch):
+    """Running collect twice produces same result as once (no accumulation)."""
+    from pipeline import deploy
+    import subprocess
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+
+    data = {
+        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
+    }
+    _mock_cm(monkeypatch, data)
+
+    call_count = [0]
+
+    def mock_run(cmd, **kwargs):
+        mock = MagicMock(returncode=0, stdout="", stderr="")
+        cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
+        if "exec" in cmd_str and "ls" in cmd_str:
+            mock.stdout = "wl-smoke"
+        elif "exec" in cmd_str and "stat" in cmd_str:
+            mock.stdout = ""
+        elif "cp" in cmd_str:
+            call_count[0] += 1
+            dest = run_dir / "results" / "baseline" / "wl-smoke"
+            dest.mkdir(parents=True, exist_ok=True)
+            (dest / "trace_data.csv").write_text(f"data-{call_count[0]}")
+            (dest / "server_logs").mkdir(exist_ok=True)
+            (dest / "server_logs" / f"pod-{call_count[0]}.log").write_text("log")
+        return mock
+
+    monkeypatch.setattr(subprocess, "run", mock_run)
+
+    deploy._extract_phases_from_pvc(
+        ["baseline"], "test-run", "ns-0", run_dir, skip_logs=False)
+
+    deploy._extract_phases_from_pvc(
+        ["baseline"], "test-run", "ns-0", run_dir, skip_logs=False)
+
+    results_dir = run_dir / "results" / "baseline" / "wl-smoke" / "server_logs"
+    log_files = list(results_dir.glob("*.log"))
+    assert len(log_files) == 1


### PR DESCRIPTION
## Summary

- Clear local workload directories before `kubectl cp` in all three collection paths within `_extract_phases_from_pvc`, preventing stale file accumulation from tar-overlay semantics
- Full-copy and per-workload paths: `shutil.rmtree(wl_dest)` before `mkdir`
- `--skip-logs` path: clear `server_logs/` and `epp_logs/` subdirs (trace files are overwritten individually so don't accumulate)

Closes #209

## Reviewer notes

The `_is_up_to_date` skip-logic runs *before* the rmtree — skipped workloads keep their existing state, which is correct since the remote hasn't changed. The rmtree only fires for workloads that failed the freshness check (i.e., remote has newer data).

## Test plan

- [x] `test_collect_full_copy_clears_stale_files` — plants stale file, verifies removed after full-copy collect
- [x] `test_collect_per_workload_clears_stale_files` — same for scoped/per-workload path
- [x] `test_collect_skip_logs_clears_stale_log_dirs` — verifies both `server_logs/` and `epp_logs/` cleared in skip-logs mode
- [x] `test_collect_idempotent_no_stale_accumulation` — simulates two consecutive collects, verifies no file accumulation
- [x] Full test suite: 790 tests pass
- [x] Lint: `ruff check pipeline/ --select F` clean