### PR TITLE
fix: build-epp.sh fails fast on Failed build pod (#275)

### DIFF
--- a/pipeline/scripts/build-epp.sh
+++ b/pipeline/scripts/build-epp.sh
@@ -175,15 +175,34 @@ spec:
 BUILDPOD
 
 # ── Step 5: Wait for build ────────────────────────────────────────
+# Poll for a terminal phase rather than `kubectl wait --for=...=Succeeded`,
+# which has no OR semantics across matchers: a pod that exits with
+# phase=Failed would otherwise be indistinguishable from a still-running
+# build and block for the full timeout. (#275)
 info "Building image (this may take several minutes)..."
-if kubectl wait --for=jsonpath='{.status.phase}'=Succeeded \
-  "pod/${BUILD_POD}" -n "${NAMESPACE}" --timeout=1800s 2>/dev/null; then
-  ok "Image built and pushed: ${FULL_IMAGE}"
-else
-  err "Build failed. Logs:"
-  kubectl logs "${BUILD_POD}" -n "${NAMESPACE}" --tail=50 2>/dev/null || true
-  exit 1
-fi
+BUILD_TIMEOUT=1800
+deadline=$(( $(date +%s) + BUILD_TIMEOUT ))
+while :; do
+  phase=$(kubectl get pod "${BUILD_POD}" -n "${NAMESPACE}" \
+    -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+  case "${phase}" in
+    Succeeded)
+      ok "Image built and pushed: ${FULL_IMAGE}"
+      break
+      ;;
+    Failed)
+      err "Build failed (phase=Failed). Logs:"
+      kubectl logs "${BUILD_POD}" -n "${NAMESPACE}" --tail=80 2>/dev/null || true
+      exit 1
+      ;;
+  esac
+  if (( $(date +%s) > deadline )); then
+    err "Timed out after ${BUILD_TIMEOUT}s waiting for build pod (phase=${phase:-unknown}). Last logs:"
+    kubectl logs "${BUILD_POD}" -n "${NAMESPACE}" --tail=80 2>/dev/null || true
+    exit 1
+  fi
+  sleep 3
+done
 
 # ── Step 6: Clean up build pod ─────────────────────────────────────
 kubectl delete pod "${BUILD_POD}" -n "${NAMESPACE}" --ignore-not-found --force --grace-period=0 2>/dev/null || true


### PR DESCRIPTION
## Summary

`pipeline/scripts/build-epp.sh` waited the full 30-minute timeout whenever the build pod failed. `kubectl wait --for=jsonpath='{.status.phase}'=Succeeded` has no OR semantics across matchers, so a pod that exits with `phase=Failed` looked identical to a still-running build. A 1-second base-image pull failure (e.g. Docker Hub 429) turned into a ~30-minute hang at "Building image (this may take several minutes)…" in `deploy.py run --remote`.

## Change

Replaced the single `kubectl wait` (Step 5) with a 3-second polling loop that:
- breaks immediately on `Succeeded`,
- on `Failed`, surfaces the last 80 log lines and `exit 1` right away,
- keeps the 1800s deadline as a backstop for genuinely-stuck (`Pending`/`Unknown`) pods, also dumping logs on timeout.

## Acceptance criteria (from #275)

- [x] `phase=Failed` detected within seconds, not after 1800s
- [x] Pod logs surfaced on failure
- [x] Timeout backstop preserved for stuck pods
- [x] Success path unchanged — falls through to Step 6 (cleanup) and Step 7 (metadata)

## Reviewer attention

- **`set -euo pipefail` safety:** the only `(( ))` arithmetic is inside an `if` (exit status consumed, so a false condition won't abort the script), and `phase=$(kubectl get ... || echo "")` guards the `get` against `pipefail`.
- **Failed pod is left in place** on failure (we `exit 1` before Step 6 cleanup) — same behavior as before, intentional so logs remain inspectable.
- **No automated test:** there is no bash test harness in the repo; build-failure unit tests are tracked separately in #193. Verified with `bash -n` and the full `pytest pipeline/` suite (866 passed, 2 xfailed; no Python regression).

## Scope

The Docker Hub 429 / registry-credentials problem that triggered this is a separate concern and is **not** addressed here — only the wait-loop hang.

Closes #275