### PR TITLE
fix: retain namespace on terminal pair failures so reset can clean helm releases (#277)

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -523,9 +523,11 @@ def _handle_pending_pods(*, pr_name: str, namespace: str, entry: dict,
 
     Side effects on *entry* (caller must persist):
       On True (non-recoverable):
-        - status: "failed", namespace: None, pending_since: None
+        - status: "failed", pending_since: None
+        - namespace retained so reset/cleanup can find releases (issue #277)
       On True (recoverable threshold exceeded):
-        - status: "pending" or "stalled", namespace: None
+        - status: "pending" (re-dispatch — namespace cleared) or
+          "stalled" (terminal — namespace retained, issue #277)
         - pending_stalls: incremented, pending_since: None
       On False (no action):
         - pending_since: set on first recoverable detection, cleared when
@@ -1461,8 +1463,12 @@ def _reset_pair(key: str, entry: dict, discovered: dict, *,
             action = "state-only reset"
         elif is_done:
             action = "deleting PipelineRun, checking orphaned releases"
-        else:
+        elif ns:
             action = "deleting PipelineRun, uninstalling helm releases"
+        else:
+            # ns is null but a PipelineRun is known — helm cleanup needs the
+            # namespace, so it will be skipped (issue #277). Don't claim it.
+            action = "deleting PipelineRun (namespace unknown — skipping helm cleanup)"
         info(f"Resetting {key} (status: {status}, ns: {slot}) — {action}")
 
     # No namespace and no pr_name — just reset state
@@ -1474,6 +1480,12 @@ def _reset_pair(key: str, entry: dict, discovered: dict, *,
                     info(f"[DRY-RUN] {key}: would check for orphaned helm releases in {completed_ns}")
                 else:
                     _uninstall_orphaned_helm(key, completed_ns)
+        elif not dry_run:
+            # Terminal pair (callers only reset non-pending pairs) with no
+            # namespace recorded — helm cleanup is skipped. Warn rather than
+            # silently report success (issue #277).
+            warn(f"{key}: namespace unknown — skipped helm cleanup; if releases "
+                 f"were installed, remove them manually (helm list/uninstall across slots)")
         if not dry_run and not (is_done and preserve_done_status):
             entry["status"] = "pending"
             entry["retries"] = 0
@@ -1554,6 +1566,12 @@ def _reset_pair(key: str, entry: dict, discovered: dict, *,
             if helm_failed:
                 warn(f"{key}: some releases failed to uninstall — state NOT reset")
                 return False
+    else:
+        # PipelineRun was known but no namespace recorded — helm needs the
+        # namespace, so cleanup is skipped. Warn rather than silently report
+        # success (issue #277).
+        warn(f"{key}: namespace unknown — skipped helm cleanup; if releases "
+             f"were installed, remove them manually (helm list/uninstall across slots)")
 
     # Reset state
     entry["status"] = "pending"

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -568,7 +568,7 @@ def _handle_pending_pods(*, pr_name: str, namespace: str, entry: dict,
             warn(f"[{entry.get('workload', '?')}] could not remove PipelineRun {pr_name!r} in {namespace} — slot NOT freed")
             return False
         entry["status"] = "failed"
-        entry["namespace"] = None
+        # Retain namespace so reset/cleanup can find the helm releases (issue #277).
         entry["pending_since"] = None
         return True
 
@@ -596,12 +596,14 @@ def _handle_pending_pods(*, pr_name: str, namespace: str, entry: dict,
     stalls = entry.get("pending_stalls", 0) + 1
     entry["pending_stalls"] = stalls
     entry["pending_since"] = None
-    entry["namespace"] = None
     if stalls >= max_pending_stalls:
         entry["status"] = "stalled"
+        # Terminal: retain namespace so reset/cleanup can find releases (issue #277).
         warn(f"[{entry.get('workload', '?')}] reached max pending stalls ({max_pending_stalls}) → stalled")
     else:
         entry["status"] = "pending"
+        # Slot freed for re-dispatch — release the namespace.
+        entry["namespace"] = None
     return True
 
 
@@ -639,10 +641,12 @@ def _handle_timeout(*, pr_name: str, namespace: str, entry: dict,
              f"(attempt {retries + 1}/{max_retries})")
         entry["status"] = "pending"
         entry["retries"] = retries + 1
+        # Slot freed for re-dispatch — release the namespace.
+        entry["namespace"] = None
     else:
         warn(f"[{entry.get('workload', '?')}] timed out, max retries → timed-out")
         entry["status"] = "timed-out"
-    entry["namespace"] = None
+        # Terminal: retain namespace so reset/cleanup can find releases (issue #277).
     entry["pending_since"] = None
     return True
 
@@ -2083,7 +2087,8 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                             "PipelineRunStoppingTimeout"):
                 warn(f"[{pair_key}] hard failure ({status}) → failed")
                 entry["status"] = "failed"
-                entry["namespace"] = None
+                # Retain namespace so reset/cleanup can find the helm releases
+                # (issue #277). Mirrors _reconcile_on_resume's failure handling.
                 store.save(progress)
                 del slots_busy[ns]
                 _last_log_state.pop("capacity", None)
@@ -2165,7 +2170,8 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                     warn(f"[{pair_key}] pod health escalation → cancelling PipelineRun")
                     if _cancel_and_delete_pipelinerun(pr_name, ns):
                         entry["status"] = "failed"
-                        entry["namespace"] = None
+                        # Retain namespace so reset/cleanup can find the helm
+                        # releases (issue #277).
                         store.save(progress)
                         del slots_busy[ns]
                         _last_log_state.pop("capacity", None)

--- a/pipeline/tests/test_deploy_reset.py
+++ b/pipeline/tests/test_deploy_reset.py
@@ -114,6 +114,77 @@ def test_reset_pair_none_namespace_resets_state(monkeypatch):
     assert entry["retries"] == 0
 
 
+def test_timed_out_entry_flows_to_reset_helm_uninstall(monkeypatch):
+    """End-to-end (issue #277): a pair driven to timed-out by _handle_timeout
+    retains its namespace, and feeding that same entry to _reset_pair actually
+    uninstalls the helm releases. Reverting retain-on-failure breaks this — the
+    consumer would see namespace=None and skip helm cleanup."""
+    import datetime as _dt
+    import pipeline.deploy as mod
+
+    old_ts = (_dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(hours=5)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ")
+
+    entry = {"workload": "wl-heavy", "package": "baseline", "status": "running",
+             "namespace": "sim2real-0", "retries": 3, "pending_since": None}
+
+    calls = []
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        calls.append(cmd)
+        class _R:
+            returncode = 0
+            stdout = (old_ts if "creationTimestamp" in " ".join(cmd)
+                      else ("release-a\n" if cmd[:2] == ["helm", "list"] else ""))
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    monkeypatch.setattr(mod, "_cancel_and_delete_pipelinerun", lambda pr, ns: True)
+
+    # Producer: timeout at max retries → timed-out, namespace retained.
+    assert mod._handle_timeout(
+        pr_name="baseline-heavy-run1", namespace="sim2real-0",
+        entry=entry, timeout_hours=4.0, max_retries=3) is True
+    assert entry["status"] == "timed-out"
+    assert entry["namespace"] == "sim2real-0"
+
+    # Consumer: reset uses the retained namespace to actually uninstall helm.
+    calls.clear()
+    assert mod._reset_pair("wl-heavy-baseline", entry, _DISCOVERED) is True
+    helm_uninstalls = [c for c in calls if c[:2] == ["helm", "uninstall"]]
+    assert len(helm_uninstalls) == 1
+    assert "release-a" in helm_uninstalls[0]
+    assert entry["status"] == "pending"
+
+
+def test_reset_pair_null_namespace_skips_helm_and_warns(monkeypatch, capsys):
+    """Negative companion (issue #277): a terminal pair with no namespace cannot
+    run helm cleanup — _reset_pair must skip helm AND warn the operator rather
+    than silently reporting success."""
+    import pipeline.deploy as mod
+
+    entry = {"workload": "wl-load", "package": "baseline", "status": "timed-out",
+             "namespace": None, "retries": 1}
+
+    calls = []
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        calls.append(cmd)
+        class _R:
+            returncode = 0
+            stdout = ""
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    result = mod._reset_pair("wl-load-baseline", entry, _DISCOVERED)
+    assert result is True
+    assert [c for c in calls if c[:2] == ["helm", "uninstall"]] == []
+    assert [c for c in calls if c[:2] == ["helm", "list"]] == []
+    out = capsys.readouterr().out.lower()
+    assert "helm" in out and "manual" in out
+
+
 def test_reset_pair_kubectl_delete_failure_does_not_reset(monkeypatch):
     """When kubectl delete pipelinerun fails, state is NOT reset."""
     import pipeline.deploy as mod

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -1434,7 +1434,8 @@ def test_early_reclaim_non_recoverable_fails_immediately(monkeypatch):
 
     assert reclaimed is True
     assert entry["status"] == "failed"
-    assert entry["namespace"] is None
+    # Namespace retained so reset/cleanup can find the helm releases (issue #277)
+    assert entry["namespace"] == "sim2real-0"
     assert entry["pending_stalls"] == 0
     assert cancelled == [("baseline-smoke-run1", "sim2real-0")]
 
@@ -1486,6 +1487,8 @@ def test_early_reclaim_stalled_at_max_pending_stalls(monkeypatch):
     assert reclaimed is True
     assert entry["status"] == "stalled"
     assert entry["pending_stalls"] == 10
+    # Terminal stall retains namespace so reset/cleanup can find releases (issue #277)
+    assert entry["namespace"] == "sim2real-0"
 
 
 def test_early_reclaim_kubectl_failure_returns_false(monkeypatch, capsys):
@@ -2430,6 +2433,43 @@ def test_handle_timeout_cancel_succeeds_requeues(monkeypatch):
     assert entry["namespace"] is None
 
 
+def test_handle_timeout_max_retries_retains_namespace(monkeypatch):
+    """At max retries, a timed-out pair stays timed-out and retains its
+    namespace so reset/cleanup can find the helm releases (issue #277)."""
+    import datetime as _dt
+    import pipeline.deploy as mod
+
+    old_ts = (_dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(hours=5)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ")
+
+    entry = {
+        "workload": "wl-smoke", "package": "treatment", "status": "running",
+        "namespace": "sim2real-0", "retries": 3, "pending_since": None,
+    }
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = old_ts
+            stderr = ""
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    monkeypatch.setattr(mod, "_cancel_and_delete_pipelinerun", lambda pr, ns: True)
+
+    result = mod._handle_timeout(
+        pr_name="treatment-smoke-run1",
+        namespace="sim2real-0",
+        entry=entry,
+        timeout_hours=4.0,
+        max_retries=3,
+    )
+
+    assert result is True
+    assert entry["status"] == "timed-out"
+    assert entry["namespace"] == "sim2real-0"
+
+
 def test_handle_timeout_not_expired_returns_none(monkeypatch):
     """When PR is not timed out, return None (no action taken)."""
     import datetime as _dt
@@ -2567,6 +2607,100 @@ def test_dispatch_sets_entry_running(tmp_path, monkeypatch):
     # the critical thing is that no UnboundLocalError was raised.
     # The final status should be "done" because _check_pipelinerun_status returns Succeeded.
     assert saved_progress["wl-a-baseline"]["status"] == "done"
+
+
+# ── Live-loop failure paths retain namespace (issue #277) ───────────────────
+
+
+def _run_harness(tmp_path, monkeypatch, *, status_fn, extra_patches=None):
+    """Drive _cmd_run through one dispatch + one poll iteration for a single pair.
+
+    status_fn is used for _check_pipelinerun_status. extra_patches is an optional
+    callable(mod, monkeypatch) for test-specific monkeypatching (e.g. pod-health
+    escalation). Returns the saved progress dict.
+    """
+    import yaml as _yaml
+    import pipeline.deploy as mod
+    import pipeline.lib.capacity as _cap_mod
+    from pipeline.lib.progress import ConfigMapProgressStore
+
+    run_dir = tmp_path / "runs" / "test-run"
+    cluster_dir = run_dir / "cluster"
+    cluster_dir.mkdir(parents=True)
+
+    pr = {
+        "metadata": {"name": "pr-a-baseline", "namespace": "ns"},
+        "spec": {"params": [
+            {"name": "workloadName", "value": "wl-a"},
+            {"name": "phase", "value": "baseline"},
+        ]},
+    }
+    (cluster_dir / "pipelinerun-a-baseline.yaml").write_text(_yaml.dump(pr))
+    (run_dir / "run_metadata.json").write_text(json.dumps({}))
+
+    setup_config = {"namespaces": ["sim2real-0"], "namespace": "sim2real-0"}
+
+    saved_progress = {}
+    monkeypatch.setattr(ConfigMapProgressStore, "load", lambda self: {})
+    monkeypatch.setattr(ConfigMapProgressStore, "save",
+                        lambda self, data: saved_progress.update(data))
+
+    monkeypatch.setattr(mod, "_cmd_build", lambda *a, **kw: "skip")
+    monkeypatch.setattr(mod, "_check_slot_ready", lambda ns, **kw: (True, []))
+    monkeypatch.setattr(_cap_mod, "probe_free_gpus", lambda **kw: (8, 8, 0))
+    monkeypatch.setattr(_cap_mod, "load_defaults",
+                        lambda root: {"decode": {"accelerator": {"count": 1}}})
+
+    def fake_run(cmd, *, check=True, capture=False, input=None, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    monkeypatch.setattr(mod, "_check_pipelinerun_status", status_fn)
+    monkeypatch.setattr(mod, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)
+
+    if extra_patches is not None:
+        extra_patches(mod, monkeypatch)
+
+    args = argparse.Namespace(
+        skip_build=True, max_retries=0, poll_interval=1, pending_threshold=600,
+        max_pending_stalls=10, max_backoff=600, default_gpu_cost=1,
+        gpu_resource_type="nvidia.com/gpu", only=None, workload=None,
+        package=None, status=None, force=False, skip_teardown=False,
+        remote=False, preserve_pipelineruns=False, shadow_ttl=0,
+    )
+    mod._cmd_run(args, run_dir, setup_config)
+    return saved_progress
+
+
+def test_cmd_run_hard_failure_retains_namespace(tmp_path, monkeypatch):
+    """On a hard PipelineRun failure, the live loop marks the pair failed but
+    retains its namespace so a later reset can find and uninstall the helm
+    releases (issue #277). Mirrors _reconcile_on_resume's retain-on-failure."""
+    saved = _run_harness(tmp_path, monkeypatch,
+                         status_fn=lambda pr_name, ns: "Failed")
+    assert saved["wl-a-baseline"]["status"] == "failed"
+    assert saved["wl-a-baseline"]["namespace"] == "sim2real-0"
+
+
+def test_cmd_run_pod_health_escalation_retains_namespace(tmp_path, monkeypatch):
+    """On pod-health escalation (cancel + delete), the live loop marks the pair
+    failed but retains its namespace for reset cleanup (issue #277)."""
+    def extra(mod, mp):
+        mp.setattr(mod, "_handle_pending_pods", lambda **kw: False)
+        mp.setattr(mod, "_handle_timeout", lambda **kw: None)
+        mp.setattr(mod, "_check_pod_health", lambda **kw: True)
+        mp.setattr(mod, "_cancel_and_delete_pipelinerun", lambda pr, ns: True)
+
+    saved = _run_harness(tmp_path, monkeypatch,
+                         status_fn=lambda pr_name, ns: "Running",
+                         extra_patches=extra)
+    assert saved["wl-a-baseline"]["status"] == "failed"
+    assert saved["wl-a-baseline"]["namespace"] == "sim2real-0"
 
 
 # ── Scoped GPU cost derivation (issue #244) ─────────────────────────────────


### PR DESCRIPTION
Closes #277

## Problem

`deploy.py reset` (and `run --force`, same code path) silently fails to clean up Helm releases whenever a failed pair's progress-ConfigMap entry has `namespace: null`. The pair flips to `pending` and the operator sees `1 pair(s) reset`, but the Helm releases / Deployments / Pods / InferencePool are left running — the opposite of reset's contract. The operator then has to manually `helm list` / `helm uninstall`.

## Root cause (corrected from the issue)

The issue's suggested fix #1 ("write `namespace` at claim time") is **already implemented** — the dispatch loop sets `entry["namespace"] = ns` the moment a pair goes `running` (`deploy.py:2322`). The real defect is the **failure paths discarding it**: the live `_cmd_run` orchestrator cleared `entry["namespace"] = None` on every terminal outcome. `_reconcile_on_resume` was already fixed to *retain* namespace on failure (`:1780`, "Retain namespace so reset/cleanup can find the resources"), but that fix was never propagated to the live loop.

## Fix

Retain `namespace` on **all terminal pair states** so the existing `_reset_pair` `if ns:` Helm cleanup can find and uninstall the releases. Five paths cleared it; all are now consistent:

| Path | Terminal status | Before | After |
|------|----------------|--------|-------|
| `_cmd_run` hard failure (`:2086`) | `failed` | cleared | **retained** |
| `_cmd_run` pod-health escalation (`:2168`) | `failed` | cleared | **retained** |
| `_handle_pending_pods` non-recoverable (`:571`) | `failed` | cleared | **retained** |
| `_handle_pending_pods` max stalls (`:601`) | `stalled` | cleared | **retained** |
| `_handle_timeout` max retries (`:644`) | `timed-out` | cleared | **retained** |

The two genuinely-recoverable branches that re-dispatch to `pending` still release the namespace (the slot is freed and the pair reinstalls on the next dispatch):
- recoverable stall under threshold → `pending`
- timeout with retries remaining → `pending`

## Scope notes for reviewers

- **Beyond the issue's two named paths.** The issue named only the two inline `_cmd_run` sites. Deep inspection found three sibling terminal paths in the `_handle_pending_pods` / `_handle_timeout` helpers with the identical orphan bug; including them keeps the fix consistent (reset is meant to clean *any* non-pending pair). Confirmed with the maintainer before extending.
- **Out of scope (deliberately):** the issue's fix #2 (best-effort orphan sweep for already-broken null-namespace entries) and the cosmetic action-banner wording. This PR is the structural fix only. Pre-existing entries already written with `namespace: null` still need a one-time manual `helm uninstall`.
- **No false busy slots:** the startup `slots_busy` map keys only off `status == "running"` (`:2030`), so retaining namespace on terminal pairs does not occupy a slot or affect dispatch.

## Tests

- New: `test_cmd_run_hard_failure_retains_namespace`, `test_cmd_run_pod_health_escalation_retains_namespace`, `test_handle_timeout_max_retries_retains_namespace`.
- Updated to assert retention: `test_early_reclaim_non_recoverable_fails_immediately`, `test_early_reclaim_stalled_at_max_pending_stalls`.
- Preserved (re-dispatch clears): `test_early_reclaim_recoverable_threshold_exceeded`, `test_handle_timeout_cancel_succeeds_requeues`.

864 passed, 2 xfailed; `ruff check pipeline/ .claude/skills/ --select F` clean.