### PR TITLE
feat: add --dispatch-cooldown to prevent over-subscription from probe lag

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -166,6 +166,9 @@ python pipeline/deploy.py pairs   [flags]   # list available pair keys, workload
 | `--pending-threshold N` | 600 | Seconds a pod may remain Pending (recoverable reason) before early reclaim |
 | `--max-pending-stalls N` | 10 | Max early reclaims before marking pair `stalled` |
 | `--max-backoff N` | 600 | Maximum backoff interval in seconds during GPU scarcity |
+| `--dispatch-cooldown N` | 15 | Seconds to wait after a dispatch batch before dispatching again (0 to disable) |
+
+**Dispatch cooldown** — after dispatching ≥1 pair, the orchestrator skips new dispatch for `--dispatch-cooldown` seconds. This prevents over-subscription when the GPU capacity probe hasn't yet reflected recently-dispatched workloads (typical probe lag: 10-20s). Completion/failure polling continues unaffected during cooldown. Set to 0 to disable.
 
 **Early reclaim** — on each poll cycle, pods in `Running`/`Started` PipelineRuns are checked for scheduling failures. Recoverable reasons (e.g. `Insufficient nvidia.com/gpu`) trigger early reclaim after `--pending-threshold` seconds. Non-recoverable reasons (e.g. node affinity mismatch, PVC not found) fail the pair immediately. Each early reclaim increments `pending_stalls`; at `--max-pending-stalls` the pair transitions to `stalled` (terminal).
 

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -2004,7 +2004,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
     from pipeline.lib.health import RemediationTracker as _HealthTracker
     _health_tracker = _HealthTracker()
 
-    dispatch_cooldown = getattr(args, "dispatch_cooldown", 15)
+    dispatch_cooldown = args.dispatch_cooldown
     _last_dispatch_time: float = 0.0
 
     while _work_remaining() or slots_busy:
@@ -2177,7 +2177,8 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
 
         # ── Assign pending work to free slots ────────────────────────────
         _cooldown_elapsed = time.time() - _last_dispatch_time if _last_dispatch_time > 0 else float('inf')
-        if dispatch_cooldown > 0 and _cooldown_elapsed < dispatch_cooldown:
+        _in_cooldown = dispatch_cooldown > 0 and _cooldown_elapsed < dispatch_cooldown
+        if _in_cooldown:
             free_slots = []
         else:
             free_slots = [ns for ns in namespaces if ns not in slots_busy]
@@ -2207,7 +2208,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                     if _disp_state != _last_log_state.get("dispatch"):
                         info(f"Dispatching {len(dispatchable)}/{len(pending)} pending pairs (capacity-limited: {free_gpus} free GPUs)")
                         _last_log_state["dispatch"] = _disp_state
-                elif len(free_slots) < len(dispatchable):
+                elif not _in_cooldown and len(free_slots) < len(dispatchable):
                     _disp_state = ("slot_limited", len(free_slots), len(pending))
                     if _disp_state != _last_log_state.get("dispatch"):
                         info(f"Dispatching {len(free_slots)}/{len(pending)} pending pairs (slot-limited)")
@@ -2503,6 +2504,7 @@ def _collect_run_flags(args) -> list[str]:
         "pending_threshold": 600,
         "max_pending_stalls": 10,
         "max_backoff": 600,
+        "dispatch_cooldown": 15,
     }
     for attr, default in _defaults.items():
         val = getattr(args, attr)

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -2004,6 +2004,9 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
     from pipeline.lib.health import RemediationTracker as _HealthTracker
     _health_tracker = _HealthTracker()
 
+    dispatch_cooldown = getattr(args, "dispatch_cooldown", 15)
+    _last_dispatch_time: float = 0.0
+
     while _work_remaining() or slots_busy:
 
         # ── Process completed/failed slots ───────────────────────────────
@@ -2173,7 +2176,11 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                 backoff.signal_capacity(free_gpus=free_gpus, max_cost=max_cost)
 
         # ── Assign pending work to free slots ────────────────────────────
-        free_slots = [ns for ns in namespaces if ns not in slots_busy]
+        _cooldown_elapsed = time.time() - _last_dispatch_time if _last_dispatch_time > 0 else float('inf')
+        if dispatch_cooldown > 0 and _cooldown_elapsed < dispatch_cooldown:
+            free_slots = []
+        else:
+            free_slots = [ns for ns in namespaces if ns not in slots_busy]
         pending = _pending_pairs()
         if free_gpus is not None and pending:
             min_cost = min(pair_costs[k] for k in pending)
