### PR TITLE
feat(deploy): add -s/--silent to status to print summary line only

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -189,6 +189,7 @@ python pipeline/deploy.py pairs   [flags]   # list available pair keys, workload
 | `--workload NAME…` | Filter by workload names (comma or space-separated) |
 | `--package NAME…` | Filter by package names (comma or space-separated) |
 | `--status STATE` | Filter by status (e.g. `running`, `done`, `failed`) |
+| `-s`, `--silent` | Suppress the per-pair table and banner; print only the summary line (machine-readable) |
 
 **`deploy.py collect`** — extracts results from the cluster PVC and writes to `workspace/runs/<run>/results/{phase}/<workload>/`. Repeated collects are incremental: each workload's remote `trace_data.csv` mtime is probed and skipped if the local copy is already up to date. If the mtime probe fails (e.g., pod not running), collection falls back to a full copy — this is the expected degradation path.
 

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -2952,9 +2952,12 @@ Examples:
 def main():
     parser = build_parser()
     args = parser.parse_args()
-    machine_readable = (args.command == "pairs" and
-                         any(getattr(args, f, False)
-                             for f in ("keys_only", "workloads_only", "packages_only")))
+    machine_readable = (
+        (args.command == "pairs" and
+         any(getattr(args, f, False)
+             for f in ("keys_only", "workloads_only", "packages_only"))) or
+        (args.command == "status" and getattr(args, "silent", False))
+    )
     if not machine_readable:
         print(_c("36", "\n━━━ sim2real-deploy ━━━\n"))
 

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -476,35 +476,45 @@ def _cmd_status(args, run_dir: Path,
         return
 
     pairs = {k: progress[k] for k in _resolve_scope(progress, args)}
+    silent = getattr(args, "silent", False)
 
     if not pairs:
         print("  0 pairs")
-        print()
+        if not silent:
+            print()
         return
 
-    pair_w = max(len(k) for k in pairs) + 2
-    col_status = 12
-    col_slot = 14
-    col_retries = 7
-
-    header = (f"{'PAIR':<{pair_w}} {'STATUS':<{col_status}} {'SLOT':<{col_slot}} {'RETRIES':<{col_retries}}")
-    print()
-    print(header)
-    print("-" * len(header))
-
     counts: dict[str, int] = {}
-    for key, entry in sorted(pairs.items()):
-        status = entry.get("status", "unknown")
-        slot = entry.get("namespace") or "—"
-        retries = entry.get("retries", 0)
-        counts[status] = counts.get(status, 0) + 1
-        print(f"{key:<{pair_w}} {status:<{col_status}} {slot:<{col_slot}} {retries}")
 
-    print()
+    if silent:
+        for entry in pairs.values():
+            status = entry.get("status", "unknown")
+            counts[status] = counts.get(status, 0) + 1
+    else:
+        pair_w = max(len(k) for k in pairs) + 2
+        col_status = 12
+        col_slot = 14
+        col_retries = 7
+
+        header = (f"{'PAIR':<{pair_w}} {'STATUS':<{col_status}} {'SLOT':<{col_slot}} {'RETRIES':<{col_retries}}")
+        print()
+        print(header)
+        print("-" * len(header))
+
+        for key, entry in sorted(pairs.items()):
+            status = entry.get("status", "unknown")
+            slot = entry.get("namespace") or "—"
+            retries = entry.get("retries", 0)
+            counts[status] = counts.get(status, 0) + 1
+            print(f"{key:<{pair_w}} {status:<{col_status}} {slot:<{col_slot}} {retries}")
+
+        print()
+
     summary_parts = [f"{v} {k}" for k, v in sorted(counts.items())]
     print(f"  {len(pairs)} pairs: " + "  ".join(summary_parts))
 
-    print()
+    if not silent:
+        print()
 
 
 # ── Pairs command ────────────────────────────────────────────────────────────
@@ -2867,6 +2877,8 @@ Examples:
     status_p.add_argument("--workload", nargs="+", metavar="NAME",  help="Scope to pairs matching these workloads (comma or space-separated)")
     status_p.add_argument("--package",  nargs="+", metavar="NAME",  help="Scope to pairs matching these packages (comma or space-separated)")
     status_p.add_argument("--status",   metavar="STATE", help="Scope to pairs with this status (e.g. running, done, failed)")
+    status_p.add_argument("-s", "--silent", action="store_true",
+                          help="Suppress the per-pair table; print only the summary line")
 
     build_p = sub.add_parser("build", help="Ensure all scenario images exist (pre-flight for run)")
     build_p.add_argument("--skip-build", action="store_true", dest="skip_build",

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -142,6 +142,113 @@ def test_status_unreachable_configmap_exits(tmp_path, capsys, monkeypatch):
     assert "0 pairs" not in combined
 
 
+def test_status_silent_prints_summary_only(tmp_path, capsys, monkeypatch):
+    """-s/--silent suppresses per-pair table; only the summary line prints (issue #290)."""
+    from pipeline.deploy import _cmd_status
+    _mock_cm(monkeypatch, _PROGRESS)
+
+    class _Args:
+        only = None
+        workload = None
+        package = None
+        status = None
+        live = False
+        silent = True
+
+    _cmd_status(_Args(), tmp_path, setup_config={"namespace": "sim2real-ns"})
+    out = capsys.readouterr().out
+
+    assert "5 pairs" in out
+    assert "PAIR" not in out
+    assert "STATUS" not in out
+    for key in _PROGRESS:
+        if not key.startswith("_"):
+            assert key not in out
+
+
+def test_status_silent_composes_with_filter(tmp_path, capsys, monkeypatch):
+    """Silent summary reflects the filtered subset, not the full progress."""
+    from pipeline.deploy import _cmd_status
+    _mock_cm(monkeypatch, _PROGRESS)
+
+    class _Args:
+        only = None
+        workload = "wl-smoke"
+        package = None
+        status = None
+        live = False
+        silent = True
+
+    _cmd_status(_Args(), tmp_path, setup_config={"namespace": "sim2real-ns"})
+    out = capsys.readouterr().out
+
+    assert "2 pairs" in out
+    assert "wl-smoke-baseline" not in out
+    assert "wl-load-baseline" not in out
+
+
+def test_status_silent_empty_progress(tmp_path, capsys, monkeypatch):
+    """Silent on empty progress prints just the '0 pairs (no progress data)' line."""
+    from pipeline.deploy import _cmd_status
+    _mock_cm(monkeypatch, {})
+
+    class _Args:
+        only = None
+        workload = None
+        package = None
+        status = None
+        live = False
+        silent = True
+
+    _cmd_status(_Args(), tmp_path / "missing-run-dir",
+                setup_config={"namespace": "sim2real-ns"})
+    out = capsys.readouterr().out
+    assert "0 pairs" in out
+    assert "PAIR" not in out
+
+
+def test_status_silent_unreachable_still_exits(tmp_path, capsys, monkeypatch):
+    """-s does not change the error path: cluster-unreachable still exits non-zero (issue #290)."""
+    from pipeline.deploy import _cmd_status
+
+    def _raise_unreachable(self):
+        raise RuntimeError("kubectl: connection refused")
+
+    monkeypatch.setattr(ConfigMapProgressStore, "load", _raise_unreachable)
+    monkeypatch.setattr(ConfigMapProgressStore, "save", lambda self, d: None)
+
+    class _Args:
+        only = None
+        workload = None
+        package = None
+        status = None
+        live = False
+        silent = True
+
+    with pytest.raises(SystemExit) as exc_info:
+        _cmd_status(_Args(), tmp_path / "run-x",
+                    setup_config={"namespace": "sim2real-ns"})
+
+    assert exc_info.value.code != 0
+    captured = capsys.readouterr()
+    assert "unreachable" in (captured.out + captured.err).lower()
+
+
+def test_status_silent_short_and_long_flag_parse():
+    """Both -s and --silent parse to args.silent=True; default is False."""
+    from pipeline.deploy import build_parser
+    parser = build_parser()
+
+    args = parser.parse_args(["status"])
+    assert args.silent is False
+
+    args = parser.parse_args(["status", "-s"])
+    assert args.silent is True
+
+    args = parser.parse_args(["status", "--silent"])
+    assert args.silent is True
+
+
 def test_status_filter_by_only(tmp_path, capsys, monkeypatch):
     """status subcommand supports --only filter."""
     from pipeline.deploy import _cmd_status

--- a/pipeline/tests/test_deploy_standalone.py
+++ b/pipeline/tests/test_deploy_standalone.py
@@ -53,3 +53,54 @@ def test_main_works_without_transfer_yaml(tmp_path, monkeypatch):
 
     assert len(status_called) == 1
     assert status_called[0] == run_dir
+
+
+def test_main_status_silent_suppresses_banner(tmp_path, monkeypatch, capsys):
+    """deploy.py status -s must not print the cyan '━━━ sim2real-deploy ━━━' banner
+    so the output is purely the summary line for scripting (issue #290)."""
+    import pipeline.deploy as deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    run_dir.mkdir(parents=True)
+    ws = tmp_path / "workspace"
+    (ws / "setup_config.json").write_text(json.dumps({"current_run": "test-run", "namespace": "ns-0"}))
+
+    progress = {"wl-a-baseline": {"workload": "wl-a", "package": "baseline", "status": "done", "namespace": "ns-0", "retries": 0}}
+    monkeypatch.setattr(ConfigMapProgressStore, "load", lambda self: progress)
+    monkeypatch.setattr(ConfigMapProgressStore, "save", lambda self, d: None)
+
+    monkeypatch.setattr("sys.argv", ["deploy.py", "--experiment-root", str(tmp_path), "status", "-s"])
+    monkeypatch.setattr(deploy, "EXPERIMENT_ROOT", tmp_path)
+
+    with patch.object(deploy, "_load_setup_config",
+                      return_value={"current_run": "test-run", "namespace": "ns-0"}):
+        deploy.main()
+
+    out = capsys.readouterr().out
+    assert "sim2real-deploy" not in out
+    assert "1 pairs" in out
+    assert "1 done" in out
+
+
+def test_main_status_without_silent_keeps_banner(tmp_path, monkeypatch, capsys):
+    """Without -s, deploy.py status still prints the banner (regression guard)."""
+    import pipeline.deploy as deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    run_dir.mkdir(parents=True)
+    ws = tmp_path / "workspace"
+    (ws / "setup_config.json").write_text(json.dumps({"current_run": "test-run", "namespace": "ns-0"}))
+
+    progress = {"wl-a-baseline": {"workload": "wl-a", "package": "baseline", "status": "done", "namespace": "ns-0", "retries": 0}}
+    monkeypatch.setattr(ConfigMapProgressStore, "load", lambda self: progress)
+    monkeypatch.setattr(ConfigMapProgressStore, "save", lambda self, d: None)
+
+    monkeypatch.setattr("sys.argv", ["deploy.py", "--experiment-root", str(tmp_path), "status"])
+    monkeypatch.setattr(deploy, "EXPERIMENT_ROOT", tmp_path)
+
+    with patch.object(deploy, "_load_setup_config",
+                      return_value={"current_run": "test-run", "namespace": "ns-0"}):
+        deploy.main()
+
+    out = capsys.readouterr().out
+    assert "sim2real-deploy" in out


### PR DESCRIPTION
## Summary

- Add `-s` / `--silent` flag to `deploy.py status`. When set, suppresses the per-pair table (header, separator, rows, surrounding blank lines) and prints only the trailing summary line — e.g. `12 pairs: 8 done  4 running`.
- The flag composes with `--only` / `--workload` / `--package` / `--status`; the summary reflects the filtered subset.
- The empty-progress path still prints the single `0 pairs (no progress data)` line (with optional `— filters ignored` suffix), unchanged.
- The error path (cluster-unreachable from #287, no-namespace-configured) is unchanged: still exits non-zero with the same messages, regardless of `-s`.

Closes #290.

## Reviewer attention

- **Short-flag namespace check:** `-s` was unused in the status subparser. `--status` (existing scoping flag) shares the leading letter, but argparse handles short vs long flags as distinct namespaces — `-s` is unambiguous, and a hypothetical `--s` would be ambiguous between `--silent` and `--status`. The standard `add_argument("-s", "--silent", ...)` pattern is used; users still write the long flag in full.
- **Backward compatibility:** `_cmd_status` reads the flag via `getattr(args, "silent", False)`, so any caller that constructs a hand-rolled `args` object without the attribute (existing tests, the `live` mode harness) still works without modification. Existing tests added the attribute only to silent-mode tests.
- **Counts loop duplication:** the count-tally is computed in the silent branch and within the per-row print loop in the verbose branch. I considered hoisting it to a shared pre-pass, but that would force two passes over `pairs` in the verbose case (currently one); given pair counts are small, the readability cost wasn't worth it.

## Test plan

- [x] `ruff check pipeline/ .claude/skills/ --select F` — clean
- [x] `python -m pytest pipeline/ .claude/skills/sim2real-analyze/tests/ .claude/skills/sim2real-translate/tests/` — 938 passed, 2 xfailed (was 933)
- [x] New: `test_status_silent_prints_summary_only` — asserts summary present, no per-pair rows, no `PAIR`/`STATUS` header
- [x] New: `test_status_silent_composes_with_filter` — `--workload wl-smoke` + `-s` reports `2 pairs`, no rows
- [x] New: `test_status_silent_empty_progress` — empty progress + `-s` still prints `0 pairs` line, no header
- [x] New: `test_status_silent_unreachable_still_exits` — cluster-unreachable + `-s` exits non-zero with the unreachable message (error path unchanged)
- [x] New: `test_status_silent_short_and_long_flag_parse` — `-s` and `--silent` both produce `args.silent=True`; default is `False`
- [ ] Live smoke: `python pipeline/deploy.py status -s` against a live cluster (manual, not in CI)