### PR TITLE
fix(deploy): unify capacity log; report effective_free in dispatch-denied warn (#272)

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -61,10 +61,13 @@ def _format_capacity(effective: int, probed: int, reserved: int,
                      allocatable: int, requested: int) -> str:
     """Return the unified orchestrator capacity log line (issue #272).
 
-    All five numbers (three ledger: effective/probed/reserved; two cluster:
-    allocatable/requested) appear in a fixed order so a single log line is
+    All five numbers appear in a fixed order so a single log line is
     self-contained — the reader does not need surrounding context to know
-    which view they are seeing.
+    which view they are seeing. The five numbers split across three layers:
+
+      - effective: derived (probed − reserved, clamped at 0)
+      - probed, allocatable, requested: cluster probe (`probe_free_gpus`)
+      - reserved: shadow ledger
     """
     return (
         f"Capacity: {effective} effective free GPUs "
@@ -2276,13 +2279,17 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                 gpu_resource_type=gpu_resource_type,
                 node_filters=list(node_filters.values()) or [NodeFilter()],
             )
+            # Snapshot the shadow ledger once per cycle. Every log line and
+            # gating decision in this cycle uses the same _reserved value,
+            # so `free_gpus − _reserved == effective_free` holds in every
+            # printed line (issue #272).
             if isinstance(capacity, tuple):
                 free_gpus, allocatable, requested = capacity
                 _reserved = shadow.reserved()
-                _effective = max(0, free_gpus - _reserved)
-                _cap_state = (_effective, free_gpus, _reserved, allocatable, requested)
+                effective_free = max(0, free_gpus - _reserved)
+                _cap_state = (effective_free, free_gpus, _reserved, allocatable, requested)
                 if pending and _cap_state != _last_log_state.get("capacity"):
-                    info(_format_capacity(_effective, free_gpus, _reserved,
+                    info(_format_capacity(effective_free, free_gpus, _reserved,
                                           allocatable, requested))
                     _last_log_state["capacity"] = _cap_state
                 if _probe_fail_count > 0:
@@ -2291,6 +2298,8 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                 _last_probe_error = ""
             else:
                 free_gpus = None
+                _reserved = 0
+                effective_free = 0
                 _probe_fail_count += 1
                 if capacity != _last_probe_error or _probe_fail_count % 10 == 0:
                     warn(f"Capacity probe failed: {capacity} — dispatching without GPU gating")
@@ -2298,14 +2307,12 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
 
             # ── Assign pending work to free slots ────────────────────────
             if free_gpus is not None and pending:
-                effective_free = shadow.effective_free(free_gpus)
                 dispatchable = _select_dispatchable(
                     pending,
                     free_gpus=effective_free, cost_map=pair_costs,
                 )
                 if len(dispatchable) == 0 and pending:
                     smallest = min(pair_costs[k] for k in pending)
-                    _reserved = shadow.reserved()
                     _disp_state = ("zero", len(pending), effective_free, _reserved, smallest)
                     _zero_dispatch_count += 1
                     if _disp_state != _last_log_state.get("dispatch") or _zero_dispatch_count % 10 == 0:
@@ -2340,9 +2347,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                 source = pair_provenance[pair_key]
                 _source_labels = {"derived": "derived from scenarioContent", "defaults-only": "derived from defaults only", "fallback": "fallback default"}
                 if free_gpus is not None:
-                    _reserved = shadow.reserved()
-                    _effective = max(0, free_gpus - _reserved)
-                    info(_format_capacity(_effective, free_gpus, _reserved,
+                    info(_format_capacity(effective_free, free_gpus, _reserved,
                                           allocatable, requested))
                 info(f"{pair_key} requires {pair_cost} GPUs ({_source_labels[source]})")
                 pr_meta = discovered.get(pair_key, {})

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -61,9 +61,10 @@ def _format_capacity(effective: int, probed: int, reserved: int,
                      allocatable: int, requested: int) -> str:
     """Return the unified orchestrator capacity log line (issue #272).
 
-    All four cluster + ledger numbers appear in a fixed order so a single
-    log line is self-contained — the reader does not need surrounding
-    context to know which view they are seeing.
+    All five numbers (three ledger: effective/probed/reserved; two cluster:
+    allocatable/requested) appear in a fixed order so a single log line is
+    self-contained — the reader does not need surrounding context to know
+    which view they are seeing.
     """
     return (
         f"Capacity: {effective} effective free GPUs "

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -57,6 +57,21 @@ def _is_pair_key(key: str) -> bool:
     return not key.startswith("_")
 
 
+def _format_capacity(effective: int, probed: int, reserved: int,
+                     allocatable: int, requested: int) -> str:
+    """Return the unified orchestrator capacity log line (issue #272).
+
+    All four cluster + ledger numbers appear in a fixed order so a single
+    log line is self-contained — the reader does not need surrounding
+    context to know which view they are seeing.
+    """
+    return (
+        f"Capacity: {effective} effective free GPUs "
+        f"({probed} probed − {reserved} reserved; "
+        f"cluster: {allocatable} allocatable − {requested} requested)"
+    )
+
+
 def step(n, title: str) -> None:
     print("\n" + _c("36", f"━━━ Step {n}: {title} ━━━"))
 
@@ -2262,9 +2277,12 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
             )
             if isinstance(capacity, tuple):
                 free_gpus, allocatable, requested = capacity
-                _cap_state = (free_gpus, allocatable, requested)
+                _reserved = shadow.reserved()
+                _effective = max(0, free_gpus - _reserved)
+                _cap_state = (_effective, free_gpus, _reserved, allocatable, requested)
                 if pending and _cap_state != _last_log_state.get("capacity"):
-                    info(f"Capacity: {free_gpus} free GPUs ({allocatable} allocatable − {requested} requested)")
+                    info(_format_capacity(_effective, free_gpus, _reserved,
+                                          allocatable, requested))
                     _last_log_state["capacity"] = _cap_state
                 if _probe_fail_count > 0:
                     info(f"Capacity probe recovered after {_probe_fail_count} failure(s)")
@@ -2286,10 +2304,15 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                 )
                 if len(dispatchable) == 0 and pending:
                     smallest = min(pair_costs[k] for k in pending)
-                    _disp_state = ("zero", len(pending), free_gpus, smallest)
+                    _reserved = shadow.reserved()
+                    _disp_state = ("zero", len(pending), effective_free, _reserved, smallest)
                     _zero_dispatch_count += 1
                     if _disp_state != _last_log_state.get("dispatch") or _zero_dispatch_count % 10 == 0:
-                        warn(f"Dispatching 0/{len(pending)} pending pairs — smallest cost ({smallest}) exceeds free GPUs ({free_gpus})")
+                        warn(
+                            f"Dispatching 0/{len(pending)} pending pairs — "
+                            f"smallest cost ({smallest}) exceeds {effective_free} "
+                            f"effective free GPUs ({free_gpus} probed − {_reserved} reserved)"
+                        )
                         _last_log_state["dispatch"] = _disp_state
                 elif len(dispatchable) < len(pending):
                     _disp_state = ("cap_limited", len(dispatchable), len(pending), free_gpus)
@@ -2317,8 +2340,9 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                 _source_labels = {"derived": "derived from scenarioContent", "defaults-only": "derived from defaults only", "fallback": "fallback default"}
                 if free_gpus is not None:
                     _reserved = shadow.reserved()
-                    _effective = shadow.effective_free(free_gpus)
-                    info(f"Capacity: {_effective} effective free GPUs ({free_gpus} probed − {_reserved} reserved)")
+                    _effective = max(0, free_gpus - _reserved)
+                    info(_format_capacity(_effective, free_gpus, _reserved,
+                                          allocatable, requested))
                 info(f"{pair_key} requires {pair_cost} GPUs ({_source_labels[source]})")
                 pr_meta = discovered.get(pair_key, {})
                 pr_path_str = pr_meta.get("pr_path", "")

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -3787,3 +3787,22 @@ def test_one_cycle_emits_unified_capacity_log_and_effective_free_warn(
     # The bug fixed by Defect 2 was reporting "free GPUs (23)" when the gate
     # was actually 3. Pin against regression.
     assert "exceeds 23" not in warn_line
+
+    # The capacity line and the warn line must report the same _reserved
+    # value: both come from a single snapshot of shadow.reserved() taken at
+    # the top of the cycle, so the printed arithmetic stays consistent
+    # (free_gpus − reserved == effective_free) in every line.
+    import re
+    cap_nums = re.search(
+        r"Capacity: (\d+) effective free GPUs \((\d+) probed − (\d+) reserved",
+        line,
+    )
+    warn_nums = re.search(
+        r"exceeds (\d+) effective free GPUs \((\d+) probed − (\d+) reserved",
+        warn_line,
+    )
+    assert cap_nums and warn_nums
+    cap_eff, cap_probed, cap_res = map(int, cap_nums.groups())
+    warn_eff, warn_probed, warn_res = map(int, warn_nums.groups())
+    assert (cap_eff, cap_probed, cap_res) == (warn_eff, warn_probed, warn_res)
+    assert cap_eff == max(0, cap_probed - cap_res)

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -3677,3 +3677,113 @@ class TestLoadProgressHelper:
         store = self._fake_store(boom)
         with pytest.raises(SystemExit):
             _load_progress(store, allow_unreachable=True)
+
+
+# ── Unified capacity log + dispatch-denied warn (issue #272) ────────────────
+
+
+class _LoopBreak(Exception):
+    """Raised inside fake_sleep to terminate _cmd_run after one cycle."""
+
+
+def test_one_cycle_emits_unified_capacity_log_and_effective_free_warn(
+    tmp_path, monkeypatch, capsys
+):
+    """Issue #272 acceptance test: drive _cmd_run through one cycle with shadow
+    reservations present, assert the unified Capacity: format is emitted with
+    all five numbers, and assert the dispatch-denied warn reports the
+    shadow-adjusted effective_free rather than the raw probed free_gpus.
+    """
+    import pipeline.deploy as mod
+    from pipeline.lib.progress import ConfigMapProgressStore
+
+    run_dir = tmp_path / "runs" / "test-run"
+    cluster_dir = run_dir / "cluster"
+    cluster_dir.mkdir(parents=True)
+    _write_pr(cluster_dir, "a")
+    (run_dir / "run_metadata.json").write_text(json.dumps({}))
+    setup_config = {"namespaces": ["sim2real-0"], "namespace": "sim2real-0"}
+
+    monkeypatch.setattr(ConfigMapProgressStore, "load", lambda self: {})
+    monkeypatch.setattr(ConfigMapProgressStore, "save", lambda self, d: None)
+    monkeypatch.setattr(mod, "_cmd_build", lambda *a, **kw: "skip")
+    monkeypatch.setattr(mod, "_check_slot_ready", lambda ns, **kw: (True, []))
+
+    # Probe returns probed=23, allocatable=48, requested=25 — distinct values
+    # so each one's appearance in the unified format string is unambiguous.
+    import pipeline.lib.capacity as _cap_mod
+    monkeypatch.setattr(_cap_mod, "probe_free_gpus", lambda **kw: (23, 48, 25))
+    monkeypatch.setattr(_cap_mod, "load_defaults",
+                        lambda root: {"decode": {"accelerator": {"count": 4}}})
+
+    # Pre-seed the shadow ledger so reserved=16 → effective_free=7 < cost=4×N…
+    # We need effective_free < smallest-cost to trigger the dispatch-denied
+    # warn. With one pending pair of cost=4 at probed=23, even effective=7 is
+    # ≥ 4. So bump the reservation to 20 so effective_free=3 < cost=4.
+    import pipeline.lib.shadow as _shadow_mod
+    _orig_init = _shadow_mod.ShadowLedger.__init__
+
+    def _seeded_init(self, ttl):
+        _orig_init(self, ttl)
+        # A 20-GPU reservation keeps effective_free=3, less than the cost=4
+        # of the lone pending pair, so the dispatch-denied warn fires.
+        # Use a far-future timestamp so TTL pruning never drops it.
+        self._entries.append((20, 1e18))
+
+    monkeypatch.setattr(_shadow_mod.ShadowLedger, "__init__", _seeded_init)
+
+    # Terminate _cmd_run after the first cycle (no dispatch happens, pending
+    # work remains, so time.sleep is called at end of cycle).
+    def fake_sleep(secs):
+        raise _LoopBreak
+
+    monkeypatch.setattr(mod.time, "sleep", fake_sleep)
+
+    def fake_run(cmd, *, check=True, capture=False, input=None, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    monkeypatch.setattr(mod, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)
+
+    args = argparse.Namespace(
+        skip_build=True, max_retries=0, poll_interval=1, pending_threshold=600,
+        max_pending_stalls=10, default_gpu_cost=4, gpu_resource_type="nvidia.com/gpu",
+        only=None, workload=None, package=None, status=None, force=False,
+        skip_teardown=False, remote=False, preserve_pipelineruns=False,
+        shadow_ttl=120,
+    )
+
+    with pytest.raises(_LoopBreak):
+        mod._cmd_run(args, run_dir, setup_config)
+
+    out = capsys.readouterr().out
+    cap_lines = [ln for ln in out.splitlines() if "Capacity:" in ln]
+
+    # Defect 1: a single unified format. The post-probe site emits it; the
+    # pre-apply site does not run because dispatch was denied. So exactly
+    # one Capacity: line in this cycle.
+    assert len(cap_lines) == 1, f"expected 1 Capacity: line, got: {cap_lines}"
+    line = cap_lines[0]
+    assert "3 effective free GPUs" in line
+    assert "23 probed" in line
+    assert "20 reserved" in line
+    assert "48 allocatable" in line
+    assert "25 requested" in line
+
+    # Defect 2: the dispatch-denied warn must report effective_free=3
+    # (shadow-adjusted), not free_gpus=23 (raw probe).
+    warn_lines = [ln for ln in out.splitlines()
+                  if "Dispatching 0/" in ln and "smallest cost" in ln]
+    assert len(warn_lines) == 1, f"expected 1 denial warn, got: {warn_lines}"
+    warn_line = warn_lines[0]
+    assert "exceeds 3 effective free GPUs" in warn_line
+    assert "23 probed" in warn_line
+    assert "20 reserved" in warn_line
+    # The bug fixed by Defect 2 was reporting "free GPUs (23)" when the gate
+    # was actually 3. Pin against regression.
+    assert "exceeds 23" not in warn_line

--- a/pipeline/tests/test_log_dedup.py
+++ b/pipeline/tests/test_log_dedup.py
@@ -1,4 +1,7 @@
-"""Tests for orchestrator log deduplication (issue #197)."""
+"""Tests for orchestrator log deduplication (issue #197) and the unified
+capacity log format (issue #272)."""
+
+from pipeline.deploy import _format_capacity
 
 
 def _make_info_collector():
@@ -12,41 +15,59 @@ def _make_info_collector():
 
 
 class TestCapacityLogDedup:
-    """Capacity log should only fire when free_gpus/allocatable/requested changes."""
+    """Capacity log should only fire when its inputs change."""
 
     def test_repeated_capacity_not_logged(self):
         """Same capacity on consecutive iterations -> only first logs."""
         messages, mock_info = _make_info_collector()
         _last_log_state = {}
 
-        def _log_capacity(free_gpus, allocatable, requested, has_pending):
+        def _log_capacity(effective, probed, reserved, allocatable, requested, has_pending):
             key = "capacity"
-            state = (free_gpus, allocatable, requested)
+            state = (effective, probed, reserved, allocatable, requested)
             if has_pending and state != _last_log_state.get(key):
-                mock_info(f"Capacity: {free_gpus} free GPUs ({allocatable} allocatable - {requested} requested)")
+                mock_info(_format_capacity(effective, probed, reserved, allocatable, requested))
                 _last_log_state[key] = state
 
-        _log_capacity(31, 93, 62, True)
-        _log_capacity(31, 93, 62, True)
-        _log_capacity(31, 93, 62, True)
+        _log_capacity(31, 31, 0, 93, 62, True)
+        _log_capacity(31, 31, 0, 93, 62, True)
+        _log_capacity(31, 31, 0, 93, 62, True)
 
         assert len(messages) == 1
-        assert "31 free GPUs" in messages[0]
+        assert "31 effective free GPUs" in messages[0]
 
     def test_changed_capacity_logs_again(self):
         """Different capacity -> logs again."""
         messages, mock_info = _make_info_collector()
         _last_log_state = {}
 
-        def _log_capacity(free_gpus, allocatable, requested, has_pending):
+        def _log_capacity(effective, probed, reserved, allocatable, requested, has_pending):
             key = "capacity"
-            state = (free_gpus, allocatable, requested)
+            state = (effective, probed, reserved, allocatable, requested)
             if has_pending and state != _last_log_state.get(key):
-                mock_info(f"Capacity: {free_gpus} free GPUs ({allocatable} allocatable - {requested} requested)")
+                mock_info(_format_capacity(effective, probed, reserved, allocatable, requested))
                 _last_log_state[key] = state
 
-        _log_capacity(31, 93, 62, True)
-        _log_capacity(25, 93, 68, True)
+        _log_capacity(31, 31, 0, 93, 62, True)
+        _log_capacity(25, 25, 0, 93, 68, True)
+
+        assert len(messages) == 2
+
+    def test_changed_reservation_logs_again(self):
+        """Same probe but different shadow reservation -> logs again (issue #272)."""
+        messages, mock_info = _make_info_collector()
+        _last_log_state = {}
+
+        def _log_capacity(effective, probed, reserved, allocatable, requested, has_pending):
+            key = "capacity"
+            state = (effective, probed, reserved, allocatable, requested)
+            if has_pending and state != _last_log_state.get(key):
+                mock_info(_format_capacity(effective, probed, reserved, allocatable, requested))
+                _last_log_state[key] = state
+
+        # Same probe (23, 48, 25), but reservation changes 0 -> 16
+        _log_capacity(23, 23, 0, 48, 25, True)
+        _log_capacity(7, 23, 16, 48, 25, True)
 
         assert len(messages) == 2
 
@@ -126,25 +147,29 @@ class TestDispatchLogDedup:
         _last_log_state = {}
         _zero_dispatch_count = 0
 
-        def _log_zero_dispatch(n_pending, free_gpus, smallest):
+        def _log_zero_dispatch(n_pending, effective_free, reserved, smallest):
             nonlocal _zero_dispatch_count
-            state = ("zero", n_pending, free_gpus, smallest)
+            state = ("zero", n_pending, effective_free, reserved, smallest)
             _zero_dispatch_count += 1
             if state != _last_log_state.get("dispatch") or _zero_dispatch_count % 10 == 0:
-                mock_warn(f"Dispatching 0/{n_pending} pending pairs — smallest cost ({smallest}) exceeds free GPUs ({free_gpus})")
+                mock_warn(
+                    f"Dispatching 0/{n_pending} pending pairs — "
+                    f"smallest cost ({smallest}) exceeds {effective_free} "
+                    f"effective free GPUs"
+                )
                 _last_log_state["dispatch"] = state
 
         # First emission
-        _log_zero_dispatch(7, 2, 4)
+        _log_zero_dispatch(7, 2, 0, 4)
         assert len(messages) == 1
 
         # Iterations 2-9: suppressed
         for _ in range(8):
-            _log_zero_dispatch(7, 2, 4)
+            _log_zero_dispatch(7, 2, 0, 4)
         assert len(messages) == 1
 
         # Iteration 10: re-emits
-        _log_zero_dispatch(7, 2, 4)
+        _log_zero_dispatch(7, 2, 0, 4)
         assert len(messages) == 2
 
     def test_zero_dispatch_includes_smallest_in_state(self):
@@ -153,16 +178,41 @@ class TestDispatchLogDedup:
         _last_log_state = {}
         _zero_dispatch_count = 0
 
-        def _log_zero_dispatch(n_pending, free_gpus, smallest):
+        def _log_zero_dispatch(n_pending, effective_free, reserved, smallest):
             nonlocal _zero_dispatch_count
-            state = ("zero", n_pending, free_gpus, smallest)
+            state = ("zero", n_pending, effective_free, reserved, smallest)
             _zero_dispatch_count += 1
             if state != _last_log_state.get("dispatch") or _zero_dispatch_count % 10 == 0:
-                mock_warn(f"smallest cost ({smallest}) exceeds free GPUs ({free_gpus})")
+                mock_warn(f"smallest cost ({smallest}) exceeds {effective_free} effective free GPUs")
                 _last_log_state["dispatch"] = state
 
-        _log_zero_dispatch(7, 2, 4)
-        _log_zero_dispatch(7, 2, 8)  # smallest changed
+        _log_zero_dispatch(7, 2, 0, 4)
+        _log_zero_dispatch(7, 2, 0, 8)  # smallest changed
+        assert len(messages) == 2
+
+    def test_zero_dispatch_includes_reservation_in_state(self):
+        """Changed shadow reservation triggers new warning even if probed/smallest unchanged.
+
+        Regression for issue #272 Defect 2: dedup must key on effective_free,
+        not the probed value, because effective_free is what the gating
+        decision actually uses.
+        """
+        messages, mock_warn = _make_info_collector()
+        _last_log_state = {}
+        _zero_dispatch_count = 0
+
+        def _log_zero_dispatch(n_pending, effective_free, reserved, smallest):
+            nonlocal _zero_dispatch_count
+            state = ("zero", n_pending, effective_free, reserved, smallest)
+            _zero_dispatch_count += 1
+            if state != _last_log_state.get("dispatch") or _zero_dispatch_count % 10 == 0:
+                mock_warn(f"smallest cost ({smallest}) exceeds {effective_free} effective free GPUs")
+                _last_log_state["dispatch"] = state
+
+        # Same probed=23, same smallest=4, but reservation drops 23->16
+        # so effective_free changes 0 -> 7. Must re-emit.
+        _log_zero_dispatch(19, 0, 23, 4)
+        _log_zero_dispatch(19, 7, 16, 4)
         assert len(messages) == 2
 
     def test_dispatch_logs_on_change(self):
@@ -196,20 +246,42 @@ class TestStateClearOnEvent:
         messages, mock_info = _make_info_collector()
         _last_log_state = {}
 
-        def _log_capacity(free_gpus, allocatable, requested, has_pending):
+        def _log_capacity(effective, probed, reserved, allocatable, requested, has_pending):
             key = "capacity"
-            state = (free_gpus, allocatable, requested)
+            state = (effective, probed, reserved, allocatable, requested)
             if has_pending and state != _last_log_state.get(key):
-                mock_info(f"Capacity: {free_gpus} free GPUs")
+                mock_info(_format_capacity(effective, probed, reserved, allocatable, requested))
                 _last_log_state[key] = state
 
         def _on_dispatch():
             _last_log_state.pop("capacity", None)
             _last_log_state.pop("dispatch", None)
 
-        _log_capacity(31, 93, 62, True)
-        _log_capacity(31, 93, 62, True)
+        _log_capacity(31, 31, 0, 93, 62, True)
+        _log_capacity(31, 31, 0, 93, 62, True)
         _on_dispatch()
-        _log_capacity(31, 93, 62, True)
+        _log_capacity(31, 31, 0, 93, 62, True)
 
         assert len(messages) == 2
+
+
+class TestUnifiedCapacityFormat:
+    """The `Capacity:` log line must be a single shared format (issue #272)."""
+
+    def test_format_includes_all_four_numbers_in_fixed_order(self):
+        msg = _format_capacity(7, 23, 16, 48, 25)
+        assert msg == (
+            "Capacity: 7 effective free GPUs "
+            "(23 probed − 16 reserved; "
+            "cluster: 48 allocatable − 25 requested)"
+        )
+
+    def test_format_with_empty_ledger_reads_cleanly(self):
+        msg = _format_capacity(23, 23, 0, 48, 25)
+        # Even when reservations are 0, the line names the term explicitly so
+        # the reader sees a stable schema regardless of ledger contents.
+        assert "0 reserved" in msg
+        assert "23 effective free GPUs" in msg
+        assert "23 probed" in msg
+        assert "48 allocatable" in msg
+        assert "25 requested" in msg

--- a/pipeline/tests/test_log_dedup.py
+++ b/pipeline/tests/test_log_dedup.py
@@ -193,9 +193,11 @@ class TestDispatchLogDedup:
     def test_zero_dispatch_includes_reservation_in_state(self):
         """Changed shadow reservation triggers new warning even if probed/smallest unchanged.
 
-        Regression for issue #272 Defect 2: dedup must key on effective_free,
-        not the probed value, because effective_free is what the gating
-        decision actually uses.
+        Regression for issue #272 Defect 2: the dedup state tuple must include
+        both effective_free and reserved as independent keys. Relying on
+        probed free_gpus alone would suppress re-emission when only the
+        shadow ledger changes, even though effective_free (and therefore the
+        gating decision) has changed.
         """
         messages, mock_warn = _make_info_collector()
         _last_log_state = {}
@@ -268,7 +270,7 @@ class TestStateClearOnEvent:
 class TestUnifiedCapacityFormat:
     """The `Capacity:` log line must be a single shared format (issue #272)."""
 
-    def test_format_includes_all_four_numbers_in_fixed_order(self):
+    def test_format_includes_all_five_numbers_in_fixed_order(self):
         msg = _format_capacity(7, 23, 16, 48, 25)
         assert msg == (
             "Capacity: 7 effective free GPUs "


### PR DESCRIPTION
## Summary

Fixes two log-quality defects in the orchestrator dispatch loop in `pipeline/deploy.py`:

- **Defect 1** — The `Capacity:` log used two distinct format strings emitted from two different sites within the same poll cycle. Whichever you saw depended on whether a dispatch happened that cycle, and the formats did not share fields.
- **Defect 2** — The dispatch-denied `WARN` interpolated `free_gpus` (the probed number) when reporting the denial, but the gating decision had actually been made on `effective_free` (probed minus shadow-ledger reservations). When the shadow ledger was the gating factor, the printed math did not add up (e.g. `\"smallest cost (4) exceeds free GPUs (23)\"` reported "23" while the gate had actually evaluated against ≈0).

Defect 3 from the issue (no log when all slots busy) was already addressed by #274 and is not touched here.

Closes #272.

## What changed

**`pipeline/deploy.py`**

- New module-level helper `_format_capacity(effective, probed, reserved, allocatable, requested)` returns the unified line:

  ```
  Capacity: <effective> effective free GPUs (<probed> probed − <reserved> reserved; cluster: <allocatable> allocatable − <requested> requested)
  ```

  Both emission sites — the post-probe site and the pre-apply site inside the dispatch for-loop — now go through this helper, so a future format change must touch one place.

- Dispatch-denied warn rewritten to:

  ```
  Dispatching 0/<pending> pending pairs — smallest cost (<min>) exceeds <effective_free> effective free GPUs (<probed> probed − <reserved> reserved)
  ```

  Its dedup state tuple now keys on `(effective_free, reserved)` rather than `free_gpus`, so a draining shadow ledger correctly re-emits the warning when the gating answer changes.

**`pipeline/tests/test_log_dedup.py`**

- Mocks updated to the new format (parameter list now includes `effective`, `reserved`).
- Added `test_changed_reservation_logs_again` — same probe but changing reservation re-emits the capacity line.
- Added `test_zero_dispatch_includes_reservation_in_state` — regression for the dedup-keys-on-effective_free fix in Defect 2.
- Added `TestUnifiedCapacityFormat` — pins the exact output of `_format_capacity` and confirms the empty-ledger case still reads cleanly.

## Reviewer attention

- **Drift prevention.** The whole point of this fix is that two callers must produce the same string. I extracted a small helper rather than duplicating the format literal — please push back if the helper feels over-engineered, but the alternative is to leave two literals in sync by convention, which is exactly the failure mode #272 documents.
- **`max(0, probed - reserved)` vs `shadow.effective_free(probed)`.** The pre-apply site previously called `shadow.effective_free(free_gpus)` (which prunes the ledger again). I changed both sites to compute `_effective = max(0, free_gpus - _reserved)` after a single `shadow.reserved()` call, to avoid double-pruning. Behavior is identical given the same input.
- **`allocatable`/`requested` scoping at Site B.** Site B (inside the for-loop) reads `allocatable` and `requested` from the enclosing function scope. They are only set inside the `isinstance(capacity, tuple)` branch, but Site B is guarded by `if free_gpus is not None:` — `free_gpus` is also only set in that same branch, so the variables are guaranteed in scope when Site B fires. Probe-failure path is unchanged.

## Test plan

- [x] `python -m pytest pipeline/ .claude/skills/sim2real-analyze/tests/ .claude/skills/sim2real-translate/tests/` — 944 passed, 2 xfailed.
- [x] `ruff check pipeline/ .claude/skills/ --select F` — clean.
- [ ] Manual: run a real `deploy.py run` cycle and eyeball that the capacity line is identical at both emission points and that the denial warn shows effective_free.