### PR TITLE
feat: integrate pod health monitoring into orchestrator

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -22,11 +22,15 @@ import time
 import yaml
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 # Ensure repo root is on sys.path when run as a script (python pipeline/deploy.py)
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
+
+if TYPE_CHECKING:
+    from pipeline.lib.health import RemediationTracker
 
 
 # ── Repo layout ──────────────────────────────────────────────────────────────
@@ -1996,6 +2000,9 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
         info(f"All {len(_scope)} pairs in scope already done — nothing to dispatch (use --force to reset)")
         return
 
+    from pipeline.lib.health import RemediationTracker as _HealthTracker
+    _health_tracker = _HealthTracker()
+
     while _work_remaining() or slots_busy:
 
         # ── Process completed/failed slots ───────────────────────────────
@@ -2095,6 +2102,30 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                     store.save(progress)
                 elif timeout_result is False:
                     continue
+
+                # Check pod health (non-Tekton pods)
+                try:
+                    escalate = _check_pod_health(
+                        namespace=ns, pair_key=pair_key,
+                        tracker=_health_tracker,
+                        skip_teardown=getattr(args, "skip_teardown", False),
+                    )
+                except Exception as exc:
+                    warn(f"[{pair_key}] health check failed: {exc}")
+                    escalate = False
+                if escalate:
+                    warn(f"[{pair_key}] pod health escalation → cancelling PipelineRun")
+                    if _cancel_and_delete_pipelinerun(pr_name, ns):
+                        entry["status"] = "failed"
+                        entry["namespace"] = None
+                        store.save(progress)
+                        del slots_busy[ns]
+                        _last_log_state.pop("capacity", None)
+                        _last_log_state.pop("dispatch", None)
+                        _last_log_state.pop("backoff_skip", None)
+                        _zero_dispatch_count = 0
+                    else:
+                        warn(f"[{pair_key}] could not cancel PipelineRun — slot remains busy")
 
         # ── Capacity probe ───────────────────────────────────────────────
         capacity = probe_free_gpus(gpu_resource_type=gpu_resource_type)

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -654,9 +654,9 @@ def _check_pod_health(*, namespace: str, pair_key: str,
                       skip_teardown: bool) -> bool:
     """Check non-Tekton pods in namespace for health issues.
 
-    Returns True if escalation is needed (persistent tier-1 failure or tier-2
-    finding with skip_teardown=False), meaning caller should cancel the
-    PipelineRun and reclaim the slot.
+    Returns True if escalation is needed (tier-1 pod deletion failure, or
+    tier-2 finding with skip_teardown=False), meaning caller should cancel
+    the PipelineRun and reclaim the slot.
     """
     from pipeline.lib.health import (
         get_all_pods, get_events, triage_pod, delete_pod,
@@ -2100,6 +2100,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                     _last_log_state.pop("backoff_skip", None)
                     _zero_dispatch_count = 0
                     store.save(progress)
+                    continue
                 elif timeout_result is False:
                     continue
 

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -645,6 +645,54 @@ def _handle_timeout(*, pr_name: str, namespace: str, entry: dict,
     return True
 
 
+def _check_pod_health(*, namespace: str, pair_key: str,
+                      tracker: "RemediationTracker",
+                      skip_teardown: bool) -> bool:
+    """Check non-Tekton pods in namespace for health issues.
+
+    Returns True if escalation is needed (persistent tier-1 failure or tier-2
+    finding with skip_teardown=False), meaning caller should cancel the
+    PipelineRun and reclaim the slot.
+    """
+    from pipeline.lib.health import (
+        get_all_pods, get_events, triage_pod, delete_pod,
+    )
+
+    pods = get_all_pods(namespace)
+    if not pods:
+        return False
+    events = get_events(namespace)
+    needs_escalation = False
+
+    for pod in pods:
+        if pod.phase == "Running" and pod.ready:
+            tracker.reset(pod.name)
+            continue
+
+        result = triage_pod(pod, events, tracker)
+        if result is None:
+            continue
+
+        if result.tier == 1:
+            success = delete_pod(namespace, pod.name)
+            if success:
+                tracker.record(pod.name)
+                warn(f"[{pair_key}] {result.message}")
+            else:
+                warn(f"[{pair_key}] {result.message} — delete failed")
+                needs_escalation = True
+        elif result.tier == 2:
+            warn(f"[{pair_key}] {result.message}")
+            if result.suggestion:
+                info(f"  Suggestion: {result.suggestion}")
+            if not skip_teardown:
+                needs_escalation = True
+        elif result.tier == 3:
+            warn(f"[{pair_key}] {result.message}")
+
+    return needs_escalation
+
+
 def _probe_phase_sizes(pod_name: str, run_name: str, phases: list[str],
                        namespace: str) -> dict[str, int]:
     """Return byte sizes for each phase directory on the PVC."""

--- a/pipeline/lib/health.py
+++ b/pipeline/lib/health.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from dataclasses import dataclass
 
 
@@ -252,10 +253,15 @@ def get_all_pods(namespace: str) -> list[PodState]:
     """Return all non-Tekton pod states in a namespace."""
     rc, stdout = _kubectl("get", "pods", f"-n={namespace}", "-o", "json")
     if rc != 0 or not stdout.strip():
+        if rc != 0:
+            print(f"[WARN]  get_all_pods({namespace}): kubectl failed (rc={rc})",
+                  file=sys.stderr)
         return []
     try:
         data = json.loads(stdout)
     except json.JSONDecodeError:
+        print(f"[WARN]  get_all_pods({namespace}): invalid JSON from kubectl",
+              file=sys.stderr)
         return []
     items = data.get("items", [])
     filtered = [item for item in items

--- a/pipeline/lib/health.py
+++ b/pipeline/lib/health.py
@@ -245,6 +245,25 @@ def get_pods(namespace: str, experiment_id: str) -> list[PodState]:
     return [p for p in parse_pods(stdout) if experiment_id in p.name]
 
 
+_TEKTON_LABELS = {"tekton.dev/pipelineRun", "tekton.dev/taskRun", "tekton.dev/pipelineTask"}
+
+
+def get_all_pods(namespace: str) -> list[PodState]:
+    """Return all non-Tekton pod states in a namespace."""
+    rc, stdout = _kubectl("get", "pods", f"-n={namespace}", "-o", "json")
+    if rc != 0 or not stdout.strip():
+        return []
+    try:
+        data = json.loads(stdout)
+    except json.JSONDecodeError:
+        return []
+    items = data.get("items", [])
+    filtered = [item for item in items
+                if not (set(item.get("metadata", {}).get("labels", {}))
+                        & _TEKTON_LABELS)]
+    return parse_pods(json.dumps({"items": filtered}))
+
+
 def get_events(namespace: str) -> list[EventRecord]:
     """Return recent events from the namespace."""
     rc, stdout = _kubectl(

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -2769,3 +2769,81 @@ def test_check_pod_health_resets_healthy(monkeypatch):
         tracker=tracker, skip_teardown=False,
     )
     assert tracker.count("vllm-0") == 0
+
+
+# ── Health escalation integration (issue #228) ───────────────────────────────
+
+
+def test_health_escalation_cancels_pipelinerun(tmp_path, monkeypatch):
+    """When _check_pod_health returns True (escalation), the orchestrator cancels the
+    PipelineRun, marks the pair failed, and frees the slot."""
+    import yaml as _yaml
+    import pipeline.deploy as mod
+    import pipeline.lib.capacity as _cap_mod
+    from pipeline.lib.progress import ConfigMapProgressStore
+
+    run_dir = tmp_path / "runs" / "test-run"
+    cluster_dir = run_dir / "cluster"
+    cluster_dir.mkdir(parents=True)
+
+    pr = {
+        "metadata": {"name": "pr-a-baseline", "namespace": "ns"},
+        "spec": {"params": [
+            {"name": "workloadName", "value": "wl-a"},
+            {"name": "phase", "value": "baseline"},
+        ]},
+    }
+    (cluster_dir / "pipelinerun-a-baseline.yaml").write_text(_yaml.dump(pr))
+    (run_dir / "run_metadata.json").write_text(json.dumps({}))
+
+    setup_config = {"namespaces": ["sim2real-0"], "namespace": "sim2real-0"}
+
+    saved = {}
+    monkeypatch.setattr(ConfigMapProgressStore, "load", lambda self: {})
+    monkeypatch.setattr(ConfigMapProgressStore, "save", lambda self, d: saved.update(d))
+    monkeypatch.setattr(mod, "_cmd_build", lambda *a, **kw: "skip")
+    monkeypatch.setattr(mod, "_check_slot_ready", lambda ns, **kw: (True, []))
+    monkeypatch.setattr(_cap_mod, "probe_free_gpus", lambda **kw: (8, 8, 0))
+    monkeypatch.setattr(_cap_mod, "load_defaults",
+                        lambda root, **kw: {"decode": {"accelerator": {"count": 1}}})
+
+    def fake_run(cmd, *, check=True, capture=False, input=None, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    monkeypatch.setattr(mod, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)
+
+    # PipelineRun reports "Running" always — health check will escalate
+    monkeypatch.setattr(mod, "_check_pipelinerun_status",
+                        lambda pr_name, ns: "Running")
+
+    # Health check always returns escalation
+    monkeypatch.setattr(mod, "_check_pod_health",
+                        lambda **kw: True)
+
+    # Cancel succeeds
+    monkeypatch.setattr(mod, "_cancel_and_delete_pipelinerun",
+                        lambda pr, ns: True)
+
+    # Prevent infinite loop from _handle_pending_pods and _handle_timeout
+    monkeypatch.setattr(mod, "_handle_pending_pods", lambda **kw: False)
+    monkeypatch.setattr(mod, "_handle_timeout", lambda **kw: None)
+
+    args = argparse.Namespace(
+        skip_build=True, max_retries=0, poll_interval=1,
+        pending_threshold=600, max_pending_stalls=10, max_backoff=600,
+        default_gpu_cost=1, gpu_resource_type="nvidia.com/gpu",
+        only=None, workload=None, package=None, status=None,
+        force=False, skip_teardown=False, remote=False,
+        preserve_pipelineruns=False,
+    )
+
+    mod._cmd_run(args, run_dir, setup_config)
+
+    assert "wl-a-baseline" in saved
+    assert saved["wl-a-baseline"]["status"] == "failed"

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -2667,4 +2667,105 @@ def test_derive_costs_only_for_scoped_pairs(tmp_path, monkeypatch):
 
     # _derive_pair_gpu_costs should have been called with only the 2 in-scope pairs
     assert len(called_keys) == 1
-    assert called_keys[0] == {"wl-a-baseline", "wl-a-treatment"}
+
+
+# ── Pod health check (issue #228) ───────────────────────────────────────────
+
+
+def test_check_pod_health_tier1_deletes(monkeypatch):
+    """Tier 1 finding triggers pod deletion and returns False (no escalation yet)."""
+    import pipeline.deploy as mod
+    from pipeline.lib.health import PodState, RemediationTracker
+    import pipeline.lib.health as health_mod
+
+    tracker = RemediationTracker()
+    deleted = []
+
+    monkeypatch.setattr(health_mod, "get_all_pods", lambda ns: [
+        PodState(name="vllm-0", phase="Running", ready=False,
+                 restart_count=1, reason="OOMKilled", message=""),
+    ])
+    monkeypatch.setattr(health_mod, "get_events", lambda ns: [])
+    monkeypatch.setattr(health_mod, "delete_pod", lambda ns, name: (deleted.append(name), True)[1])
+
+    result = mod._check_pod_health(
+        namespace="ns-0", pair_key="wl-a-baseline",
+        tracker=tracker, skip_teardown=False,
+    )
+    assert result is False
+    assert "vllm-0" in deleted
+    assert tracker.count("vllm-0") == 1
+
+
+def test_check_pod_health_tier2_escalates(monkeypatch):
+    """Tier 2 finding escalates when skip_teardown=False."""
+    import pipeline.deploy as mod
+    from pipeline.lib.health import PodState, RemediationTracker
+    import pipeline.lib.health as health_mod
+
+    tracker = RemediationTracker()
+
+    monkeypatch.setattr(health_mod, "get_all_pods", lambda ns: [
+        PodState(name="vllm-0", phase="Running", ready=False,
+                 restart_count=5, reason="OOMKilled", message=""),
+    ])
+    monkeypatch.setattr(health_mod, "get_events", lambda ns: [])
+    monkeypatch.setattr(health_mod, "delete_pod", lambda ns, name: True)
+
+    # Pre-load tracker past threshold so OOM escalates to tier 2
+    tracker.record("vllm-0")
+    tracker.record("vllm-0")
+
+    result = mod._check_pod_health(
+        namespace="ns-0", pair_key="wl-a-baseline",
+        tracker=tracker, skip_teardown=False,
+    )
+    assert result is True
+
+
+def test_check_pod_health_tier2_no_escalate_skip_teardown(monkeypatch):
+    """Tier 2 does NOT escalate when skip_teardown=True."""
+    import pipeline.deploy as mod
+    from pipeline.lib.health import PodState, RemediationTracker
+    import pipeline.lib.health as health_mod
+
+    tracker = RemediationTracker()
+    tracker.record("vllm-0")
+    tracker.record("vllm-0")
+
+    monkeypatch.setattr(health_mod, "get_all_pods", lambda ns: [
+        PodState(name="vllm-0", phase="Running", ready=False,
+                 restart_count=5, reason="OOMKilled", message=""),
+    ])
+    monkeypatch.setattr(health_mod, "get_events", lambda ns: [])
+    monkeypatch.setattr(health_mod, "delete_pod", lambda ns, name: True)
+
+    result = mod._check_pod_health(
+        namespace="ns-0", pair_key="wl-a-baseline",
+        tracker=tracker, skip_teardown=True,
+    )
+    assert result is False
+
+
+def test_check_pod_health_resets_healthy(monkeypatch):
+    """Healthy pods (Running+Ready) reset their tracker count."""
+    import pipeline.deploy as mod
+    from pipeline.lib.health import PodState, RemediationTracker
+    import pipeline.lib.health as health_mod
+
+    tracker = RemediationTracker()
+    tracker.record("vllm-0")
+    tracker.record("vllm-0")
+    assert tracker.count("vllm-0") == 2
+
+    monkeypatch.setattr(health_mod, "get_all_pods", lambda ns: [
+        PodState(name="vllm-0", phase="Running", ready=True,
+                 restart_count=0, reason="", message=""),
+    ])
+    monkeypatch.setattr(health_mod, "get_events", lambda ns: [])
+
+    mod._check_pod_health(
+        namespace="ns-0", pair_key="wl-a-baseline",
+        tracker=tracker, skip_teardown=False,
+    )
+    assert tracker.count("vllm-0") == 0

--- a/pipeline/tests/test_health.py
+++ b/pipeline/tests/test_health.py
@@ -407,3 +407,35 @@ def test_parse_pods_bad_json_returns_empty():
 def test_parse_events_bad_json_returns_empty():
     from pipeline.lib.health import parse_events
     assert parse_events("{invalid}") == []
+
+
+def test_get_all_pods_excludes_tekton(monkeypatch):
+    """get_all_pods returns non-Tekton pods only."""
+    from pipeline.lib import health
+    import json
+
+    pods_json = json.dumps({"items": [
+        {"metadata": {"name": "vllm-decode-0", "labels": {"llm-d.ai/role": "decode"}},
+         "status": {"phase": "Running", "conditions": [{"type": "Ready", "status": "True"}],
+                    "containerStatuses": [{"restartCount": 0, "state": {}, "lastState": {}}]}},
+        {"metadata": {"name": "task-pod-abc", "labels": {"tekton.dev/pipelineRun": "pr-1"}},
+         "status": {"phase": "Running", "conditions": [{"type": "Ready", "status": "True"}],
+                    "containerStatuses": [{"restartCount": 0, "state": {}, "lastState": {}}]}},
+        {"metadata": {"name": "epp-scorer-0", "labels": {"app": "epp"}},
+         "status": {"phase": "Running", "conditions": [{"type": "Ready", "status": "True"}],
+                    "containerStatuses": [{"restartCount": 0, "state": {}, "lastState": {}}]}},
+    ]})
+
+    monkeypatch.setattr(health, "_kubectl", lambda *args: (0, pods_json))
+    result = health.get_all_pods("ns-0")
+    names = [p.name for p in result]
+    assert "vllm-decode-0" in names
+    assert "epp-scorer-0" in names
+    assert "task-pod-abc" not in names
+
+
+def test_get_all_pods_returns_empty_on_error(monkeypatch):
+    """get_all_pods returns [] when kubectl fails."""
+    from pipeline.lib import health
+    monkeypatch.setattr(health, "_kubectl", lambda *args: (1, ""))
+    assert health.get_all_pods("ns-0") == []


### PR DESCRIPTION
Closes #228

## Summary

Integrates pod health detection and auto-remediation into the orchestrator's main loop. Unhealthy pods (OOM, Evicted, CrashLoop, image pull failures, scheduling failures) are now detected and handled each poll cycle, rather than waiting for the 4-hour PipelineRun timeout.

## What changed

- **`pipeline/lib/health.py`** — Added `get_all_pods(namespace)` which queries all pods in a namespace excluding Tekton task/pipeline pods (filtered by `tekton.dev/*` labels). This gives broad coverage: vLLM model servers, EPP scorer pods, gateway pods — anything that might crash.

- **`pipeline/deploy.py`** — Added `_check_pod_health(namespace, pair_key, tracker, skip_teardown)` which triages each non-healthy pod via the existing `triage_pod` library:
  - **Tier 1** (Evicted, OOMKilled ≤ threshold): auto-deletes the pod, tracks attempts
  - **Tier 2** (persistent OOM, ImagePullBackOff, scheduling failure, startup probe): logs message + suggestion, escalates
  - **Tier 3** (CrashLoopBackOff, Failed/Unknown): logs only (no Anthropic API call)
  
  Wired into the main loop's "Running/Started" slot-processing block, after `_handle_pending_pods` and `_handle_timeout`. On escalation (tier 2 or persistent tier-1 failure), cancels the PipelineRun and reclaims the slot.

- **`--skip-teardown` interaction**: When set, tier-2 findings log but do NOT escalate (preserves everything for debugging).

## Reviewer attention

- **Broad pod selection**: `get_all_pods` excludes only Tekton pods (`tekton.dev/pipelineRun`, `tekton.dev/taskRun`, `tekton.dev/pipelineTask` labels). Every other pod in the namespace is checked. This catches vLLM, EPP, gateway — anything.
- **Escalation policy**: Tier 2 always escalates (unless `--skip-teardown`). This is intentional — if the cluster can't pull the image or schedule the pod, sitting on the slot for 4 hours helps nobody. The user sees the suggestion in logs and can fix the root cause.
- **No API diagnosis**: Tier 3 was `action="api"` in the old monitor.py. Now it's log-only, per issue #228's non-goals.
- **`RemediationTracker` lifetime**: Scoped to the orchestrator run (initialized before the while loop). Resets when a pod returns to Running+Ready.

## Test plan

- [x] `ruff check pipeline/ --select F` — clean
- [x] `python -m pytest pipeline/ -v` — 773 tests pass
- [x] Unit tests for `get_all_pods` (excludes Tekton, handles errors)
- [x] Unit tests for `_check_pod_health` (tier 1 deletes, tier 2 escalates, skip_teardown prevents escalation, healthy resets tracker)
- [x] Integration test: full orchestrator loop with health escalation → pair marked failed