@@ -2275,6 +2282,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
             _last_log_state.pop("dispatch", None)
             _last_log_state.pop("backoff_skip", None)
             _zero_dispatch_count = 0
+            _last_dispatch_time = time.time()
 
         # Persist backoff state
         progress["_orchestrator"] = backoff.to_dict()
@@ -2762,6 +2770,8 @@ Examples:
                        help="Max early reclaims before marking pair stalled [10]")
     run_p.add_argument("--max-backoff", type=int, default=600, dest="max_backoff",
                        help="Maximum backoff interval in seconds during GPU scarcity [600]")
+    run_p.add_argument("--dispatch-cooldown", type=int, default=15, dest="dispatch_cooldown",
+                       help="Seconds to wait after a dispatch batch before dispatching again (0 to disable) [15]")
     run_p.add_argument("--defaults-path", type=Path, default=None, dest="defaults_path",
                        help=argparse.SUPPRESS)
 

--- a/pipeline/tests/test_deploy_remote.py
+++ b/pipeline/tests/test_deploy_remote.py
@@ -14,7 +14,8 @@ def _make_run_args(*, remote=False, workload=None, only=None, package=None,
                    skip_teardown=False,
                    max_retries=2, poll_interval=30, gpu_resource_type=None,
                    default_gpu_cost=1, pending_threshold=600,
-                   max_pending_stalls=10, max_backoff=600):
+                   max_pending_stalls=10, max_backoff=600,
+                   dispatch_cooldown=15):
     return argparse.Namespace(
         remote=remote, workload=workload, only=only, package=package,
         status=status, force=force, skip_build=skip_build,
@@ -22,7 +23,7 @@ def _make_run_args(*, remote=False, workload=None, only=None, package=None,
         max_retries=max_retries, poll_interval=poll_interval,
         gpu_resource_type=gpu_resource_type, default_gpu_cost=default_gpu_cost,
         pending_threshold=pending_threshold, max_pending_stalls=max_pending_stalls,
-        max_backoff=max_backoff,
+        max_backoff=max_backoff, dispatch_cooldown=dispatch_cooldown,
     )
 
 

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -576,6 +576,7 @@ def test_collect_run_flags_list_values():
         pending_threshold = 600
         max_pending_stalls = 10
         max_backoff = 600
+        dispatch_cooldown = 15
 
     flags = _collect_run_flags(_Args())
     assert "--only" in flags
@@ -608,6 +609,7 @@ def test_collect_run_flags_single_string_status():
         pending_threshold = 600
         max_pending_stalls = 10
         max_backoff = 600
+        dispatch_cooldown = 15
 
     flags = _collect_run_flags(_Args())
     assert flags == ["--status", "failed"]
@@ -2554,6 +2556,7 @@ def test_dispatch_sets_entry_running(tmp_path, monkeypatch):
         skip_teardown=False,
         remote=False,
         preserve_pipelineruns=False,
+        dispatch_cooldown=0,
     )
 
     mod._cmd_run(args, run_dir, setup_config)
@@ -2661,6 +2664,7 @@ def test_derive_costs_only_for_scoped_pairs(tmp_path, monkeypatch):
         skip_teardown=False,
         remote=False,
         preserve_pipelineruns=False,
+        dispatch_cooldown=0,
     )
 
     mod._cmd_run(args, run_dir, setup_config)
@@ -2840,7 +2844,7 @@ def test_health_escalation_cancels_pipelinerun(tmp_path, monkeypatch):
         default_gpu_cost=1, gpu_resource_type="nvidia.com/gpu",
         only=None, workload=None, package=None, status=None,
         force=False, skip_teardown=False, remote=False,
-        preserve_pipelineruns=False,
+        preserve_pipelineruns=False, dispatch_cooldown=0,
     )
 
     mod._cmd_run(args, run_dir, setup_config)
@@ -2912,7 +2916,7 @@ def test_dispatch_shuffles_dispatchable(tmp_path, monkeypatch):
         default_gpu_cost=1, gpu_resource_type="nvidia.com/gpu",
         only=None, workload=None, package=None, status=None,
         force=False, skip_teardown=False, remote=False,
-        preserve_pipelineruns=False,
+        preserve_pipelineruns=False, dispatch_cooldown=0,
     )
 
     mod._cmd_run(args, run_dir, setup_config)

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -2919,3 +2919,166 @@ def test_dispatch_shuffles_dispatchable(tmp_path, monkeypatch):
 
     assert len(shuffle_calls) >= 1
     assert "wl-a-baseline" in shuffle_calls[0]
