### PR TITLE
fix: scoped collect dispatches per-slot, not single namespace

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1013,9 +1013,6 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
         scoped_phases = sorted({
             progress[k].get("package", "") for k in collectible
         } - {""})
-        scoped_workloads = sorted({
-            progress[k].get("workload", "") for k in collectible
-        } - {""})
 
         if not scoped_phases:
             warn("No done phases for scoped pairs.")
@@ -1038,52 +1035,113 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
         else:
             phases_to_collect = list(scoped_phases)
 
-        step(1, "Collecting Results")
+        # Group collectible pairs by completed_namespace (same model as unscoped path)
+        ns_phase_map: dict[str, list[str]] = {}
+        ns_pair_map: dict[str, set[tuple[str, str]]] = {}
+        missing_ns_keys: list[str] = []
+        for key in collectible:
+            entry = progress[key]
+            pkg = entry.get("package", "")
+            if pkg not in phases_to_collect:
+                continue
+            ns = entry.get("completed_namespace")
+            if not ns:
+                missing_ns_keys.append(key)
+                continue
+            if pkg not in ns_phase_map.setdefault(ns, []):
+                ns_phase_map[ns].append(pkg)
+            wl = entry.get("workload", "")
+            if wl:
+                ns_pair_map.setdefault(ns, set()).add((pkg, wl))
+
+        total_pairs = sum(len(pairs) for pairs in ns_pair_map.values())
+
+        ns_items = sorted(ns_phase_map.items())
+        if len(ns_items) > 1:
+            step(1, f"Collecting Results ({len(ns_items)} slots in parallel)")
+        else:
+            step(1, "Collecting Results")
+
+        for key in missing_ns_keys:
+            warn(f"{key}: completed_namespace missing — skipping (re-run the workload with a newer orchestrator to collect results)")
+
         collected: list[str] = []
         failed: list[str] = []
         collected_pairs: list[str] = []
         failed_pairs: list[str] = []
-        total_pairs = len(collectible)
 
         skip_logs = getattr(args, "skip_logs", False)
-        for wl_name in scoped_workloads:
-            wl_ns = next(
-                (progress[k].get("completed_namespace")
-                 for k in collectible
-                 if isinstance(progress[k], dict)
-                 and progress[k].get("workload") == wl_name
-                 and progress[k].get("completed_namespace")),
-                None,
-            )
-            if not wl_ns:
-                warn(f"{wl_name}: completed_namespace missing — skipping (re-run the workload with a newer orchestrator to collect results)")
-                for p in phases_to_collect:
-                    if p not in failed:
-                        failed.append(p)
-                    failed_pairs.append(f"{p}/{wl_name}")
-                continue
-            try:
-                errors = _extract_phases_from_pvc(
-                    phases_to_collect, run_name, wl_ns, run_dir,
-                    skip_logs=skip_logs, workload=wl_name)
-            except RuntimeError as e:
-                warn(f"Extractor pod failed for workload {wl_name}: {e}")
-                for p in phases_to_collect:
-                    if p not in failed:
-                        failed.append(p)
-                    failed_pairs.append(f"{p}/{wl_name}")
+
+        def _on_workload_done(phase, wl_name, ns, error):
+            if error is None:
+                ok(f"{phase}/{wl_name}    ({ns})")
+                collected_pairs.append(f"{phase}/{wl_name}")
+                if phase not in collected:
+                    collected.append(phase)
             else:
-                for phase, exc in errors.items():
-                    if exc is None:
-                        ok(f"{phase}/{wl_name}    ({wl_ns})")
-                        if phase not in collected:
-                            collected.append(phase)
-                        collected_pairs.append(f"{phase}/{wl_name}")
-                    else:
-                        warn(f"{phase}/{wl_name}    ({wl_ns}): {exc}")
-                        if phase not in failed:
-                            failed.append(phase)
-                        failed_pairs.append(f"{phase}/{wl_name}")
+                warn(f"{phase}/{wl_name}    ({ns}): {error}")
+                failed_pairs.append(f"{phase}/{wl_name}")
+                if phase not in failed:
+                    failed.append(phase)
+
+        def _handle_slot_failure(ns, pairs_in_ns):
+            ns_phases_local = ns_phase_map[ns]
+            for p in ns_phases_local:
+                if p not in failed:
+                    failed.append(p)
+                for pkg, wl in sorted(pairs_in_ns):
+                    if pkg == p:
+                        warn(f"{p}/{wl}    ({ns})")
+                        failed_pairs.append(f"{p}/{wl}")
+
+        if len(ns_items) > 1:
+            import concurrent.futures
+
+            def _extract_one_slot(ns, ns_phases):
+                pairs_in_ns = ns_pair_map.get(ns, set())
+                allowed = {}
+                for pkg, wl in pairs_in_ns:
+                    allowed.setdefault(pkg, set()).add(wl)
+                try:
+                    _extract_phases_from_pvc(
+                        sorted(ns_phases), run_name, ns, run_dir,
+                        skip_logs=skip_logs,
+                        allowed_workloads=allowed,
+                        on_workload_done=_on_workload_done)
+                except Exception as e:
+                    return (ns, pairs_in_ns, e)
+                return (ns, pairs_in_ns, None)
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=len(ns_items)) as executor:
+                futures = {
+                    executor.submit(_extract_one_slot, ns, ns_phases): ns
+                    for ns, ns_phases in ns_items
+                }
+                for future in concurrent.futures.as_completed(futures):
+                    try:
+                        ns, pairs_in_ns, result = future.result()
+                    except Exception as e:
+                        ns = futures[future]
+                        pairs_in_ns = ns_pair_map.get(ns, set())
+                        result = e
+                    if isinstance(result, Exception):
+                        warn(f"Extractor pod failed in {ns}: {result}")
+                        _handle_slot_failure(ns, pairs_in_ns)
+        else:
+            for ns, ns_phases in ns_items:
+                pairs_in_ns = ns_pair_map.get(ns, set())
+                allowed = {}
+                for pkg, wl in pairs_in_ns:
+                    allowed.setdefault(pkg, set()).add(wl)
+                try:
+                    _extract_phases_from_pvc(
+                        sorted(ns_phases), run_name, ns, run_dir,
+                        skip_logs=skip_logs,
+                        allowed_workloads=allowed,
+                        on_workload_done=_on_workload_done)
+                except Exception as e:
+                    warn(f"Extractor pod failed in {ns}: {e}")
+                    _handle_slot_failure(ns, pairs_in_ns)
 
         collected = [p for p in collected if p not in failed]
     else:

--- a/pipeline/tests/test_deploy_collect.py
+++ b/pipeline/tests/test_deploy_collect.py
@@ -346,15 +346,20 @@ def test_collect_with_workload_scope(tmp_path, monkeypatch):
     extract_calls = []
 
     def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
-        extract_calls.append({"phases": phases, "workload": workload})
+        extract_calls.append({"phases": sorted(phases), "allowed_workloads": allowed_workloads, "namespace": namespace})
+        if on_workload_done and allowed_workloads:
+            for phase in phases:
+                for wl in allowed_workloads.get(phase, set()):
+                    on_workload_done(phase, wl, namespace, None)
         return {p: None for p in phases}
 
     with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
         deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
 
     assert len(extract_calls) == 1
-    assert extract_calls[0]["workload"] == "smoke"
+    assert extract_calls[0]["namespace"] == "ns-0"
     assert sorted(extract_calls[0]["phases"]) == ["baseline", "treatment"]
+    assert extract_calls[0]["allowed_workloads"] == {"baseline": {"smoke"}, "treatment": {"smoke"}}
 
 
 def test_collect_with_only_scope(tmp_path, monkeypatch):
@@ -379,15 +384,20 @@ def test_collect_with_only_scope(tmp_path, monkeypatch):
     extract_calls = []
 
     def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
-        extract_calls.append({"phases": phases, "workload": workload})
+        extract_calls.append({"phases": sorted(phases), "allowed_workloads": allowed_workloads, "namespace": namespace})
+        if on_workload_done and allowed_workloads:
+            for phase in phases:
+                for wl in allowed_workloads.get(phase, set()):
+                    on_workload_done(phase, wl, namespace, None)
         return {p: None for p in phases}
 
     with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
         deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
 
     assert len(extract_calls) == 1
