### PR TITLE
fix(deploy): surface orchestrator pod logs on Failed phase

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -2543,6 +2543,45 @@ def _check_existing_job(namespace: str) -> "str | None":
     return "completed"
 
 
+def _report_failed_pod(pod: dict, namespace: str) -> None:
+    """Print the cause of an orchestrator pod failure before the caller exits.
+
+    `pod.status.message` is only populated for pod-level failures (evicted,
+    preempted, OOMKilled at the pod level). When a container simply exits
+    non-zero that field is empty, so fall back to the container's terminated
+    `exitCode`/`reason` and tail the orchestrator logs, where the real
+    diagnostic lives. See issue #276.
+    """
+    status = pod.get("status", {})
+    msg = status.get("message", "")
+    details = []
+    all_statuses = (status.get("initContainerStatuses", [])
+                    + status.get("containerStatuses", []))
+    for cs in all_statuses:
+        term = cs.get("state", {}).get("terminated", {})
+        if term and term.get("exitCode", 0) != 0:
+            cname = cs.get("name", "?")
+            reason = term.get("reason", "")
+            code = term.get("exitCode", "")
+            details.append(f"{cname} exited {code}"
+                           + (f" ({reason})" if reason else ""))
+
+    header = "Orchestrator pod failed"
+    if msg:
+        header += f": {msg}"
+    elif details:
+        header += ": " + "; ".join(details)
+    err(header)
+
+    pod_name = pod.get("metadata", {}).get("name", "")
+    if pod_name:
+        logs = run(["kubectl", "logs", pod_name, "-n", namespace,
+                    "-c", "orchestrator", "--tail=80"],
+                   check=False, capture=True)
+        if logs.stdout:
+            err("Orchestrator pod logs:\n" + logs.stdout)
+
+
 def _wait_for_job_pod(namespace: str, *, timeout: int = 120, poll: int = 5) -> None:
     """Poll until the orchestrator pod reaches Running or Succeeded.
 
@@ -2585,8 +2624,7 @@ def _wait_for_job_pod(namespace: str, *, timeout: int = 120, poll: int = 5) -> N
                 if phase in ("Running", "Succeeded"):
                     return
                 if phase == "Failed":
-                    msg = pod.get("status", {}).get("message", "unknown reason")
-                    err(f"Orchestrator pod failed: {msg}")
+                    _report_failed_pod(pod, namespace)
                     sys.exit(1)
                 all_statuses = (pod.get("status", {}).get("initContainerStatuses", [])
                                 + pod.get("status", {}).get("containerStatuses", []))

--- a/pipeline/tests/test_deploy_remote.py
+++ b/pipeline/tests/test_deploy_remote.py
@@ -269,6 +269,7 @@ def test_wait_for_pod_failed_surfaces_logs(monkeypatch, capsys):
         }],
     })
     log_text = "[ERROR] --workload: unrecognized values ['balanced-20']"
+    log_cmds = []
 
     def fake_run(cmd, *, check=True, capture=False, cwd=None):
         class _R:
@@ -276,6 +277,7 @@ def test_wait_for_pod_failed_surfaces_logs(monkeypatch, capsys):
             stderr = ""
         r = _R()
         if "logs" in cmd:
+            log_cmds.append(cmd)
             r.stdout = log_text
         else:
             r.stdout = pod_json
@@ -291,6 +293,40 @@ def test_wait_for_pod_failed_surfaces_logs(monkeypatch, capsys):
     assert "orchestrator exited 2 (Error)" in combined
     # The actual diagnostic from the pod logs is surfaced.
     assert log_text in combined
+    # Logs are fetched for the orchestrator container with a bounded tail.
+    assert log_cmds, "expected a kubectl logs call"
+    cmd = log_cmds[0]
+    assert "orch-pod-xyz" in cmd
+    assert cmd[cmd.index("-c") + 1] == "orchestrator"
+    assert any(a.startswith("--tail") for a in cmd)
+
+
+def test_report_failed_pod_init_container_in_header(monkeypatch, capsys):
+    """A non-zero terminated init container surfaces in the failure header,
+    even when the orchestrator container never started. Issue #276."""
+    pod = {
+        "metadata": {"name": "orch-pod-xyz"},
+        "status": {
+            "phase": "Failed",
+            "initContainerStatuses": [{
+                "name": "fetch-inputs",
+                "state": {"terminated": {"exitCode": 1, "reason": "Error"}},
+            }],
+            "containerStatuses": [],
+        },
+    }
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 1  # orchestrator container never ran -> no logs
+            stdout = ""
+            stderr = "container orchestrator is not valid"
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    mod._report_failed_pod(pod, "ns")
+    combined = "".join(capsys.readouterr())
+    assert "fetch-inputs exited 1 (Error)" in combined
 
 
 def test_report_failed_pod_no_logs_no_crash(monkeypatch, capsys):