+
+
+# ── Dispatch cooldown (issue #249) ──────────────────────────────────────────
+
+
+def test_dispatch_cooldown_prevents_immediate_redispatch(tmp_path, monkeypatch):
+    """With dispatch_cooldown > 0, dispatch is skipped when within cooldown window.
+
+    Uses 2 pairs and 1 slot. Pair A dispatches on first iteration (cooldown
+    inactive since _last_dispatch_time=0). Pair A immediately succeeds, freeing
+    the slot. Next iterations skip dispatch until simulated time advances past
+    the cooldown window, at which point pair B dispatches.
+    """
+    import time as _time_mod
+    import yaml as _yaml
+    import pipeline.deploy as mod
+    from pipeline.lib.progress import ConfigMapProgressStore
+
+    run_dir = tmp_path / "runs" / "test-run"
+    cluster_dir = run_dir / "cluster"
+    cluster_dir.mkdir(parents=True)
+
+    # Two pairs: a-baseline, b-baseline
+    for name in ("a", "b"):
+        pr = {
+            "metadata": {"name": f"pr-{name}-baseline", "namespace": "ns"},
+            "spec": {"params": [
+                {"name": "workloadName", "value": f"wl-{name}"},
+                {"name": "phase", "value": "baseline"},
+            ]},
+        }
+        (cluster_dir / f"pipelinerun-{name}-baseline.yaml").write_text(_yaml.dump(pr))
+
+    (run_dir / "run_metadata.json").write_text(json.dumps({}))
+
+    # Only 1 slot — forces sequential dispatch
+    setup_config = {"namespaces": ["sim2real-0"], "namespace": "sim2real-0"}
+
+    monkeypatch.setattr(ConfigMapProgressStore, "load", lambda self: {})
+    monkeypatch.setattr(ConfigMapProgressStore, "save", lambda self, d: None)
+    monkeypatch.setattr(mod, "_cmd_build", lambda *a, **kw: "skip")
+    monkeypatch.setattr(mod, "_check_slot_ready", lambda ns, **kw: (True, []))
+
+    import pipeline.lib.capacity as _cap_mod
+    monkeypatch.setattr(_cap_mod, "probe_free_gpus", lambda **kw: (8, 8, 0))
+    monkeypatch.setattr(_cap_mod, "load_defaults", lambda root: {"decode": {"accelerator": {"count": 1}}})
+
+    # Track dispatches (kubectl apply calls only)
+    dispatch_times = []
+
+    def fake_run(cmd, *, check=True, capture=False, input=None, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+        if "apply" in cmd:
+            dispatch_times.append(clock[0])
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    # Both pairs succeed immediately once dispatched
+    monkeypatch.setattr(mod, "_check_pipelinerun_status",
+                        lambda pr_name, ns: "Succeeded")
+    monkeypatch.setattr(mod, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)
+
+    # Controlled clock: advances by 1 second per call to time.time()
+    # Cooldown is 10s, so iterations at t=1..10 will be blocked; t=11+ allows dispatch
+    clock = [100.0]
+
+    def fake_time():
+        val = clock[0]
+        clock[0] += 1.0
+        return val
+
+    monkeypatch.setattr(_time_mod, "time", fake_time)
+    monkeypatch.setattr(mod.time, "time", fake_time)
+    monkeypatch.setattr(mod.time, "sleep", lambda s: None)
+
+    args = argparse.Namespace(
+        skip_build=True, max_retries=0, poll_interval=1,
+        pending_threshold=600, max_pending_stalls=10, max_backoff=600,
+        default_gpu_cost=1, gpu_resource_type="nvidia.com/gpu",
+        only=None, workload=None, package=None, status=None,
+        force=False, skip_teardown=False, remote=False,
+        preserve_pipelineruns=False, dispatch_cooldown=10,
+    )
+
+    mod._cmd_run(args, run_dir, setup_config)
+
+    # Both pairs dispatched (2 kubectl apply calls)
+    assert len(dispatch_times) == 2
+    # Second dispatch happened AFTER cooldown elapsed (time gap > 10)
+    assert dispatch_times[1] - dispatch_times[0] > 10
+
+
+def test_dispatch_cooldown_zero_disables(tmp_path, monkeypatch):
+    """dispatch_cooldown=0 preserves original behavior (no delay between dispatches)."""
+    import yaml as _yaml
+    import pipeline.deploy as mod
+    from pipeline.lib.progress import ConfigMapProgressStore
+
+    run_dir = tmp_path / "runs" / "test-run"
+    cluster_dir = run_dir / "cluster"
+    cluster_dir.mkdir(parents=True)
+
+    # Two pairs
+    for name in ("a", "b"):
+        pr = {
+            "metadata": {"name": f"pr-{name}-baseline", "namespace": "ns"},
+            "spec": {"params": [
+                {"name": "workloadName", "value": f"wl-{name}"},
+                {"name": "phase", "value": "baseline"},
+            ]},
+        }
+        (cluster_dir / f"pipelinerun-{name}-baseline.yaml").write_text(_yaml.dump(pr))
+
+    (run_dir / "run_metadata.json").write_text(json.dumps({}))
+
+    # 2 slots — both can dispatch in same iteration
+    setup_config = {"namespaces": ["sim2real-0", "sim2real-1"], "namespace": "sim2real-0"}
+
+    monkeypatch.setattr(ConfigMapProgressStore, "load", lambda self: {})
+    monkeypatch.setattr(ConfigMapProgressStore, "save", lambda self, d: None)
+    monkeypatch.setattr(mod, "_cmd_build", lambda *a, **kw: "skip")
+    monkeypatch.setattr(mod, "_check_slot_ready", lambda ns, **kw: (True, []))
+
+    import pipeline.lib.capacity as _cap_mod
+    monkeypatch.setattr(_cap_mod, "probe_free_gpus", lambda **kw: (8, 8, 0))
+    monkeypatch.setattr(_cap_mod, "load_defaults", lambda root: {"decode": {"accelerator": {"count": 1}}})
+
+    dispatch_count = {"n": 0}
+
+    def fake_run(cmd, *, check=True, capture=False, input=None, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+        if "apply" in cmd:
+            dispatch_count["n"] += 1
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    monkeypatch.setattr(mod, "_check_pipelinerun_status",
+                        lambda pr_name, ns: "Succeeded")
+    monkeypatch.setattr(mod, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)
+    monkeypatch.setattr(mod.time, "sleep", lambda s: None)
+
+    args = argparse.Namespace(
+        skip_build=True, max_retries=0, poll_interval=1,
+        pending_threshold=600, max_pending_stalls=10, max_backoff=600,
+        default_gpu_cost=1, gpu_resource_type="nvidia.com/gpu",
+        only=None, workload=None, package=None, status=None,
+        force=False, skip_teardown=False, remote=False,
+        preserve_pipelineruns=False, dispatch_cooldown=0,
+    )
+
+    mod._cmd_run(args, run_dir, setup_config)
+
+    # Both pairs dispatched (2 kubectl apply calls)
+    assert dispatch_count["n"] == 2


### PR DESCRIPTION
Closes #249

## Summary

Adds `--dispatch-cooldown` (default 15s) to `deploy.py run`. After a dispatch batch, subsequent poll iterations skip new dispatch until the cooldown elapses, giving the GPU capacity probe time to reflect recently-dispatched workloads. This prevents the over-subscription → scheduling failure → backoff cycle documented in the issue.

## What changed

- **CLI arg**: `--dispatch-cooldown N` on the `run` subparser (default 15, 0 to disable)
- **Gate logic**: At the top of the "Assign pending work to free slots" section, if `_last_dispatch_time > 0` and elapsed time < cooldown, `free_slots` is set to `[]` — making the dispatch `for` loop a no-op without re-indenting the existing block
- **Timestamp recording**: `_last_dispatch_time = time.time()` after each successful `kubectl apply` dispatch
- **First iteration exempt**: `_last_dispatch_time` starts at 0.0, and the condition uses `if _last_dispatch_time > 0`, so the first dispatch is never blocked

## Reviewer attention

- The cooldown only gates *new dispatch*. Completion/failure polling, health checks, backoff signals all continue unaffected during cooldown.
- The capacity-limited selection still computes `dispatchable` during cooldown (harmless since `zip([], dispatchable)` yields nothing). This avoids re-indenting ~50 lines for a marginal optimization.
- `dispatch_cooldown=0` bypasses the check entirely (backward compat with existing behavior).

## Test plan

- [x] `test_dispatch_cooldown_prevents_immediate_redispatch` — verifies second pair delayed by cooldown
- [x] `test_dispatch_cooldown_zero_disables` — verifies 0 disables the gate (backward compat)
- [x] `ruff check pipeline/ --select F` — clean
- [x] `python -m pytest pipeline/ -v` — 776 tests pass