-    assert extract_calls[0]["workload"] == "smoke"
+    assert extract_calls[0]["namespace"] == "ns-0"
     assert extract_calls[0]["phases"] == ["baseline"]
+    assert extract_calls[0]["allowed_workloads"] == {"baseline": {"smoke"}}
 
 
 def test_collect_only_without_prefix(tmp_path, monkeypatch):
@@ -410,14 +420,18 @@ def test_collect_only_without_prefix(tmp_path, monkeypatch):
     extract_calls = []
 
     def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
-        extract_calls.append({"phases": phases, "workload": workload})
+        extract_calls.append({"phases": sorted(phases), "allowed_workloads": allowed_workloads})
+        if on_workload_done and allowed_workloads:
+            for phase in phases:
+                for wl in allowed_workloads.get(phase, set()):
+                    on_workload_done(phase, wl, namespace, None)
         return {p: None for p in phases}
 
     with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
         deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
 
     assert len(extract_calls) == 1
-    assert extract_calls[0]["workload"] == "smoke"
+    assert extract_calls[0]["allowed_workloads"] == {"baseline": {"smoke"}}
 
 
 def test_collect_workload_with_package_filter(tmp_path, monkeypatch):
@@ -442,15 +456,19 @@ def test_collect_workload_with_package_filter(tmp_path, monkeypatch):
     extract_calls = []
 
     def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
-        extract_calls.append({"phases": phases, "workload": workload})
+        extract_calls.append({"phases": sorted(phases), "allowed_workloads": allowed_workloads})
+        if on_workload_done and allowed_workloads:
+            for phase in phases:
+                for wl in allowed_workloads.get(phase, set()):
+                    on_workload_done(phase, wl, namespace, None)
         return {p: None for p in phases}
 
     with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
         deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
 
     assert len(extract_calls) == 1
-    assert extract_calls[0]["workload"] == "smoke"
     assert extract_calls[0]["phases"] == ["baseline"]
+    assert extract_calls[0]["allowed_workloads"] == {"baseline": {"smoke"}}
 
 
 def test_collect_workload_no_match_exits(tmp_path, monkeypatch):
@@ -635,6 +653,9 @@ def test_collect_scoped_per_phase_failure(tmp_path, monkeypatch):
         skip_logs = False
 
     def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
