### PR TITLE
fix: update sim2real-translate skill for per-algorithm layout

### DIFF
--- a/.claude/skills/sim2real-translate/SKILL.md
+++ b/.claude/skills/sim2real-translate/SKILL.md
@@ -139,7 +139,8 @@ import json, sys
 si = json.load(open('$RUN_DIR/skill_input.json'))
 required = ['run_name', 'run_dir', 'scenario', 'context_path', 'manifest_path',
             'algorithm_source', 'baseline_sim_config',
-            'target', 'build_commands', 'config_kind', 'context']
+            'target', 'build_commands', 'config_kind', 'context',
+            'current_algorithm']
 missing = [f for f in required if f not in si]
 if missing:
     print(f'HALT: skill_input.json missing fields: {missing}')
@@ -163,6 +164,7 @@ ALGO_SOURCE=$EXPERIMENT_ROOT/$(python3 -c "import json; print(json.load(open('$R
 ALGO_CONFIG=$(python3 -c "import json; v=json.load(open('$RUN_DIR/skill_input.json')).get('algorithm_config'); print('$EXPERIMENT_ROOT/' + v if v else '')")
 TARGET_REPO=$EXPERIMENT_ROOT/$(python3 -c "import json; print(json.load(open('$RUN_DIR/skill_input.json'))['target']['repo'])")
 CONFIG_KIND=$(python3 -c "import json; print(json.load(open('$RUN_DIR/skill_input.json'))['config_kind'])")
+CURRENT_ALGORITHM=$(python3 -c "import json; print(json.load(open('$RUN_DIR/skill_input.json'))['current_algorithm'])")
 CONTEXT_TEXT=$(python3 -c "import json; print(json.load(open('$RUN_DIR/skill_input.json')).get('context', {}).get('text', ''))")
 BASELINE_SIM_CONFIG=$(python3 -c "import json; v=json.load(open('$RUN_DIR/skill_input.json'))['baseline_sim_config']; print('$EXPERIMENT_ROOT/' + v if v else '')")
 BASELINE_REAL_CONFIG=$(python3 -c "import json; v=json.load(open('$RUN_DIR/skill_input.json')).get('baseline_real_config'); print('$EXPERIMENT_ROOT/' + v if v else 'null')")
@@ -215,12 +217,13 @@ BASELINE_DONE=$(grep '^BASELINE_DONE=' /tmp/resume_state.txt | cut -d= -f2)
 TREATMENT_DONE=$(grep '^TREATMENT_DONE=' /tmp/resume_state.txt | cut -d= -f2)
 ```
 
-**If `translate` phase is `done` and `translation_output.json` exists:**
-- Read `translation_output.json` and verify all `files_created` + `files_modified` exist
-  in `$RUN_DIR/generated/`
+**If `translate` phase is `done` and per-algorithm output exists:**
+- Check `$RUN_DIR/generated/$CURRENT_ALGORITHM/${CURRENT_ALGORITHM}_output.json`
+- Read it and verify all `files_created` + `files_modified` exist
+  in `$RUN_DIR/generated/$CURRENT_ALGORITHM/`
 - If complete: print the summary (see Step 6) and HALT with:
-  `Translation already complete. Re-run prepare.py to continue.`
-- If `generated/` is missing files: jump directly to Step 6 to re-copy
+  `Translation for $CURRENT_ALGORITHM already complete. Re-run prepare.py to continue.`
+- If `generated/$CURRENT_ALGORITHM/` is missing files: jump directly to Step 6 to re-copy
 
 **If `context_file_populated=true` in state AND `$CONTEXT_PATH` exists AND `REBUILD_CONTEXT=false`:**
 - Skip Step 1 entirely
@@ -363,6 +366,7 @@ corresponding shell variables:
 - `{CONFIG_KIND}` → `$CONFIG_KIND`
 - `{REVIEW_ROUNDS}` → `$REVIEW_ROUNDS`
 - `{SCENARIO}` → `$SCENARIO`
+- `{ALGO_NAME}` → `$CURRENT_ALGORITHM`
 - `{BUILD_COMMANDS}` → `$BUILD_COMMANDS`
 - `{CONTEXT_TEXT}` → `$CONTEXT_TEXT`
 - `{MAIN_SESSION_NAME}` → `"main-session"`
@@ -432,7 +436,7 @@ SendMessage("writer", "continue")
 
 **On "treatment-ready: ...":**
 
-Read `$RUN_DIR/generated/treatment_config.yaml` and print to user:
+Read `$RUN_DIR/generated/$CURRENT_ALGORITHM/${CURRENT_ALGORITHM}_config.yaml` and print to user:
 ```
 ━━━ Treatment Config (derived from baseline + algorithm) ━━━
 <file contents>
@@ -471,7 +475,7 @@ import json
 o = json.load(open('$RUN_DIR/translation_output.json'))
 print('Plugin files:', o.get('files_created', []))
 "
-python3 -c "print(open('$RUN_DIR/generated/treatment_config.yaml').read())"
+python3 -c "print(open('$RUN_DIR/generated/$CURRENT_ALGORITHM/${CURRENT_ALGORITHM}_config.yaml').read())"
 ```
 
 Print to user:
@@ -579,7 +583,7 @@ python3 -c "
 import sys
 sys.path.insert(0, '$REPO_ROOT/.claude/skills/sim2real-translate/scripts')
 from copy_generated import copy_generated
-copy_generated('$TARGET_REPO', '$RUN_DIR')
+copy_generated('$TARGET_REPO', '$RUN_DIR', algo_name='$CURRENT_ALGORITHM')
 " || exit 1
 ```
 
@@ -593,10 +597,13 @@ from datetime import datetime, timezone
 
 state_path = Path('$RUN_DIR') / '.state.json'
 state = json.loads(state_path.read_text())
-o = json.load(open('$RUN_DIR/translation_output.json'))
+algo = '$CURRENT_ALGORITHM'
+algo_out = Path('$RUN_DIR/generated') / algo / f'{algo}_output.json'
+o = json.load(open(algo_out))
 state.setdefault('phases', {})['translate'] = {
     'status': 'done',
     'timestamp': datetime.now(timezone.utc).isoformat(),
+    'algorithm': '$CURRENT_ALGORITHM',
     'files': o['files_created'],
     'review_rounds': $REVIEW_ROUNDS_DONE,
     'consensus': '$FINAL_CONSENSUS',
@@ -615,19 +622,24 @@ Verify outputs:
 python3 -c "
 import json, sys
 from pathlib import Path
-o = json.load(open('$RUN_DIR/translation_output.json'))
+algo = '$CURRENT_ALGORITHM'
+algo_dir = Path('$RUN_DIR/generated') / algo
+algo_out = algo_dir / f'{algo}_output.json'
+if not algo_out.exists():
+    print(f'ERROR: {algo_dir}/{algo}_output.json not found')
+    sys.exit(1)
+o = json.load(open(algo_out))
 required = ['plugin_type', 'files_created', 'files_modified', 'package',
             'register_file', 'test_commands', 'config_kind',
             'treatment_config_generated', 'description']
 missing = [f for f in required if f not in o]
 if missing:
-    print(f'ERROR: translation_output.json missing: {missing}')
+    print(f'ERROR: {algo}_output.json missing: {missing}')
     sys.exit(1)
-gen = Path('$RUN_DIR/generated')
 for f in o['files_created'] + o.get('files_modified', []):
-    dst = gen / Path(f).name
+    dst = algo_dir / f
     if not dst.exists():
-        print(f'ERROR: generated/ missing: {Path(f).name}')
+        print(f'ERROR: generated/{algo}/{f} not found')
         sys.exit(1)
 print(f'Verified: plugin_type={o[\"plugin_type\"]}, '
       f'{len(o[\"files_created\"])} created, '
@@ -652,12 +664,13 @@ Review:   <consensus> after <N> rounds
 Snapshots: <N> versions in $RUN_DIR/snapshots/
 
 Output artifacts:
-  $RUN_DIR/translation_output.json
-  $RUN_DIR/generated/
+  $RUN_DIR/generated/$CURRENT_ALGORITHM/${CURRENT_ALGORITHM}_output.json
+  $RUN_DIR/generated/$CURRENT_ALGORITHM/
   $RUN_DIR/snapshots/
   $RUN_DIR/review/
 
-Next: re-run prepare.py to continue through Assembly, Summary, and Gate.
+Next: re-run prepare.py to pick up the next untranslated algorithm (or continue
+through Assembly if all algorithms are complete).
   python3 $REPO_ROOT/pipeline/prepare.py
   (or: cd $EXPERIMENT_ROOT && python3 $REPO_ROOT/pipeline/prepare.py)
 ```

--- a/.claude/skills/sim2real-translate/SKILL.md
+++ b/.claude/skills/sim2real-translate/SKILL.md
@@ -148,7 +148,10 @@ if missing:
 if 'repo' not in si['target']:
     print('HALT: skill_input.json target.repo missing')
     sys.exit(1)
-print(f'Loaded: run={si[\"run_name\"]} scenario={si[\"scenario\"]} config_kind={si[\"config_kind\"]}')
+if not si.get('current_algorithm'):
+    print('HALT: skill_input.json current_algorithm is empty')
+    sys.exit(1)
+print(f'Loaded: run={si[\"run_name\"]} scenario={si[\"scenario\"]} algorithm={si[\"current_algorithm\"]}')
 " || exit 1
 ```
 
@@ -472,7 +475,10 @@ SendMessage("writer", "continue")
 ```bash
 python3 -c "
 import json
-o = json.load(open('$RUN_DIR/translation_output.json'))
+from pathlib import Path
+algo = '$CURRENT_ALGORITHM'
+algo_out = Path('$RUN_DIR/generated') / algo / f'{algo}_output.json'
+o = json.load(open(algo_out))
 print('Plugin files:', o.get('files_created', []))
 "
 python3 -c "print(open('$RUN_DIR/generated/$CURRENT_ALGORITHM/${CURRENT_ALGORITHM}_config.yaml').read())"
@@ -576,7 +582,7 @@ print(len(list((Path('$RUN_DIR/review')).glob('round_*.json'))))
 " 2>/dev/null || echo 0)
 ```
 
-Derive file lists from git state, overwrite `translation_output.json`, and copy to `$RUN_DIR/generated/`:
+Derive file lists from git state, update per-algorithm output, and copy to `$RUN_DIR/generated/$CURRENT_ALGORITHM/`:
 
 ```bash
 python3 -c "
@@ -600,10 +606,9 @@ state = json.loads(state_path.read_text())
 algo = '$CURRENT_ALGORITHM'
 algo_out = Path('$RUN_DIR/generated') / algo / f'{algo}_output.json'
 o = json.load(open(algo_out))
-state.setdefault('phases', {})['translate'] = {
-    'status': 'done',
+translate_phase = state.setdefault('phases', {}).setdefault('translate', {})
+translate_phase.setdefault('completed_algorithms', {})[algo] = {
     'timestamp': datetime.now(timezone.utc).isoformat(),
-    'algorithm': '$CURRENT_ALGORITHM',
     'files': o['files_created'],
     'review_rounds': $REVIEW_ROUNDS_DONE,
     'consensus': '$FINAL_CONSENSUS',

--- a/.claude/skills/sim2real-translate/prompts/agent-reviewer.md
+++ b/.claude/skills/sim2real-translate/prompts/agent-reviewer.md
@@ -34,6 +34,8 @@ Read and hold in context:
 
 You will read the generated plugin files and treatment config fresh on each review request.
 
+Algorithm being reviewed: {ALGO_NAME}
+
 Context from the operator (held in mind, not written to disk):
 
 {CONTEXT_TEXT}
@@ -41,7 +43,7 @@ Context from the operator (held in mind, not written to disk):
 ## Tool Discipline
 
 **Do not explore `{TARGET_REPO}` yourself** beyond the specific files you must read per
-review request (plugin files, registration file, treatment_config.yaml, translation_output.json).
+review request (plugin files, registration file, {ALGO_NAME}_config.yaml, {ALGO_NAME}_output.json).
 
 For anything that requires verifying code-level details — Go interface signatures,
 config struct field names, whether a built-in plugin already exists, exact type string
@@ -67,9 +69,9 @@ Example queries:
 You stay idle after initialization. When the writer sends you a review request:
 
 1. Read ALL plugin files listed in the writer's message (paths provided in the request) — fresh
-2. Read `{RUN_DIR}/generated/treatment_config.yaml` fresh
-3. Read `{RUN_DIR}/translation_output.json` for metadata cross-reference
-4. Read the registration file mentioned in `translation_output.json` — just the relevant section
+2. Read `{RUN_DIR}/generated/{ALGO_NAME}/{ALGO_NAME}_config.yaml` fresh
+3. Read `{RUN_DIR}/generated/{ALGO_NAME}/{ALGO_NAME}_output.json` for metadata cross-reference
+4. Read the registration file mentioned in `{ALGO_NAME}_output.json` — just the relevant section
 5. Apply ALL review criteria below (never skip one)
 6. Send your verdict to the writer using SendMessage
 
@@ -112,15 +114,15 @@ Verify the complete registration chain — ALL of these must be true:
 1. Plugin Go file defines a `Type` constant (string must be kebab-case)
 2. Plugin Go file defines a `Factory` function with the correct signature (ask Expert if uncertain)
 3. The registration file contains the correct registration call for this plugin
-4. The type string in the Go constant matches `plugin_type` in `translation_output.json` exactly
-5. The type string in the Go constant matches the `type:` field for this plugin in `treatment_config.yaml`
+4. The type string in the Go constant matches `plugin_type` in `{ALGO_NAME}_output.json` exactly
+5. The type string in the Go constant matches the `type:` field for this plugin in `{ALGO_NAME}_config.yaml`
 
 If any of these five items is missing or mismatched, raise `[registration]` NEEDS_CHANGES.
 This is the most common failure mode — check it carefully.
 
 ### Criterion 4: Config Correctness
 
-- `treatment_config.yaml` is a valid **scenario overlay** (top-level `scenario:` list with a dict)
+- `{ALGO_NAME}_config.yaml` is a valid **scenario overlay** (top-level `scenario:` list with a dict)
 - The plugin config within `inferenceExtension.pluginsCustomConfig` references the correct
   plugin type string
 - All plugin `type:` values in the config reference plugins that are registered
@@ -132,7 +134,7 @@ This verifies that `prepare.py` Phase 4 Assembly will succeed when it deep-merge
 treatment overlay into the baseline-resolved scenario.
 
 **Step A — Validate overlay structure:**
-Confirm `treatment_config.yaml` follows the scenario overlay format from
+Confirm `{ALGO_NAME}_config.yaml` follows the scenario overlay format from
 `{REPO_ROOT}/pipeline/README.md`:
 - Top-level `scenario:` key with a list containing a single dict
 - The dict has a `name` field matching the experiment's scenario name
@@ -147,7 +149,7 @@ treatment_resolved = deep_merge(deep_merge(baseline_resolved, treatment_diffs), 
 ```
 
 Verify:
-- `treatment_config_generated: true` is set in `translation_output.json`
+- `treatment_config_generated: true` is set in `{ALGO_NAME}_output.json`
 - Every key in the treatment overlay also appears in the baseline structure, or is
   explicitly justified (no invented keys that would be silently ignored)
 
@@ -157,12 +159,12 @@ Raise any problem as `[assembly]` NEEDS_CHANGES.
 
 Determine whether the algorithm has configurable parameters:
 - If `{ALGO_CONFIG}` is non-empty: use it as the reference (every threshold and weight
-  must have a corresponding field in treatment_config.yaml)
+  must have a corresponding field in {ALGO_NAME}_config.yaml)
 - If `{ALGO_CONFIG}` is empty: check `{ALGO_SOURCE}` for numeric literals that represent
   configurable thresholds or weights
 
 **If the algorithm has configurable parameters:**
-1. Confirm each parameter has a corresponding field in `treatment_config.yaml`
+1. Confirm each parameter has a corresponding field in `{ALGO_NAME}_config.yaml`
 2. Confirm the plugin Go file has config parsing (struct with yaml/json tags, or decoder logic)
    that reads these fields
 3. If a scoring threshold or weight appears as a numeric literal in the Go code without
@@ -189,7 +191,7 @@ Verification summary (required — one line per criterion):
 - Code quality: [confirm interfaces correct, tests present, patterns followed]
 - Registration: TypeConst=<exact value>, Factory=<name>, registration file=<path>
 - Config: overlay format valid, plugin types registered, keys consistent
-- Assembly: overlay YAML valid, scenario name matches, treatment_config_generated=true
+- Assembly: overlay YAML valid, scenario name matches, treatment_config_generated=true in {ALGO_NAME}_output.json
 - Treatment config: [parameter-free / parameters match algo config]
 ```
 

--- a/.claude/skills/sim2real-translate/prompts/agent-writer.md
+++ b/.claude/skills/sim2real-translate/prompts/agent-writer.md
@@ -16,6 +16,7 @@ Experiment root: {EXPERIMENT_ROOT}
 Target repo (submodule): {TARGET_REPO}
 Run directory: {RUN_DIR}
 Main session name: {MAIN_SESSION_NAME}
+Algorithm being translated: {ALGO_NAME}
 
 Run Go commands via: `(cd {TARGET_REPO} && <cmd>)`
 (If a `go.work` file exists in `{TARGET_REPO}`, add `GOWORK=off` to the command.)
@@ -68,6 +69,13 @@ Example queries:
 
 Use TaskCreate: `"Phase 2: Baseline Config Derivation"` → TaskUpdate in_progress
 
+**Skip check:** If `{RUN_DIR}/generated/baseline_config.yaml` already exists (written by a
+prior algorithm's skill invocation), skip Phase 2 — send:
+```
+SendMessage({MAIN_SESSION_NAME}, "baseline-ready: {RUN_DIR}/generated/baseline_config.yaml")
+```
+and wait for "continue". Baseline config is shared across algorithms.
+
 Read:
 1. `{REPO_ROOT}/pipeline/README.md` — the "Scenario Overlay Format" section defines the
    required output structure. Follow it exactly.
@@ -115,7 +123,7 @@ Read:
 2. If `{ALGO_CONFIG}` is non-empty: read it — the algorithm policy config (what changes from baseline)
 3. `{ALGO_SOURCE}` — the algorithm source
 
-Your goal: produce `{RUN_DIR}/generated/treatment_config.yaml` — a **llmdbenchmark scenario overlay**
+Your goal: produce `{RUN_DIR}/generated/{ALGO_NAME}/{ALGO_NAME}_config.yaml` — a **llmdbenchmark scenario overlay**
 containing ONLY what differs from the baseline. Since assembly computes
 `treatment_resolved = deep_merge(baseline_resolved, treatment_overlay)`, anything already in
 baseline propagates automatically.
@@ -136,9 +144,9 @@ baseline propagates automatically.
   no `parameters:` block is needed — just declare the plugin type and name
 - Ask the Expert about config struct field names if needed
 
-Write `{RUN_DIR}/generated/treatment_config.yaml`. Then send to main session:
+Create the directory `{RUN_DIR}/generated/{ALGO_NAME}/` if needed, then write `{RUN_DIR}/generated/{ALGO_NAME}/{ALGO_NAME}_config.yaml`. Then send to main session:
 ```
-SendMessage({MAIN_SESSION_NAME}, "treatment-ready: {RUN_DIR}/generated/treatment_config.yaml")
+SendMessage({MAIN_SESSION_NAME}, "treatment-ready: {RUN_DIR}/generated/{ALGO_NAME}/{ALGO_NAME}_config.yaml")
 ```
 
 Wait for the reply. Handle feedback / continue as in Phase 2.
@@ -155,7 +163,7 @@ TaskUpdate Phase 3 → completed
 4. Define a `Type` constant (kebab-case string) and a `Factory` function matching the
    pattern used by existing plugins in this subsystem
 5. **Register** the plugin in the registration file identified by the Expert
-6. Update `{RUN_DIR}/generated/treatment_config.yaml` if the plugin type or parameters changed
+6. Update `{RUN_DIR}/generated/{ALGO_NAME}/{ALGO_NAME}_config.yaml` if the plugin type or parameters changed
 7. **Follow logging and code patterns** used by existing plugins in the same subsystem —
    ask the Expert for a representative example if the context document doesn't show one
 8. **Write tests** — for every new plugin Go file (e.g., `foo.go`), write a corresponding
@@ -163,9 +171,9 @@ TaskUpdate Phase 3 → completed
    algorithm logic (at least main branches), and (if configurable) at least one
    threshold/weight value from the algorithm config
 
-## Phase 4.5: Write Preliminary translation_output.json
+## Phase 4.5: Write Preliminary {ALGO_NAME}_output.json
 
-After writing all plugin code (but before running the build), write `{RUN_DIR}/translation_output.json`
+After writing all plugin code (but before running the build), write `{RUN_DIR}/generated/{ALGO_NAME}/{ALGO_NAME}_output.json`
 with all 9 required fields. If the file list changes in a later round, update it.
 
 ```json
@@ -215,13 +223,13 @@ mkdir -p "$SNAP_DIR"
 ```
 
 Copy all `files_created` + `files_modified` entries (relative to `{TARGET_REPO}`) plus
-`{RUN_DIR}/generated/treatment_config.yaml` into `$SNAP_DIR`:
+`{RUN_DIR}/generated/{ALGO_NAME}/{ALGO_NAME}_config.yaml` into `$SNAP_DIR`:
 
 ```bash
 python3 -c "
 import json, shutil
 from pathlib import Path
-o = json.load(open('{RUN_DIR}/translation_output.json'))
+o = json.load(open('{RUN_DIR}/generated/{ALGO_NAME}/{ALGO_NAME}_output.json'))
 snap = Path('$SNAP_DIR')
 target = Path('{TARGET_REPO}')
 for f in o['files_created'] + o.get('files_modified', []):
@@ -229,7 +237,9 @@ for f in o['files_created'] + o.get('files_modified', []):
     dst = snap / Path(f).name
     shutil.copy2(src, dst)
     print(f'  {Path(f).name} -> snapshots/v$SNAP_NUM/')
-shutil.copy2('{RUN_DIR}/generated/treatment_config.yaml', snap / 'treatment_config.yaml')
+algo_cfg = Path('{RUN_DIR}/generated/{ALGO_NAME}/{ALGO_NAME}_config.yaml')
+if algo_cfg.exists():
+    shutil.copy2(algo_cfg, snap / '{ALGO_NAME}_config.yaml')
 print(f'Snapshot v$SNAP_NUM saved')
 "
 ```
@@ -252,7 +262,7 @@ After each green build, send a review request to the reviewer agent:
 REVIEW REQUEST — Round <N>
 Plugin files: <absolute paths of all files_created (excluding test files), one per line>
 Test files: <absolute paths of all _test.go files created or modified, one per line>
-Treatment config: {RUN_DIR}/generated/treatment_config.yaml
+Treatment config: {RUN_DIR}/generated/{ALGO_NAME}/{ALGO_NAME}_config.yaml
 Build: PASSED
 Changed since last round: <brief description, or "initial" for round 1>
 ```
@@ -261,7 +271,7 @@ Wait for the reviewer's reply.
 
 ### On APPROVE
 
-1. Write `{RUN_DIR}/translation_output.json` (update if needed)
+1. Write `{RUN_DIR}/generated/{ALGO_NAME}/{ALGO_NAME}_output.json` (update if needed)
 2. Create `{RUN_DIR}/review/` directory if needed, write `round_<N>.json` (see schema below)
 3. Send to main session:
    ```

--- a/.claude/skills/sim2real-translate/prompts/agent-writer.md
+++ b/.claude/skills/sim2real-translate/prompts/agent-writer.md
@@ -237,9 +237,7 @@ for f in o['files_created'] + o.get('files_modified', []):
     dst = snap / Path(f).name
     shutil.copy2(src, dst)
     print(f'  {Path(f).name} -> snapshots/v$SNAP_NUM/')
-algo_cfg = Path('{RUN_DIR}/generated/{ALGO_NAME}/{ALGO_NAME}_config.yaml')
-if algo_cfg.exists():
-    shutil.copy2(algo_cfg, snap / '{ALGO_NAME}_config.yaml')
+shutil.copy2('{RUN_DIR}/generated/{ALGO_NAME}/{ALGO_NAME}_config.yaml', snap / '{ALGO_NAME}_config.yaml')
 print(f'Snapshot v$SNAP_NUM saved')
 "
 ```

--- a/.claude/skills/sim2real-translate/scripts/copy_generated.py
+++ b/.claude/skills/sim2real-translate/scripts/copy_generated.py
@@ -73,25 +73,20 @@ def copy_generated(
         else:
             print(f"  {Path(f).name} → generated/")
 
-    # Update top-level translation_output.json
-    to_path = rd / "translation_output.json"
-    o = json.loads(to_path.read_text())
-    o["files_created"] = files_created
-    o["files_modified"] = files_modified
-    to_path.write_text(json.dumps(o, indent=2))
-
-    # Per-algorithm output JSON
     if algo_name is not None:
-        algo_output = {
-            "files_created": files_created,
-            "files_modified": files_modified,
-        }
-        # Include other fields from translation_output.json
-        for k, v in o.items():
-            if k not in ("files_created", "files_modified"):
-                algo_output[k] = v
+        # Per-algorithm mode: update the per-algo output JSON (written by the writer)
         algo_out_path = gen / f"{algo_name}_output.json"
-        algo_out_path.write_text(json.dumps(algo_output, indent=2))
+        o = json.loads(algo_out_path.read_text())
+        o["files_created"] = files_created
+        o["files_modified"] = files_modified
+        algo_out_path.write_text(json.dumps(o, indent=2))
+    else:
+        # Flat mode: update top-level translation_output.json
+        to_path = rd / "translation_output.json"
+        o = json.loads(to_path.read_text())
+        o["files_created"] = files_created
+        o["files_modified"] = files_modified
+        to_path.write_text(json.dumps(o, indent=2))
 
     count = len(files_created) + len(files_modified)
     if count:

--- a/.claude/skills/sim2real-translate/tests/test_copy_generated.py
+++ b/.claude/skills/sim2real-translate/tests/test_copy_generated.py
@@ -175,8 +175,26 @@ def test_preserves_other_json_fields(git_repo, run_dir):
 # --- Per-algorithm subdirectory tests ---
 
 
+def _setup_algo_output(run_dir, algo_name="myalgo"):
+    """Pre-create per-algo output JSON as the writer would before copy_generated runs."""
+    algo_dir = run_dir / "generated" / algo_name
+    algo_dir.mkdir(parents=True, exist_ok=True)
+    (algo_dir / f"{algo_name}_output.json").write_text(json.dumps({
+        "plugin_type": "scorer",
+        "files_created": [],
+        "files_modified": [],
+        "package": "pkg",
+        "register_file": "register.go",
+        "test_commands": ["go test ./..."],
+        "config_kind": "ScorerConfig",
+        "treatment_config_generated": True,
+        "description": "test plugin",
+    }))
+
+
 def test_per_algorithm_subdirectory(git_repo, run_dir):
     """With algo_name, files go to generated/{algo_name}/ preserving full paths."""
+    _setup_algo_output(run_dir)
     (git_repo / "pkg" / "scorer").mkdir(parents=True)
     (git_repo / "pkg" / "scorer" / "plugin.go").write_text("package scorer")
     (git_repo / "existing.go").write_text("package main\n// changed")
@@ -192,6 +210,7 @@ def test_per_algorithm_subdirectory(git_repo, run_dir):
 
 def test_per_algorithm_no_basename_collision(git_repo, run_dir):
     """With algo_name, same basename in different dirs does NOT raise."""
+    _setup_algo_output(run_dir)
     (git_repo / "pkg" / "scorer").mkdir(parents=True)
     (git_repo / "pkg" / "admission").mkdir(parents=True)
     (git_repo / "pkg" / "scorer" / "config.go").write_text("package scorer")
@@ -204,7 +223,8 @@ def test_per_algorithm_no_basename_collision(git_repo, run_dir):
 
 
 def test_per_algorithm_output_json(git_repo, run_dir):
-    """With algo_name, {algo_name}_output.json is created in the subdirectory."""
+    """With algo_name, {algo_name}_output.json is updated in the subdirectory."""
+    _setup_algo_output(run_dir)
     (git_repo / "existing.go").write_text("package main\n// changed")
     cg.copy_generated(str(git_repo), str(run_dir), algo_name="myalgo")
     gen = run_dir / "generated" / "myalgo"
@@ -213,6 +233,6 @@ def test_per_algorithm_output_json(git_repo, run_dir):
     data = json.loads(algo_out.read_text())
     assert data["files_modified"] == ["existing.go"]
     assert data["files_created"] == []
-    # Should also contain other fields from translation_output.json
+    # Other fields preserved from pre-existing output
     assert data["plugin_type"] == "scorer"
     assert data["description"] == "test plugin"

--- a/.claude/skills/sim2real-translate/tests/test_skill_substitution.py
+++ b/.claude/skills/sim2real-translate/tests/test_skill_substitution.py
@@ -54,3 +54,17 @@ def test_skill_md_requires_current_algorithm_field():
     """skill_input.json validation must require current_algorithm."""
     content = (SKILL_DIR / "SKILL.md").read_text()
     assert "'current_algorithm'" in content
+
+
+def test_skill_md_no_translation_output_in_code_blocks():
+    """SKILL.md code blocks must not read translation_output.json directly."""
+    content = (SKILL_DIR / "SKILL.md").read_text()
+    import re
+    blocks = re.findall(r"```(?:bash|python3?|)\n(.*?)```", content, re.DOTALL)
+    for block in blocks:
+        for i, line in enumerate(block.splitlines(), 1):
+            if "translation_output.json" in line:
+                pytest.fail(
+                    f"SKILL.md code block still reads translation_output.json: "
+                    f"{line.strip()}"
+                )

--- a/.claude/skills/sim2real-translate/tests/test_skill_substitution.py
+++ b/.claude/skills/sim2real-translate/tests/test_skill_substitution.py
@@ -1,0 +1,56 @@
+"""Tests for SKILL.md placeholder substitution — verifies {ALGO_NAME} is present."""
+from pathlib import Path
+
+import pytest
+
+
+SKILL_DIR = Path(__file__).parents[1]
+
+
+def test_skill_md_contains_algo_name_placeholder():
+    """SKILL.md must reference {ALGO_NAME} in the substitution table."""
+    content = (SKILL_DIR / "SKILL.md").read_text()
+    assert "{ALGO_NAME}" in content
+    assert "CURRENT_ALGORITHM" in content
+
+
+def test_writer_prompt_uses_algo_name():
+    """agent-writer.md must use {ALGO_NAME} for treatment config paths."""
+    content = (SKILL_DIR / "prompts" / "agent-writer.md").read_text()
+    assert "{ALGO_NAME}/{ALGO_NAME}_config.yaml" in content
+    assert "{ALGO_NAME}/{ALGO_NAME}_output.json" in content
+    # Must NOT reference flat treatment_config.yaml as an output target
+    lines = content.splitlines()
+    for i, line in enumerate(lines, 1):
+        if "generated/treatment_config.yaml" in line and "legacy" not in line.lower():
+            pytest.fail(
+                f"agent-writer.md line {i} still references flat "
+                f"treatment_config.yaml: {line.strip()}"
+            )
+
+
+def test_reviewer_prompt_uses_algo_name():
+    """agent-reviewer.md must use {ALGO_NAME} for treatment config paths."""
+    content = (SKILL_DIR / "prompts" / "agent-reviewer.md").read_text()
+    assert "{ALGO_NAME}/{ALGO_NAME}_config.yaml" in content
+    assert "{ALGO_NAME}/{ALGO_NAME}_output.json" in content
+    # Must NOT reference flat treatment_config.yaml as a read target
+    lines = content.splitlines()
+    for i, line in enumerate(lines, 1):
+        if "generated/treatment_config.yaml" in line and "legacy" not in line.lower():
+            pytest.fail(
+                f"agent-reviewer.md line {i} still references flat "
+                f"treatment_config.yaml: {line.strip()}"
+            )
+
+
+def test_skill_md_copy_generated_passes_algo_name():
+    """copy_generated call in SKILL.md must pass algo_name parameter."""
+    content = (SKILL_DIR / "SKILL.md").read_text()
+    assert "algo_name='$CURRENT_ALGORITHM'" in content
+
+
+def test_skill_md_requires_current_algorithm_field():
+    """skill_input.json validation must require current_algorithm."""
+    content = (SKILL_DIR / "SKILL.md").read_text()
+    assert "'current_algorithm'" in content


### PR DESCRIPTION
## Summary

- SKILL.md: loads `current_algorithm` from `skill_input.json`, adds `{ALGO_NAME}` placeholder, passes `algo_name='$CURRENT_ALGORITHM'` to `copy_generated()`, verifies output at per-algo subdirectory
- Writer prompt: writes treatment config to `generated/{ALGO_NAME}/{ALGO_NAME}_config.yaml` and output JSON to `generated/{ALGO_NAME}/{ALGO_NAME}_output.json`; skips Phase 2 if `baseline_config.yaml` already exists
- Reviewer prompt: reads from per-algo paths instead of flat `treatment_config.yaml`/`translation_output.json`
- New test: `test_skill_substitution.py` validates placeholder presence in all three files

## Design decision

Baseline config remains **shared/flat** (`generated/baseline_config.yaml`) — it doesn't vary between algorithms, so the writer skips Phase 2 if it already exists from a prior algorithm's skill invocation. This matches option (a) from issue #237 item 8.

## Reviewer attention

- The `copy_generated` script already supports the `algo_name` parameter (added in PR #235). This PR only wires it through the skill orchestration.
- `prepare.py` owns the cross-algorithm loop — it invokes the skill once per algorithm via the `current_algorithm` field. The skill itself does NOT loop.
- The `.state.json` `translate` phase entry now includes an `algorithm` field identifying which algorithm was translated in that invocation.

## Test plan

- [x] `ruff check pipeline/ .claude/skills/ --select F` — passes
- [x] `python3 -m pytest pipeline/ .claude/skills/sim2real-translate/tests/ -v` — 798 tests pass
- [ ] Manual: run pipeline with multi-algorithm experiment (expceil) to verify end-to-end

Closes #237