### PR TITLE
fix(deploy): raise RuntimeError when kubectl run fails creating extractor pod

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -866,8 +866,17 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
             "restartPolicy": "Never",
         }
     })
-    run(["kubectl", "run", pod_name, "--image=alpine:3.19", "--restart=Never",
-         "--overrides", overrides, "-n", namespace], capture=True)
+    create_result = run(
+        ["kubectl", "run", pod_name, "--image=alpine:3.19", "--restart=Never",
+         "--overrides", overrides, "-n", namespace],
+        check=False, capture=True,
+    )
+    if create_result.returncode != 0:
+        run(["kubectl", "delete", "pod", pod_name, "-n", namespace,
+             "--ignore-not-found", "--force", "--grace-period=0"],
+            check=False, capture=True)
+        raise RuntimeError(
+            f"Extractor pod {pod_name} create failed: {create_result.stderr.strip()}")
 
     result = run(
         ["kubectl", "wait", f"pod/{pod_name}", "--for=condition=Ready",

--- a/pipeline/tests/test_deploy_collect.py
+++ b/pipeline/tests/test_deploy_collect.py
@@ -1870,3 +1870,30 @@ def test_collect_scoped_multi_slot_per_workload(tmp_path, monkeypatch):
     assert ns_to_allowed["ns-0"] == {"constantcontrol": {"mid"}}
     assert ns_to_allowed["ns-1"] == {"expceil": {"mid"}}
     assert ns_to_allowed["ns-2"] == {"expceiling": {"mid"}}
+
+
+# ── Issue #204: kubectl run failure surfaces as RuntimeError ─────────────────
+
+
+def test_extract_phases_kubectl_run_failure_raises_runtime_error(tmp_path, monkeypatch):
+    """When kubectl run fails creating the extractor pod, the function raises
+    a clean RuntimeError — not a raw CalledProcessError that escapes callers
+    catching only RuntimeError."""
+    from pipeline import deploy
+    import subprocess
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    run_dir.mkdir(parents=True)
+
+    def mock_run(cmd, **kwargs):
+        cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
+        if "run" in cmd and "--image=alpine:3.19" in cmd_str:
+            return MagicMock(returncode=1, stdout="",
+                             stderr="forbidden: namespace quota exceeded")
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", mock_run)
+
+    with pytest.raises(RuntimeError, match="create failed.*quota exceeded"):
+        deploy._extract_phases_from_pvc(
+            ["baseline"], "test-run", "ns-0", run_dir, skip_logs=False)


### PR DESCRIPTION
## Summary

In `_extract_phases_from_pvc`, the `kubectl run` that creates the extractor pod used the `run()` helper's default `check=True`, so a non-zero exit raised `subprocess.CalledProcessError`. The unscoped collect fallback at `pipeline/deploy.py:1408` catches only `RuntimeError`, so the error escaped as a raw traceback to the user.

Apply the same `check=False` + explicit `raise RuntimeError(...)` pattern already used three lines below for the adjacent `kubectl wait` call, and clean up any partial pod on failure (mirrors the wait-failure cleanup).

## Test plan

- [x] New unit test `test_extract_phases_kubectl_run_failure_raises_runtime_error` mocks a `kubectl run` failure and asserts `RuntimeError` is raised with the stderr message embedded
- [x] Full pipeline test suite: `python -m pytest pipeline/ -v` → 854 passed, 2 xfailed
- [x] Lint: `ruff check pipeline/ .claude/skills/ --select F` → clean

## Reviewer attention

- The new test exercises `_extract_phases_from_pvc` directly (matching the pattern already used by the `test_collect_*_clears_stale_files` tests below it), monkeypatching `subprocess.run` to fail only the create call.
- Pre-existing scoped collect callers (`_extract_one_slot` at lines 1205, 1236, 1366, 1397) catch the broader `Exception`, so they would have caught a `CalledProcessError` already — the user-visible regression was specifically on the unscoped fallback path. The fix unifies the two paths on `RuntimeError`.

Closes #204