### PR TITLE
feat: add per-pair INFO log to deploy.py reset

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1453,6 +1453,17 @@ def _reset_pair(key: str, entry: dict, discovered: dict, *,
     pr_name = discovered.get(key, {}).get("pr_name", "")
     is_done = entry.get("status") == "done"
 
+    if not dry_run:
+        status = entry.get("status", "unknown")
+        slot = ns or "—"
+        if not ns and not pr_name:
+            action = "state-only reset"
+        elif is_done:
+            action = "deleting PipelineRun, checking orphaned releases"
+        else:
+            action = "deleting PipelineRun, uninstalling helm releases"
+        info(f"Resetting {key} (status: {status}, ns: {slot}) — {action}")
+
     # No namespace and no pr_name — just reset state
     if not ns and not pr_name:
         if is_done:

--- a/pipeline/tests/test_deploy_reset.py
+++ b/pipeline/tests/test_deploy_reset.py
@@ -708,3 +708,35 @@ def test_reset_pair_cancel_failure_does_not_reset(monkeypatch):
     assert result is False
     assert entry["status"] == "running"
     assert entry["namespace"] == "sim2real-1"
+
+
+def test_reset_pair_logs_info_before_cleanup(monkeypatch, capsys):
+    """Non-dry-run reset emits an INFO line per pair before cleanup (#253)."""
+    import pipeline.deploy as mod
+
+    monkeypatch.setattr(mod, "run", lambda cmd, **kw: type("R", (), {"returncode": 0, "stdout": ""})())
+
+    # Case 1: state-only reset (no namespace, no pr_name)
+    entry1 = {"workload": "wl-a", "package": "baseline", "status": "failed",
+              "namespace": None, "retries": 0}
+    mod._reset_pair("wl-a-baseline", entry1, {})
+    out = capsys.readouterr().out
+    assert "Resetting wl-a-baseline" in out
+    assert "status: failed" in out
+    assert "state-only reset" in out
+
+    # Case 2: with namespace (full cleanup)
+    entry2 = {"workload": "wl-b", "package": "baseline", "status": "failed",
+              "namespace": "sim2real-0", "retries": 0}
+    mod._reset_pair("wl-b-baseline", entry2, _DISCOVERED)
+    out = capsys.readouterr().out
+    assert "Resetting wl-b-baseline" in out
+    assert "ns: sim2real-0" in out
+    assert "uninstalling helm releases" in out
+
+    # Case 3: dry-run does NOT emit the new info line
+    entry3 = {"workload": "wl-c", "package": "baseline", "status": "failed",
+              "namespace": None, "retries": 0}
+    mod._reset_pair("wl-c-baseline", entry3, {}, dry_run=True)
+    out = capsys.readouterr().out
+    assert "Resetting wl-c-baseline" not in out


### PR DESCRIPTION
Closes #253

## Summary

Adds a one-line `[INFO]` log at the start of each pair's cleanup in `_reset_pair()`, so the user can see progress and identify which pair is slow during long reset operations.

Example output:
```
[INFO]  Resetting wl-blindspot-mid-expceil (status: done, ns: kalantar-2) — deleting PipelineRun, checking orphaned releases
[INFO]  Resetting wl-balanced-mid-expceil (status: failed, ns: —) — state-only reset
```

## What changed

- `pipeline/deploy.py` — Added `info()` call in `_reset_pair()` after determining `ns`, `pr_name`, and `is_done`. Guarded with `if not dry_run:` since dry-run already has its own per-pair logging.
- `pipeline/tests/test_deploy_reset.py` — New test verifying: (1) info line emitted with correct content for state-only and full cleanup cases, (2) dry-run does NOT emit the new line.

## Test plan

- [x] `test_reset_pair_logs_info_before_cleanup` — 3 sub-cases pass
- [x] All 780 tests pass
- [x] `ruff check pipeline/ --select F` — clean