### PR TITLE
fix(deploy): distinguish 'cluster unreachable' from 'no progress yet'

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -114,6 +114,16 @@ def _load_setup_config() -> dict:
 
 # ── Progress store loading ───────────────────────────────────────────────────
 
+class ProgressUnavailable(RuntimeError):
+    """Progress store is reachable-failure (transient kubectl error).
+
+    Distinct from the empty-result case (ConfigMap NotFound or empty data),
+    which ``ConfigMapProgressStore.load`` returns as ``{}``. Only raised by
+    ``_load_progress`` when ``allow_unreachable=True`` so callers can decide
+    whether to abort or degrade. See issue #287.
+    """
+
+
 def _load_progress(store, *, allow_unreachable: bool = False) -> dict:
     """Load progress data with consistent corrupt/unreachable handling.
 
@@ -125,8 +135,10 @@ def _load_progress(store, *, allow_unreachable: bool = False) -> dict:
     guidance, then ``sys.exit(1)``. Corrupt data is never recoverable by
     retry, so this applies regardless of ``allow_unreachable``.
 
-    On ``RuntimeError`` (e.g. kubectl cannot reach the cluster): re-raise by
-    default, or warn and return ``{}`` when ``allow_unreachable=True``.
+    On ``RuntimeError`` (e.g. kubectl cannot reach the cluster): re-raise the
+    original ``RuntimeError`` by default, or raise ``ProgressUnavailable`` when
+    ``allow_unreachable=True`` so callers can distinguish unreachable from
+    legitimate empty progress data (issue #287).
     """
     try:
         return store.load()
@@ -137,8 +149,7 @@ def _load_progress(store, *, allow_unreachable: bool = False) -> dict:
         sys.exit(1)
     except RuntimeError as exc:
         if allow_unreachable:
-            warn(f"Failed to load progress: {exc}")
-            return {}
+            raise ProgressUnavailable(str(exc)) from exc
         raise
 
 
@@ -444,7 +455,12 @@ def _cmd_status(args, run_dir: Path,
         err("No namespace configured. Run setup.py first.")
         sys.exit(1)
     store = ConfigMapProgressStore(primary_ns, run_name=run_dir.name)
-    progress = _load_progress(store, allow_unreachable=True)
+    try:
+        progress = _load_progress(store, allow_unreachable=True)
+    except ProgressUnavailable as exc:
+        err(f"Cluster unreachable — cannot read progress ConfigMap: {exc}")
+        err("Retry once kubectl can reach the cluster.")
+        sys.exit(1)
 
     if not progress:
         suffix = " (no progress data)"
@@ -1080,7 +1096,14 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
         err("No namespace configured. Run setup.py first.")
         sys.exit(1)
     store = ConfigMapProgressStore(primary_ns, run_name=run_dir.name)
-    progress = _load_progress(store, allow_unreachable=True) or None
+    try:
+        progress = _load_progress(store, allow_unreachable=True) or None
+    except ProgressUnavailable as exc:
+        err(f"Cluster unreachable — cannot read progress ConfigMap: {exc}")
+        err("Refusing to collect from filesystem-discovered phases without "
+            "authoritative progress data. Retry once kubectl can reach the "
+            "cluster.")
+        sys.exit(1)
 
     # ── Pair-level scoping (--only / --workload) ──────────────────────────
     scope_only = getattr(args, "only", None)
@@ -2731,7 +2754,12 @@ def _cmd_run_remote(args, run_dir: "Path", setup_config: dict) -> None:
     if discovered:
         from pipeline.lib.progress import ConfigMapProgressStore
         store = ConfigMapProgressStore(namespace, run_name=run_dir.name)
-        progress = _load_progress(store, allow_unreachable=True) or None
+        try:
+            progress = _load_progress(store, allow_unreachable=True) or None
+        except ProgressUnavailable as exc:
+            warn(f"ConfigMap unreachable — skipping pre-flight filter "
+                 f"validation: {exc}")
+            progress = None
         if progress:
             _resolve_scope(progress, args)
 

--- a/pipeline/tests/test_deploy_collect.py
+++ b/pipeline/tests/test_deploy_collect.py
@@ -209,6 +209,48 @@ def test_collect_corrupt_configmap_exits(tmp_path, monkeypatch):
     assert collected_phases == []
 
 
+def test_collect_unreachable_configmap_exits(tmp_path, monkeypatch, capsys):
+    """Cluster-unreachable causes _cmd_collect to exit non-zero rather than
+    falling through to filesystem-discovered phases (issue #287)."""
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    cluster_dir = run_dir / "cluster"
+    cluster_dir.mkdir(parents=True)
+    # Drop a file that _discover_phases would otherwise consume — we want to
+    # confirm the unreachable path refuses this fallback.
+    (cluster_dir / "pipelinerun-baseline-wl.yaml").write_text(
+        "kind: PipelineRun\n")
+
+    def _raise_unreachable(self):
+        raise RuntimeError("kubectl: connection refused")
+
+    monkeypatch.setattr(ConfigMapProgressStore, "load", _raise_unreachable)
+    monkeypatch.setattr(ConfigMapProgressStore, "save", lambda self, d: None)
+
+    class Args:
+        package = None
+        skip_logs = False
+        only = None
+        workload = None
+
+    collected_phases = []
+
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
+        collected_phases.extend(phases)
+        return {p: None for p in phases}
+
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract), \
+         pytest.raises(SystemExit) as exc_info:
+        deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
+
+    assert exc_info.value.code != 0
+    assert collected_phases == []
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "unreachable" in combined.lower()
+
+
 def test_collect_only_done_phases(tmp_path, monkeypatch):
     """Only phases with status done are included."""
     from pipeline import deploy

