### PR TITLE
fix: deploy.py run — three regressions from PR #241

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1882,12 +1882,6 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
     if not discovered:
         err("No pairs found in cluster/. Run prepare.py first."); sys.exit(1)
 
-    pair_costs_with_prov = _derive_pair_gpu_costs(
-        discovered, defaults=defaults_result, fallback_cost=fallback_cost,
-    )
-    pair_costs = {k: v[0] for k, v in pair_costs_with_prov.items()}
-    pair_provenance = {k: v[1] for k, v in pair_costs_with_prov.items()}
-
     # Initialize new entries (first run or new pairs added)
     for key, meta in discovered.items():
         if key not in progress:
@@ -1906,6 +1900,13 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
     total_pairs = sum(1 for k in progress if _is_pair_key(k))
     if len(_scope) < total_pairs:
         info(f"Scope: {len(_scope)}/{total_pairs} pairs")
+
+    scoped_discovered = {k: v for k, v in discovered.items() if k in _scope}
+    pair_costs_with_prov = _derive_pair_gpu_costs(
+        scoped_discovered, defaults=defaults_result, fallback_cost=fallback_cost,
+    )
+    pair_costs = {k: v[0] for k, v in pair_costs_with_prov.items()}
+    pair_provenance = {k: v[1] for k, v in pair_costs_with_prov.items()}
 
     if getattr(args, "force", False):
         n = _force_reset(progress, _scope, discovered, namespaces=namespaces)

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -2174,6 +2174,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                 warn(f"[{pair_key}] kubectl apply failed: {result.stderr.strip()}")
                 continue
 
+            entry = progress[pair_key]
             entry["status"] = "running"
             entry["namespace"] = ns
             entry["pending_since"] = None

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1835,7 +1835,11 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
     # CLI --gpu-resource-type overrides auto-derivation when explicitly set
     gpu_resource_type = args.gpu_resource_type  # None means auto-derive
     fallback_cost = args.default_gpu_cost
-    defaults_result = load_defaults(REPO_ROOT)
+    defaults_path_override = getattr(args, "defaults_path", None)
+    if defaults_path_override:
+        defaults_result = load_defaults(REPO_ROOT, defaults_path=defaults_path_override)
+    else:
+        defaults_result = load_defaults(REPO_ROOT)
     if isinstance(defaults_result, str):
         warn(defaults_result)
         defaults_result = None
@@ -2540,10 +2544,15 @@ def _cmd_run_remote(args, run_dir: "Path", setup_config: dict) -> None:
     workspace_dir = EXPERIMENT_ROOT / "workspace"
     run_name = run_dir.name
 
+    # Read defaults.yaml locally — not available in-cluster
+    defaults_path = REPO_ROOT / "llm-d-benchmark" / "config" / "templates" / "values" / "defaults.yaml"
+    defaults_content = defaults_path.read_text() if defaults_path.exists() else None
+
     try:
         cm = build_run_inputs_configmap(
             run_dir=run_dir, workspace_dir=workspace_dir,
             namespace=namespace, run_name=run_name,
+            defaults_content=defaults_content,
         )
     except OSError as exc:
         err(f"{exc} — run setup.py and prepare.py first")
@@ -2560,6 +2569,9 @@ def _cmd_run_remote(args, run_dir: "Path", setup_config: dict) -> None:
         sys.exit(1)
 
     run_flags = _collect_run_flags(args)
+    if defaults_content:
+        run_flags.append("--defaults-path")
+        run_flags.append("/data/workspace/defaults.yaml")
     job = build_orchestrator_job(
         namespace=namespace, image=orchestrator_image,
         run_name=run_name, run_flags=run_flags,
@@ -2660,6 +2672,8 @@ Examples:
                        help="Max early reclaims before marking pair stalled [10]")
     run_p.add_argument("--max-backoff", type=int, default=600, dest="max_backoff",
                        help="Maximum backoff interval in seconds during GPU scarcity [600]")
+    run_p.add_argument("--defaults-path", type=Path, default=None, dest="defaults_path",
+                       help=argparse.SUPPRESS)
 
     sub.add_parser("stop", help="Stop the remote orchestrator Job")
 

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1838,6 +1838,8 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
     defaults_path_override = getattr(args, "defaults_path", None)
     if defaults_path_override:
         defaults_result = load_defaults(REPO_ROOT, defaults_path=defaults_path_override)
