### PR TITLE
feat: log effective GPU capacity before each pair-to-slot assignment

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -2232,6 +2232,10 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
             pair_cost = pair_costs[pair_key]
             source = pair_provenance[pair_key]
             _source_labels = {"derived": "derived from scenarioContent", "defaults-only": "derived from defaults only", "fallback": "fallback default"}
+            if free_gpus is not None:
+                _reserved = shadow.reserved()
+                _effective = shadow.effective_free(free_gpus)
+                info(f"Capacity: {_effective} effective free GPUs ({free_gpus} probed − {_reserved} reserved)")
             info(f"{pair_key} requires {pair_cost} GPUs ({_source_labels[source]})")
             pr_meta = discovered.get(pair_key, {})
             pr_path_str = pr_meta.get("pr_path", "")


### PR DESCRIPTION
Closes #259

## Summary

Adds a per-iteration log line in the dispatch assignment loop showing effective free GPUs alongside the probed value and reserved count.

After #257 introduced the shadow reservation ledger, `effective_free = probed_free - shadow_reserved` became the actual gate for dispatch — but it was never logged. Shadow ledger behavior was unobservable: if reservations suppressed a dispatch, no trace appeared in the log.

The new line, emitted before each pair's `requires N GPUs` info line:

```
[INFO]  Capacity: 50 effective free GPUs (54 probed − 4 reserved)
[INFO]  wl-codecompletion-mid-expceil requires 4 GPUs (derived from scenarioContent)
[OK]    [wl-codecompletion-mid-expceil] → kalantar-0 (...)
```

Re-queries `shadow.reserved()` / `shadow.effective_free(...)` per pair so intra-batch decrements (from earlier pairs already recorded by `shadow.record(...)` in this same dispatch) are visible.

## Test plan

- [x] `python -m pytest pipeline/ -v` — 794 passed
- [x] `ruff check pipeline/ --select F` — clean
- [x] No behavior change — purely additional logging; existing shadow tests unaffected