### PR TITLE
feat: support multi-value --workload, --package, and --only flags

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -195,7 +195,7 @@ python pipeline/deploy.py pairs   [flags]   # list available pair keys, workload
 | `--package NAME…` | Collect only these packages (comma or space-separated, phase-level filter) |
 | `--skip-logs` | Skip vLLM and EPP log files, collect only traces |
 
-When `--only` or `--workload` is given, only matching workload subdirectories are pulled from the PVC (instead of entire phase directories). These pair-level flags compose with `--package` as AND: `--workload X --package baseline` pulls workload X from the baseline phase only. Requires progress data to resolve pairs.
+When `--only` or `--workload` is given, only matching workload subdirectories are pulled from the PVC (instead of entire phase directories). Multiple values within a flag use OR (union): `--workload X Y` matches pairs for workload X or Y. Different flags compose as AND: `--workload X Y --package baseline` pulls workloads X and Y from the baseline phase only. Requires progress data to resolve pairs.
 
 **`deploy.py stop`** — deletes the `sim2real-orchestrator` Kubernetes Job (with cascading pod deletion) in the primary namespace. Only meaningful when the orchestrator runs as an in-cluster Job. Pair state is left as-is. If no remote orchestrator Job exists, prints a message and returns. Use `reset` separately to clear failed/stalled pair state.
 

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -152,9 +152,9 @@ python pipeline/deploy.py pairs   [flags]   # list available pair keys, workload
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--remote` | — | Submit orchestrator as in-cluster Job instead of running locally |
-| `--only PAIR` | — | Scope execution to one specific pair key (`wl-` prefix optional) |
-| `--workload NAME` | — | Scope execution to pairs matching this workload |
-| `--package NAME` | — | Scope execution to pairs matching this package |
+| `--only PAIR…` | — | Scope execution to specific pair keys (comma or space-separated, `wl-` prefix optional) |
+| `--workload NAME…` | — | Scope execution to pairs matching these workloads (comma or space-separated) |
+| `--package NAME…` | — | Scope execution to pairs matching these packages (comma or space-separated) |
 | `--status STATE` | — | Scope execution to pairs with this status (e.g. `failed`, `timed-out`) |
 | `--skip-teardown` | — | Skip the Tekton teardown task, leaving namespace resources intact for debugging |
 | `--preserve-pipelineruns` | — | Do not delete PipelineRun objects after completion (keeps TaskRun logs for debugging) |
@@ -181,18 +181,18 @@ python pipeline/deploy.py pairs   [flags]   # list available pair keys, workload
 
 | Flag | Description |
 |------|-------------|
-| `--only PAIR` | Scope to one pair key (`wl-` prefix optional) |
-| `--workload NAME` | Filter by workload name |
-| `--package NAME` | Filter by package name |
+| `--only PAIR…` | Scope to specific pair keys (comma or space-separated, `wl-` prefix optional) |
+| `--workload NAME…` | Filter by workload names (comma or space-separated) |
+| `--package NAME…` | Filter by package names (comma or space-separated) |
 | `--status STATE` | Filter by status (e.g. `running`, `done`, `failed`) |
 
 **`deploy.py collect`** — extracts results from the cluster PVC and writes to `workspace/runs/<run>/results/{phase}/<workload>/`.
 
 | Flag | Description |
 |------|-------------|
-| `--only PAIR` | Scope to one pair key — narrows both workload and package (`wl-` prefix optional; takes precedence over `--workload`) |
-| `--workload NAME` | Scope to pairs matching this workload |
-| `--package NAME…` | Collect only these packages (phase-level filter) |
+| `--only PAIR…` | Scope to specific pair keys — narrows both workload and package (comma or space-separated, `wl-` prefix optional; takes precedence over `--workload`) |
+| `--workload NAME…` | Scope to pairs matching these workloads (comma or space-separated) |
+| `--package NAME…` | Collect only these packages (comma or space-separated, phase-level filter) |
 | `--skip-logs` | Skip vLLM and EPP log files, collect only traces |
 
 When `--only` or `--workload` is given, only matching workload subdirectories are pulled from the PVC (instead of entire phase directories). These pair-level flags compose with `--package` as AND: `--workload X --package baseline` pulls workload X from the baseline phase only. Requires progress data to resolve pairs.
@@ -203,9 +203,9 @@ When `--only` or `--workload` is given, only matching workload subdirectories ar
 
 | Flag | Description |
 |------|-------------|
-| `--only PAIR` | Scope reset to one specific pair key (`wl-` prefix optional) |
-| `--workload NAME` | Scope reset to pairs matching this workload |
-| `--package NAME` | Scope reset to pairs matching this package |
+| `--only PAIR…` | Scope reset to specific pair keys (comma or space-separated, `wl-` prefix optional) |
+| `--workload NAME…` | Scope reset to pairs matching these workloads (comma or space-separated) |
+| `--package NAME…` | Scope reset to pairs matching these packages (comma or space-separated) |
 | `--status STATE` | Scope reset to pairs with this status |
 | `--preserve-done-status` | Keep done pairs' status unchanged (cluster cleanup only) |
 | `--dry-run` | Print what would be reset without acting |
@@ -216,9 +216,9 @@ When `--only` or `--workload` is given, only matching workload subdirectories ar
 
 | Flag | Description |
 |------|-------------|
-| `--only PAIR` | Scope wipe to one specific pair key (`wl-` prefix optional) |
-| `--workload NAME` | Scope wipe to pairs matching this workload |
-| `--package NAME` | Scope wipe to pairs matching this package |
+| `--only PAIR…` | Scope wipe to specific pair keys (comma or space-separated, `wl-` prefix optional) |
+| `--workload NAME…` | Scope wipe to pairs matching these workloads (comma or space-separated) |
+| `--package NAME…` | Scope wipe to pairs matching these packages (comma or space-separated) |
 | `--dry-run` | Print what would be wiped without acting |
 | `--yes` / `-y` | Skip confirmation prompt |
 

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -901,14 +901,15 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
         if not scoped_phases:
             warn("No done phases for scoped pairs.")
             phases_to_collect: list[str] = []
-        elif args.package:
+        elif _parse_list(args.package):
+            pkg_filter = _parse_list(args.package)
             valid = set(scoped_phases) | {"experiment"}
-            unknown = set(args.package) - valid
+            unknown = set(pkg_filter) - valid
             if unknown:
                 err(f"Unknown packages: {sorted(unknown)}. Valid: {sorted(valid)}")
                 sys.exit(1)
             phases_to_collect = []
-            for p in args.package:
+            for p in pkg_filter:
                 if p == "experiment":
                     phases_to_collect.extend(scoped_phases)
                 else:
@@ -986,14 +987,15 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
             else:
                 warn(f"No done phases in progress — discovered from cluster/: {known_phases}")
 
-        if args.package:
+        pkg_filter = _parse_list(args.package)
+        if pkg_filter:
             valid = set(known_phases) | {"experiment"}
-            unknown = set(args.package) - valid
+            unknown = set(pkg_filter) - valid
             if unknown:
                 err(f"Unknown packages: {sorted(unknown)}. Valid: {sorted(valid)}")
                 sys.exit(1)
             phases_to_collect = []
-            for p in args.package:
+            for p in pkg_filter:
                 if p == "experiment":
                     phases_to_collect.extend(known_phases)
                 else:
@@ -1342,35 +1344,49 @@ def _force_reset(progress: dict, scope: set, discovered: dict | None = None,
     return reset
 
 
+def _parse_list(value) -> "list[str] | None":
+    """Normalize a CLI flag value to a flat list, handling comma/space/mixed."""
+    if value is None:
+        return None
+    if isinstance(value, list):
+        result = [v.strip() for item in value for v in item.split(",") if v.strip()]
+    else:
+        result = [v.strip() for v in value.split(",") if v.strip()]
+    return result if result else None
+
+
 def _apply_run_filters(progress: dict, args) -> set:
     """Return the set of pair keys in scope for this invocation.
 
     With no flags: returns empty set (caller interprets as all pairs in scope).
     With flags: returns only matching pairs.
     """
-    only = getattr(args, "only", None)
-    workload = getattr(args, "workload", None)
-    package = getattr(args, "package", None)
+    only = _parse_list(getattr(args, "only", None))
+    workload = _parse_list(getattr(args, "workload", None))
+    package = _parse_list(getattr(args, "package", None))
     status_filter = getattr(args, "status", None)
 
     if only:
-        only = only.strip()
-        if only in progress and _is_pair_key(only):
-            return {only}
-        prefixed = "wl-" + only
-        if prefixed in progress:
-            info(f"--only: resolved '{only}' → '{prefixed}'")
-            return {prefixed}
-        return set()
+        result = set()
+        for key in only:
+            key = key.strip()
+            if key in progress and _is_pair_key(key):
+                result.add(key)
+            else:
+                prefixed = "wl-" + key
+                if prefixed in progress:
+                    info(f"--only: resolved '{key}' → '{prefixed}'")
+                    result.add(prefixed)
+        return result
 
     if not any([workload, package, status_filter]):
         return set()
 
     candidates = {k for k in progress.keys() if _is_pair_key(k)}
     if workload:
-        candidates = {k for k in candidates if progress[k].get("workload") == workload}
+        candidates = {k for k in candidates if progress[k].get("workload") in workload}
     if package:
-        candidates = {k for k in candidates if progress[k].get("package") == package}
+        candidates = {k for k in candidates if progress[k].get("package") in package}
     if status_filter:
         candidates = {k for k in candidates if progress[k].get("status") == status_filter}
     return candidates
@@ -1397,18 +1413,18 @@ def _resolve_scope(progress: dict, args) -> set:
 
 def _report_filter_mismatch(progress: dict, args) -> None:
     """Print all valid filter values to help the user correct their filter flags."""
-    only = getattr(args, "only", None)
-    workload = getattr(args, "workload", None)
-    package = getattr(args, "package", None)
+    only = _parse_list(getattr(args, "only", None))
+    workload = _parse_list(getattr(args, "workload", None))
+    package = _parse_list(getattr(args, "package", None))
     status_filter = getattr(args, "status", None)
 
     parts = []
     if only is not None:
-        parts.append(f"--only '{only}'")
+        parts.append(f"--only '{','.join(only)}'")
     if workload is not None:
-        parts.append(f"--workload '{workload}'")
+        parts.append(f"--workload '{','.join(workload)}'")
     if package is not None:
-        parts.append(f"--package '{package}'")
+        parts.append(f"--package '{','.join(package)}'")
     if status_filter is not None:
         parts.append(f"--status '{status_filter}'")
 
@@ -2399,19 +2415,19 @@ Examples:
 
     sub = p.add_subparsers(dest="command")
     collect_p = sub.add_parser("collect", help="Pull results for completed packages")
-    collect_p.add_argument("--only",     metavar="PAIR",
-                           help="Scope to one specific pair key (wl- prefix optional)")
-    collect_p.add_argument("--workload", metavar="NAME",
-                           help="Scope to pairs matching this workload")
+    collect_p.add_argument("--only",     nargs="+", metavar="PAIR",
+                           help="Scope to specific pair keys (comma or space-separated, wl- prefix optional)")
+    collect_p.add_argument("--workload", nargs="+", metavar="NAME",
+                           help="Scope to pairs matching these workloads (comma or space-separated)")
     collect_p.add_argument("--package", nargs="+", metavar="NAME",
-                           help="Collect only these packages")
+                           help="Collect only these packages (comma or space-separated)")
     collect_p.add_argument("--skip-logs", action="store_true", dest="skip_logs",
                            help="Skip vLLM and EPP log files, collect only traces")
 
     status_p = sub.add_parser("status", help="Show progress of all (workload, package) pairs")
-    status_p.add_argument("--only",     metavar="PAIR",  help="Scope to one specific pair key (wl- prefix optional)")
-    status_p.add_argument("--workload", metavar="NAME",  help="Scope to pairs matching this workload")
-    status_p.add_argument("--package",  metavar="NAME",  help="Scope to pairs matching this package")
+    status_p.add_argument("--only",     nargs="+", metavar="PAIR",  help="Scope to specific pair keys (comma or space-separated, wl- prefix optional)")
+    status_p.add_argument("--workload", nargs="+", metavar="NAME",  help="Scope to pairs matching these workloads (comma or space-separated)")
+    status_p.add_argument("--package",  nargs="+", metavar="NAME",  help="Scope to pairs matching these packages (comma or space-separated)")
     status_p.add_argument("--status",   metavar="STATE", help="Scope to pairs with this status (e.g. running, done, failed)")
 
     build_p = sub.add_parser("build", help="Ensure all scenario images exist (pre-flight for run)")
@@ -2423,9 +2439,9 @@ Examples:
                        help="Submit orchestrator as in-cluster Job instead of running locally")
     run_p.add_argument("--skip-build", action="store_true", dest="skip_build",
                        help="Skip image build")
-    run_p.add_argument("--only",         metavar="PAIR",  help="Scope execution to one specific pair key (wl- prefix optional)")
-    run_p.add_argument("--workload",     metavar="NAME",  help="Scope execution to pairs matching this workload")
-    run_p.add_argument("--package",      metavar="NAME",  help="Scope execution to pairs matching this package")
+    run_p.add_argument("--only",         nargs="+", metavar="PAIR",  help="Scope execution to specific pair keys (comma or space-separated, wl- prefix optional)")
+    run_p.add_argument("--workload",     nargs="+", metavar="NAME",  help="Scope execution to pairs matching these workloads (comma or space-separated)")
+    run_p.add_argument("--package",      nargs="+", metavar="NAME",  help="Scope execution to pairs matching these packages (comma or space-separated)")
     run_p.add_argument("--status",       metavar="STATE", help="Scope execution to pairs with this status (e.g. failed, timed-out)")
     run_p.add_argument("--force",        action="store_true",
                        help="Reset non-pending pairs to pending, cleaning cluster resources for pairs with assigned namespaces")
@@ -2451,9 +2467,9 @@ Examples:
     sub.add_parser("stop", help="Stop the remote orchestrator Job")
 
     reset_p = sub.add_parser("reset", help="Reset all non-pending pairs to pending (with cluster cleanup)")
-    reset_p.add_argument("--only",     metavar="PAIR",  help="Scope to one specific pair key (wl- prefix optional)")
-    reset_p.add_argument("--workload", metavar="NAME",  help="Scope to pairs matching this workload")
-    reset_p.add_argument("--package",  metavar="NAME",  help="Scope to pairs matching this package")
+    reset_p.add_argument("--only",     nargs="+", metavar="PAIR",  help="Scope to specific pair keys (comma or space-separated, wl- prefix optional)")
+    reset_p.add_argument("--workload", nargs="+", metavar="NAME",  help="Scope to pairs matching these workloads (comma or space-separated)")
+    reset_p.add_argument("--package",  nargs="+", metavar="NAME",  help="Scope to pairs matching these packages (comma or space-separated)")
     reset_p.add_argument("--status",   metavar="STATE", help="Scope to pairs with this status")
     reset_p.add_argument("--preserve-done-status", action="store_true", dest="preserve_done_status",
                          help="Keep done pairs' status unchanged (cluster cleanup only)")
@@ -2461,9 +2477,9 @@ Examples:
                          help="Print what would be reset without doing it")
 
     wipe_p = sub.add_parser("wipe", help="Delete local result files for pairs in scope")
-    wipe_p.add_argument("--only",     metavar="PAIR",  help="Scope to one specific pair key (wl- prefix optional)")
-    wipe_p.add_argument("--workload", metavar="NAME",  help="Scope to pairs matching this workload")
-    wipe_p.add_argument("--package",  metavar="NAME",  help="Scope to pairs matching this package")
+    wipe_p.add_argument("--only",     nargs="+", metavar="PAIR",  help="Scope to specific pair keys (comma or space-separated, wl- prefix optional)")
+    wipe_p.add_argument("--workload", nargs="+", metavar="NAME",  help="Scope to pairs matching these workloads (comma or space-separated)")
+    wipe_p.add_argument("--package",  nargs="+", metavar="NAME",  help="Scope to pairs matching these packages (comma or space-separated)")
     wipe_p.add_argument("--dry-run",  action="store_true", dest="dry_run",
                          help="Print what would be wiped without doing it")
     wipe_p.add_argument("--yes", "-y", action="store_true",

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -901,8 +901,7 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
         if not scoped_phases:
             warn("No done phases for scoped pairs.")
             phases_to_collect: list[str] = []
-        elif _parse_list(args.package):
-            pkg_filter = _parse_list(args.package)
+        elif (pkg_filter := _parse_list(args.package)):
             valid = set(scoped_phases) | {"experiment"}
             unknown = set(pkg_filter) - valid
             if unknown:
@@ -1368,8 +1367,8 @@ def _apply_run_filters(progress: dict, args) -> set:
 
     if only:
         result = set()
+        unresolved = []
         for key in only:
-            key = key.strip()
             if key in progress and _is_pair_key(key):
                 result.add(key)
             else:
@@ -1377,6 +1376,10 @@ def _apply_run_filters(progress: dict, args) -> set:
                 if prefixed in progress:
                     info(f"--only: resolved '{key}' → '{prefixed}'")
                     result.add(prefixed)
+                else:
+                    unresolved.append(key)
+        if unresolved:
+            warn(f"--only: no match for {unresolved}")
         return result
 
     if not any([workload, package, status_filter]):

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1344,7 +1344,7 @@ def _force_reset(progress: dict, scope: set, discovered: dict | None = None,
 
 
 def _parse_list(value) -> "list[str] | None":
-    """Normalize a CLI flag value to a flat list, handling comma/space/mixed."""
+    """Flatten a CLI flag value (possibly a list from nargs='+') by splitting on commas."""
     if value is None:
         return None
     if isinstance(value, list):
@@ -1379,7 +1379,10 @@ def _apply_run_filters(progress: dict, args) -> set:
                 else:
                     unresolved.append(key)
         if unresolved:
-            warn(f"--only: no match for {unresolved}")
+            err(f"--only: no match for {unresolved}")
+            valid = sorted(k for k in progress.keys() if _is_pair_key(k))
+            print(f"  Valid pair keys: {valid}", file=sys.stderr)
+            sys.exit(1)
         return result
 
     if not any([workload, package, status_filter]):
@@ -2204,7 +2207,10 @@ def _collect_run_flags(args) -> list[str]:
     for name in ("only", "workload", "package", "status"):
         val = getattr(args, name)
         if val is not None:
-            flags.extend([f"--{name}", str(val)])
+            if isinstance(val, list):
+                flags.extend([f"--{name}"] + val)
+            else:
+                flags.extend([f"--{name}", str(val)])
     if getattr(args, "force"):
         flags.append("--force")
     if getattr(args, "skip_teardown", False):

--- a/pipeline/tests/test_deploy_reset.py
+++ b/pipeline/tests/test_deploy_reset.py
@@ -530,7 +530,7 @@ def test_cmd_reset_aborts_on_filter_mismatch(tmp_path, monkeypatch, capsys):
                        setup_config={"namespace": "sim2real-ns"})
     assert exc_info.value.code == 1
     captured = capsys.readouterr()
-    assert "No pairs matched" in captured.out + captured.err
+    assert "no match" in captured.out + captured.err
 
 
 def test_reset_pair_done_uninstalls_helm_in_completed_namespace(monkeypatch):

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -299,25 +299,29 @@ def test_apply_run_filters_only_without_prefix(capsys):
 
 
 def test_apply_run_filters_only_no_match():
-    """--only returns empty set when neither exact nor prefixed form matches."""
+    """--only aborts when neither exact nor prefixed form matches."""
+    import pytest
     from pipeline.deploy import _apply_run_filters
 
     class _Args:
         only = "nonexistent"; workload = None; package = None; status = None
 
-    result = _apply_run_filters(dict(_PROGRESS), _Args())
-    assert result == set()
+    with pytest.raises(SystemExit) as exc_info:
+        _apply_run_filters(dict(_PROGRESS), _Args())
+    assert exc_info.value.code == 1
 
 
 def test_apply_run_filters_only_no_double_prefix():
     """--only wl-nonexistent doesn't false-match via double-prefixing."""
+    import pytest
     from pipeline.deploy import _apply_run_filters
 
     class _Args:
         only = "wl-nonexistent"; workload = None; package = None; status = None
 
-    result = _apply_run_filters(dict(_PROGRESS), _Args())
-    assert result == set()
+    with pytest.raises(SystemExit) as exc_info:
+        _apply_run_filters(dict(_PROGRESS), _Args())
+    assert exc_info.value.code == 1
 
 
 def test_apply_run_filters_only_empty_string():
@@ -421,15 +425,19 @@ def test_apply_run_filters_multi_only_with_prefix_resolution(capsys):
 
 
 def test_apply_run_filters_multi_only_partial_unresolved(capsys):
-    """Partial match in --only warns about unresolved keys."""
+    """Partial match in --only aborts with error listing unresolved keys."""
+    import pytest
     from pipeline.deploy import _apply_run_filters
 
     class _Args:
         only = ["wl-smoke-baseline", "nonexistent"]; workload = None; package = None; status = None
 
-    result = _apply_run_filters(dict(_PROGRESS), _Args())
-    assert result == {"wl-smoke-baseline"}
-    assert "no match" in capsys.readouterr().err
+    with pytest.raises(SystemExit) as exc_info:
+        _apply_run_filters(dict(_PROGRESS), _Args())
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr().err
+    assert "no match" in captured
+    assert "nonexistent" in captured
 
 
 def test_apply_run_filters_comma_in_workload():
@@ -441,6 +449,106 @@ def test_apply_run_filters_comma_in_workload():
 
     result = _apply_run_filters(dict(_PROGRESS), _Args())
     assert result == {"wl-smoke-baseline", "wl-smoke-treatment", "wl-heavy-baseline"}
+
+
+def test_apply_run_filters_multi_only_all_unresolved(capsys):
+    """All --only keys unresolved aborts with exit code 1."""
+    import pytest
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = ["nonexistent1", "nonexistent2"]; workload = None; package = None; status = None
+
+    with pytest.raises(SystemExit) as exc_info:
+        _apply_run_filters(dict(_PROGRESS), _Args())
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr().err
+    assert "no match" in captured
+    assert "nonexistent1" in captured
+
+
+def test_resolve_scope_multi_only_all_unresolved_aborts(capsys):
+    """Multi-value --only with all keys unresolved aborts via _apply_run_filters."""
+    import pytest
+    from pipeline.deploy import _resolve_scope
+
+    class _Args:
+        only = ["bad1", "bad2"]; workload = None; package = None; status = None
+
+    with pytest.raises(SystemExit) as exc_info:
+        _resolve_scope(dict(_PROGRESS), _Args())
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr().err
+    assert "no match" in captured
+
+
+def test_report_filter_mismatch_multi_value_formatting(capsys):
+    """_report_filter_mismatch formats multi-value lists with commas."""
+    from pipeline.deploy import _report_filter_mismatch
+
+    class _Args:
+        only = None; workload = ["wl-smoke", "wl-heavy"]; package = ["baseline", "treatment"]; status = None
+
+    _report_filter_mismatch(dict(_PROGRESS), _Args())
+    captured = capsys.readouterr().err
+    assert "--workload 'wl-smoke,wl-heavy'" in captured
+    assert "--package 'baseline,treatment'" in captured
+
+
+def test_collect_run_flags_list_values():
+    """_collect_run_flags correctly serializes list-valued args."""
+    from pipeline.deploy import _collect_run_flags
+
+    class _Args:
+        only = ["wl-smoke-baseline", "wl-load-treatment"]
+        workload = None
+        package = ["baseline", "treatment"]
+        status = None
+        force = False
+        skip_teardown = False
+        preserve_pipelineruns = False
+        max_retries = 2
+        poll_interval = 30
+        gpu_resource_type = None
+        default_gpu_cost = 1
+        pending_threshold = 600
+        max_pending_stalls = 10
+        max_backoff = 600
+
+    flags = _collect_run_flags(_Args())
+    assert "--only" in flags
+    idx = flags.index("--only")
+    assert flags[idx + 1] == "wl-smoke-baseline"
+    assert flags[idx + 2] == "wl-load-treatment"
+    assert "--package" in flags
+    pidx = flags.index("--package")
+    assert flags[pidx + 1] == "baseline"
+    assert flags[pidx + 2] == "treatment"
+    assert "['wl-smoke-baseline'" not in " ".join(flags)
+
+
+def test_collect_run_flags_single_string_status():
+    """_collect_run_flags handles single-string status correctly."""
+    from pipeline.deploy import _collect_run_flags
+
+    class _Args:
+        only = None
+        workload = None
+        package = None
+        status = "failed"
+        force = False
+        skip_teardown = False
+        preserve_pipelineruns = False
+        max_retries = 2
+        poll_interval = 30
+        gpu_resource_type = None
+        default_gpu_cost = 1
+        pending_threshold = 600
+        max_pending_stalls = 10
+        max_backoff = 600
+
+    flags = _collect_run_flags(_Args())
+    assert flags == ["--status", "failed"]
 
 
 def test_resolve_scope_shows_valid_keys_on_only_mismatch(capsys):
@@ -455,7 +563,7 @@ def test_resolve_scope_shows_valid_keys_on_only_mismatch(capsys):
         _resolve_scope(dict(_PROGRESS), _Args())
     assert exc_info.value.code == 1
     captured = capsys.readouterr().err
-    assert "No pairs matched" in captured
+    assert "no match" in captured
     assert "wl-smoke-baseline" in captured
     assert "wl-load-treatment" in captured
 

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -331,6 +331,118 @@ def test_apply_run_filters_only_empty_string():
     assert result == set()
 
 
+# ── Multi-value flag tests (issue #212) ────────────────────────────────────
+
+
+def test_parse_list_none():
+    from pipeline.deploy import _parse_list
+    assert _parse_list(None) is None
+
+
+def test_parse_list_empty_list():
+    from pipeline.deploy import _parse_list
+    assert _parse_list([]) is None
+
+
+def test_parse_list_single_string():
+    from pipeline.deploy import _parse_list
+    assert _parse_list("smoke") == ["smoke"]
+
+
+def test_parse_list_comma_separated():
+    from pipeline.deploy import _parse_list
+    assert _parse_list("smoke,load") == ["smoke", "load"]
+
+
+def test_parse_list_list_input():
+    from pipeline.deploy import _parse_list
+    assert _parse_list(["smoke", "load"]) == ["smoke", "load"]
+
+
+def test_parse_list_mixed_comma_and_list():
+    from pipeline.deploy import _parse_list
+    assert _parse_list(["smoke,load", "heavy"]) == ["smoke", "load", "heavy"]
+
+
+def test_parse_list_strips_whitespace():
+    from pipeline.deploy import _parse_list
+    assert _parse_list(" smoke , load ") == ["smoke", "load"]
+
+
+def test_parse_list_whitespace_only():
+    from pipeline.deploy import _parse_list
+    assert _parse_list("  ,  ") is None
+
+
+def test_apply_run_filters_multi_workload():
+    """Multiple --workload values match any of the specified workloads."""
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = None; workload = ["wl-smoke", "wl-heavy"]; package = None; status = None
+
+    result = _apply_run_filters(dict(_PROGRESS), _Args())
+    assert result == {"wl-smoke-baseline", "wl-smoke-treatment", "wl-heavy-baseline"}
+
+
+def test_apply_run_filters_multi_package():
+    """Multiple --package values use union semantics."""
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = None; workload = None; package = ["baseline", "treatment"]; status = None
+
+    result = _apply_run_filters(dict(_PROGRESS), _Args())
+    assert result == {"wl-smoke-baseline", "wl-load-baseline", "wl-heavy-baseline",
+                      "wl-smoke-treatment", "wl-load-treatment"}
+
+
+def test_apply_run_filters_multi_only():
+    """Multiple --only values resolve independently and return the union."""
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = ["wl-smoke-baseline", "wl-load-treatment"]; workload = None; package = None; status = None
+
+    result = _apply_run_filters(dict(_PROGRESS), _Args())
+    assert result == {"wl-smoke-baseline", "wl-load-treatment"}
+
+
+def test_apply_run_filters_multi_only_with_prefix_resolution(capsys):
+    """Multiple --only values with wl- prefix resolution."""
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = ["smoke-baseline", "load-treatment"]; workload = None; package = None; status = None
+
+    result = _apply_run_filters(dict(_PROGRESS), _Args())
+    assert result == {"wl-smoke-baseline", "wl-load-treatment"}
+    assert "resolved" in capsys.readouterr().out
+
+
+def test_apply_run_filters_multi_only_partial_unresolved(capsys):
+    """Partial match in --only warns about unresolved keys."""
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = ["wl-smoke-baseline", "nonexistent"]; workload = None; package = None; status = None
+
+    result = _apply_run_filters(dict(_PROGRESS), _Args())
+    assert result == {"wl-smoke-baseline"}
+    assert "no match" in capsys.readouterr().err
+
+
+def test_apply_run_filters_comma_in_workload():
+    """Comma-separated --workload values are parsed correctly."""
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = None; workload = ["wl-smoke,wl-heavy"]; package = None; status = None
+
+    result = _apply_run_filters(dict(_PROGRESS), _Args())
+    assert result == {"wl-smoke-baseline", "wl-smoke-treatment", "wl-heavy-baseline"}
+
+
 def test_resolve_scope_shows_valid_keys_on_only_mismatch(capsys):
     """--only mismatch prints valid pair keys before aborting with exit code 1."""
     import pytest


### PR DESCRIPTION
## Summary

- Add `_parse_list` helper that normalizes comma-separated, space-separated, or mixed CLI input into flat lists
- Change `--only`, `--workload`, and `--package` to `nargs="+"` on all 5 subcommands (collect, status, run, reset, wipe)
- Update `_apply_run_filters` to iterate over multi-value `--only` (union of resolved keys) and use `in` for workload/package membership
- Update `_report_filter_mismatch` to format lists with comma-join
- Normalize `args.package` via `_parse_list` in `_cmd_collect`'s phase-filtering paths (both scoped and unscoped)

Closes #212

## Usage examples

```bash
# All equivalent:
deploy.py status --workload chatbot_mid chatbot_high
deploy.py status --workload chatbot_mid,chatbot_high
deploy.py status --workload chatbot_mid,chatbot_high load

# Multi-value --only (union):
deploy.py collect --only smoke-baseline smoke-treatment

# Multi-value --package with commas:
deploy.py run --package baseline,treatment
```

## Reviewer attention

- **`_parse_list` returns None (not empty list)** when input is None or produces no items. This preserves the existing "no filter given" semantics throughout `_apply_run_filters` and `_resolve_scope`.
- **`collect --package` already had `nargs="+"`** — the only change there is adding comma normalization via `_parse_list`, so `--package baseline,treatment` now works in addition to `--package baseline treatment`.
- **`--status` remains single-value** — it wasn't part of the issue scope and filtering by multiple statuses simultaneously is a different semantic (would need its own design decision).

## Test plan

- [x] Full suite: 795 tests pass (existing single-value tests exercise backward compat)
- [x] Lint: `ruff check pipeline/ --select F` clean
- [x] Existing `--workload` and `--only` scoped collect tests pass unchanged (single-value usage)
- [x] Existing `--package` multi-value tests pass (already `nargs="+"`)