### PR TITLE
fix: validate filter flags before image build in remote mode

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -2365,6 +2365,13 @@ def _cmd_run_remote(args, run_dir: "Path", setup_config: dict) -> None:
             err(f"Failed to delete completed Job: {detail}")
             sys.exit(1)
 
+    # Validate filter flags before building images (fail fast)
+    cluster_dir = run_dir / "cluster"
+    discovered = _load_pairs(cluster_dir)
+    if discovered:
+        progress = {k: v for k, v in discovered.items()}
+        _resolve_scope(progress, args)
+
     _cmd_build(run_dir, namespace=namespace, skip_build=args.skip_build)
 
     workspace_dir = EXPERIMENT_ROOT / "workspace"

--- a/pipeline/tests/test_deploy_remote.py
+++ b/pipeline/tests/test_deploy_remote.py
@@ -424,6 +424,13 @@ def test_run_remote_job_uses_initcontainer_and_emptydir(monkeypatch, tmp_path):
 
 def test_run_remote_passes_scoping_flags(monkeypatch, tmp_path):
     run_dir = _setup_run_dir(tmp_path)
+    cluster_dir = run_dir / "cluster"
+    (cluster_dir / "pipelinerun-smoke-baseline.yaml").write_text(
+        "metadata:\n  name: pipelinerun-smoke-baseline\n"
+        "spec:\n  params:\n"
+        "  - name: workloadName\n    value: wl-smoke\n"
+        "  - name: phase\n    value: baseline\n"
+    )
     monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)
     monkeypatch.setattr(mod, "_check_existing_job", lambda ns: None)
     monkeypatch.setattr(mod, "_cmd_build", lambda *a, **kw: "skip")


### PR DESCRIPTION
## Summary

- `deploy.py run --remote --workload foo` was building images before validating the `--workload` value. Invalid workloads only failed inside the orchestrator pod after the full image build completed.
- Now `_resolve_scope` runs against cluster/ PipelineRun files before `_cmd_build`, failing fast locally with the same error message.

## Test plan

- [x] `python -m pytest pipeline/tests/test_deploy_remote.py` — 33 passed
- [ ] Manual: `deploy.py run --remote --workload invalid-name` exits immediately with valid values listed