### PR TITLE
fix: shuffle pending pairs before capacity gate

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1866,6 +1866,28 @@ def _capacity_limited_pairs(
     return result
 
 
+def _select_dispatchable(
+    pending: list[str],
+    *,
+    free_gpus: int,
+    cost_map: dict[str, int],
+) -> list[str]:
+    """Shuffle pending then capacity-gate.
+
+    Shuffling before the gate (rather than after) makes the chosen subset an
+    unbiased random sample of the full pending list. With all-equal costs,
+    `_capacity_limited_pairs`'s stable sort preserves shuffled order so the
+    greedy fill picks a uniform random subset. With heterogeneous costs,
+    smallest-cost-first packing is preserved across cost groups while
+    randomization applies within each group.
+
+    Does not mutate `pending` — operates on a shuffled copy.
+    """
+    shuffled = list(pending)
+    random.shuffle(shuffled)
+    return _capacity_limited_pairs(shuffled, free_gpus=free_gpus, cost_map=cost_map)
+
+
 def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
     """Orchestrate parallel pool execution across namespace slots."""
     import tempfile as _tmp

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -2232,7 +2232,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                 dispatchable = []
             else:
                 effective_free = shadow.effective_free(free_gpus)
-                dispatchable = _capacity_limited_pairs(
+                dispatchable = _select_dispatchable(
                     pending,
                     free_gpus=effective_free, cost_map=pair_costs,
                 )
@@ -2254,9 +2254,8 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                         info(f"Dispatching {len(free_slots)}/{len(pending)} pending pairs (slot-limited)")
                         _last_log_state["dispatch"] = _disp_state
         else:
-            dispatchable = pending
-
-        random.shuffle(dispatchable)
+            dispatchable = list(pending)
+            random.shuffle(dispatchable)
 
         for ns, pair_key in zip(free_slots, dispatchable):
             hf_secret_name = setup_config.get("hf_secret_name", "hf-secret")

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -2853,6 +2853,117 @@ def test_health_escalation_cancels_pipelinerun(tmp_path, monkeypatch):
     assert saved["wl-a-baseline"]["status"] == "failed"
 
 
+class TestSelectDispatchable:
+    """Tests for _select_dispatchable: shuffle then capacity-gate."""
+
+    def test_returns_empty_when_pending_empty(self):
+        from pipeline.deploy import _select_dispatchable
+        result = _select_dispatchable([], free_gpus=8, cost_map={})
+        assert result == []
+
+    def test_returns_all_when_budget_fits_all(self):
+        from pipeline.deploy import _select_dispatchable
+        pending = [f"p{i}" for i in range(5)]
+        cost_map = {k: 1 for k in pending}
+        result = _select_dispatchable(pending, free_gpus=10, cost_map=cost_map)
+        assert sorted(result) == sorted(pending)
+
+    def test_does_not_mutate_input_pending_list(self):
+        from pipeline.deploy import _select_dispatchable
+        pending = ["a", "b", "c", "d"]
+        original = list(pending)
+        cost_map = {k: 1 for k in pending}
+        _select_dispatchable(pending, free_gpus=2, cost_map=cost_map)
+        assert pending == original, "input list must not be mutated"
+
+    def test_picks_uniform_random_subset_under_equal_costs(self):
+        """The fairness criterion from issue #266.
+
+        With 24 pairs at 4 GPUs each and budget=48 (fits 12), each pair should
+        appear in roughly 12/24 = 50% of trials. Run many trials and check the
+        per-pair appearance rate is within tolerance of 0.5.
+        """
+        from pipeline.deploy import _select_dispatchable
+        import random as _random
+        pending = [f"p{i:02d}" for i in range(24)]
+        cost_map = {k: 4 for k in pending}
+        trials = 2000
+        counts = {k: 0 for k in pending}
+        rng = _random.Random(42)  # deterministic for the test
+        for _ in range(trials):
+            with patch("pipeline.deploy.random", rng):
+                picked = _select_dispatchable(pending, free_gpus=48, cost_map=cost_map)
+            assert len(picked) == 12
+            for k in picked:
+                counts[k] += 1
+        # Each pair should appear in roughly 50% ± 5% of trials.
+        for k, c in counts.items():
+            rate = c / trials
+            assert 0.40 <= rate <= 0.60, (
+                f"{k} appeared {c}/{trials} = {rate:.2%}, expected ~50%"
+            )
+
+    def test_first_half_not_overrepresented_under_equal_costs(self):
+        """Direct test of the regression #266 fixes: first-half pairs are not
+        systematically picked over second-half pairs."""
+        from pipeline.deploy import _select_dispatchable
+        import random as _random
+        pending = [f"p{i:02d}" for i in range(24)]
+        cost_map = {k: 4 for k in pending}
+        trials = 1000
+        first_half_appearances = 0
+        second_half_appearances = 0
+        rng = _random.Random(123)
+        for _ in range(trials):
+            with patch("pipeline.deploy.random", rng):
+                picked = _select_dispatchable(pending, free_gpus=48, cost_map=cost_map)
+            for k in picked:
+                idx = int(k[1:])
+                if idx < 12:
+                    first_half_appearances += 1
+                else:
+                    second_half_appearances += 1
+        # Expected: ~6000 each (12 picks/trial × 1000 trials × 0.5 from each half).
+        # Pre-fix behavior: first_half = 12000, second_half = 0.
+        ratio = first_half_appearances / (first_half_appearances + second_half_appearances)
+        assert 0.45 <= ratio <= 0.55, (
+            f"first-half got {ratio:.2%} of picks (expected ~50%); pre-fix bias?"
+        )
+
+    def test_smallest_cost_first_packing_with_heterogeneous_costs(self):
+        """When costs differ, the gate must still prefer smallest costs to
+        maximize dispatch count (existing _capacity_limited_pairs invariant).
+
+        With pairs of cost 1, 1, 1, 8, 8 and budget=4: only the three cost-1
+        pairs fit. Verify all three are picked regardless of shuffle order.
+        """
+        from pipeline.deploy import _select_dispatchable
+        pending = ["big1", "small1", "big2", "small2", "small3"]
+        cost_map = {"big1": 8, "big2": 8, "small1": 1, "small2": 1, "small3": 1}
+        # Run many trials — every trial should pick exactly the three small pairs.
+        for _ in range(50):
+            picked = _select_dispatchable(pending, free_gpus=4, cost_map=cost_map)
+            assert sorted(picked) == ["small1", "small2", "small3"], (
+                f"got {picked}; smallest-first packing violated"
+            )
+
+    def test_within_cost_group_randomization_with_heterogeneous_costs(self):
+        """Within a cost tier, the helper must randomize. With four cost-1
+        pairs and budget=2, any two of the four should be possible picks."""
+        from pipeline.deploy import _select_dispatchable
+        import random as _random
+        pending = ["a", "b", "c", "d"]
+        cost_map = {k: 1 for k in pending}
+        seen_pairs = set()
+        rng = _random.Random(7)
+        for _ in range(200):
+            with patch("pipeline.deploy.random", rng):
+                picked = _select_dispatchable(pending, free_gpus=2, cost_map=cost_map)
+            seen_pairs.add(frozenset(picked))
+        # 4-choose-2 = 6 possible 2-element subsets; expect to see most of them.
+        assert len(seen_pairs) >= 4, f"only saw {seen_pairs}; randomness too narrow"
+
+
 def test_dispatch_shuffles_dispatchable(tmp_path, monkeypatch):
     """Verify that dispatchable list is shuffled before slot assignment (#247).
 


### PR DESCRIPTION
Closes #266

## Summary

Today the orchestrator's dispatch cycle calls `random.shuffle(dispatchable)` *after* `_capacity_limited_pairs` has already taken the first N entries of `pending` (in insertion order, because Python's `sorted` is stable and every pair currently costs the same). The shuffle therefore only randomizes which slot a chosen pair lands on; it does not randomize which pairs get chosen. The first wave is always the first 12 pairs in manifest order; second-half pairs only enter after first-half pairs complete.

This PR moves the shuffle upstream of the capacity gate via a new helper `_select_dispatchable(pending, *, free_gpus, cost_map)` that shuffles a copy of pending and then delegates to `_capacity_limited_pairs`. The greedy budget fill now picks a uniform random subset under all-equal costs; smallest-cost-first packing is preserved across cost groups under heterogeneous costs.

## What changed

- **`pipeline/deploy.py`**
  - New `_select_dispatchable(pending, *, free_gpus, cost_map)` adjacent to `_capacity_limited_pairs` — shuffles a `list(pending)` copy, then capacity-gates.
  - `_cmd_run` dispatch block: replace the inline `_capacity_limited_pairs(...)` call with `_select_dispatchable(...)`. The no-filter `else: dispatchable = pending` branch now takes a shuffled copy too. The trailing post-gate `random.shuffle(dispatchable)` is deleted (the shuffle is now upstream).
- **`pipeline/tests/test_deploy_run.py`**
  - New `TestSelectDispatchable` (7 tests): empty-pending, all-fits, no-input-mutation, uniform 50% per-pair appearance over 2000 trials, first-half-not-overrepresented over 1000 trials (the regression test for #266), smallest-first packing preserved under heterogeneous costs, intra-cost-group randomization.
  - Existing `test_dispatch_shuffles_dispatchable` continues to pass unchanged.

## Reviewer attention

- **The fairness invariant relies on Python's `sorted` being stable.** With all-equal costs (today's reality), the stable sort preserves shuffled input order through the gate, so the greedy fill picks a uniform random subset. With heterogeneous costs, sort still orders by cost ascending across groups while randomization applies within each group — `_capacity_limited_pairs`'s smallest-first packing is preserved.
- **The `else: dispatchable = pending` path now copies before shuffling.** Pre-fix, the post-gate `random.shuffle(dispatchable)` mutated `pending` itself when `free_gpus is None` or `pending` was empty. `_pending_pairs()` returns a fresh list each call (see `deploy.py:2031-2033`), so no caller relied on order — but `dispatchable = list(pending); random.shuffle(dispatchable)` removes that footgun.
- **Slot-assignment randomness from #248 is preserved.** `dispatchable` is in shuffled order when `zip(free_slots, dispatchable)` runs, just sourced from `_select_dispatchable` rather than the post-gate shuffle.
- **Issue #266 explicitly defers two related concerns.** Makespan-aware scheduling (LPT) is out of scope — this change buys fairness, not optimal scheduling, and may slightly regress wall time in expectation when slow pairs land late by luck. Run-to-run timing variance also increases. RNG seeding for reproducibility is also deferred.

## Test plan

- [x] `python -m pytest pipeline/ .claude/skills/sim2real-analyze/tests/ .claude/skills/sim2real-translate/tests/` — 913 passed
- [x] `ruff check pipeline/ .claude/skills/ --select F` — clean
- [x] Existing `test_dispatch_shuffles_dispatchable` passes unchanged (slot-assignment randomness contract from #248 preserved)
- [x] New `test_first_half_not_overrepresented_under_equal_costs` is the direct regression test for #266
- [x] `_capacity_limited_pairs` has no production callers remaining outside `_select_dispatchable`; existing tests of the lower-level function still pass