--- a/pipeline/tests/test_deploy_remote.py
+++ b/pipeline/tests/test_deploy_remote.py
@@ -253,6 +253,68 @@ def test_wait_for_pod_failed_phase_exits(monkeypatch):
     assert exc_info.value.code == 1
 
 
+def test_wait_for_pod_failed_surfaces_logs(monkeypatch, capsys):
+    """A container exiting non-zero (empty pod.status.message) surfaces the
+    container terminated detail and the orchestrator pod logs. Issue #276."""
+    pod_json = json.dumps({
+        "items": [{
+            "metadata": {"name": "orch-pod-xyz"},
+            "status": {
+                "phase": "Failed",
+                "containerStatuses": [{
+                    "name": "orchestrator",
+                    "state": {"terminated": {"exitCode": 2, "reason": "Error"}},
+                }],
+            },
+        }],
+    })
+    log_text = "[ERROR] --workload: unrecognized values ['balanced-20']"
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 0
+            stderr = ""
+        r = _R()
+        if "logs" in cmd:
+            r.stdout = log_text
+        else:
+            r.stdout = pod_json
+        return r
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    with pytest.raises(SystemExit) as exc_info:
+        mod._wait_for_job_pod("ns", timeout=10, poll=1)
+    assert exc_info.value.code == 1
+    out = capsys.readouterr()
+    combined = out.out + out.err
+    # Container terminated detail appears in the header.
+    assert "orchestrator exited 2 (Error)" in combined
+    # The actual diagnostic from the pod logs is surfaced.
+    assert log_text in combined
+
+
+def test_report_failed_pod_no_logs_no_crash(monkeypatch, capsys):
+    """If the orchestrator container never started (no logs), reporting still
+    succeeds and prints the pod-level message."""
+    pod = {
+        "metadata": {"name": "orch-pod-xyz"},
+        "status": {"phase": "Failed", "message": "Evicted",
+                   "containerStatuses": []},
+    }
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 1
+            stdout = ""
+            stderr = "container not found"
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    mod._report_failed_pod(pod, "ns")
+    combined = "".join(capsys.readouterr())
+    assert "Orchestrator pod failed: Evicted" in combined
+
+
 def test_wait_for_pod_consecutive_kubectl_failures_exits(monkeypatch):
     """Three consecutive kubectl failures trigger early exit."""
     def fake_run(cmd, *, check=True, capture=False, cwd=None):


### PR DESCRIPTION
Closes #276

## Problem

When the orchestrator Job's pod exits non-zero (e.g. argparse rejects an invalid `--workload` value), `deploy.py run --remote` printed:

```
[ERROR] Orchestrator pod failed: unknown reason
```

and exited without the actual error, forcing the user to manually run `kubectl logs <pod> -c orchestrator`.

The `Failed`-phase branch in `_wait_for_job_pod` read only `pod.status.message`. That field is populated by the kubelet only for **pod-level** failures (evicted, preempted, OOMKilled). When a container simply exits non-zero, `pod.status.message` is empty — the detail lives in `containerStatuses[].state.terminated.{exitCode,reason}` and the real diagnostic is in the container's stdout/stderr. Neither was consulted.

## Change

Extracted the failure-reporting into `_report_failed_pod(pod, namespace)`, which:

1. Uses `pod.status.message` when present (preserves prior behavior for OOMKilled/evicted).
2. Otherwise falls back to the container terminated `exitCode`/`reason` from `containerStatuses` / `initContainerStatuses` (the issue's "Bonus").
3. Tails the orchestrator container logs (`kubectl logs ... -c orchestrator --tail=80`) and prints them before exit.

Exit behavior is unchanged (`sys.exit(1)` on `Failed`).

## Reviewer attention

- **Init-container edge case:** if the failure is in an init container, the orchestrator container never started, so the `-c orchestrator` log fetch returns empty. Handled gracefully (logs only printed when `logs.stdout` is non-empty), and the container terminated detail still surfaces the init-container exit in the header.
- Log fetch uses `run(..., check=False, capture=True)` so a failed `kubectl logs` (e.g. container not found) never masks the original failure.
- Same theme as #275 (build-pod failures hidden by an inadequate report path).

## Tests

- Updated `test_wait_for_pod_failed_phase_exits` (its `fake_run` now also serves the `kubectl logs` call).
- Added `test_wait_for_pod_failed_surfaces_logs` — container exits 2 with empty `pod.status.message`; asserts both the terminated detail (`orchestrator exited 2 (Error)`) and the log text are surfaced.
- Added `test_report_failed_pod_no_logs_no_crash` — no logs available; reporting still prints the pod-level message without crashing.

Full suite: `840 passed, 2 xfailed`. Lint: `ruff check pipeline/ --select F` clean.