### PR TITLE
feat: per-algorithm translation and treatment configs

### DIFF
--- a/.claude/skills/sim2real-translate/scripts/copy_generated.py
+++ b/.claude/skills/sim2real-translate/scripts/copy_generated.py
@@ -13,19 +13,28 @@ import subprocess
 from pathlib import Path
 
 
-def copy_generated(target_repo: str, run_dir: str) -> tuple[list[str], list[str]]:
+def copy_generated(
+    target_repo: str, run_dir: str, algo_name: str | None = None
+) -> tuple[list[str], list[str]]:
     """Discover changed/new files via git, update translation_output.json, copy to generated/.
 
     Args:
         target_repo: Path to the target repo (e.g., llm-d-inference-scheduler directory).
         run_dir: Path to the run directory containing translation_output.json.
+        algo_name: When set, files are written to generated/{algo_name}/ preserving
+            full relative paths; an {algo_name}_output.json is also written there.
+            When None, existing flat-copy behavior with basename collision check.
 
     Returns:
         Tuple of (files_created, files_modified) as written to translation_output.json.
     """
     target = Path(target_repo)
     rd = Path(run_dir)
-    gen = rd / "generated"
+
+    if algo_name is not None:
+        gen = rd / "generated" / algo_name
+    else:
+        gen = rd / "generated"
     gen.mkdir(parents=True, exist_ok=True)
 
     diff = subprocess.run(
@@ -40,26 +49,49 @@ def copy_generated(target_repo: str, run_dir: str) -> tuple[list[str], list[str]
     )
     files_created = [f for f in untracked.stdout.strip().splitlines() if f]
 
-    seen: dict[str, str] = {}
-    for f in files_created + files_modified:
-        base = Path(f).name
-        if base in seen:
-            raise ValueError(
-                f"Basename collision: '{base}' from both '{seen[base]}' and '{f}'"
-            )
-        seen[base] = f
+    if algo_name is None:
+        # Flat mode: basename collision check required
+        seen: dict[str, str] = {}
+        for f in files_created + files_modified:
+            base = Path(f).name
+            if base in seen:
+                raise ValueError(
+                    f"Basename collision: '{base}' from both '{seen[base]}' and '{f}'"
+                )
+            seen[base] = f
 
     for f in files_created + files_modified:
         src = target / f
-        dst = gen / Path(f).name
+        if algo_name is not None:
+            dst = gen / f
+            dst.parent.mkdir(parents=True, exist_ok=True)
+        else:
+            dst = gen / Path(f).name
         shutil.copy2(src, dst)
-        print(f"  {Path(f).name} → generated/")
+        if algo_name is not None:
+            print(f"  {f} → generated/{algo_name}/{f}")
+        else:
+            print(f"  {Path(f).name} → generated/")
 
+    # Update top-level translation_output.json
     to_path = rd / "translation_output.json"
     o = json.loads(to_path.read_text())
     o["files_created"] = files_created
     o["files_modified"] = files_modified
     to_path.write_text(json.dumps(o, indent=2))
+
+    # Per-algorithm output JSON
+    if algo_name is not None:
+        algo_output = {
+            "files_created": files_created,
+            "files_modified": files_modified,
+        }
+        # Include other fields from translation_output.json
+        for k, v in o.items():
+            if k not in ("files_created", "files_modified"):
+                algo_output[k] = v
+        algo_out_path = gen / f"{algo_name}_output.json"
+        algo_out_path.write_text(json.dumps(algo_output, indent=2))
 
     count = len(files_created) + len(files_modified)
     if count:

--- a/.claude/skills/sim2real-translate/tests/test_copy_generated.py
+++ b/.claude/skills/sim2real-translate/tests/test_copy_generated.py
@@ -170,3 +170,49 @@ def test_preserves_other_json_fields(git_repo, run_dir):
     result = json.loads((run_dir / "translation_output.json").read_text())
     assert result["plugin_type"] == "scorer"
     assert result["description"] == "test plugin"
+
+
+# --- Per-algorithm subdirectory tests ---
+
+
+def test_per_algorithm_subdirectory(git_repo, run_dir):
+    """With algo_name, files go to generated/{algo_name}/ preserving full paths."""
+    (git_repo / "pkg" / "scorer").mkdir(parents=True)
+    (git_repo / "pkg" / "scorer" / "plugin.go").write_text("package scorer")
+    (git_repo / "existing.go").write_text("package main\n// changed")
+    created, modified = cg.copy_generated(str(git_repo), str(run_dir), algo_name="myalgo")
+    gen = run_dir / "generated" / "myalgo"
+    assert gen.exists()
+    # Full relative paths preserved
+    assert (gen / "pkg" / "scorer" / "plugin.go").exists()
+    assert (gen / "existing.go").exists()
+    assert "pkg/scorer/plugin.go" in created
+    assert "existing.go" in modified
+
+
+def test_per_algorithm_no_basename_collision(git_repo, run_dir):
+    """With algo_name, same basename in different dirs does NOT raise."""
+    (git_repo / "pkg" / "scorer").mkdir(parents=True)
+    (git_repo / "pkg" / "admission").mkdir(parents=True)
+    (git_repo / "pkg" / "scorer" / "config.go").write_text("package scorer")
+    (git_repo / "pkg" / "admission" / "config.go").write_text("package admission")
+    # Should not raise — full paths can't collide
+    created, modified = cg.copy_generated(str(git_repo), str(run_dir), algo_name="myalgo")
+    gen = run_dir / "generated" / "myalgo"
+    assert (gen / "pkg" / "scorer" / "config.go").exists()
+    assert (gen / "pkg" / "admission" / "config.go").exists()
+
+
+def test_per_algorithm_output_json(git_repo, run_dir):
+    """With algo_name, {algo_name}_output.json is created in the subdirectory."""
+    (git_repo / "existing.go").write_text("package main\n// changed")
+    cg.copy_generated(str(git_repo), str(run_dir), algo_name="myalgo")
+    gen = run_dir / "generated" / "myalgo"
+    algo_out = gen / "myalgo_output.json"
+    assert algo_out.exists()
+    data = json.loads(algo_out.read_text())
+    assert data["files_modified"] == ["existing.go"]
+    assert data["files_created"] == []
+    # Should also contain other fields from translation_output.json
+    assert data["plugin_type"] == "scorer"
+    assert data["description"] == "test plugin"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,9 +83,11 @@ All artifacts live under `<experiment-root>/workspace/` (gitignored). When no `-
 | `runs/<run>/.state.json` | `prepare.py` | `prepare.py`, `deploy.py` |
 | `runs/<run>/run_metadata.json` | `setup.py`, `deploy.py` | `deploy.py`, `run.py` |
 | `runs/<run>/skill_input.json` | `prepare.py` Phase 3 | `/sim2real-translate` skill |
-| `runs/<run>/translation_output.json` | `/sim2real-translate` skill | `prepare.py` Phase 4 |
+| `runs/<run>/translation_output.json` | `prepare.py` Phase 3 (index) | `prepare.py` Phase 4, `deploy.py`, `run.py` |
 | `runs/<run>/generated/baseline_config.yaml` | `/sim2real-translate` skill | `prepare.py` Phase 4 (overlay) |
-| `runs/<run>/generated/treatment_config.yaml` | `/sim2real-translate` skill | `prepare.py` Phase 4 (overlay) |
+| `runs/<run>/generated/{algo}/{algo}_config.yaml` | `/sim2real-translate` skill | `prepare.py` Phase 4 (per-algo overlay) |
+| `runs/<run>/generated/{algo}/{algo}_output.json` | `/sim2real-translate` skill | `prepare.py` Phase 3 (completeness check) |
+| `runs/<run>/generated/treatment_config.yaml` | `/sim2real-translate` skill (legacy) | `prepare.py` Phase 4 (fallback overlay) |
 | `runs/<run>/cluster/baseline.yaml` | `prepare.py` Phase 4 | `deploy.py` |
 | `runs/<run>/cluster/treatment.yaml` | `prepare.py` Phase 4 | `deploy.py` |
 | `runs/<run>/cluster/pipelinerun-*.yaml` | `prepare.py` Phase 4 | `deploy.py run` |

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -87,9 +87,9 @@ python pipeline/prepare.py [--force] [--rebuild-context] [--manifest PATH] [--ru
 
 **Phase 1 ref validation**: If `component.ref` is set in the manifest, Phase 1 resolves it via `git rev-parse` in the component submodule and compares against HEAD. A mismatch produces a warning (not a hard error) with the expected/actual SHA and a checkout command. Missing submodule or non-git directory with `component.ref` set is a hard error with an init command.
 
-**Phase 3 checkpoint**: writes `skill_input.json` and exits cleanly (exit 0). Run `/sim2real-translate` in Claude Code, then re-run `prepare.py` to continue from Phase 4. When no `algorithm` is present in the manifest, Phase 3 is skipped entirely (baseline-only mode).
+**Phase 3 checkpoint**: iterates over each algorithm in the manifest. For each, checks whether `generated/{algo_name}/{algo_name}_output.json` exists. If any algorithm is untranslated, writes `skill_input.json` (with `current_algorithm` targeting the next pending algorithm) and exits cleanly (exit 0). Run `/sim2real-translate` in Claude Code, then re-run `prepare.py`. When all algorithms are translated, writes a top-level `translation_output.json` index and proceeds to Phase 4. When no `algorithm` is present in the manifest, Phase 3 is skipped entirely (baseline-only mode).
 
-**Phase 4 assembly** reads `baseline.yaml` and `treatment.yaml` from the experiment root, merges them with skill-generated overlay files (`generated/baseline_config.yaml`, `generated/treatment_config.yaml`), and writes resolved scenario files to `cluster/`. PipelineRuns are generated with a `scenarioContent` param containing the fully resolved scenario YAML. Workloads are loaded from the manifest.
+**Phase 4 assembly** reads baseline scenario files from the experiment root, merges them with skill-generated overlay files from `generated/`. For multi-algorithm runs, each algorithm's overlay is in `generated/{algo_name}/{algo_name}_config.yaml`. For single-algorithm runs, the overlay may be at `generated/{name}_config.yaml` or `generated/treatment_config.yaml` (legacy). Resolved scenario files are written to `cluster/`. PipelineRuns are generated with a `scenarioContent` param containing the fully resolved scenario YAML. Workloads are loaded from the manifest.
 
 **Phase 6 gate**: `d` marks the run `READY TO DEPLOY` (required by `deploy.py`). `e` drops you back to edit files, then re-displays the summary. `q` marks `abandoned` and exits.
 
@@ -126,7 +126,7 @@ Common flags (all subcommands):
 | `--experiment-root PATH` | cwd | path to experiment repo |
 | `--skip-build` | false | skip image build pre-flight |
 
-**Image build** — `deploy.py build` (called implicitly as pre-flight by `deploy.py run`) iterates over all resolved scenarios in `cluster/`, collects unique `images.inferenceScheduler` refs, and builds any that are stale. Baseline images are tagged by the component directory's HEAD SHA (8 chars); treatment images by the run name. Source hash comparison skips builds when the image is already current.
+**Image build** — `deploy.py build` (called implicitly as pre-flight by `deploy.py run`) iterates over all resolved scenarios in `cluster/`, collects unique `images.inferenceScheduler` refs, and builds any that are stale. Baseline images are tagged by the component directory's HEAD SHA (8 chars); algorithm images are tagged `{run_name}-{algo_name}` (per-algorithm). For each algorithm build, the component working tree is reset to baseline and only that algorithm's files are applied before building. Source hash comparison skips builds when the image is already current.
 
 **Pair discovery** — `deploy.py run` discovers `pipelinerun-*.yaml` files at the `cluster/` root. Each file's pair key is derived as `wl-` + filename stem minus the `pipelinerun-` prefix.
 
@@ -248,7 +248,7 @@ python pipeline/run.py --experiment-root ../admission-control switch <name>
 
 `--experiment-root` defaults to the current working directory; omit it when running from the experiment repo root.
 
-**`switch`** copies files listed in `translation_output.json` (`files_created` + `files_modified`) into the experiment repo's `llm-d-inference-scheduler/` directory and updates `setup_config.json`. Prompts before overwriting uncommitted changes.
+**`switch`** copies files listed in `translation_output.json` (`files_created` + `files_modified`) into the experiment repo's `llm-d-inference-scheduler/` directory and updates `setup_config.json`. For per-algorithm index format, copies from `generated/{algo_name}/` using full relative paths. Prompts before overwriting uncommitted changes.
 
 ---
 
@@ -323,8 +323,15 @@ All subcommands (`status`, `collect`, `run`, `reset`, `wipe`) use a run-scoped `
 
 ## Scenario Overlay Format
 
-The `/sim2real-translate` skill produces two overlay files in `workspace/runs/<run>/generated/`:
+The `/sim2real-translate` skill produces overlay files in `workspace/runs/<run>/generated/`:
 
+**Per-algorithm layout** (multi-algorithm manifests):
+- `baseline_config.yaml` — shared baseline overlay (merged onto all baselines)
+- `{algo_name}/{algo_name}_config.yaml` — per-algorithm treatment overlay
+- `{algo_name}/{algo_name}_output.json` — per-algorithm translation metadata
+- `{algo_name}/...` — generated source files with full relative paths
+
+**Legacy flat layout** (single-algorithm, backward compat):
 - `baseline_config.yaml` — overlay merged onto `baseline.yaml`
 - `treatment_config.yaml` — overlay merged onto the already-resolved baseline
 

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -195,8 +195,13 @@ def _cmd_build(run_dir: Path, namespace: str, skip_build: bool) -> str:
 
         if "per_algorithm" in raw_output:
             per_algorithm_outputs = raw_output["per_algorithm"]
-        else:
+        elif "plugin_type" in raw_output:
             translation_output = raw_output
+        else:
+            err("translation_output.json has unrecognized format "
+                "(missing both 'per_algorithm' and 'plugin_type' keys). "
+                "Re-run /sim2real-translate.")
+            sys.exit(1)
 
     build_script = REPO_ROOT / "pipeline" / "scripts" / "build-epp.sh"
     if not build_script.exists():
@@ -213,7 +218,7 @@ def _cmd_build(run_dir: Path, namespace: str, skip_build: bool) -> str:
         # Determine which translation output governs this image and whether it's an algo build
         algo_output = None
         algo_name = None
-        if per_algorithm_outputs and pkg_name in per_algorithm_outputs:
+        if per_algorithm_outputs is not None and pkg_name in per_algorithm_outputs:
             algo_output = per_algorithm_outputs[pkg_name]
             algo_name = pkg_name
         elif translation_output:

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -185,35 +185,70 @@ def _cmd_build(run_dir: Path, namespace: str, skip_build: bool) -> str:
     # Load translation output for source toggle (if available)
     translation_output_path = run_dir / "translation_output.json"
     translation_output = None
+    per_algorithm_outputs = None
     if translation_output_path.exists():
         try:
-            translation_output = json.loads(translation_output_path.read_text())
+            raw_output = json.loads(translation_output_path.read_text())
         except json.JSONDecodeError as e:
             err(f"translation_output.json is not valid JSON: {e}. Re-run /sim2real-translate.")
             sys.exit(1)
+
+        if "per_algorithm" in raw_output:
+            per_algorithm_outputs = raw_output["per_algorithm"]
+        else:
+            translation_output = raw_output
 
     build_script = REPO_ROOT / "pipeline" / "scripts" / "build-epp.sh"
     if not build_script.exists():
         err(f"build-epp.sh not found at {build_script.relative_to(REPO_ROOT)}")
         sys.exit(1)
 
-    # Treatment ref for comparison (to distinguish baseline from treatment builds)
-    treatment_ref = f"{registry}/{repo_name}:{run_name}"
     generated_dir = run_dir / "generated"
 
     built_any = False
     for img_info in to_build:
         ref = img_info["image_ref"]
-        is_treatment = (ref == treatment_ref)
+        pkg_name = img_info["package"]
 
-        # Source toggle: ensure working tree is in correct state for baseline builds
-        if translation_output and not is_treatment:
+        # Determine which translation output governs this image and whether it's an algo build
+        algo_output = None
+        algo_name = None
+        if per_algorithm_outputs and pkg_name in per_algorithm_outputs:
+            algo_output = per_algorithm_outputs[pkg_name]
+            algo_name = pkg_name
+        elif translation_output:
+            # Legacy single-algo format: check if this is the treatment image
+            treatment_ref = f"{registry}/{repo_name}:{run_name}"
+            if ref == treatment_ref:
+                algo_output = translation_output
+                algo_name = None  # legacy mode, no per-algo subdirectory
+            else:
+                # Baseline build — need to restore baseline state
+                algo_output = translation_output
+
+        is_algorithm_build = (algo_name is not None) or (
+            translation_output and ref == f"{registry}/{repo_name}:{run_name}"
+        )
+        is_baseline_build = not is_algorithm_build and algo_output is not None
+
+        # Source toggle: ensure working tree is in correct state
+        if is_baseline_build:
             from pipeline.lib.source_toggle import restore_baseline
             info(f"Restoring baseline state for: {ref}")
             try:
-                restore_baseline(source_dir, translation_output)
+                restore_baseline(source_dir, algo_output)
             except (subprocess.CalledProcessError, OSError) as exc:
                 err(f"Failed to restore baseline state in {source_dir}: {exc}")
+                sys.exit(1)
+        elif is_algorithm_build and algo_name:
+            # Per-algorithm: apply only this algorithm's files
+            from pipeline.lib.source_toggle import restore_baseline, restore_treatment
+            info(f"Applying algorithm state for: {ref} (algo={algo_name})")
+            try:
+                restore_baseline(source_dir, algo_output)
+                restore_treatment(source_dir, generated_dir, algo_output, algo_name=algo_name)
+            except (subprocess.CalledProcessError, OSError, FileNotFoundError) as exc:
+                err(f"Failed to apply algorithm state for {algo_name}: {exc}")
                 sys.exit(1)
 
         info(f"Building image: {ref}")
@@ -228,8 +263,19 @@ def _cmd_build(run_dir: Path, namespace: str, skip_build: bool) -> str:
             cwd=REPO_ROOT,
         )
 