+        if defaults_result is None:
+            warn(f"--defaults-path {defaults_path_override} not found — GPU cost derivation will use fallback")
     else:
         defaults_result = load_defaults(REPO_ROOT)
     if isinstance(defaults_result, str):
@@ -2546,7 +2548,12 @@ def _cmd_run_remote(args, run_dir: "Path", setup_config: dict) -> None:
 
     # Read defaults.yaml locally — not available in-cluster
     defaults_path = REPO_ROOT / "llm-d-benchmark" / "config" / "templates" / "values" / "defaults.yaml"
-    defaults_content = defaults_path.read_text() if defaults_path.exists() else None
+    defaults_content = None
+    if defaults_path.exists():
+        try:
+            defaults_content = defaults_path.read_text()
+        except OSError as exc:
+            warn(f"defaults.yaml read failed: {exc} — remote Job will run without GPU cost defaults")
 
     try:
         cm = build_run_inputs_configmap(
@@ -2569,7 +2576,7 @@ def _cmd_run_remote(args, run_dir: "Path", setup_config: dict) -> None:
         sys.exit(1)
 
     run_flags = _collect_run_flags(args)
-    if defaults_content:
+    if defaults_content is not None:
         run_flags.append("--defaults-path")
         run_flags.append("/data/workspace/defaults.yaml")
     job = build_orchestrator_job(

--- a/pipeline/lib/capacity.py
+++ b/pipeline/lib/capacity.py
@@ -161,15 +161,22 @@ def gpu_cost_per_pair(resolved_scenario: dict, defaults: dict) -> Union[int, str
     return gpu_cost
 
 
-def load_defaults(repo_root: Path) -> Union[dict, str, None]:
+def load_defaults(repo_root: Path, *, defaults_path: "Path | None" = None) -> Union[dict, str, None]:
     """Load llm-d-benchmark defaults.yaml.
+
+    Args:
+        repo_root: experiment repo root (used to locate defaults.yaml by convention).
+        defaults_path: if provided, read from this path directly instead of
+            constructing from repo_root. Used by the remote orchestrator where
+            the file is mounted at a known location.
 
     Returns:
         dict: parsed defaults on success.
         None: file not found (expected when submodule not initialized).
         str: error message when file exists but can't be parsed.
     """
-    defaults_path = repo_root / "llm-d-benchmark" / "config" / "templates" / "values" / "defaults.yaml"
+    if defaults_path is None:
+        defaults_path = repo_root / "llm-d-benchmark" / "config" / "templates" / "values" / "defaults.yaml"
     if not defaults_path.exists():
         return None
     try:

--- a/pipeline/lib/remote.py
+++ b/pipeline/lib/remote.py
@@ -9,7 +9,8 @@ MOUNT_BASE = "/data"
 
 
 def build_run_inputs_configmap(
-    *, run_dir: Path, workspace_dir: Path, namespace: str, run_name: str
+    *, run_dir: Path, workspace_dir: Path, namespace: str, run_name: str,
+    defaults_content: "str | None" = None,
 ) -> dict:
     setup_path = workspace_dir / "setup_config.json"
     if not setup_path.exists():
@@ -23,6 +24,9 @@ def build_run_inputs_configmap(
         "setup_config.json": setup_path.read_text(),
         "run_metadata.json": metadata_path.read_text(),
     }
+
+    if defaults_content is not None:
+        data["defaults.yaml"] = defaults_content
 
     cluster_dir = run_dir / "cluster"
     yaml_files = sorted(cluster_dir.glob("*.yaml")) if cluster_dir.is_dir() else []
@@ -47,6 +51,8 @@ def _configmap_items(data: dict, run_name: str) -> list[dict]:
     for key in sorted(data):
         if key == "setup_config.json":
             items.append({"key": key, "path": key})
+        elif key == "defaults.yaml":
+            items.append({"key": key, "path": "defaults.yaml"})
         elif key == "run_metadata.json":
             items.append({"key": key, "path": f"runs/{run_name}/{key}"})
         elif key.startswith("cluster--"):

--- a/pipeline/tests/test_capacity.py
+++ b/pipeline/tests/test_capacity.py
@@ -305,3 +305,23 @@ class TestGpuCostPerPair:
         assert isinstance(cost, str)
         assert "bad" in cost
         assert "decode.accelerator.count" in cost
+
+
+# ── load_defaults tests ───────────────────────────────────────────────────────
+
+
+from pipeline.lib.capacity import load_defaults
+
+
+def test_load_defaults_explicit_path(tmp_path):
+    """load_defaults with explicit defaults_path reads from that path directly."""
+    defaults_file = tmp_path / "my-defaults.yaml"
+    defaults_file.write_text("decode:\n  accelerator:\n    count: 4\n")
+    result = load_defaults(tmp_path, defaults_path=defaults_file)
+    assert result == {"decode": {"accelerator": {"count": 4}}}
+
+
+def test_load_defaults_explicit_path_missing(tmp_path):
+    """load_defaults with explicit path to non-existent file returns None."""
+    result = load_defaults(tmp_path, defaults_path=tmp_path / "nope.yaml")
+    assert result is None

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -2460,3 +2460,107 @@ def test_handle_timeout_not_expired_returns_none(monkeypatch):
 
     assert result is None
     assert entry["status"] == "running"
+
+
+# ── dispatch loop entry assignment (issue #244) ──────────────────────────────
+
+
+def test_dispatch_sets_entry_running(tmp_path, monkeypatch):
+    """After successful kubectl apply, the dispatched pair must be marked 'running'."""
+    import yaml as _yaml
+    import pipeline.deploy as mod
+    from pipeline.lib.progress import ConfigMapProgressStore
+
+    # Set up run directory structure
+    run_dir = tmp_path / "runs" / "test-run"
+    cluster_dir = run_dir / "cluster"
+    cluster_dir.mkdir(parents=True)
+
+    # Write a single PipelineRun YAML
+    # Key derivation: "wl-" + stem.removeprefix("pipelinerun-") → "wl-a-baseline"
+    pr = {
+        "metadata": {"name": "pr-a-baseline", "namespace": "ns"},
+        "spec": {"params": [
+            {"name": "workloadName", "value": "wl-a"},
+            {"name": "phase", "value": "baseline"},
+        ]},
+    }
+    (cluster_dir / "pipelinerun-a-baseline.yaml").write_text(_yaml.dump(pr))
+
+    # Write run_metadata.json (needed by _cmd_build)
+    (run_dir / "run_metadata.json").write_text(json.dumps({}))
+
+    # Setup config with one namespace slot
+    setup_config = {"namespaces": ["sim2real-0"], "namespace": "sim2real-0"}
+
+    # Track progress store saves
+    saved_progress = {}
+
+    def mock_save(self, data):
+        saved_progress.update(data)
+
+    monkeypatch.setattr(ConfigMapProgressStore, "load", lambda self: {})
+    monkeypatch.setattr(ConfigMapProgressStore, "save", mock_save)
+
+    # _cmd_build → no-op (skip)
+    monkeypatch.setattr(mod, "_cmd_build", lambda *a, **kw: "skip")
+
+    # _check_slot_ready → always ready
+    monkeypatch.setattr(mod, "_check_slot_ready", lambda ns, **kw: (True, []))
+
+    # probe_free_gpus → plenty of capacity (imported inside _cmd_run from pipeline.lib.capacity)
+    import pipeline.lib.capacity as _cap_mod
+    monkeypatch.setattr(_cap_mod, "probe_free_gpus", lambda **kw: (8, 8, 0))
+
+    # load_defaults → minimal defaults (also imported inside _cmd_run)
+    monkeypatch.setattr(_cap_mod, "load_defaults", lambda root: {"decode": {"accelerator": {"count": 1}}})
+
+    # subprocess run → kubectl apply succeeds; then PipelineRun completes
+    call_count = {"n": 0}
+
+    def fake_run(cmd, *, check=True, capture=False, input=None, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+        call_count["n"] += 1
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    # After dispatch, PipelineRun immediately "Succeeds" so loop terminates
+    monkeypatch.setattr(mod, "_check_pipelinerun_status",
+                        lambda pr_name, ns: "Succeeded")
+
+    # Set REPO_ROOT and EXPERIMENT_ROOT
+    monkeypatch.setattr(mod, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)
+
+    # Build args namespace
+    args = argparse.Namespace(
+        skip_build=True,
+        max_retries=0,
+        poll_interval=1,
+        pending_threshold=600,
+        max_pending_stalls=10,
+        max_backoff=600,
+        default_gpu_cost=1,
+        gpu_resource_type="nvidia.com/gpu",
+        only=None,
+        workload=None,
+        package=None,
+        status=None,
+        force=False,
+        skip_teardown=False,
+        remote=False,
+        preserve_pipelineruns=False,
+    )
+
+    mod._cmd_run(args, run_dir, setup_config)
+
+    # The pair should have been marked running at some point during dispatch
+    assert "wl-a-baseline" in saved_progress
+    # After full loop it ends as "done" (since we mock Succeeded), but
+    # the critical thing is that no UnboundLocalError was raised.
+    # The final status should be "done" because _check_pipelinerun_status returns Succeeded.
+    assert saved_progress["wl-a-baseline"]["status"] == "done"

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -2564,3 +2564,107 @@ def test_dispatch_sets_entry_running(tmp_path, monkeypatch):
     # the critical thing is that no UnboundLocalError was raised.
     # The final status should be "done" because _check_pipelinerun_status returns Succeeded.
     assert saved_progress["wl-a-baseline"]["status"] == "done"
+
+
+# ── Scoped GPU cost derivation (issue #244) ─────────────────────────────────
+
+
+def test_derive_costs_only_for_scoped_pairs(tmp_path, monkeypatch):
+    """_derive_pair_gpu_costs must only be called with in-scope pairs, not all discovered."""
+    import yaml as _yaml
+    import pipeline.deploy as mod
+    import pipeline.lib.capacity as _cap_mod
+    from pipeline.lib.progress import ConfigMapProgressStore
+
+    # Create cluster dir with 3 workloads x 2 packages = 6 pairs
+    run_dir = tmp_path / "runs" / "test-run"
+    cluster_dir = run_dir / "cluster"
+    cluster_dir.mkdir(parents=True)
+
+    for wl in ("a", "b", "c"):
+        for pkg in ("baseline", "treatment"):
+            pr = {
+                "metadata": {"name": f"pr-{wl}-{pkg}", "namespace": "ns"},
+                "spec": {"params": [
+                    {"name": "workloadName", "value": f"wl-{wl}"},
+                    {"name": "phase", "value": pkg},
+                ]},
+            }
+            (cluster_dir / f"pipelinerun-{wl}-{pkg}.yaml").write_text(_yaml.dump(pr))
+
+    # Write run_metadata.json
+    (run_dir / "run_metadata.json").write_text(json.dumps({}))
+
+    # Setup config
+    setup_config = {"namespaces": ["sim2real-0"], "namespace": "sim2real-0"}
+
+    # Mock ConfigMapProgressStore
+    monkeypatch.setattr(ConfigMapProgressStore, "load", lambda self: {})
+    monkeypatch.setattr(ConfigMapProgressStore, "save", lambda self, d: None)
+
+    # _cmd_build → no-op
+    monkeypatch.setattr(mod, "_cmd_build", lambda *a, **kw: "skip")
+
+    # _check_slot_ready → always ready
+    monkeypatch.setattr(mod, "_check_slot_ready", lambda ns, **kw: (True, []))
+
+    # probe_free_gpus → plenty of capacity
+    monkeypatch.setattr(_cap_mod, "probe_free_gpus", lambda **kw: (8, 8, 0))
+
+    # load_defaults → minimal defaults
+    monkeypatch.setattr(_cap_mod, "load_defaults",
+                        lambda root: {"decode": {"accelerator": {"count": 1}}})
+
+    # subprocess run → success
+    def fake_run(cmd, *, check=True, capture=False, input=None, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    # PipelineRun immediately succeeds so loop terminates
+    monkeypatch.setattr(mod, "_check_pipelinerun_status",
+                        lambda pr_name, ns: "Succeeded")
+
+    # Set REPO_ROOT and EXPERIMENT_ROOT
+    monkeypatch.setattr(mod, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)
+
+    # Track which keys are passed to _derive_pair_gpu_costs
+    from pipeline.deploy import _derive_pair_gpu_costs as _orig_derive
+    called_keys: list[set] = []
+
+    def tracking_derive(discovered, *, defaults, fallback_cost):
+        called_keys.append(set(discovered.keys()))
+        return _orig_derive(discovered, defaults=defaults, fallback_cost=fallback_cost)
+
+    monkeypatch.setattr(mod, "_derive_pair_gpu_costs", tracking_derive)
+
+    # Args: scope to workload "wl-a" only (2 pairs: wl-a-baseline, wl-a-treatment)
+    args = argparse.Namespace(
+        skip_build=True,
+        max_retries=0,
+        poll_interval=1,
+        pending_threshold=600,
+        max_pending_stalls=10,
+        max_backoff=600,
+        default_gpu_cost=1,
+        gpu_resource_type="nvidia.com/gpu",
+        only=None,
+        workload="wl-a",
+        package=None,
+        status=None,
+        force=False,
+        skip_teardown=False,
+        remote=False,
+        preserve_pipelineruns=False,
+    )
+
+    mod._cmd_run(args, run_dir, setup_config)
+
+    # _derive_pair_gpu_costs should have been called with only the 2 in-scope pairs
+    assert len(called_keys) == 1
+    assert called_keys[0] == {"wl-a-baseline", "wl-a-treatment"}

--- a/pipeline/tests/test_remote.py
+++ b/pipeline/tests/test_remote.py
@@ -252,3 +252,37 @@ def test_job_backoff_limit_zero():
 def test_job_active_deadline():
     job = _build_job()
     assert job["spec"]["activeDeadlineSeconds"] == 18000
+
+
+# --- defaults.yaml bundling tests ---
+
+
+def test_defaults_yaml_packed(workspace):
+    """defaults.yaml content is included in ConfigMap when provided."""
+    workspace_dir, run_dir = workspace
+    _write_defaults(workspace_dir, run_dir)
+    defaults_content = "decode:\n  accelerator:\n    count: 2\n"
+    cm = build_run_inputs_configmap(
+        run_dir=run_dir, workspace_dir=workspace_dir,
+        namespace="ns", run_name="test-run",
+        defaults_content=defaults_content,
+    )
+    assert cm["data"]["defaults.yaml"] == defaults_content
+
+
+def test_defaults_yaml_omitted_when_none(workspace):
+    """When defaults_content is None, no defaults.yaml key in ConfigMap."""
+    workspace_dir, run_dir = workspace
+    _write_defaults(workspace_dir, run_dir)
+    cm = build_run_inputs_configmap(
+        run_dir=run_dir, workspace_dir=workspace_dir,
+        namespace="ns", run_name="test-run",
+    )
+    assert "defaults.yaml" not in cm["data"]
+
+
+def test_configmap_items_defaults_at_root():
+    """defaults.yaml maps to workspace root."""
+    data = {"defaults.yaml": "content", "setup_config.json": "{}"}
+    items = _configmap_items(data, "run1")
+    assert {"key": "defaults.yaml", "path": "defaults.yaml"} in items


### PR DESCRIPTION
Closes #244

## Summary

Fixes three regressions introduced by PR #241 (make `gpu_cost` derived per-invocation):

- **Crash on dispatch** — `UnboundLocalError` on `entry` in the dispatch loop. The PR removed `entry = progress[pair_key]` but left three lines referencing `entry`. Restored the assignment.
- **Spurious cost warnings** — `_derive_pair_gpu_costs` ran on all 24 discovered pairs before `_resolve_scope` filtered to the 3 in-scope. Moved cost derivation after scoping so only in-scope pairs are processed.
- **`defaults.yaml` unavailable in remote** — The orchestrator container image only contains `pipeline/`; the `llm-d-benchmark` submodule isn't present. Added plumbing to read `defaults.yaml` locally, bundle it into the ConfigMap, and inject `--defaults-path` into the remote Job args.

## Changes

| File | What |
|------|------|
| `pipeline/deploy.py` | Restore `entry` assignment; reorder cost derivation after scoping; use `--defaults-path` override; read+inject defaults in `_cmd_run_remote` |
| `pipeline/lib/capacity.py` | Add optional `defaults_path` kwarg to `load_defaults` |
| `pipeline/lib/remote.py` | Accept `defaults_content` in ConfigMap builder; handle `defaults.yaml` key in item mapping |
| `pipeline/tests/test_deploy_run.py` | Tests for dispatch entry fix + scoped cost derivation |
| `pipeline/tests/test_capacity.py` | Tests for `load_defaults` explicit path |
| `pipeline/tests/test_remote.py` | Tests for defaults bundling in ConfigMap |

## Reviewer attention

- The `--defaults-path` CLI arg is hidden (`argparse.SUPPRESS`) — it's internal plumbing injected only by the `--remote` codepath. Users never see or set it.
- The `scoped_discovered` filtering in Task 2 means `pair_costs` only has entries for in-scope pairs. This is safe because `_capacity_limited_pairs` and the dispatch loop only operate on `pending` (a subset of scope). Verified by tracing all consumers.

## Test plan

- [x] `ruff check pipeline/ --select F` — clean
- [x] `python -m pytest pipeline/ -v` — 766 tests pass
- [ ] Manual: `deploy.py run --remote --workload <wl>` on cluster confirms no crash, scoped warnings only, and correct GPU costs