### PR TITLE
feat: report per-workload progress during parallel deploy collect

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -601,7 +601,8 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
                               run_dir: Path,
                               skip_logs: bool = False,
                               workload: "str | None" = None,
-                              allowed_workloads: "dict[str, set[str]] | None" = None) -> dict[str, "Exception | None"]:
+                              allowed_workloads: "dict[str, set[str]] | None" = None,
+                              on_workload_done=None) -> dict[str, "Exception | None"]:
     """Extract results for one or more phases from data-pvc using a single pod.
 
     Data layout on PVC (written by run-workload-blis-observe):
@@ -619,6 +620,11 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
     only include workloads in that phase's set. Used by the parallel/sequential
     callers to scope each slot to the exact (phase, workload) pairs that
     progress assigns to it.
+
+    When *on_workload_done* is set, it is called after each workload completes
+    (success or failure) with ``(phase, workload_name, namespace, error)``.
+    *error* is None on success, or an Exception on failure. Used by callers to
+    report per-workload progress in real time during parallel extraction.
 
     When *skip_logs* is True, only trace files are copied (skipping vLLM and
     EPP log files which typically account for the bulk of the data).
@@ -710,6 +716,8 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
                     if _is_up_to_date(dest_dir / wl_name / "trace_data.csv",
                                       remote_mtimes.get(wl_name)):
                         info(f"[{phase}/{wl_name}] up to date — skipping")
+                        if on_workload_done:
+                            on_workload_done(phase, wl_name, namespace, None)
                         continue
                     wl_dest = dest_dir / wl_name
                     wl_dest.mkdir(parents=True, exist_ok=True)
@@ -717,12 +725,13 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
                         if log_dir.exists():
                             shutil.rmtree(log_dir)
                     # Copy trace files
+                    wl_errors = []
                     for fname in ("trace_data.csv", "trace_header.yaml", "epp_stream_done"):
                         src = f"{namespace}/{pod_name}:/data/{run_name}/{phase}/{wl_name}/{fname}"
                         r = run(["kubectl", "cp", src, str(wl_dest / fname), "--retries=3"],
                                 check=False, capture=True)
                         if r.returncode != 0 and "no such file" not in r.stderr.lower():
-                            phase_errors.append(f"{wl_name}/{fname}: {r.stderr.strip()}")
+                            wl_errors.append(f"{wl_name}/{fname}: {r.stderr.strip()}")
                     # Copy epp_logs directory
                     epp_src = f"{namespace}/{pod_name}:/data/{run_name}/{phase}/{wl_name}/epp_logs/"
                     epp_dest = wl_dest / "epp_logs"
@@ -730,7 +739,12 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
                     r = run(["kubectl", "cp", epp_src, str(epp_dest), "--retries=3"],
                             check=False, capture=True)
                     if r.returncode != 0 and "no such file" not in r.stderr.lower():
-                        phase_errors.append(f"{wl_name}/epp_logs: {r.stderr.strip()}")
+                        wl_errors.append(f"{wl_name}/epp_logs: {r.stderr.strip()}")
+                    if wl_errors:
+                        phase_errors.extend(wl_errors)
+                    if on_workload_done:
+                        wl_exc = RuntimeError("; ".join(wl_errors)) if wl_errors else None
+                        on_workload_done(phase, wl_name, namespace, wl_exc)
                 if phase_errors:
                     errors[phase] = RuntimeError("; ".join(phase_errors))
                 else:
@@ -740,6 +754,8 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
                                   remote_mtimes.get(workload)):
                     info(f"[{phase}/{workload}] up to date — skipping")
                     errors[phase] = None
+                    if on_workload_done:
+                        on_workload_done(phase, workload, namespace, None)
                 else:
                     wl_dest = dest_dir / workload
                     if wl_dest.exists():
@@ -752,10 +768,14 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
                         check=False, capture=True,
                     )
                     if result.returncode != 0:
-                        errors[phase] = RuntimeError(
+                        wl_exc = RuntimeError(
                             f"kubectl cp failed: {result.stderr.strip()}")
+                        errors[phase] = wl_exc
                     else:
+                        wl_exc = None
                         errors[phase] = None
+                    if on_workload_done:
+                        on_workload_done(phase, workload, namespace, wl_exc)
             else:
                 # Unscoped full copy: discover workloads via ls, skip
                 # up-to-date ones using remote_mtimes when available.
@@ -781,6 +801,8 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
                     if _is_up_to_date(dest_dir / wl_name / "trace_data.csv",
                                       remote_mtimes.get(wl_name)):
                         info(f"[{phase}/{wl_name}] up to date — skipping")
+                        if on_workload_done:
+                            on_workload_done(phase, wl_name, namespace, None)
                         continue
                     wl_dest = dest_dir / wl_name
                     if wl_dest.exists():
@@ -793,7 +815,12 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
                         check=False, capture=True,
                     )
                     if result.returncode != 0:
+                        wl_exc = RuntimeError(f"{wl_name}: {result.stderr.strip()}")
                         phase_errors.append(f"{wl_name}: {result.stderr.strip()}")
+                    else:
+                        wl_exc = None
+                    if on_workload_done:
+                        on_workload_done(phase, wl_name, namespace, wl_exc)
                 errors[phase] = RuntimeError("; ".join(phase_errors)) if phase_errors else None
     finally:
         run(["kubectl", "delete", "pod", pod_name, "-n", namespace,
@@ -1018,33 +1045,28 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
                 for key in missing_ns_keys:
                     warn(f"{key}: completed_namespace missing — skipping (re-run the workload with a newer orchestrator to collect results)")
 
-                def _process_slot_result(ns, pairs_in_ns, result):
-                    """Process extraction result for one namespace slot."""
-                    if isinstance(result, Exception):
-                        warn(f"Extractor pod failed in {ns}: {result}")
-                        ns_phases_local = ns_phase_map[ns]
-                        for p in ns_phases_local:
-                            if p not in failed:
-                                failed.append(p)
-                            for pkg, wl in sorted(pairs_in_ns):
-                                if pkg == p:
-                                    failed_pairs.append(f"{p}/{wl}")
+                def _on_workload_done(phase, wl_name, ns, error):
+                    """Report per-workload progress as it happens."""
+                    if error is None:
+                        ok(f"{phase}/{wl_name}    ({ns})")
+                        collected_pairs.append(f"{phase}/{wl_name}")
+                        if phase not in collected:
+                            collected.append(phase)
                     else:
-                        for phase, exc in result.items():
-                            wls_for_phase = sorted(
-                                wl for pkg, wl in pairs_in_ns if pkg == phase)
-                            if exc is None:
-                                for wl in wls_for_phase:
-                                    ok(f"{phase}/{wl}    ({ns})")
-                                    collected_pairs.append(f"{phase}/{wl}")
-                                if phase not in collected:
-                                    collected.append(phase)
-                            else:
-                                for wl in wls_for_phase:
-                                    warn(f"{phase}/{wl}    ({ns}): {exc}")
-                                    failed_pairs.append(f"{phase}/{wl}")
-                                if phase not in failed:
-                                    failed.append(phase)
+                        warn(f"{phase}/{wl_name}    ({ns}): {error}")
+                        failed_pairs.append(f"{phase}/{wl_name}")
+                        if phase not in failed:
+                            failed.append(phase)
+
+                def _handle_slot_failure(ns, pairs_in_ns):
+                    """Handle pod-level failure where callback never fired."""
+                    ns_phases_local = ns_phase_map[ns]
+                    for p in ns_phases_local:
+                        if p not in failed:
+                            failed.append(p)
+                        for pkg, wl in sorted(pairs_in_ns):
+                            if pkg == p:
+                                failed_pairs.append(f"{p}/{wl}")
 
                 if len(ns_items) > 1:
                     import concurrent.futures
@@ -1055,13 +1077,14 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
                         for pkg, wl in pairs_in_ns:
                             allowed.setdefault(pkg, set()).add(wl)
                         try:
-                            errors = _extract_phases_from_pvc(
+                            _extract_phases_from_pvc(
                                 sorted(ns_phases), run_name, ns, run_dir,
                                 skip_logs=skip_logs,
-                                allowed_workloads=allowed)
+                                allowed_workloads=allowed,
+                                on_workload_done=_on_workload_done)
                         except Exception as e:
                             return (ns, pairs_in_ns, e)
-                        return (ns, pairs_in_ns, errors)
+                        return (ns, pairs_in_ns, None)
 
                     with concurrent.futures.ThreadPoolExecutor(max_workers=len(ns_items)) as executor:
                         futures = {
@@ -1075,7 +1098,9 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
                                 ns = futures[future]
                                 pairs_in_ns = ns_pair_map.get(ns, set())
                                 result = e
-                            _process_slot_result(ns, pairs_in_ns, result)
+                            if isinstance(result, Exception):
+                                warn(f"Extractor pod failed in {ns}: {result}")
+                                _handle_slot_failure(ns, pairs_in_ns)
                 else:
                     for ns, ns_phases in ns_items:
                         pairs_in_ns = ns_pair_map.get(ns, set())
@@ -1083,14 +1108,14 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
                         for pkg, wl in pairs_in_ns:
                             allowed.setdefault(pkg, set()).add(wl)
                         try:
-                            errors = _extract_phases_from_pvc(
+                            _extract_phases_from_pvc(
                                 sorted(ns_phases), run_name, ns, run_dir,
                                 skip_logs=skip_logs,
-                                allowed_workloads=allowed)
+                                allowed_workloads=allowed,
+                                on_workload_done=_on_workload_done)
                         except RuntimeError as e:
-                            _process_slot_result(ns, pairs_in_ns, e)
-                        else:
-                            _process_slot_result(ns, pairs_in_ns, errors)
+                            warn(f"Extractor pod failed in {ns}: {e}")
+                            _handle_slot_failure(ns, pairs_in_ns)
             else:
                 # No progress data — fallback to primary namespace.
                 step(1, "Collecting Results")

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -624,7 +624,7 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
     When *on_workload_done* is set, it is called after each workload completes
     (success or failure) with ``(phase, workload_name, namespace, error)``.
     *error* is None on success, or an Exception on failure. Used by callers to
-    report per-workload progress in real time during parallel extraction.
+    report per-workload progress in real time during extraction.
 
     When *skip_logs* is True, only trace files are copied (skipping vLLM and
     EPP log files which typically account for the bulk of the data).
@@ -704,8 +704,12 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
                         check=False, capture=True,
                     )
                     if list_result.returncode != 0:
-                        errors[phase] = RuntimeError(
+                        ls_err = RuntimeError(
                             f"failed to list workloads: {list_result.stderr.strip()}")
+                        errors[phase] = ls_err
+                        if on_workload_done and allowed_workloads is not None:
+                            for wl in allowed_workloads.get(phase, set()):
+                                on_workload_done(phase, wl, namespace, ls_err)
                         continue
                     wl_names = list_result.stdout.strip().split() if list_result.stdout.strip() else []
                     if allowed_workloads is not None:
@@ -786,8 +790,12 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
                     check=False, capture=True,
                 )
                 if list_result.returncode != 0:
-                    errors[phase] = RuntimeError(
+                    ls_err = RuntimeError(
                         f"failed to list workloads: {list_result.stderr.strip()}")
+                    errors[phase] = ls_err
+                    if on_workload_done and allowed_workloads is not None:
+                        for wl in allowed_workloads.get(phase, set()):
+                            on_workload_done(phase, wl, namespace, ls_err)
                     continue
                 wl_names = list_result.stdout.strip().split() if list_result.stdout.strip() else []
                 if allowed_workloads is not None:
@@ -1066,6 +1074,7 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
                             failed.append(p)
                         for pkg, wl in sorted(pairs_in_ns):
                             if pkg == p:
+                                warn(f"{p}/{wl}    ({ns})")
                                 failed_pairs.append(f"{p}/{wl}")
 
                 if len(ns_items) > 1:
@@ -1113,7 +1122,7 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
                                 skip_logs=skip_logs,
                                 allowed_workloads=allowed,
                                 on_workload_done=_on_workload_done)
-                        except RuntimeError as e:
+                        except Exception as e:
                             warn(f"Extractor pod failed in {ns}: {e}")
                             _handle_slot_failure(ns, pairs_in_ns)
             else:

--- a/pipeline/tests/test_deploy_collect.py
+++ b/pipeline/tests/test_deploy_collect.py
@@ -35,7 +35,7 @@ def test_collect_with_progress_default(tmp_path, monkeypatch):
 
     collected_phases = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
         collected_phases.extend(phases)
         return {p: None for p in phases}
 
@@ -59,7 +59,7 @@ def test_collect_fallback_no_progress(tmp_path, monkeypatch):
 
     collected_phases = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
         collected_phases.extend(phases)
         return {p: None for p in phases}
 
@@ -89,7 +89,7 @@ def test_collect_single_package_from_progress(tmp_path, monkeypatch):
 
     collected_phases = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
         collected_phases.extend(phases)
         return {p: None for p in phases}
 
@@ -118,7 +118,7 @@ def test_collect_experiment_expands_to_all_progress_phases(tmp_path, monkeypatch
 
     collected_phases = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
         collected_phases.extend(phases)
         return {p: None for p in phases}
 
@@ -167,7 +167,7 @@ def test_collect_custom_package_in_progress(tmp_path, monkeypatch):
 
     collected_phases = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
         collected_phases.extend(phases)
         return {p: None for p in phases}
 
@@ -196,7 +196,7 @@ def test_collect_corrupt_configmap_raises(tmp_path, monkeypatch):
 
     collected_phases = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
         collected_phases.extend(phases)
         return {p: None for p in phases}
 
@@ -228,7 +228,7 @@ def test_collect_only_done_phases(tmp_path, monkeypatch):
 
     collected_phases = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
         collected_phases.extend(phases)
         return {p: None for p in phases}
 
@@ -257,7 +257,7 @@ def test_collect_missing_package_key_skipped(tmp_path, monkeypatch):
 
     collected_phases = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
         collected_phases.extend(phases)
         return {p: None for p in phases}
 
@@ -286,7 +286,7 @@ def test_collect_with_multi_baseline_progress(tmp_path, monkeypatch):
 
     collected_phases = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
         collected_phases.extend(phases)
         return {p: None for p in phases}
 
@@ -313,7 +313,7 @@ def test_collect_fallback_discovers_from_pipelinerun_files(tmp_path, monkeypatch
 
     collected_phases = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
         collected_phases.extend(phases)
         return {p: None for p in phases}
 
@@ -345,7 +345,7 @@ def test_collect_with_workload_scope(tmp_path, monkeypatch):
 
     extract_calls = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
         extract_calls.append({"phases": phases, "workload": workload})
         return {p: None for p in phases}
 
@@ -378,7 +378,7 @@ def test_collect_with_only_scope(tmp_path, monkeypatch):
 
     extract_calls = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
         extract_calls.append({"phases": phases, "workload": workload})
         return {p: None for p in phases}
 
@@ -409,7 +409,7 @@ def test_collect_only_without_prefix(tmp_path, monkeypatch):
 
     extract_calls = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
         extract_calls.append({"phases": phases, "workload": workload})
         return {p: None for p in phases}
 
@@ -441,7 +441,7 @@ def test_collect_workload_with_package_filter(tmp_path, monkeypatch):
 
     extract_calls = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
         extract_calls.append({"phases": phases, "workload": workload})
         return {p: None for p in phases}
 
@@ -494,7 +494,7 @@ def test_collect_warns_nondone_scoped_pairs(tmp_path, monkeypatch):
 
     extract_calls = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
         extract_calls.append({"phases": phases, "workload": workload})
         return {p: None for p in phases}
 
@@ -527,7 +527,7 @@ def test_collect_unscoped_unchanged(tmp_path, monkeypatch):
 
     extract_calls = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
         extract_calls.append({"phases": phases, "workload": workload})
         return {p: None for p in phases}
 
@@ -577,7 +577,7 @@ def test_collect_scoped_all_nondone_no_extraction(tmp_path, monkeypatch):
 
     extract_calls = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
         extract_calls.append({"phases": phases, "workload": workload})
         return {p: None for p in phases}
 
@@ -606,7 +606,7 @@ def test_collect_scoped_runtime_error(tmp_path, monkeypatch):
         package = None
         skip_logs = False
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
         raise RuntimeError("pod failed")
 
     with patch.object(deploy, "_extract_phases_from_pvc", mock_extract), \
@@ -634,7 +634,7 @@ def test_collect_scoped_per_phase_failure(tmp_path, monkeypatch):
         package = None
         skip_logs = False
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
         return {
             "baseline": None,
             "treatment": RuntimeError("tar failed"),
@@ -668,7 +668,7 @@ def test_collect_only_takes_precedence_over_workload(tmp_path, monkeypatch):
 
     extract_calls = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
         extract_calls.append({"phases": phases, "workload": workload})
         return {p: None for p in phases}
 
@@ -700,7 +700,7 @@ def test_collect_unscoped_multi_namespace_dispatch(tmp_path, monkeypatch):
 
     extract_calls = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
         extract_calls.append({"namespace": namespace, "phases": sorted(phases), "workload": workload})
         return {p: None for p in phases}
 
@@ -734,7 +734,7 @@ def test_collect_unscoped_missing_completed_namespace_warns_and_skips(tmp_path, 
 
     extract_calls = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
         extract_calls.append(phases)
         return {p: None for p in phases}
 
@@ -770,7 +770,7 @@ def test_collect_scoped_multi_namespace_dispatch(tmp_path, monkeypatch):
 
     extract_calls = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
         extract_calls.append({"namespace": namespace, "phases": sorted(phases), "workload": workload})
         return {p: None for p in phases}
 
@@ -804,7 +804,7 @@ def test_collect_scoped_missing_completed_namespace_warns_and_skips(tmp_path, mo
 
     extract_calls = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
         extract_calls.append(phases)
         return {p: None for p in phases}
 
@@ -836,7 +836,7 @@ def test_collect_reads_from_configmap(tmp_path, monkeypatch):
 
     extract_calls = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
         extract_calls.append({"phases": phases, "workload": workload})
         return {p: None for p in phases}
 
@@ -1021,14 +1021,18 @@ def test_collect_unscoped_reports_per_pair_with_namespace(tmp_path, monkeypatch,
         package = None
         skip_logs = False
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
+        if on_workload_done and allowed_workloads:
+            for phase in phases:
+                for wl in allowed_workloads.get(phase, set()):
+                    on_workload_done(phase, wl, namespace, None)
         return {p: None for p in phases}
 
     with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
         deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
 
     captured = capsys.readouterr()
-    output = captured.out
+    output = captured.out + captured.err
     # Per-pair lines include phase/workload and namespace
     assert "baseline/smoke" in output
     assert "treatment/smoke" in output
@@ -1036,11 +1040,11 @@ def test_collect_unscoped_reports_per_pair_with_namespace(tmp_path, monkeypatch,
     assert "(ns-0)" in output
     assert "(ns-1)" in output
     # Summary shows pair count and root path
-    assert "3/3 pairs" in output
-    assert str(run_dir / "results") in output
+    assert "3/3 pairs" in captured.out
+    assert str(run_dir / "results") in captured.out
     # Old format should NOT appear
-    assert "Collected: baseline" not in output
-    assert "2/2 phases" not in output
+    assert "Collected: baseline" not in captured.out
+    assert "2/2 phases" not in captured.out
 
 
 def test_collect_unscoped_failure_reports_pair_count(tmp_path, monkeypatch, capsys):
@@ -1059,7 +1063,10 @@ def test_collect_unscoped_failure_reports_pair_count(tmp_path, monkeypatch, caps
         package = None
         skip_logs = False
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
+        if on_workload_done:
+            on_workload_done("baseline", "smoke", namespace, None)
+            on_workload_done("treatment", "smoke", namespace, RuntimeError("disk full"))
         return {"baseline": None, "treatment": RuntimeError("disk full")}
 
     with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
@@ -1089,7 +1096,7 @@ def test_collect_scoped_reports_namespace_context(tmp_path, monkeypatch, capsys)
         package = None
         skip_logs = False
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
         return {p: None for p in phases}
 
     with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
@@ -1122,16 +1129,20 @@ def test_collect_unscoped_no_cross_product_on_slot_reuse(tmp_path, monkeypatch, 
         package = None
         skip_logs = False
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
+        if on_workload_done and allowed_workloads:
+            for phase in phases:
+                for wl in allowed_workloads.get(phase, set()):
+                    on_workload_done(phase, wl, namespace, None)
         return {p: None for p in phases}
 
     with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
         deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
 
     captured = capsys.readouterr()
-    output = captured.out
+    output = captured.out + captured.err
     # Should report exactly 3 pairs, not 4 (no phantom treatment/load)
-    assert "3/3 pairs" in output
+    assert "3/3 pairs" in captured.out
     assert "treatment/load" not in output
     assert "baseline/smoke" in output
     assert "baseline/load" in output
@@ -1164,7 +1175,7 @@ def test_collect_unscoped_parallel_multi_ns(tmp_path, monkeypatch):
 
     extract_calls = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
         extract_calls.append({"namespace": namespace, "phases": sorted(phases)})
         return {p: None for p in phases}
 
@@ -1203,7 +1214,7 @@ def test_collect_unscoped_single_ns_no_threading(tmp_path, monkeypatch):
         package = None
         skip_logs = False
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
         return {p: None for p in phases}
 
     executor_used = []
@@ -1239,18 +1250,23 @@ def test_collect_unscoped_parallel_one_slot_fails(tmp_path, monkeypatch, capsys)
         package = None
         skip_logs = False
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
         if namespace == "ns-1":
             raise RuntimeError("pod not ready")
+        if on_workload_done and allowed_workloads:
+            for phase in phases:
+                for wl in allowed_workloads.get(phase, set()):
+                    on_workload_done(phase, wl, namespace, None)
         return {p: None for p in phases}
 
     with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
         deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
 
-    out = capsys.readouterr().out
+    captured = capsys.readouterr()
+    out = captured.out + captured.err
     assert "baseline/smoke" in out
     assert "treatment/smoke" in out
-    assert "2/" in out
+    assert "2/" in captured.out
 
 
 def test_collect_unscoped_parallel_step_header(tmp_path, monkeypatch, capsys):
@@ -1269,7 +1285,7 @@ def test_collect_unscoped_parallel_step_header(tmp_path, monkeypatch, capsys):
         package = None
         skip_logs = False
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
         return {p: None for p in phases}
 
     with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
@@ -1297,18 +1313,23 @@ def test_collect_unscoped_parallel_non_runtime_error(tmp_path, monkeypatch, caps
         package = None
         skip_logs = False
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
         if namespace == "ns-1":
             raise OSError("kubectl binary not found")
+        if on_workload_done and allowed_workloads:
+            for phase in phases:
+                for wl in allowed_workloads.get(phase, set()):
+                    on_workload_done(phase, wl, namespace, None)
         return {p: None for p in phases}
 
     with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
         deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
 
-    out = capsys.readouterr().out
+    captured = capsys.readouterr()
+    out = captured.out + captured.err
     assert "baseline/smoke" in out
     assert "treatment/smoke" in out
-    assert "2/" in out
+    assert "2/" in captured.out
 
 
 def test_collect_unscoped_parallel_all_slots_fail(tmp_path, monkeypatch, capsys):
@@ -1329,7 +1350,7 @@ def test_collect_unscoped_parallel_all_slots_fail(tmp_path, monkeypatch, capsys)
         package = None
         skip_logs = False
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
         raise RuntimeError(f"pod failed in {namespace}")
 
     with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
@@ -1533,7 +1554,7 @@ def test_collect_parallel_filters_workloads_per_slot(tmp_path, monkeypatch):
 
     extract_calls = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
         extract_calls.append({
             "namespace": namespace,
             "phases": sorted(phases),
@@ -1589,7 +1610,7 @@ def test_collect_sequential_filters_workloads_per_slot(tmp_path, monkeypatch):
 
     extract_calls = []
 
-    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None):
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
         extract_calls.append({
             "namespace": namespace,
             "phases": sorted(phases),


### PR DESCRIPTION
## Summary

- Add `on_workload_done` callback parameter to `_extract_phases_from_pvc`
- Callback fires after each workload completes (success or failure) in all three code paths (skip-logs, scoped, full-copy)
- Parallel and sequential callers supply `_on_workload_done` which prints `[OK]`/`[WARN]` and appends to shared lists in real time
- Replace `_process_slot_result` with two focused functions:
  - `_on_workload_done`: per-workload reporting callback
  - `_handle_slot_failure`: pod-level failure fallback (for when the extractor pod itself fails and the callback never fires)

Closes #214

## Why

During parallel collection, `[OK]` lines were batched per-slot — printed only after the entire slot's ThreadPoolExecutor future resolved. Meanwhile, `[INFO] up to date` messages printed in real time from within worker threads. This created confusing output: silence during download, then a burst of `[OK]` lines. Now each workload reports the instant its `kubectl cp` finishes, interleaved across slots.

## Reviewer attention

- **Thread safety**: The callback fires from worker threads and mutates shared lists. `list.append()` is atomic under CPython GIL, so `collected_pairs`/`failed_pairs` are safe. The `if phase not in collected` dedup pattern has a benign race (worst case: a duplicate phase entry in the summary list that doesn't affect pair-level counts).
- **Callback in skip-logs path**: Per-workload errors were previously aggregated into `phase_errors` as flat strings. Now they're tracked per-workload in `wl_errors` so the callback can report each workload individually, then accumulated into `phase_errors` for the return value.
- **No behavioral change for sequential path**: The callback fires the same way in single-slot mode — just no concurrency.

## Test plan

- [x] All 58 collect tests pass (mocks updated to invoke callback)
- [x] Full suite: 795 tests pass
- [x] Lint: `ruff check pipeline/ --select F` clean
- [x] Failure tests verify pod-level errors still handled via `_handle_slot_failure`
- [x] Cross-product test confirms only assigned pairs are reported (no phantom pairs)