-        # Restore treatment state after baseline build
-        if translation_output and not is_treatment:
+        # Restore baseline after algorithm build (clean state for next iteration)
+        if is_algorithm_build and algo_output:
+            from pipeline.lib.source_toggle import restore_baseline
+            try:
+                restore_baseline(source_dir, algo_output)
+            except (subprocess.CalledProcessError, OSError) as exc:
+                err(f"Failed to restore baseline after build: {exc}\n"
+                    f"  Working tree may be in modified state. To recover:\n"
+                    f"  cd {source_dir} && git checkout -- .")
+                sys.exit(1)
+
+        # Restore treatment state after baseline build (legacy mode)
+        if is_baseline_build and translation_output:
             from pipeline.lib.source_toggle import restore_treatment
             try:
                 restore_treatment(source_dir, generated_dir, translation_output)

--- a/pipeline/lib/assemble.py
+++ b/pipeline/lib/assemble.py
@@ -107,10 +107,14 @@ def _resolve_overlay(name: str, generated_dir: Path, kind: str) -> dict:
     """Find overlay for a package.
 
     Lookup order:
-      1. {name}_config.yaml (per-package overlay)
-      2. baseline_config.yaml (shared fallback for baselines)
-      3. treatment_config.yaml (legacy fallback for algorithms)
+      1. {name}/{name}_config.yaml (per-algorithm subdirectory)
+      2. {name}_config.yaml (per-package flat overlay)
+      3. baseline_config.yaml (shared fallback for baselines)
+      4. treatment_config.yaml (legacy fallback for algorithms)
     """