--- a/pipeline/tests/test_deploy_remote.py
+++ b/pipeline/tests/test_deploy_remote.py
@@ -696,8 +696,9 @@ def test_run_remote_status_filter_rejects_unmatched(monkeypatch, tmp_path):
     assert exc_info.value.code == 1
 
 
-def test_run_remote_skips_validation_when_configmap_unreachable(monkeypatch, tmp_path):
-    """When ConfigMap is unreachable, pre-flight validation is skipped (not errored)."""
+def test_run_remote_skips_validation_when_configmap_unreachable(monkeypatch, tmp_path, capsys):
+    """When ConfigMap is unreachable, pre-flight validation is skipped (not
+    errored), and the warning explicitly names what was skipped (issue #287)."""
     from pipeline.lib.progress import ConfigMapProgressStore
 
     run_dir = _setup_run_dir(tmp_path)
@@ -715,3 +716,8 @@ def test_run_remote_skips_validation_when_configmap_unreachable(monkeypatch, tmp
         args = _make_run_args(remote=True, skip_build=True, status="failed")
         setup_config = {"namespaces": ["ns"], "orchestrator_image": "img:latest"}
         mod._cmd_run_remote(args, run_dir, setup_config)
+
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "ConfigMap unreachable" in combined
+    assert "skipping pre-flight filter validation" in combined

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -113,6 +113,35 @@ def test_status_missing_progress_file(tmp_path, capsys, monkeypatch):
     assert "0 pairs" in out
 
 
+def test_status_unreachable_configmap_exits(tmp_path, capsys, monkeypatch):
+    """Cluster-unreachable causes _cmd_status to exit non-zero with a
+    distinct message instead of printing '0 pairs' (issue #287)."""
+    from pipeline.deploy import _cmd_status
+
+    def _raise_unreachable(self):
+        raise RuntimeError("kubectl: connection refused")
+
+    monkeypatch.setattr(ConfigMapProgressStore, "load", _raise_unreachable)
+    monkeypatch.setattr(ConfigMapProgressStore, "save", lambda self, d: None)
+
+    class _Args:
+        only = None
+        workload = None
+        package = None
+        status = None
+        live = False
+
+    with pytest.raises(SystemExit) as exc_info:
+        _cmd_status(_Args(), tmp_path / "run-x",
+                    setup_config={"namespace": "sim2real-ns"})
+
+    assert exc_info.value.code != 0
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "unreachable" in combined.lower()
+    assert "0 pairs" not in combined
+
+
 def test_status_filter_by_only(tmp_path, capsys, monkeypatch):
     """status subcommand supports --only filter."""
     from pipeline.deploy import _cmd_status
@@ -3516,14 +3545,22 @@ class TestLoadProgressHelper:
         with pytest.raises(RuntimeError, match="kubectl unreachable"):
             _load_progress(store)
 
-    def test_swallows_runtime_error_when_allow_unreachable(self):
-        from pipeline.deploy import _load_progress
+    def test_raises_progress_unavailable_when_allow_unreachable(self):
+        """allow_unreachable=True converts RuntimeError into ProgressUnavailable
+        so callers can distinguish unreachable from legitimate empty data
+        (issue #287)."""
+        from pipeline.deploy import _load_progress, ProgressUnavailable
 
         def boom():
             raise RuntimeError("kubectl unreachable")
         store = self._fake_store(boom)
-        result = _load_progress(store, allow_unreachable=True)
-        assert result == {}
+        with pytest.raises(ProgressUnavailable, match="kubectl unreachable"):
+            _load_progress(store, allow_unreachable=True)
+
+    def test_progress_unavailable_subclasses_runtime_error(self):
+        """Existing handlers that catch RuntimeError continue to work."""
+        from pipeline.deploy import ProgressUnavailable
+        assert issubclass(ProgressUnavailable, RuntimeError)
 
     def test_value_error_exits_even_when_allow_unreachable(self):
         from pipeline.deploy import _load_progress


### PR DESCRIPTION
## Summary

- `_load_progress(store, allow_unreachable=True)` previously collapsed `RuntimeError` (kubectl unreachable) to `{}` — indistinguishable from the legitimate `ConfigMap NotFound` / empty-data path. This made three subcommands silently degrade on cluster outage.
- Introduce a `ProgressUnavailable(RuntimeError)` sentinel that the helper raises only when `allow_unreachable=True`, so callers can pick their own policy.
- `_cmd_status` exits non-zero with a clear "cluster unreachable" message instead of printing `0 pairs`.
- `_cmd_collect` exits non-zero and refuses to fall through to filesystem-discovered phases when the cluster is unreachable.
- `_cmd_run_remote` pre-flight restores the previously-specific warning `ConfigMap unreachable — skipping pre-flight filter validation: <detail>` and keeps the soft-fail behavior.
- `ConfigMap genuinely empty / NotFound` (fresh run with no progress recorded) still returns `{}` — unchanged.

Closes #287.

## Reviewer attention

- **Helper contract change:** `_load_progress(store, allow_unreachable=True)` no longer returns `{}` on `RuntimeError` — it now raises `ProgressUnavailable`. This is intentional: the whole point of the issue is that the previous return value was lossy. `ProgressUnavailable` subclasses `RuntimeError`, so any pre-existing `except RuntimeError:` branches still catch it; the only callers using `allow_unreachable=True` are the three explicitly updated here.
- **`_cmd_status` UX shift:** previously printed `0 pairs (no progress data)` and exited 0 on cluster outage; now exits 1 with `Cluster unreachable — cannot read progress ConfigMap: ...`. Wrapper scripts polling for health were getting a false-OK; this is the intended fix.
- **`_cmd_collect` UX shift:** previously fell through to `_discover_phases(cluster_dir)` and proceeded with filesystem-discovered phases on cluster outage, succeeding with a partial result set and only a stderr warning. Now exits 1 with a message explaining the refusal. Genuinely-empty progress (a fresh run that has not produced any pair data yet) still falls through unchanged — only the unreachable case is refused.
- **`_cmd_run_remote` regression-recovery:** PR #286 inadvertently lost the specific `ConfigMap unreachable — skipping pre-flight filter validation` message in the consolidation. This PR restores it verbatim while keeping the helper as the single source of truth.
- **No change to the corrupt-data path:** `ValueError` continues to call `sys.exit(1)` with the same recovery message, regardless of `allow_unreachable`. Issue #287 is explicitly out of scope for the corrupt path (already addressed in #286).

## Test plan

- [x] `ruff check pipeline/ .claude/skills/ --select F` — clean
- [x] `python -m pytest pipeline/ .claude/skills/sim2real-analyze/tests/ .claude/skills/sim2real-translate/tests/` — 933 passed, 2 xfailed (was 929)
- [x] New: `TestLoadProgressHelper.test_raises_progress_unavailable_when_allow_unreachable` — replaces the old swallow-and-return-`{}` assertion
- [x] New: `TestLoadProgressHelper.test_progress_unavailable_subclasses_runtime_error` — guards the catch-RuntimeError compatibility property
- [x] New: `test_status_unreachable_configmap_exits` — asserts non-zero exit + "unreachable" message and absence of `0 pairs`
- [x] New: `test_collect_unreachable_configmap_exits` — asserts non-zero exit, no extractor invocation, "unreachable" in output, even with a `cluster/` file present that `_discover_phases` would otherwise pick up
- [x] Updated: `test_run_remote_skips_validation_when_configmap_unreachable` — now also asserts the focused pre-flight skip message
- [ ] Live smoke: stop kubectl access and run each of `deploy.py status`, `deploy.py collect`, `deploy.py run --remote` against a setup config; confirm clean errors / warnings (manual, not in CI)