### PR TITLE
fix: _cancel_and_delete_pipelinerun reports failure to caller

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -253,15 +253,19 @@ def _cmd_build(run_dir: Path, namespace: str, skip_build: bool) -> str:
 
 # ── PipelineRun helpers ──────────────────────────────────────────────────────
 
-def _cancel_and_delete_pipelinerun(pr_name: str, namespace: str) -> None:
+def _cancel_and_delete_pipelinerun(pr_name: str, namespace: str) -> bool:
     """If a PipelineRun with the given name exists, cancel it, wait for it to
-    finish cancelling, then delete it so a fresh one can be submitted."""
+    finish cancelling, then delete it so a fresh one can be submitted.
+
+    Returns True if the PipelineRun was successfully deleted (or didn't exist).
+    Returns False if the delete failed — caller should NOT free the slot.
+    """
     exists = run(
         ["kubectl", "get", "pipelinerun", pr_name, "-n", namespace],
         check=False, capture=True,
     )
     if exists.returncode != 0:
-        return  # doesn't exist, nothing to cancel
+        return True  # doesn't exist, nothing to cancel
 
     status = _check_pipelinerun_status(pr_name, namespace)
     info(f"Existing PipelineRun {pr_name!r} found (status: {status}); cancelling …")
@@ -282,11 +286,17 @@ def _cancel_and_delete_pipelinerun(pr_name: str, namespace: str) -> None:
         else:
             warn(f"PipelineRun {pr_name!r} did not cancel within 120 s; deleting anyway")
 
-    run(
+    result = run(
         ["kubectl", "delete", "pipelinerun", pr_name, "-n", namespace,
          "--ignore-not-found"],
         check=False, capture=True,
     )
+    if result.returncode != 0:
+        detail = result.stderr.strip() if result.stderr else ""
+        warn(f"Failed to delete PipelineRun {pr_name!r} in {namespace}"
+             + (f": {detail}" if detail else ""))
+        return False
+    return True
 
 
 def _delete_pipelinerun(pr_name: str, namespace: str) -> None:

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -499,7 +499,9 @@ def _handle_pending_pods(*, pr_name: str, namespace: str, entry: dict,
 
     if category == "non_recoverable":
         warn(f"[{entry.get('workload', '?')}] non-recoverable pending: {detail}")
-        _cancel_and_delete_pipelinerun(pr_name, namespace)
+        if not _cancel_and_delete_pipelinerun(pr_name, namespace):
+            warn(f"[{entry.get('workload', '?')}] cancel failed — slot NOT freed")
+            return False
         entry["status"] = "failed"
         entry["namespace"] = None
         entry["pending_since"] = None
@@ -523,7 +525,9 @@ def _handle_pending_pods(*, pr_name: str, namespace: str, entry: dict,
         return False
 
     warn(f"[{entry.get('workload', '?')}] pending {int(elapsed)}s > {pending_threshold}s threshold → reclaim")
-    _cancel_and_delete_pipelinerun(pr_name, namespace)
+    if not _cancel_and_delete_pipelinerun(pr_name, namespace):
+        warn(f"[{entry.get('workload', '?')}] cancel failed — slot NOT freed")
+        return False
     stalls = entry.get("pending_stalls", 0) + 1
     entry["pending_stalls"] = stalls
     entry["pending_since"] = None

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -258,33 +258,45 @@ def _cancel_and_delete_pipelinerun(pr_name: str, namespace: str) -> bool:
     finish cancelling, then delete it so a fresh one can be submitted.
 
     Returns True if the PipelineRun was successfully deleted (or didn't exist).
-    Returns False if the delete failed — caller should NOT free the slot.
+    Returns False if it could not be removed — caller should NOT free the slot.
+    The cancel-patch step is best-effort: if the patch fails the function still
+    attempts the delete, and the return value reflects whether delete succeeded.
     """
     exists = run(
         ["kubectl", "get", "pipelinerun", pr_name, "-n", namespace],
         check=False, capture=True,
     )
     if exists.returncode != 0:
-        return True  # doesn't exist, nothing to cancel
+        stderr = exists.stderr.strip() if exists.stderr else ""
+        if "NotFound" in stderr or "not found" in stderr:
+            return True  # doesn't exist, nothing to cancel
+        warn(f"Cannot reach PipelineRun {pr_name!r} in {namespace}"
+             + (f": {stderr}" if stderr else "") + " — assuming still active")
+        return False
 
     status = _check_pipelinerun_status(pr_name, namespace)
     info(f"Existing PipelineRun {pr_name!r} found (status: {status}); cancelling …")
 
     if status in ("Running", "Started"):
-        run(
+        patch_result = run(
             ["kubectl", "patch", "pipelinerun", pr_name,
              "--type=merge", "-p", '{"spec":{"status":"CancelledRunFinally"}}',
              "-n", namespace],
             check=False, capture=True,
         )
-        for _ in range(40):  # wait up to 120 s
-            time.sleep(3)
-            current = _check_pipelinerun_status(pr_name, namespace)
-            if current not in ("Running", "Started"):
-                info(f"PipelineRun {pr_name!r} cancelled (now: {current})")
-                break
+        if patch_result.returncode != 0:
+            detail = patch_result.stderr.strip() if patch_result.stderr else ""
+            warn(f"Failed to patch PipelineRun {pr_name!r} for cancellation"
+                 + (f": {detail}" if detail else ""))
         else:
-            warn(f"PipelineRun {pr_name!r} did not cancel within 120 s; deleting anyway")
+            for _ in range(40):  # wait up to 120 s
+                time.sleep(3)
+                current = _check_pipelinerun_status(pr_name, namespace)
+                if current not in ("Running", "Started"):
+                    info(f"PipelineRun {pr_name!r} cancelled (now: {current})")
+                    break
+            else:
+                warn(f"PipelineRun {pr_name!r} did not cancel within 120 s; deleting anyway")
 
     result = run(
         ["kubectl", "delete", "pipelinerun", pr_name, "-n", namespace,
@@ -500,7 +512,7 @@ def _handle_pending_pods(*, pr_name: str, namespace: str, entry: dict,
     if category == "non_recoverable":
         warn(f"[{entry.get('workload', '?')}] non-recoverable pending: {detail}")
         if not _cancel_and_delete_pipelinerun(pr_name, namespace):
-            warn(f"[{entry.get('workload', '?')}] cancel failed — slot NOT freed")
+            warn(f"[{entry.get('workload', '?')}] could not remove PipelineRun {pr_name!r} in {namespace} — slot NOT freed")
             return False
         entry["status"] = "failed"
         entry["namespace"] = None
@@ -526,7 +538,7 @@ def _handle_pending_pods(*, pr_name: str, namespace: str, entry: dict,
 
     warn(f"[{entry.get('workload', '?')}] pending {int(elapsed)}s > {pending_threshold}s threshold → reclaim")
     if not _cancel_and_delete_pipelinerun(pr_name, namespace):
-        warn(f"[{entry.get('workload', '?')}] cancel failed — slot NOT freed")
+        warn(f"[{entry.get('workload', '?')}] could not remove PipelineRun {pr_name!r} in {namespace} — slot NOT freed")
         return False
     stalls = entry.get("pending_stalls", 0) + 1
     entry["pending_stalls"] = stalls
@@ -537,6 +549,48 @@ def _handle_pending_pods(*, pr_name: str, namespace: str, entry: dict,
         warn(f"[{entry.get('workload', '?')}] reached max pending stalls ({max_pending_stalls}) → stalled")
     else:
         entry["status"] = "pending"
+    return True
+
+
+def _handle_timeout(*, pr_name: str, namespace: str, entry: dict,
+                    timeout_hours: float, max_retries: int) -> bool | None:
+    """Check if a PipelineRun has exceeded its timeout and handle accordingly.
+
+    Returns True if the entry was timed out and cleaned up, False if timeout
+    was detected but cancel failed (slot left busy), None if not timed out.
+    """
+    import datetime as _dt
+    ts_result = run(
+        ["kubectl", "get", "pipelinerun", pr_name, f"-n={namespace}",
+         "-o", "jsonpath={.metadata.creationTimestamp}"],
+        check=False, capture=True,
+    )
+    if ts_result.returncode != 0 or not ts_result.stdout.strip():
+        return None
+    try:
+        created = _dt.datetime.fromisoformat(
+            ts_result.stdout.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    age_h = (_dt.datetime.now(_dt.timezone.utc) - created).total_seconds() / 3600
+    if age_h <= timeout_hours:
+        return None
+
+    retries = entry.get("retries", 0)
+    if not _cancel_and_delete_pipelinerun(pr_name, namespace):
+        warn(f"[{entry.get('workload', '?')}] timed out but could not remove "
+             f"PipelineRun {pr_name!r} in {namespace} — slot NOT freed")
+        return False
+    if retries < max_retries:
+        warn(f"[{entry.get('workload', '?')}] timed out → requeue "
+             f"(attempt {retries + 1}/{max_retries})")
+        entry["status"] = "pending"
+        entry["retries"] = retries + 1
+    else:
+        warn(f"[{entry.get('workload', '?')}] timed out, max retries → timed-out")
+        entry["status"] = "timed-out"
+    entry["namespace"] = None
+    entry["pending_since"] = None
     return True
 
 
@@ -1643,7 +1697,6 @@ def _capacity_limited_pairs(
 
 def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
     """Orchestrate parallel pool execution across namespace slots."""
-    import datetime as _dt
     import tempfile as _tmp
     from pipeline.lib.progress import ConfigMapProgressStore
     from pipeline.lib.backoff import BackoffController
@@ -1863,38 +1916,19 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                         store.save(progress)
 
                 # Check for timeout
-                ts_result = run(
-                    ["kubectl", "get", "pipelinerun", pr_name, f"-n={ns}",
-                     "-o", "jsonpath={.metadata.creationTimestamp}"],
-                    check=False, capture=True,
+                timeout_result = _handle_timeout(
+                    pr_name=pr_name, namespace=ns, entry=entry,
+                    timeout_hours=timeout_hours, max_retries=max_retries,
                 )
-                if ts_result.returncode == 0 and ts_result.stdout.strip():
-                    try:
-                        created = _dt.datetime.fromisoformat(
-                            ts_result.stdout.strip().replace("Z", "+00:00"))
-                        age_h = (_dt.datetime.now(_dt.timezone.utc) - created).total_seconds() / 3600
-                        if age_h > timeout_hours:
-                            retries = entry.get("retries", 0)
-                            if not _cancel_and_delete_pipelinerun(pr_name, ns):
-                                warn(f"[{pair_key}] timed out but cancel failed — slot NOT freed")
-                                continue
-                            if retries < max_retries:
-                                warn(f"[{pair_key}] timed out → requeue (attempt {retries + 1}/{max_retries})")
-                                entry["status"] = "pending"
-                                entry["retries"] = retries + 1
-                            else:
-                                warn(f"[{pair_key}] timed out, max retries → timed-out")
-                                entry["status"] = "timed-out"
-                            entry["namespace"] = None
-                            entry["pending_since"] = None
-                            del slots_busy[ns]
-                            _last_log_state.pop("capacity", None)
-                            _last_log_state.pop("dispatch", None)
-                            _last_log_state.pop("backoff_skip", None)
-                            _zero_dispatch_count = 0
-                            store.save(progress)
-                    except ValueError:
-                        pass
+                if timeout_result is True:
+                    del slots_busy[ns]
+                    _last_log_state.pop("capacity", None)
+                    _last_log_state.pop("dispatch", None)
+                    _last_log_state.pop("backoff_skip", None)
+                    _zero_dispatch_count = 0
+                    store.save(progress)
+                elif timeout_result is False:
+                    continue
 
         # ── Capacity probe ───────────────────────────────────────────────
         capacity = probe_free_gpus(gpu_resource_type=gpu_resource_type)

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1875,7 +1875,9 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                         age_h = (_dt.datetime.now(_dt.timezone.utc) - created).total_seconds() / 3600
                         if age_h > timeout_hours:
                             retries = entry.get("retries", 0)
-                            _cancel_and_delete_pipelinerun(pr_name, ns)
+                            if not _cancel_and_delete_pipelinerun(pr_name, ns):
+                                warn(f"[{pair_key}] timed out but cancel failed — slot NOT freed")
+                                continue
                             if retries < max_retries:
                                 warn(f"[{pair_key}] timed out → requeue (attempt {retries + 1}/{max_retries})")
                                 entry["status"] = "pending"

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1270,8 +1270,7 @@ def _reset_pair(key: str, entry: dict, discovered: dict, *,
         warn(f"{key}: no PipelineRun name found — skipping PR deletion (manual check needed)")
     elif ns:
         if entry.get("status") == "running":
-            _cancel_and_delete_pipelinerun(pr_name, ns)
-            pr_deleted = True
+            pr_deleted = _cancel_and_delete_pipelinerun(pr_name, ns)
         else:
             result = run(["kubectl", "delete", "pipelinerun", pr_name, "-n", ns,
                          "--ignore-not-found"], check=False, capture=True)

--- a/pipeline/tests/test_deploy_cancel.py
+++ b/pipeline/tests/test_deploy_cancel.py
@@ -1,0 +1,60 @@
+"""Tests for _cancel_and_delete_pipelinerun return value."""
+import pipeline.deploy as mod
+
+
+def test_cancel_returns_true_on_successful_delete(monkeypatch):
+    """When the final kubectl delete succeeds, return True."""
+    calls = []
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        calls.append(cmd)
+        class _R:
+            returncode = 0
+            stdout = '{"status":{"conditions":[{"type":"Succeeded","reason":"Cancelled"}]}}'
+            stderr = ""
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    monkeypatch.setattr(mod, "_check_pipelinerun_status", lambda pr, ns: "Cancelled")
+
+    result = mod._cancel_and_delete_pipelinerun("my-pr", "ns-0")
+    assert result is True
+
+
+def test_cancel_returns_true_when_pr_does_not_exist(monkeypatch):
+    """When the PipelineRun doesn't exist, nothing to cancel — return True."""
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 1
+            stdout = ""
+            stderr = "not found"
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    result = mod._cancel_and_delete_pipelinerun("my-pr", "ns-0")
+    assert result is True
+
+
+def test_cancel_returns_false_when_delete_fails(monkeypatch):
+    """When the final kubectl delete fails, return False and warn."""
+    call_count = {"n": 0}
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        call_count["n"] += 1
+        class _R:
+            stdout = ""
+            stderr = "connection refused"
+        if "get" in cmd:
+            _R.returncode = 0
+        elif "delete" in cmd:
+            _R.returncode = 1
+        else:
+            _R.returncode = 0
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    monkeypatch.setattr(mod, "_check_pipelinerun_status", lambda pr, ns: "Cancelled")
+
+    result = mod._cancel_and_delete_pipelinerun("my-pr", "ns-0")
+    assert result is False

--- a/pipeline/tests/test_deploy_cancel.py
+++ b/pipeline/tests/test_deploy_cancel.py
@@ -38,10 +38,7 @@ def test_cancel_returns_true_when_pr_does_not_exist(monkeypatch):
 
 def test_cancel_returns_false_when_delete_fails(monkeypatch):
     """When the final kubectl delete fails, return False and warn."""
-    call_count = {"n": 0}
-
     def fake_run(cmd, *, check=True, capture=False, cwd=None):
-        call_count["n"] += 1
         class _R:
             stdout = ""
             stderr = "connection refused"
@@ -58,3 +55,46 @@ def test_cancel_returns_false_when_delete_fails(monkeypatch):
 
     result = mod._cancel_and_delete_pipelinerun("my-pr", "ns-0")
     assert result is False
+
+
+def test_cancel_returns_false_when_get_fails_not_notfound(monkeypatch):
+    """When kubectl get fails with a non-NotFound error (RBAC, network), return False."""
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 1
+            stdout = ""
+            stderr = "error: You must be logged in to the server (Unauthorized)"
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    result = mod._cancel_and_delete_pipelinerun("my-pr", "ns-0")
+    assert result is False
+
+
+def test_cancel_patch_failure_still_attempts_delete(monkeypatch):
+    """When cancel patch fails, function still tries delete and returns based on delete result."""
+    calls = []
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        calls.append(cmd[:3])
+        class _R:
+            stdout = ""
+            stderr = ""
+        if "get" in cmd:
+            _R.returncode = 0
+        elif "patch" in cmd:
+            _R.returncode = 1
+            _R.stderr = "forbidden"
+        elif "delete" in cmd:
+            _R.returncode = 0
+        else:
+            _R.returncode = 0
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    monkeypatch.setattr(mod, "_check_pipelinerun_status", lambda pr, ns: "Running")
+
+    result = mod._cancel_and_delete_pipelinerun("my-pr", "ns-0")
+    assert result is True
+    assert ["kubectl", "delete", "pipelinerun"] in calls

--- a/pipeline/tests/test_deploy_reset.py
+++ b/pipeline/tests/test_deploy_reset.py
@@ -83,6 +83,7 @@ def test_reset_pair_running_cancels_first(monkeypatch):
 
     def fake_cancel(pr_name, ns):
         cancelled.append((pr_name, ns))
+        return True
 
     def fake_run(cmd, *, check=True, capture=False, cwd=None):
         class _R:
@@ -389,7 +390,7 @@ def test_cmd_reset_saves_progress_on_success(tmp_path, monkeypatch, capsys):
         return _R()
 
     def fake_cancel(pr_name, ns):
-        pass
+        return True
 
     monkeypatch.setattr(mod, "run", fake_run)
     monkeypatch.setattr(mod, "_cancel_and_delete_pipelinerun", fake_cancel)
@@ -691,3 +692,19 @@ def test_reset_pair_done_no_pr_name_still_cleans_helm(monkeypatch):
     assert "sim2real-0" in helm_lists[0]
     helm_uninstalls = [c for c in calls if c[:2] == ["helm", "uninstall"]]
     assert len(helm_uninstalls) == 1
+
+
+def test_reset_pair_cancel_failure_does_not_reset(monkeypatch):
+    """When _cancel_and_delete_pipelinerun returns False, _reset_pair returns False."""
+    import pipeline.deploy as mod
+
+    entry = {"workload": "wl-smoke", "package": "treatment", "status": "running",
+             "namespace": "sim2real-1", "retries": 0}
+
+    monkeypatch.setattr(mod, "_cancel_and_delete_pipelinerun", lambda pr, ns: False)
+    monkeypatch.setattr(mod, "run", lambda cmd, **kw: type("R", (), {"returncode": 0, "stdout": ""})())
+
+    result = mod._reset_pair("wl-smoke-treatment", entry, _DISCOVERED)
+    assert result is False
+    assert entry["status"] == "running"
+    assert entry["namespace"] == "sim2real-1"

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -2356,3 +2356,113 @@ def test_early_reclaim_recoverable_cancel_fails_leaves_slot_busy(monkeypatch):
     assert reclaimed is False
     assert entry["status"] == "running"
     assert entry["namespace"] == "sim2real-0"
+
+
+# ── _handle_timeout tests ────────────────────────────────────────────────────
+
+
+def test_handle_timeout_cancel_fails_leaves_entry_unchanged(monkeypatch):
+    """When PR is timed out but cancel fails, return False and leave entry unchanged."""
+    import datetime as _dt
+    import pipeline.deploy as mod
+
+    old_ts = (_dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(hours=5)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ")
+
+    entry = {
+        "workload": "wl-smoke", "package": "treatment", "status": "running",
+        "namespace": "sim2real-0", "retries": 0, "pending_since": None,
+    }
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = old_ts
+            stderr = ""
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    monkeypatch.setattr(mod, "_cancel_and_delete_pipelinerun", lambda pr, ns: False)
+
+    result = mod._handle_timeout(
+        pr_name="treatment-smoke-run1",
+        namespace="sim2real-0",
+        entry=entry,
+        timeout_hours=4.0,
+        max_retries=3,
+    )
+
+    assert result is False
+    assert entry["status"] == "running"
+    assert entry["namespace"] == "sim2real-0"
+
+
+def test_handle_timeout_cancel_succeeds_requeues(monkeypatch):
+    """When PR is timed out and cancel succeeds, requeue entry."""
+    import datetime as _dt
+    import pipeline.deploy as mod
+
+    old_ts = (_dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(hours=5)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ")
+
+    entry = {
+        "workload": "wl-smoke", "package": "treatment", "status": "running",
+        "namespace": "sim2real-0", "retries": 0, "pending_since": None,
+    }
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = old_ts
+            stderr = ""
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    monkeypatch.setattr(mod, "_cancel_and_delete_pipelinerun", lambda pr, ns: True)
+
+    result = mod._handle_timeout(
+        pr_name="treatment-smoke-run1",
+        namespace="sim2real-0",
+        entry=entry,
+        timeout_hours=4.0,
+        max_retries=3,
+    )
+
+    assert result is True
+    assert entry["status"] == "pending"
+    assert entry["retries"] == 1
+    assert entry["namespace"] is None
+
+
+def test_handle_timeout_not_expired_returns_none(monkeypatch):
+    """When PR is not timed out, return None (no action taken)."""
+    import datetime as _dt
+    import pipeline.deploy as mod
+
+    recent_ts = (_dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(hours=1)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ")
+
+    entry = {
+        "workload": "wl-smoke", "package": "treatment", "status": "running",
+        "namespace": "sim2real-0", "retries": 0, "pending_since": None,
+    }
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = recent_ts
+            stderr = ""
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    result = mod._handle_timeout(
+        pr_name="treatment-smoke-run1",
+        namespace="sim2real-0",
+        entry=entry,
+        timeout_hours=4.0,
+        max_retries=3,
+    )
+
+    assert result is None
+    assert entry["status"] == "running"

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -1314,7 +1314,7 @@ def test_early_reclaim_recoverable_threshold_exceeded(monkeypatch):
 
     monkeypatch.setattr(mod, "run", fake_run)
     monkeypatch.setattr(mod, "_cancel_and_delete_pipelinerun",
-                        lambda pr, ns: cancelled.append((pr, ns)))
+                        lambda pr, ns: cancelled.append((pr, ns)) or True)
 
     reclaimed = mod._handle_pending_pods(
         pr_name="baseline-smoke-run1",
@@ -1413,7 +1413,7 @@ def test_early_reclaim_non_recoverable_fails_immediately(monkeypatch):
 
     monkeypatch.setattr(mod, "run", fake_run)
     monkeypatch.setattr(mod, "_cancel_and_delete_pipelinerun",
-                        lambda pr, ns: cancelled.append((pr, ns)))
+                        lambda pr, ns: cancelled.append((pr, ns)) or True)
 
     reclaimed = mod._handle_pending_pods(
         pr_name="baseline-smoke-run1",
@@ -1464,7 +1464,7 @@ def test_early_reclaim_stalled_at_max_pending_stalls(monkeypatch):
         return _R()
 
     monkeypatch.setattr(mod, "run", fake_run)
-    monkeypatch.setattr(mod, "_cancel_and_delete_pipelinerun", lambda pr, ns: None)
+    monkeypatch.setattr(mod, "_cancel_and_delete_pipelinerun", lambda pr, ns: True)
 
     reclaimed = mod._handle_pending_pods(
         pr_name="baseline-smoke-run1",
@@ -2262,3 +2262,97 @@ def test_status_uses_configmap_directly(tmp_path, capsys, monkeypatch):
 
     out = capsys.readouterr().out
     assert "wl-remote-baseline" in out
+
+
+def test_early_reclaim_non_recoverable_cancel_fails_leaves_slot_busy(monkeypatch):
+    """When cancel fails for non-recoverable pod, slot stays busy (not freed)."""
+    import json
+    import pipeline.deploy as mod
+
+    pods_json = {
+        "items": [{
+            "status": {
+                "phase": "Pending",
+                "conditions": [{
+                    "type": "PodScheduled",
+                    "status": "False",
+                    "reason": "Unschedulable",
+                    "message": "node(s) had untolerated taint {nvidia.com/gpu=present}",
+                }],
+            },
+        }],
+    }
+    entry = {
+        "workload": "wl-smoke", "package": "baseline", "status": "running",
+        "namespace": "sim2real-0", "retries": 0, "gpu_cost": 1,
+        "pending_stalls": 0, "pending_since": None,
+    }
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = json.dumps(pods_json)
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    monkeypatch.setattr(mod, "_cancel_and_delete_pipelinerun", lambda pr, ns: False)
+
+    reclaimed = mod._handle_pending_pods(
+        pr_name="baseline-smoke-run1",
+        namespace="sim2real-0",
+        entry=entry,
+        pending_threshold=600,
+        max_pending_stalls=10,
+    )
+
+    assert reclaimed is False
+    assert entry["status"] == "running"
+    assert entry["namespace"] == "sim2real-0"
+
+
+def test_early_reclaim_recoverable_cancel_fails_leaves_slot_busy(monkeypatch):
+    """When cancel fails for recoverable timeout, slot stays busy."""
+    import datetime as _dt
+    import json
+    import pipeline.deploy as mod
+
+    pods_json = {
+        "items": [{
+            "status": {
+                "phase": "Pending",
+                "conditions": [{
+                    "type": "PodScheduled",
+                    "status": "False",
+                    "reason": "Unschedulable",
+                    "message": "0/8 nodes are available: 8 Insufficient nvidia.com/gpu.",
+                }],
+            },
+        }],
+    }
+    old_time = (_dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(seconds=700)).isoformat()
+    entry = {
+        "workload": "wl-smoke", "package": "baseline", "status": "running",
+        "namespace": "sim2real-0", "retries": 0, "gpu_cost": 1,
+        "pending_stalls": 0, "pending_since": old_time,
+    }
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = json.dumps(pods_json)
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    monkeypatch.setattr(mod, "_cancel_and_delete_pipelinerun", lambda pr, ns: False)
+
+    reclaimed = mod._handle_pending_pods(
+        pr_name="baseline-smoke-run1",
+        namespace="sim2real-0",
+        entry=entry,
+        pending_threshold=600,
+        max_pending_stalls=10,
+    )
+
+    assert reclaimed is False
+    assert entry["status"] == "running"
+    assert entry["namespace"] == "sim2real-0"


### PR DESCRIPTION
## Summary

- `_cancel_and_delete_pipelinerun` now returns `bool` — `True` when deletion succeeded (or PR didn't exist), `False` when `kubectl delete` fails
- All four callers check the return value and leave the slot marked busy on failure, preventing new work from being dispatched to a namespace whose PipelineRun is still consuming GPUs
- Added warning messages on failure so operators see exactly what happened

Closes #79

## Call sites updated

| Call site | Behavior on failure |
|-----------|-------------------|
| `_handle_pending_pods` (non-recoverable) | Returns `False`, entry stays `running` |
| `_handle_pending_pods` (recoverable timeout) | Returns `False`, entry stays `running` |
| `_reset_pair` (running pair) | Returns `False`, state NOT reset |
| Timeout handler (poll loop) | `continue`s loop, slot stays busy |

## Reviewer attention

- The `_reset_pair` path already had correct failure handling for non-running pairs (checking `kubectl delete` returncode directly). The running-pair path was the inconsistency — it now uses the same pattern via the return value.
- The "PR doesn't exist" case returns `True` (success) since there's nothing to clean up — this preserves backward compatibility for the reset subcommand which may encounter already-deleted PipelineRuns.

## Test plan

- [x] `python3 -m pytest pipeline/ -v` — 744 tests pass
- [x] `ruff check pipeline/ --select F` — clean
- [x] 6 new tests covering the failure paths across all call sites