+    per_algo_subdir = generated_dir / name / f"{name}_config.yaml"
+    if per_algo_subdir.exists():
+        return _load_yaml(per_algo_subdir)
     per_pkg = generated_dir / f"{name}_config.yaml"
     if per_pkg.exists():
         return _load_yaml(per_pkg)
@@ -181,13 +185,15 @@ def assemble_packages(
 
     if overlays_expected:
         for algo in algorithms:
-            overlay_path = generated_dir / f"{algo['name']}_config.yaml"
-            if not overlay_path.exists():
-                legacy = generated_dir / "treatment_config.yaml"
-                if not legacy.exists():
-                    raise AssemblyError(
-                        f"Overlay expected but missing for algorithm '{algo['name']}': {overlay_path}"
-                    )
+            algo_name = algo["name"]
+            subdir_path = generated_dir / algo_name / f"{algo_name}_config.yaml"
+            flat_path = generated_dir / f"{algo_name}_config.yaml"
+            legacy = generated_dir / "treatment_config.yaml"
+            if not (subdir_path.exists() or flat_path.exists() or legacy.exists()):
+                raise AssemblyError(
+                    f"Overlay expected but missing for algorithm '{algo_name}': "
+                    f"checked {subdir_path}, {flat_path}, and {legacy}"
+                )
 
     return packages
 

--- a/pipeline/lib/epp.py
+++ b/pipeline/lib/epp.py
@@ -1,19 +1,21 @@
 """EPP image injection utilities."""
 
 
-def inject_epp_image(scenario_dict: dict, registry: str, repo_name: str, tag: str) -> bool:
+def inject_epp_image(scenario_dict: dict, registry: str, repo_name: str, tag: str, algo_name: str | None = None) -> bool:
     """Inject EPP image into all scenario entries.
 
     Returns True if injection occurred, False if skipped (empty registry or no scenarios).
+    When *algo_name* is provided the effective tag becomes ``{tag}-{algo_name}``.
     """
     if not registry:
         return False
     scenario_list = scenario_dict.get("scenario", [])
     if not scenario_list:
         return False
+    effective_tag = f"{tag}-{algo_name}" if algo_name else tag
     epp_img = {
         "repository": f"{registry}/{repo_name}",
-        "tag": tag,
+        "tag": effective_tag,
         "pullPolicy": "Always",
     }
     for entry in scenario_list:

--- a/pipeline/lib/run_manager.py
+++ b/pipeline/lib/run_manager.py
@@ -176,8 +176,13 @@ def inspect_run(run_dir: Path, active_run: str = "") -> RunDetail:
     if to_path.exists():
         try:
             to = json.loads(to_path.read_text())
-            files_created = to.get("files_created") or []
-            files_modified = to.get("files_modified") or []
+            if "per_algorithm" in to:
+                for algo_output in to["per_algorithm"].values():
+                    files_created.extend(algo_output.get("files_created", []))
+                    files_modified.extend(algo_output.get("files_modified", []))
+            else:
+                files_created = to.get("files_created") or []
+                files_modified = to.get("files_modified") or []
         except (json.JSONDecodeError, OSError):
             pass
 
@@ -205,7 +210,11 @@ def inspect_run(run_dir: Path, active_run: str = "") -> RunDetail:
 
 
 def _load_translation_output(run_dir: Path, run_name: str) -> "tuple[list[str], list[str]]":
-    """Load and validate translation_output.json. Returns (files_created, files_modified)."""
+    """Load and validate translation_output.json. Returns (files_created, files_modified).
+
+    Handles both per-algorithm index format and legacy single format.
+    Returns aggregated (files_created, files_modified) across all algorithms.
+    """
     to_path = run_dir / "translation_output.json"
     if not to_path.exists():
         raise TranslationOutputError(
@@ -217,6 +226,24 @@ def _load_translation_output(run_dir: Path, run_name: str) -> "tuple[list[str], 
         raise TranslationOutputError(
             f"Error: translation_output.json is malformed — {e}"
         )
+
+    if "per_algorithm" in data:
+        all_created: list[str] = []
+        all_modified: list[str] = []
+        for algo_output in data["per_algorithm"].values():
+            fc = algo_output.get("files_created", [])
+            fm = algo_output.get("files_modified", [])
+            if (not isinstance(fc, list) or not isinstance(fm, list)
+                    or not all(isinstance(x, str) for x in fc)
+                    or not all(isinstance(x, str) for x in fm)):
+                raise TranslationOutputError(
+                    "Error: translation_output.json is malformed — expected 'files_created' and "
+                    "'files_modified' as lists of strings in per_algorithm entries"
+                )
+            all_created.extend(fc)
+            all_modified.extend(fm)
+        return all_created, all_modified
+
     fc = data.get("files_created")
     fm = data.get("files_modified")
     if (not isinstance(fc, list) or not isinstance(fm, list)
@@ -286,21 +313,34 @@ def switch_run(
     files_created, files_modified = _load_translation_output(run_dir, run_name)
     target_files = set(files_created + files_modified)
 
-    # Step 2: basename collision check
-    seen: set[str] = set()
-    for rel_path in target_files:
-        basename = Path(rel_path).name
-        if basename in seen:
-            raise ValueError(
-                f"Error: basename collision in translation_output.json: "
-                f"'{basename}' maps to multiple paths"
-            )
-        seen.add(basename)
+    # Detect per-algorithm mode
+    output = json.loads((run_dir / "translation_output.json").read_text())
+    is_per_algorithm = "per_algorithm" in output
+
+    # Step 2: basename collision check (only for legacy flat mode)
+    if not is_per_algorithm:
+        seen: set[str] = set()
+        for rel_path in target_files:
+            basename = Path(rel_path).name
+            if basename in seen:
+                raise ValueError(
+                    f"Error: basename collision in translation_output.json: "
+                    f"'{basename}' maps to multiple paths"
+                )
+            seen.add(basename)
 
     # Step 3: pre-validate all source files exist in generated/
     generated_dir = run_dir / "generated"
-    missing = [Path(f).name for f in target_files
-               if not (generated_dir / Path(f).name).exists()]
+    if is_per_algorithm:
+        missing = []
+        for algo_name, algo_output in output["per_algorithm"].items():
+            algo_dir = generated_dir / algo_name
+            for f in algo_output.get("files_created", []) + algo_output.get("files_modified", []):
+                if not (algo_dir / f).exists():
+                    missing.append(f"{algo_name}/{f}")
+    else:
+        missing = [Path(f).name for f in target_files
+                   if not (generated_dir / Path(f).name).exists()]
     if missing:
         raise ValueError(
             f"Error: missing source files in workspace/runs/{run_name}/generated/: "
@@ -339,15 +379,32 @@ def switch_run(
 
     # Step 8: copy all generated files to their destinations in the submodule
     files_written: list[str] = []
-    for rel_path in sorted(target_files):
-        src = generated_dir / Path(rel_path).name
-        dst = submodule_dir / rel_path
-        dst.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            shutil.copy2(src, dst)
-            files_written.append(rel_path)
-        except OSError as e:
-            raise OSError(f"Error: failed to copy {rel_path}: {e}") from e
+    if is_per_algorithm:
+        for algo_name, algo_output in output["per_algorithm"].items():
+            algo_dir = generated_dir / algo_name
+            algo_files = (
+                algo_output.get("files_created", []) +
+                algo_output.get("files_modified", [])
+            )
+            for rel_path in sorted(algo_files):
+                src = algo_dir / rel_path
+                dst = submodule_dir / rel_path
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                try:
+                    shutil.copy2(src, dst)
+                    files_written.append(rel_path)
+                except OSError as e:
+                    raise OSError(f"Error: failed to copy {rel_path}: {e}") from e
+    else:
+        for rel_path in sorted(target_files):
+            src = generated_dir / Path(rel_path).name
+            dst = submodule_dir / rel_path
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                shutil.copy2(src, dst)
+                files_written.append(rel_path)
+            except OSError as e:
+                raise OSError(f"Error: failed to copy {rel_path}: {e}") from e
 
     # Step 9: update setup_config only after all copies succeed
     cfg["current_run"] = run_name

--- a/pipeline/lib/run_manager.py
+++ b/pipeline/lib/run_manager.py
@@ -50,6 +50,7 @@ class RunDetail:
 class SwitchResult:
     files_written: list  # list[str]
     active_run: str
+    algorithm: "str | None"  # which algorithm was applied (None for legacy)
 
 
 # ── Conformance helpers ───────────────────────────────────────────────────────
@@ -283,12 +284,17 @@ def switch_run(
     submodule_dir: Path,
     setup_config_path: Path,
     confirm_fn: "callable",
+    algorithm: "str | None" = None,
     _is_dirty: "callable | None" = None,
     _reset: "callable | None" = None,
 ) -> SwitchResult:
     """
     Switch the active run: reset the submodule, delete stale files from the
     previous run, copy all generated files from the target run, update setup_config.
+
+    For per-algorithm runs, applies only one algorithm's files at a time
+    (the working tree can only represent one algorithm state). Specify
+    `algorithm` to choose which; defaults to the first algorithm in the index.
 
     confirm_fn(dirty: bool) -> bool  — called when submodule has uncommitted changes;
         return True to proceed with the reset.
@@ -313,9 +319,28 @@ def switch_run(
     files_created, files_modified = _load_translation_output(run_dir, run_name)
     target_files = set(files_created + files_modified)
 
-    # Detect per-algorithm mode
+    # Detect per-algorithm mode and select target algorithm
     output = json.loads((run_dir / "translation_output.json").read_text())
     is_per_algorithm = "per_algorithm" in output
+    selected_algo = None
+
+    if is_per_algorithm:
+        available = list(output["per_algorithm"].keys())
+        if algorithm:
+            if algorithm not in output["per_algorithm"]:
+                raise ValueError(
+                    f"Error: algorithm '{algorithm}' not found in run '{run_name}'. "
+                    f"Available: {', '.join(available)}"
+                )
+            selected_algo = algorithm
+        else:
+            selected_algo = available[0]
+        # Narrow target_files to just this algorithm
+        algo_output = output["per_algorithm"][selected_algo]
+        target_files = set(
+            algo_output.get("files_created", []) +
+            algo_output.get("files_modified", [])
+        )
 
     # Step 2: basename collision check (only for legacy flat mode)
     if not is_per_algorithm:
@@ -332,12 +357,8 @@ def switch_run(
     # Step 3: pre-validate all source files exist in generated/
     generated_dir = run_dir / "generated"
     if is_per_algorithm:
-        missing = []
-        for algo_name, algo_output in output["per_algorithm"].items():
-            algo_dir = generated_dir / algo_name
-            for f in algo_output.get("files_created", []) + algo_output.get("files_modified", []):
-                if not (algo_dir / f).exists():
-                    missing.append(f"{algo_name}/{f}")
+        algo_dir = generated_dir / selected_algo
+        missing = [f for f in target_files if not (algo_dir / f).exists()]
     else:
         missing = [Path(f).name for f in target_files
                    if not (generated_dir / Path(f).name).exists()]
@@ -377,24 +398,19 @@ def switch_run(
         if stale.exists():
             stale.unlink()
 
-    # Step 8: copy all generated files to their destinations in the submodule
+    # Step 8: copy generated files to their destinations in the submodule
     files_written: list[str] = []
     if is_per_algorithm:
-        for algo_name, algo_output in output["per_algorithm"].items():
-            algo_dir = generated_dir / algo_name
-            algo_files = (
-                algo_output.get("files_created", []) +
-                algo_output.get("files_modified", [])
-            )
-            for rel_path in sorted(algo_files):
-                src = algo_dir / rel_path
-                dst = submodule_dir / rel_path
-                dst.parent.mkdir(parents=True, exist_ok=True)
-                try:
-                    shutil.copy2(src, dst)
-                    files_written.append(rel_path)
-                except OSError as e:
-                    raise OSError(f"Error: failed to copy {rel_path}: {e}") from e
+        algo_dir = generated_dir / selected_algo
+        for rel_path in sorted(target_files):
+            src = algo_dir / rel_path
+            dst = submodule_dir / rel_path
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                shutil.copy2(src, dst)
+                files_written.append(rel_path)
+            except OSError as e:
+                raise OSError(f"Error: failed to copy {rel_path}: {e}") from e
     else:
         for rel_path in sorted(target_files):
             src = generated_dir / Path(rel_path).name
@@ -410,4 +426,5 @@ def switch_run(
     cfg["current_run"] = run_name
     setup_config_path.write_text(json.dumps(cfg, indent=2))
 
-    return SwitchResult(files_written=files_written, active_run=run_name)
+    return SwitchResult(files_written=files_written, active_run=run_name,
+                        algorithm=selected_algo)

--- a/pipeline/lib/source_toggle.py
+++ b/pipeline/lib/source_toggle.py
@@ -27,17 +27,26 @@ def restore_treatment(
     component_dir: Path,
     generated_dir: Path,
     translation_output: dict,
+    algo_name: str | None = None,
 ) -> None:
     """Restore component_dir to its post-translation (treatment) state.
 
     Copies files from generated_dir back to their relative paths in component_dir.
+
+    When *algo_name* is provided, files are read from
+    ``generated_dir/{algo_name}/{rel_path}`` using full relative paths.
+    When *algo_name* is None (default), the legacy basename lookup is used:
+    ``generated_dir/{basename}``.
     """
     all_files = (
         translation_output.get("files_created", [])
         + translation_output.get("files_modified", [])
     )
     for rel_path in all_files:
-        src = generated_dir / Path(rel_path).name
+        if algo_name is not None:
+            src = generated_dir / algo_name / rel_path
+        else:
+            src = generated_dir / Path(rel_path).name
         dst = component_dir / rel_path
         dst.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(src, dst)

--- a/pipeline/prepare.py
+++ b/pipeline/prepare.py
@@ -686,6 +686,19 @@ def _verify_generated_dir(run_dir: Path):
             "Re-run the /sim2real-translate skill.")
         sys.exit(1)
 
+    # Per-algorithm index format
+    if "per_algorithm" in output:
+        for algo_name, algo_output in output["per_algorithm"].items():
+            algo_dir = generated_dir / algo_name
+            if not algo_dir.exists():
+                warn(f"generated/{algo_name}/ directory not found")
+                continue
+            for f in algo_output.get("files_created", []) + algo_output.get("files_modified", []):
+                if not (algo_dir / f).exists():
+                    warn(f"generated/{algo_name}/ missing: {f}")
+        return
+
+    # Legacy flat format
     for f in output.get("files_created", []) + output.get("files_modified", []):
         if not (generated_dir / Path(f).name).exists():
             warn(f"generated/ missing: {Path(f).name}")
@@ -701,6 +714,32 @@ def _validate_assembly(run_dir: Path, resolved: dict, algorithm_packages: list[s
     except json.JSONDecodeError:
         warn("translation_output.json is not valid JSON — skipping validation")
         return
+
+    # Per-algorithm index format
+    if "per_algorithm" in output:
+        target_path = resolved.get("path", "")
+        errors = []
+        for algo_name, algo_output in output["per_algorithm"].items():
+            plugin_type = algo_output.get("plugin_type", "")
+            treatment_config_generated = algo_output.get("treatment_config_generated", True)
+
+            # Check: plugin_type in scenario YAML
+            if treatment_config_generated:
+                pkg_yaml = run_dir / "cluster" / f"{algo_name}.yaml"
+                if pkg_yaml.exists():
+                    if plugin_type not in pkg_yaml.read_text():
+                        errors.append(
+                            f"[{algo_name}] plugin_type '{plugin_type}' not found in {algo_name}.yaml")
+
+        if errors:
+            err("validate-assembly FAILED:")
+            for e in errors:
+                err(f"  - {e}")
+            sys.exit(1)
+        ok("validate-assembly: all checks passed")
+        return
+
+    # Legacy single-output format
     plugin_type = output["plugin_type"]
     target_path = resolved.get("path", "")
     treatment_config_generated = output.get("treatment_config_generated", True)

--- a/pipeline/prepare.py
+++ b/pipeline/prepare.py
@@ -807,23 +807,43 @@ def _phase_summary(state: StateMachine, manifest: dict, run_dir: Path, resolved:
         output = json.loads(translation_output_path.read_text())
         translate_meta = state.get_phase("translate")
 
-        lines = [
-            f"**Run Summary: `{state.run_name}`**",
-            f"Generated: {datetime.now(timezone.utc).isoformat()} | Scenario: {manifest['scenario']}",
-            "",
-            "**Algorithm**",
-            f"- Source: `{(manifest.get('algorithms') or [{}])[0].get('source', 'N/A')}`",
-            f"- Description: {output.get('description', 'N/A')}",
-            "",
-            "**Translation**",
-            f"- Plugin type: `{output['plugin_type']}`",
-            f"- Files created: {', '.join(f'`{f}`' for f in output.get('files_created', []))}",
-            f"- Files modified: {', '.join(f'`{f}`' for f in output.get('files_modified', []))}",
-        ]
+        if "per_algorithm" in output:
+            lines = [
+                f"**Run Summary: `{state.run_name}`**",
+                f"Generated: {datetime.now(timezone.utc).isoformat()} | Scenario: {manifest['scenario']}",
+                "",
+                "**Algorithms**",
+            ]
+            for algo_name, algo_output in output["per_algorithm"].items():
+                algo_src = next(
+                    (a.get("source", "N/A") for a in manifest.get("algorithms", [])
+                     if a["name"] == algo_name),
+                    "N/A"
+                )
+                lines.append(f"- **{algo_name}**")
+                lines.append(f"  - Source: `{algo_src}`")
+                lines.append(f"  - Plugin type: `{algo_output.get('plugin_type', 'N/A')}`")
+                lines.append(f"  - Description: {algo_output.get('description', 'N/A')}")
+                lines.append(f"  - Files: {len(algo_output.get('files_created', []))} created, "
+                             f"{len(algo_output.get('files_modified', []))} modified")
+        else:
+            lines = [
+                f"**Run Summary: `{state.run_name}`**",
+                f"Generated: {datetime.now(timezone.utc).isoformat()} | Scenario: {manifest['scenario']}",
+                "",
+                "**Algorithm**",
+                f"- Source: `{(manifest.get('algorithms') or [{}])[0].get('source', 'N/A')}`",
+                f"- Description: {output.get('description', 'N/A')}",
+                "",
+                "**Translation**",
+                f"- Plugin type: `{output['plugin_type']}`",
+                f"- Files created: {', '.join(f'`{f}`' for f in output.get('files_created', []))}",
+                f"- Files modified: {', '.join(f'`{f}`' for f in output.get('files_modified', []))}",
+            ]
 
-        if translate_meta.get("review_rounds"):
-            lines.append(f"- Review: {translate_meta.get('consensus', 'N/A')} "
-                         f"after {translate_meta['review_rounds']} rounds")
+            if translate_meta.get("review_rounds"):
+                lines.append(f"- Review: {translate_meta.get('consensus', 'N/A')} "
+                             f"after {translate_meta['review_rounds']} rounds")
     else:
         baselines_str = ", ".join(bl["name"] for bl in manifest.get("baselines", []))
         lines = [

--- a/pipeline/prepare.py
+++ b/pipeline/prepare.py
@@ -457,9 +457,10 @@ def _phase_assembly(args, state: StateMachine, manifest: dict, run_dir: Path,
             sys.exit(1)
         for pkg in packages:
             if pkg.kind == "algorithm":
-                injected = inject_epp_image(pkg.resolved, registry, repo_name, run_name_tag)
+                injected = inject_epp_image(pkg.resolved, registry, repo_name, run_name_tag, algo_name=pkg.name)
                 if injected:
-                    ok(f"EPP image injected into {pkg.name}: {registry}/{repo_name}:{run_name_tag}")
+                    effective_tag = f"{run_name_tag}-{pkg.name}"
+                    ok(f"EPP image injected into {pkg.name}: {registry}/{repo_name}:{effective_tag}")
                 else:
                     err(f"{pkg.name} has no 'scenario' entries — EPP image cannot be injected.")
                     sys.exit(1)

--- a/pipeline/prepare.py
+++ b/pipeline/prepare.py
@@ -302,12 +302,18 @@ def _phase_translate(args, state: StateMachine, manifest: dict, run_dir: Path,
     build_cfg = resolved.get("build", {})
     commands = [" ".join(c) if isinstance(c, list) else c for c in build_cfg.get("commands", [])]
 
-    # Check legacy single translation_output.json first (backward compat)
+    # Check for existing translation_output.json
     output_path = run_dir / "translation_output.json"
     if output_path.exists():
-        output = json.loads(output_path.read_text())
-        # If it's already an index (per_algorithm key present), check completeness
+        try:
+            output = json.loads(output_path.read_text())
+        except json.JSONDecodeError as e:
+            err(f"translation_output.json is not valid JSON: {e}. "
+                "Delete the file and re-run the /sim2real-translate skill.")
+            sys.exit(1)
+
         if "per_algorithm" in output:
+            # Per-algorithm index format — check completeness
             all_present = all(
                 (generated_dir / a["name"] / f"{a['name']}_output.json").exists()
                 for a in algorithms
@@ -334,6 +340,11 @@ def _phase_translate(args, state: StateMachine, manifest: dict, run_dir: Path,
                             treatment_config_generated=output.get("treatment_config_generated", False))
             ok(f"Translation found: {output['plugin_type']}")
             return
+        else:
+            err("translation_output.json has unrecognized format "
+                "(missing both 'per_algorithm' and 'plugin_type' keys). "
+                "Delete the file and re-run the /sim2real-translate skill.")
+            sys.exit(1)
 
     # Determine which algorithms still need translation
     translated = []
@@ -688,15 +699,29 @@ def _verify_generated_dir(run_dir: Path):
 
     # Per-algorithm index format
     if "per_algorithm" in output:
+        missing_dirs = []
+        missing_files = []
         for algo_name, algo_output in output["per_algorithm"].items():
             algo_dir = generated_dir / algo_name
             if not algo_dir.exists():
-                warn(f"generated/{algo_name}/ directory not found")
+                missing_dirs.append(algo_name)
                 continue
             for f in algo_output.get("files_created", []) + algo_output.get("files_modified", []):
                 if not (algo_dir / f).exists():
-                    warn(f"generated/{algo_name}/ missing: {f}")
+                    missing_files.append(f"generated/{algo_name}/{f}")
+        if missing_dirs:
+            err(f"Per-algorithm directories missing from generated/: {', '.join(missing_dirs)}. "
+                "Re-run the /sim2real-translate skill for these algorithms.")
+            sys.exit(1)
+        if missing_files:
+            for f in missing_files:
+                warn(f"missing: {f}")
         return
+
+    if "plugin_type" not in output:
+        err("translation_output.json has unrecognized format. "
+            "Re-run the /sim2real-translate skill.")
+        sys.exit(1)
 
     # Legacy flat format
     for f in output.get("files_created", []) + output.get("files_modified", []):
@@ -726,10 +751,12 @@ def _validate_assembly(run_dir: Path, resolved: dict, algorithm_packages: list[s
             # Check: plugin_type in scenario YAML
             if treatment_config_generated:
                 pkg_yaml = run_dir / "cluster" / f"{algo_name}.yaml"
-                if pkg_yaml.exists():
-                    if plugin_type not in pkg_yaml.read_text():
-                        errors.append(
-                            f"[{algo_name}] plugin_type '{plugin_type}' not found in {algo_name}.yaml")
+                if not pkg_yaml.exists():
+                    errors.append(
+                        f"[{algo_name}] scenario YAML not found: cluster/{algo_name}.yaml")
+                elif plugin_type not in pkg_yaml.read_text():
+                    errors.append(
+                        f"[{algo_name}] plugin_type '{plugin_type}' not found in {algo_name}.yaml")
 
         if errors:
             err("validate-assembly FAILED:")
@@ -738,6 +765,11 @@ def _validate_assembly(run_dir: Path, resolved: dict, algorithm_packages: list[s
             sys.exit(1)
         ok("validate-assembly: all checks passed")
         return
+
+    if "plugin_type" not in output:
+        err("translation_output.json has unrecognized format — skipping validation. "
+            "Re-run the /sim2real-translate skill.")
+        sys.exit(1)
 
     # Legacy single-output format
     plugin_type = output["plugin_type"]

--- a/pipeline/prepare.py
+++ b/pipeline/prepare.py
@@ -279,27 +279,86 @@ def _phase_context(args, state: StateMachine, manifest: dict, run_dir: Path) -> 
 
 def _phase_translate(args, state: StateMachine, manifest: dict, run_dir: Path,
                      resolved: dict, context_path: Path):
-    """Phase 3: Write skill_input.json (or skip if no algorithm in manifest)."""
+    """Phase 3: Per-algorithm translation checkpoint.
+
+    For each algorithm in manifest, check if its per-algo output exists in
+    generated/{algo_name}/{algo_name}_output.json. If all exist, write the
+    top-level translation_output.json index and mark phase done. Otherwise,
+    write skill_input.json targeting the next untranslated algorithm and exit.
+    """
     step(3, "Translation Checkpoint")
 
     if state.is_done("translate") and not args.force:
         info("[skip] Translation already complete")
         return
 
-    if not manifest.get("algorithms"):
+    algorithms = manifest.get("algorithms", [])
+    if not algorithms:
         info("[skip] No algorithm in manifest — baseline-only mode")
         state.mark_done("translate", mode="baseline-only")
         return
 
+    generated_dir = run_dir / "generated"
     build_cfg = resolved.get("build", {})
-
-    # Build commands: common commands (skill determines test scope)
     commands = [" ".join(c) if isinstance(c, list) else c for c in build_cfg.get("commands", [])]
 
-    # Write skill_input.json
-    first_bl = manifest.get("baselines", [{}])[0]
-    first_algo = manifest.get("algorithms", [{}])[0]
+    # Check legacy single translation_output.json first (backward compat)
+    output_path = run_dir / "translation_output.json"
+    if output_path.exists():
+        output = json.loads(output_path.read_text())
+        # If it's already an index (per_algorithm key present), check completeness
+        if "per_algorithm" in output:
+            all_present = all(
+                (generated_dir / a["name"] / f"{a['name']}_output.json").exists()
+                for a in algorithms
+            )
+            if all_present:
+                state.mark_done("translate", algorithms=[a["name"] for a in algorithms])
+                ok(f"All {len(algorithms)} algorithms translated")
+                return
+        elif "plugin_type" in output:
+            # Legacy single-algo format — validate and mark done
+            for f in ["plugin_type", "files_created", "files_modified",
+                      "package", "test_commands", "config_kind",
+                      "treatment_config_generated", "description"]:
+                if f not in output:
+                    err(f"translation_output.json missing required field: {f}")
+                    sys.exit(1)
+            if "register_file" not in output:
+                err("translation_output.json missing required field: register_file")
+                sys.exit(1)
+            state.mark_done("translate",
+                            plugin_type=output["plugin_type"],
+                            files_created=output["files_created"],
+                            register_file=output.get("register_file"),
+                            treatment_config_generated=output.get("treatment_config_generated", False))
+            ok(f"Translation found: {output['plugin_type']}")
+            return
 
+    # Determine which algorithms still need translation
+    translated = []
+    pending = []
+    for algo in algorithms:
+        algo_output = generated_dir / algo["name"] / f"{algo['name']}_output.json"
+        if algo_output.exists():
+            translated.append(algo)
+        else:
+            pending.append(algo)
+
+    if not pending:
+        # All algorithms translated — write index and mark done
+        _write_translation_index(run_dir, algorithms, generated_dir)
+        state.mark_done("translate", algorithms=[a["name"] for a in algorithms])
+        ok(f"All {len(algorithms)} algorithms translated — index written")
+        return
+
+    # Target the next pending algorithm
+    target_algo = pending[0]
+    info(f"Translation needed for: {target_algo['name']} "
+         f"({len(translated)}/{len(algorithms)} complete)")
+
+    # Write skill_input.json targeting this algorithm
+    first_bl = manifest.get("baselines", [{}])[0]
     skill_input = {
         "run_name": state.run_name,
         "run_dir": _display_path(run_dir),
@@ -322,11 +381,12 @@ def _phase_translate(args, state: StateMachine, manifest: dict, run_dir: Path,
                 "config": algo.get("config"),
                 "defaults": algo["defaults"],
             }
-            for algo in manifest.get("algorithms", [])
+            for algo in algorithms
         ],
-        # Legacy fields for backward compat with existing skill
-        "algorithm_source": first_algo.get("source", ""),
-        "algorithm_config": first_algo.get("config"),
+        "current_algorithm": target_algo["name"],
+        # Legacy fields — point at current target algorithm
+        "algorithm_source": target_algo.get("source", ""),
+        "algorithm_config": target_algo.get("config"),
         "baseline_sim_config": first_bl.get("sim", {}).get("config"),
         "baseline_real_config": first_bl.get("real", {}).get("config"),
         "baseline_real_notes": first_bl.get("real", {}).get("notes", ""),
@@ -338,43 +398,35 @@ def _phase_translate(args, state: StateMachine, manifest: dict, run_dir: Path,
     skill_input_path = run_dir / "skill_input.json"
     skill_input_path.write_text(json.dumps(skill_input, indent=2))
 
-    # Check for translation output
-    output_path = run_dir / "translation_output.json"
-    if output_path.exists():
-        output = json.loads(output_path.read_text())
-        # Validate required fields
-        for f in ["plugin_type", "files_created", "files_modified",
-                  "package", "test_commands", "config_kind",
-                  "treatment_config_generated", "description"]:
-            if f not in output:
-                err(f"translation_output.json missing required field: {f}")
-                sys.exit(1)
-        if "register_file" not in output:
-            err("translation_output.json missing required field: register_file")
-            sys.exit(1)
-
-        state.mark_done("translate",
-                        plugin_type=output["plugin_type"],
-                        files_created=output["files_created"],
-                        register_file=output.get("register_file"),
-                        treatment_config_generated=output.get("treatment_config_generated", False))
-        ok(f"Translation found: {output['plugin_type']}")
-        return
-
-    # No translation output yet — checkpoint
+    # Checkpoint — exit and wait for skill invocation
     state.increment("translate", "checkpoint_hits")
     hits = state.get_phase("translate").get("checkpoint_hits", 1)
 
     print(f"\n{'='*60}")
     print("  TRANSLATION CHECKPOINT")
     print(f"{'='*60}")
-    print(f"\n  skill_input.json written to: {_display_path(skill_input_path)}")
+    print(f"\n  Algorithm: {target_algo['name']} ({len(translated)}/{len(algorithms)} done)")
+    print(f"  skill_input.json written to: {_display_path(skill_input_path)}")
     print("\n  Next step: run the /sim2real-translate skill in Claude Code,")
     print("  then re-run: python pipeline/prepare.py")
     if hits >= 3:
         warn(f"Checkpoint hit {hits} times. Have you run the translation skill?")
     print(f"\n{'='*60}\n")
     sys.exit(0)
+
+
+def _write_translation_index(run_dir: Path, algorithms: list[dict], generated_dir: Path):
+    """Write top-level translation_output.json as an index of per-algorithm outputs."""
+    per_algorithm = {}
+    for algo in algorithms:
+        algo_output_path = generated_dir / algo["name"] / f"{algo['name']}_output.json"
+        per_algorithm[algo["name"]] = json.loads(algo_output_path.read_text())
+
+    index = {
+        "algorithms": [a["name"] for a in algorithms],
+        "per_algorithm": per_algorithm,
+    }
+    (run_dir / "translation_output.json").write_text(json.dumps(index, indent=2))
 
 
 # ── Phase 4: Assembly ────────────────────────────────────────────────────────

--- a/pipeline/run.py
+++ b/pipeline/run.py
@@ -90,7 +90,8 @@ def cmd_switch(args, workspace_dir: Path, submodule_dir: Path, setup_config: Pat
 
     try:
         result = switch_run(
-            args.name, workspace_dir, submodule_dir, setup_config, confirm_fn
+            args.name, workspace_dir, submodule_dir, setup_config, confirm_fn,
+            algorithm=getattr(args, "algorithm", None),
         )
     except (RunNotFoundError, TranslationOutputError, ValueError) as e:
         err(str(e))
@@ -103,6 +104,8 @@ def cmd_switch(args, workspace_dir: Path, submodule_dir: Path, setup_config: Pat
         sys.exit(1)
 
     ok(f"Switched to run: {result.active_run}")
+    if result.algorithm:
+        info(f"  algorithm: {result.algorithm}")
     for f in result.files_written:
         info(f"  wrote {f}")
 
@@ -134,6 +137,8 @@ Examples:
 
     switch_p = sub.add_parser("switch", help="Switch active run and sync scorer plugin files")
     switch_p.add_argument("name", metavar="NAME", help="Run name to switch to")
+    switch_p.add_argument("--algorithm", metavar="ALGO",
+                          help="Which algorithm to apply (default: first in index)")
 
     return p
 

--- a/pipeline/tests/test_assemble.py
+++ b/pipeline/tests/test_assemble.py
@@ -275,6 +275,82 @@ def test_assemble_packages_algorithm_unknown_baseline_raises(tmp_path):
         )
 
 
+def test_assemble_packages_per_algo_subdir_overlay(tmp_path):
+    """Algorithm overlay resolved from generated/{name}/{name}_config.yaml subdirectory."""
+    _write(tmp_path / "b1.yaml", BASELINE)
+    _write(tmp_path / "treatment.yaml", TREATMENT_DIFFS)
+    # Place overlay in subdirectory instead of flat layout
+    _write(tmp_path / "generated" / "ac1" / "ac1_config.yaml", TREATMENT_OVERLAY)
+    pkgs = assemble_packages(
+        baselines=[{"name": "b1", "scenario_path": tmp_path / "b1.yaml"}],
+        algorithms=[{"name": "ac1", "scenario_path": tmp_path / "treatment.yaml", "defaults": "b1"}],
+        generated_dir=tmp_path / "generated",
+        overlays_expected=True,
+    )
+    assert len(pkgs) == 2
+    assert pkgs[1].kind == "algorithm"
+    assert pkgs[1].name == "ac1"
+    # Overlay applied — quintic-shed plugin present
+    assert "quintic-shed" in pkgs[1].resolved["scenario"][0]["inferenceExtension"]["pluginsCustomConfig"]["custom-plugins.yaml"]
+    # Treatment diffs applied — image tag overridden
+    assert pkgs[1].resolved["scenario"][0]["images"]["inferenceScheduler"]["tag"] == "ac"
+
+
+def test_assemble_packages_multi_algo_independent_overlays(tmp_path):
+    """Two algorithms with different subdirectory overlays produce distinct scenarios."""
+    _write(tmp_path / "b1.yaml", BASELINE)
+    _write(tmp_path / "treatment.yaml", TREATMENT_DIFFS)
+
+    # Algorithm 1 overlay — quintic-shed plugin
+    overlay_algo1 = {
+        "scenario": [{
+            "name": "admission-control",
+            "inferenceExtension": {
+                "pluginsConfigFile": "custom-plugins.yaml",
+                "pluginsCustomConfig": {
+                    "custom-plugins.yaml": "kind: EndpointPickerConfig\nplugins:\n- type: quintic-shed\n",
+                },
+            },
+        }],
+    }
+    # Algorithm 2 overlay — cubic-bloom plugin (different)
+    overlay_algo2 = {
+        "scenario": [{
+            "name": "admission-control",
+            "inferenceExtension": {
+                "pluginsConfigFile": "custom-plugins.yaml",
+                "pluginsCustomConfig": {
+                    "custom-plugins.yaml": "kind: EndpointPickerConfig\nplugins:\n- type: cubic-bloom\n",
+                },
+            },
+        }],
+    }
+    _write(tmp_path / "generated" / "algo1" / "algo1_config.yaml", overlay_algo1)
+    _write(tmp_path / "generated" / "algo2" / "algo2_config.yaml", overlay_algo2)
+
+    pkgs = assemble_packages(
+        baselines=[{"name": "b1", "scenario_path": tmp_path / "b1.yaml"}],
+        algorithms=[
+            {"name": "algo1", "scenario_path": tmp_path / "treatment.yaml", "defaults": "b1"},
+            {"name": "algo2", "scenario_path": tmp_path / "treatment.yaml", "defaults": "b1"},
+        ],
+        generated_dir=tmp_path / "generated",
+        overlays_expected=True,
+    )
+    assert len(pkgs) == 3
+    algo1_pkg = pkgs[1]
+    algo2_pkg = pkgs[2]
+    assert algo1_pkg.name == "algo1"
+    assert algo2_pkg.name == "algo2"
+    # Each algorithm gets its own distinct plugin config
+    algo1_plugins = algo1_pkg.resolved["scenario"][0]["inferenceExtension"]["pluginsCustomConfig"]["custom-plugins.yaml"]
+    algo2_plugins = algo2_pkg.resolved["scenario"][0]["inferenceExtension"]["pluginsCustomConfig"]["custom-plugins.yaml"]
+    assert "quintic-shed" in algo1_plugins
+    assert "cubic-bloom" in algo2_plugins
+    assert "cubic-bloom" not in algo1_plugins
+    assert "quintic-shed" not in algo2_plugins
+
+
 class TestInjectHfSecretName:
     """inject_hf_secret_name sets huggingface.secretName on all scenario entries."""
 

--- a/pipeline/tests/test_epp.py
+++ b/pipeline/tests/test_epp.py
@@ -87,6 +87,23 @@ class TestInjectEppImage:
         assert scenario["scenario"][0]["images"]["vllm"] == {"repository": "vllm-r", "tag": "vllm-t"}
         assert scenario["scenario"][0]["images"]["inferenceScheduler"]["tag"] == "v2"
 
+    def test_inject_epp_image_with_algo_suffix(self):
+        """Per-algorithm tag: tag becomes '{tag}-{algo_name}' when algo_name is set."""
+        scenario = {"scenario": [{"name": "s1"}]}
+        result = inject_epp_image(scenario, "reg.io", "epp", "r1", algo_name="algo1")
+        assert result is True
+        img = scenario["scenario"][0]["images"]["inferenceScheduler"]
+        assert img["tag"] == "r1-algo1"
+        assert img["repository"] == "reg.io/epp"
+
+    def test_inject_epp_image_without_algo_name_unchanged(self):
+        """Backward compat: tag stays as-is when algo_name is None."""
+        scenario = {"scenario": [{"name": "s1"}]}
+        result = inject_epp_image(scenario, "reg.io", "epp", "r1")
+        assert result is True
+        img = scenario["scenario"][0]["images"]["inferenceScheduler"]
+        assert img["tag"] == "r1"
+
 
 class TestInjectImageRef:
     def test_injects_complete_ref(self):

--- a/pipeline/tests/test_run.py
+++ b/pipeline/tests/test_run.py
@@ -31,11 +31,11 @@ class TestExperimentRootPaths:
 
         captured = {}
 
-        def fake_switch(run_name, workspace_dir, submodule_dir, setup_config, confirm_fn):
+        def fake_switch(run_name, workspace_dir, submodule_dir, setup_config, confirm_fn, **kwargs):
             captured["workspace_dir"] = workspace_dir
             captured["submodule_dir"] = submodule_dir
             captured["setup_config"] = setup_config
-            return MagicMock(active_run=run_name, files_written=[])
+            return MagicMock(active_run=run_name, files_written=[], algorithm=None)
 
         with patch.object(mod, "switch_run", side_effect=fake_switch), \
              patch.object(sys, "argv",

--- a/pipeline/tests/test_source_toggle.py
+++ b/pipeline/tests/test_source_toggle.py
@@ -139,6 +139,81 @@ class TestRestoreTreatment:
         assert (component_dir / "a" / "b" / "c" / "deep.go").read_text() == "deep file"
 
 
+class TestPerAlgorithmRestore:
+    def test_restore_treatment_from_subdirectory(self, tmp_path):
+        """When algo_name is set, files are read from generated_dir/{algo_name}/{rel_path}."""
+        component_dir = tmp_path / "component"
+        component_dir.mkdir()
+        _init_repo(component_dir)
+
+        generated_dir = tmp_path / "generated"
+        algo_subdir = generated_dir / "my_algo" / "cmd" / "epp" / "runner"
+        algo_subdir.mkdir(parents=True)
+        (algo_subdir / "runner.go").write_text("algo runner content")
+
+        # Also a top-level modified file
+        (generated_dir / "my_algo" / "base.txt").write_text("algo base content")
+
+        translation_output = {
+            "files_created": ["cmd/epp/runner/runner.go"],
+            "files_modified": ["base.txt"],
+        }
+
+        restore_treatment(component_dir, generated_dir, translation_output, algo_name="my_algo")
+        assert (component_dir / "cmd" / "epp" / "runner" / "runner.go").read_text() == "algo runner content"
+        assert (component_dir / "base.txt").read_text() == "algo base content"
+
+    def test_restore_treatment_without_algo_name_uses_basename(self, tmp_path):
+        """When algo_name is None, the legacy basename lookup is used."""
+        component_dir = tmp_path / "component"
+        component_dir.mkdir()
+        _init_repo(component_dir)
+
+        generated_dir = tmp_path / "generated"
+        generated_dir.mkdir()
+        (generated_dir / "runner.go").write_text("flat runner content")
+
+        translation_output = {
+            "files_created": ["cmd/epp/runner/runner.go"],
+            "files_modified": [],
+        }
+
+        restore_treatment(component_dir, generated_dir, translation_output)
+        assert (component_dir / "cmd" / "epp" / "runner" / "runner.go").read_text() == "flat runner content"
+
+    def test_round_trip_per_algorithm(self, tmp_path):
+        """Full cycle: baseline -> treatment (per-algo) -> baseline -> treatment (per-algo)."""
+        component_dir = tmp_path / "component"
+        component_dir.mkdir()
+        _init_repo(component_dir)
+
+        generated_dir = tmp_path / "generated"
+        algo_subdir = generated_dir / "evolved_v2"
+        (algo_subdir / "pkg").mkdir(parents=True)
+        (algo_subdir / "pkg" / "scorer.go").write_text("evolved scorer")
+        (algo_subdir / "base.txt").write_text("evolved base")
+
+        translation_output = {
+            "files_created": ["pkg/scorer.go"],
+            "files_modified": ["base.txt"],
+        }
+
+        # Apply treatment with per-algorithm path
+        restore_treatment(component_dir, generated_dir, translation_output, algo_name="evolved_v2")
+        assert (component_dir / "pkg" / "scorer.go").read_text() == "evolved scorer"
+        assert (component_dir / "base.txt").read_text() == "evolved base"
+
+        # Restore baseline
+        restore_baseline(component_dir, translation_output)
+        assert not (component_dir / "pkg" / "scorer.go").exists()
+        assert (component_dir / "base.txt").read_text() == "original"
+
+        # Restore treatment again
+        restore_treatment(component_dir, generated_dir, translation_output, algo_name="evolved_v2")
+        assert (component_dir / "pkg" / "scorer.go").read_text() == "evolved scorer"
+        assert (component_dir / "base.txt").read_text() == "evolved base"
+
+
 class TestRoundTrip:
     def test_baseline_then_treatment_restores_state(self, tmp_path):
         """Full round-trip: start with treatment state, restore baseline, restore treatment."""


### PR DESCRIPTION
## Summary

Closes #225

Enables multi-algorithm manifests to produce independently translated, independently built, and independently deployed algorithm packages. Each algorithm gets its own:
- Generated files subdirectory (`generated/{algo_name}/`) with full relative paths
- Config overlay (`{algo_name}_config.yaml`)
- Translation output (`{algo_name}_output.json`)
- Container image tag (`run_name-algo_name`)

Single-algorithm manifests continue to work unchanged via fallback lookup paths.

## Changes

- **`assemble.py`** — `_resolve_overlay` checks `generated/{name}/{name}_config.yaml` before flat layout
- **`source_toggle.py`** — `restore_treatment` accepts `algo_name` param; reads from per-algo subdirectory with full paths
- **`copy_generated.py`** — `algo_name` param writes to `generated/{algo_name}/` preserving full paths; also writes per-algo output JSON
- **`epp.py`** — `inject_epp_image` accepts `algo_name`; tag becomes `{run_name}-{algo_name}`
- **`prepare.py` Phase 3** — loops over algorithms, checks per-algo output existence, targets next untranslated algorithm in `skill_input.json`, writes index `translation_output.json` when all complete
- **`prepare.py` Phase 4** — `_verify_generated_dir` and `_validate_assembly` handle per-algorithm index format
- **`prepare.py` Phase 5** — summary lists all algorithms with their plugin types
- **`deploy.py`** — `ensure_images` loads per-algo outputs, applies per-algorithm source toggle for each image build
- **`run_manager.py`** — `switch_run` copies from per-algorithm subdirectories with full paths

## Reviewer attention

- **Backward compat**: All existing single-algorithm behavior preserved via fallback paths. The per-algorithm format is only written when `generated/{algo_name}/{algo_name}_output.json` files exist.
- **`translation_output.json` dual format**: Can now be either legacy single-output (`{"plugin_type": ...}`) or per-algorithm index (`{"per_algorithm": {...}}`). All consumers check for `"per_algorithm"` key first.
- **Deploy build loop**: Per-algorithm mode does baseline→apply→build→baseline for each algorithm image. This is O(N) builds but ensures clean state between algorithms.
- **Subsumes #190 and #192**: Per-algorithm subdirectories with full relative paths eliminate the basename collision class entirely.

## Test plan

- [x] All 782 existing + new tests pass
- [x] Lint passes (ruff --select F)
- [x] Existing single-algorithm tests verify backward compatibility
- [x] New tests cover: subdirectory overlay resolution, per-algo restore round-trip, per-algo copy with full paths, per-algo image tags, multi-algo independent overlays
- [ ] Manual: run pipeline with expceil experiment (two algorithms) to verify end-to-end