### PR TITLE
feat: validate --workload and --package filter values before filtering

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1388,13 +1388,31 @@ def _apply_run_filters(progress: dict, args) -> set:
     if not any([workload, package, status_filter]):
         return set()
 
-    candidates = {k for k in progress.keys() if _is_pair_key(k)}
+    pair_entries = {k: v for k, v in progress.items() if _is_pair_key(k)}
+
     if workload:
-        candidates = {k for k in candidates if progress[k].get("workload") in workload}
+        valid_workloads = {v.get("workload", "") for v in pair_entries.values()} - {""}
+        unknown = set(workload) - valid_workloads
+        if unknown:
+            err(f"--workload: unrecognized values {sorted(unknown)}")
+            print(f"  Valid --workload values: {', '.join(sorted(valid_workloads))}", file=sys.stderr)
+            sys.exit(1)
+
     if package:
-        candidates = {k for k in candidates if progress[k].get("package") in package}
+        valid_packages = {v.get("package", "") for v in pair_entries.values()} - {""}
+        unknown = set(package) - valid_packages
+        if unknown:
+            err(f"--package: unrecognized values {sorted(unknown)}")
+            print(f"  Valid --package values: {', '.join(sorted(valid_packages))}", file=sys.stderr)
+            sys.exit(1)
+
+    candidates = set(pair_entries.keys())
+    if workload:
+        candidates = {k for k in candidates if pair_entries[k].get("workload") in workload}
+    if package:
+        candidates = {k for k in candidates if pair_entries[k].get("package") in package}
     if status_filter:
-        candidates = {k for k in candidates if progress[k].get("status") == status_filter}
+        candidates = {k for k in candidates if pair_entries[k].get("status") == status_filter}
     return candidates
 
 

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -153,7 +153,7 @@ def test_status_mismatch_shows_valid_values(tmp_path, capsys, monkeypatch):
         _cmd_status(_Args(), tmp_path, setup_config={"namespace": "sim2real-ns"})
     assert exc_info.value.code == 1
     captured = capsys.readouterr().err
-    assert "No pairs matched" in captured
+    assert "unrecognized" in captured
     assert "wl-smoke" in captured
 
 
@@ -467,6 +467,68 @@ def test_apply_run_filters_multi_only_all_unresolved(capsys):
     assert "nonexistent1" in captured
 
 
+def test_apply_run_filters_invalid_workload_aborts(capsys):
+    """--workload with a value not in progress aborts with exit 1."""
+    import pytest
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = None; workload = "nonexistent"; package = None; status = None
+
+    with pytest.raises(SystemExit) as exc_info:
+        _apply_run_filters(dict(_PROGRESS), _Args())
+    assert exc_info.value.code == 1
+    err = capsys.readouterr().err
+    assert "nonexistent" in err
+    assert "wl-smoke" in err
+
+
+def test_apply_run_filters_partial_invalid_workload_aborts(capsys):
+    """--workload with one valid and one invalid value still aborts."""
+    import pytest
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = None; workload = "wl-smoke,bogus"; package = None; status = None
+
+    with pytest.raises(SystemExit) as exc_info:
+        _apply_run_filters(dict(_PROGRESS), _Args())
+    assert exc_info.value.code == 1
+    err = capsys.readouterr().err
+    assert "bogus" in err
+
+
+def test_apply_run_filters_invalid_package_aborts(capsys):
+    """--package with a value not in progress aborts with exit 1."""
+    import pytest
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = None; workload = None; package = "baseline1x"; status = None
+
+    with pytest.raises(SystemExit) as exc_info:
+        _apply_run_filters(dict(_PROGRESS), _Args())
+    assert exc_info.value.code == 1
+    err = capsys.readouterr().err
+    assert "baseline1x" in err
+    assert "baseline" in err
+
+
+def test_apply_run_filters_partial_invalid_package_aborts(capsys):
+    """--package with one valid and one invalid value still aborts."""
+    import pytest
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = None; workload = None; package = "treatment,bogus"; status = None
+
+    with pytest.raises(SystemExit) as exc_info:
+        _apply_run_filters(dict(_PROGRESS), _Args())
+    assert exc_info.value.code == 1
+    err = capsys.readouterr().err
+    assert "bogus" in err
+
+
 def test_resolve_scope_multi_only_all_unresolved_aborts(capsys):
     """Multi-value --only with all keys unresolved aborts via _apply_run_filters."""
     import pytest
@@ -580,7 +642,7 @@ def test_resolve_scope_shows_valid_workloads_on_mismatch(capsys):
         _resolve_scope(dict(_PROGRESS), _Args())
     assert exc_info.value.code == 1
     captured = capsys.readouterr().err
-    assert "No pairs matched" in captured
+    assert "unrecognized" in captured
     assert "wl-smoke" in captured
     assert "wl-load" in captured
     assert "wl-heavy" in captured
@@ -598,7 +660,7 @@ def test_resolve_scope_shows_valid_packages_on_mismatch(capsys):
         _resolve_scope(dict(_PROGRESS), _Args())
     assert exc_info.value.code == 1
     captured = capsys.readouterr().err
-    assert "No pairs matched" in captured
+    assert "unrecognized" in captured
     assert "baseline" in captured
     assert "treatment" in captured
 


### PR DESCRIPTION
Closes #220

## Summary

- Pre-validates `--workload` and `--package` values against the set of known values in progress before applying filters
- If any value is unrecognized, prints the specific bad values plus valid values for that dimension and aborts (exit 1)
- Catches typos and partial mismatches immediately rather than silently narrowing scope or dumping the full universe of valid keys

## What changed

`_apply_run_filters` in `pipeline/deploy.py` now validates `--workload` and `--package` values before filtering, matching the existing `--only` validation pattern. The error message is dimension-specific (shows only valid workloads or packages, not the full pair key list).

## Reviewer attention

- The `collect` subcommand has its own separate `--package` validation (phase-level filter at lines 904-908) that bypasses `_resolve_scope` — it remains unchanged and unaffected.
- `_report_filter_mismatch` (the "No pairs matched" path) still serves a purpose: it fires when individually valid values combine to match zero pairs (e.g., valid workload + valid package with no pairs in common). The new validation only catches values that don't exist at all.
- Three existing tests were updated to expect the new targeted error message ("unrecognized") instead of the old broad "No pairs matched" message.

## Test plan

- [x] 4 new tests: invalid/partial-invalid for both `--workload` and `--package`
- [x] All 20 `_apply_run_filters` tests pass
- [x] Full suite: 751 tests pass
- [x] Lint: `ruff check pipeline/ --select F` clean