+        if on_workload_done:
+            on_workload_done("baseline", "smoke", namespace, None)
+            on_workload_done("treatment", "smoke", namespace, RuntimeError("tar failed"))
         return {
             "baseline": None,
             "treatment": RuntimeError("tar failed"),
@@ -669,15 +690,19 @@ def test_collect_only_takes_precedence_over_workload(tmp_path, monkeypatch):
     extract_calls = []
 
     def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
-        extract_calls.append({"phases": phases, "workload": workload})
+        extract_calls.append({"phases": sorted(phases), "allowed_workloads": allowed_workloads})
+        if on_workload_done and allowed_workloads:
+            for phase in phases:
+                for wl in allowed_workloads.get(phase, set()):
+                    on_workload_done(phase, wl, namespace, None)
         return {p: None for p in phases}
 
     with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
         deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
 
     assert len(extract_calls) == 1
-    assert extract_calls[0]["workload"] == "smoke"
     assert extract_calls[0]["phases"] == ["baseline"]
+    assert extract_calls[0]["allowed_workloads"] == {"baseline": {"smoke"}}
 
 
 def test_collect_unscoped_multi_namespace_dispatch(tmp_path, monkeypatch):
@@ -771,17 +796,20 @@ def test_collect_scoped_multi_namespace_dispatch(tmp_path, monkeypatch):
     extract_calls = []
 
     def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
-        extract_calls.append({"namespace": namespace, "phases": sorted(phases), "workload": workload})
+        extract_calls.append({"namespace": namespace, "phases": sorted(phases), "allowed_workloads": allowed_workloads})
+        if on_workload_done and allowed_workloads:
+            for phase in phases:
+                for wl in allowed_workloads.get(phase, set()):
+                    on_workload_done(phase, wl, namespace, None)
         return {p: None for p in phases}
 
     with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
         deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-primary"})
 
     assert len(extract_calls) == 1
-    # Must use smoke's completed_namespace (ns-0), NOT the primary namespace
     assert extract_calls[0]["namespace"] == "ns-0"
-    assert extract_calls[0]["workload"] == "smoke"
     assert sorted(extract_calls[0]["phases"]) == ["baseline", "treatment"]
+    assert extract_calls[0]["allowed_workloads"] == {"baseline": {"smoke"}, "treatment": {"smoke"}}
 
 
 def test_collect_scoped_missing_completed_namespace_warns_and_skips(tmp_path, monkeypatch):
@@ -1097,6 +1125,10 @@ def test_collect_scoped_reports_namespace_context(tmp_path, monkeypatch, capsys)
         skip_logs = False
 
     def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
+        if on_workload_done and allowed_workloads:
+            for phase in phases:
+                for wl in allowed_workloads.get(phase, set()):
+                    on_workload_done(phase, wl, namespace, None)
         return {p: None for p in phases}
 
     with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
@@ -1789,3 +1821,52 @@ def test_extract_phases_per_phase_filter_prevents_cross_phase_leak(tmp_path, mon
         "baseline/balanced is stale — should NOT be collected (cross-phase leak)")
     assert "treatment/chatbot" not in copied_pairs, (
         "treatment/chatbot is stale — should NOT be collected (cross-phase leak)")
+
+
+# ── Issue #242: scoped collect must dispatch per-slot ─────────────────────────
+
+
+def test_collect_scoped_multi_slot_per_workload(tmp_path, monkeypatch):
+    """--workload dispatches per-slot when a workload's packages span multiple slots."""
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    data = {
+        "wl-mid-constantcontrol": {"workload": "mid", "package": "constantcontrol", "status": "done", "completed_namespace": "ns-0"},
+        "wl-mid-expceil":         {"workload": "mid", "package": "expceil",         "status": "done", "completed_namespace": "ns-1"},
+        "wl-mid-expceiling":      {"workload": "mid", "package": "expceiling",      "status": "done", "completed_namespace": "ns-2"},
+    }
+    _mock_cm(monkeypatch, data)
+
+    class Args:
+        only = None
+        workload = "mid"
+        package = None
+        skip_logs = False
+
+    extract_calls = []
+
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
+        extract_calls.append({
+            "namespace": namespace,
+            "phases": sorted(phases),
+            "allowed_workloads": allowed_workloads,
+        })
+        if on_workload_done and allowed_workloads:
+            for phase in phases:
+                for wl in allowed_workloads.get(phase, set()):
+                    on_workload_done(phase, wl, namespace, None)
+        return {p: None for p in phases}
+
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
+        deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-primary"})
+
+    assert len(extract_calls) == 3, f"Expected 3 slot dispatches, got {len(extract_calls)}"
+    ns_set = {c["namespace"] for c in extract_calls}
+    assert ns_set == {"ns-0", "ns-1", "ns-2"}
+
+    ns_to_allowed = {c["namespace"]: c["allowed_workloads"] for c in extract_calls}
+    assert ns_to_allowed["ns-0"] == {"constantcontrol": {"mid"}}
+    assert ns_to_allowed["ns-1"] == {"expceil": {"mid"}}
+    assert ns_to_allowed["ns-2"] == {"expceiling": {"mid"}}


### PR DESCRIPTION
## Summary

Closes #242

- Rewrote the scoped `collect --only/--workload` branch to group collectible pairs by `completed_namespace` and dispatch one extractor pod per slot (parallel when >1 slot), matching the unscoped path's per-slot model.
- Removed the broken per-workload loop that picked only the first matching pair's namespace for all phases.
- Added `test_collect_scoped_multi_slot_per_workload` reproducing the exact bug scenario (one workload, packages in 3 different slots).

## Reviewer attention

The scoped branch now uses `allowed_workloads` + `on_workload_done` callbacks (same as the unscoped branch) instead of the old `workload=` parameter. Eight existing tests were updated to assert on the new dispatch shape. The behavioral contract is unchanged — scoped collect still restricts extraction to in-scope pairs — but the extraction is now correctly routed to the slot where each pair actually ran.

## Test plan

- [x] New test `test_collect_scoped_multi_slot_per_workload` verifies 3-slot dispatch
- [x] All 59 collect tests pass
- [x] Full pipeline suite: 759 tests pass
- [x] Lint clean (`ruff check pipeline/ --select F`)