### PR TITLE
feat(sim2real-bootstrap): bare-flag prefix-caching input + symmetric output

### DIFF
--- a/.claude/skills/sim2real-bootstrap/SKILL.md
+++ b/.claude/skills/sim2real-bootstrap/SKILL.md
@@ -178,7 +178,7 @@ Generate llm-d-benchmark scenario YAML(s) for baseline arm(s).
    The script will:
    - Parse the vLLM configuration table from config.md
    - Apply MODEL_METADATA and HARDWARE_LABELS lookups
-   - Emit `--no-enable-prefix-caching` only when explicitly disabled in config.md (otherwise defer to vLLM's default)
+   - Emit a single bare prefix-caching flag matching the user's intent: `--enable-prefix-caching` if explicitly enabled, `--no-enable-prefix-caching` if explicitly disabled, nothing if unspecified in config.md (defers to vLLM's per-model default). Input accepts either the legacy keyed form (`enable_prefix_caching | true|false`) or a bare flag row label (`--enable-prefix-caching` / `--no-enable-prefix-caching` with an empty value column); contradictory specifications error.
    - Write YAML with inline provenance comments showing each value's source
    - Error on unknown models/hardware (update lookup tables in the script if needed)
 
@@ -371,6 +371,6 @@ This skill ships with supporting files in its directory. Invoke in place — do 
 
 | File | Purpose |
 |------|---------|
-| `generate_from_config.py` | Parses `config.md` markdown tables → scenario YAMLs with provenance comments. Preferred for most experiments. Handles hardware normalization, vLLM-default-aware flag emission, and unknown model/hardware detection. |
+| `generate_from_config.py` | Parses `config.md` markdown tables → scenario YAMLs with provenance comments. Preferred for most experiments. Handles hardware normalization, bare-flag prefix-caching input/output, and unknown model/hardware detection. |
 | `generate_scenarios.py` | Converts JSON config (`top3_selection.json`) → scenario YAMLs. Use when JSON input exists. |
 | `generate_scenarios.README.md` | Coverage map for the JSON-input path. Documents field mappings, omission rules, and gaps. |

--- a/.claude/skills/sim2real-bootstrap/SKILL.md
+++ b/.claude/skills/sim2real-bootstrap/SKILL.md
@@ -178,7 +178,7 @@ Generate llm-d-benchmark scenario YAML(s) for baseline arm(s).
    The script will:
    - Parse the vLLM configuration table from config.md
    - Apply MODEL_METADATA and HARDWARE_LABELS lookups
-   - Emit `--no-enable-prefix-caching` unless explicitly enabled
+   - Emit `--no-enable-prefix-caching` only when explicitly disabled in config.md (otherwise defer to vLLM's default)
    - Write YAML with inline provenance comments showing each value's source
    - Error on unknown models/hardware (update lookup tables in the script if needed)
 
@@ -371,6 +371,6 @@ This skill ships with supporting files in its directory. Invoke in place — do 
 
 | File | Purpose |
 |------|---------|
-| `generate_from_config.py` | Parses `config.md` markdown tables → scenario YAMLs with provenance comments. Preferred for most experiments. Handles hardware normalization, safe defaults (`--no-enable-prefix-caching`), and unknown model/hardware detection. |
+| `generate_from_config.py` | Parses `config.md` markdown tables → scenario YAMLs with provenance comments. Preferred for most experiments. Handles hardware normalization, vLLM-default-aware flag emission, and unknown model/hardware detection. |
 | `generate_scenarios.py` | Converts JSON config (`top3_selection.json`) → scenario YAMLs. Use when JSON input exists. |
 | `generate_scenarios.README.md` | Coverage map for the JSON-input path. Documents field mappings, omission rules, and gaps. |

--- a/.claude/skills/sim2real-bootstrap/generate_from_config.py
+++ b/.claude/skills/sim2real-bootstrap/generate_from_config.py
@@ -275,8 +275,15 @@ def extract_fields(table: TableSection) -> dict[str, ProvenanceValue]:
             else:
                 bv = parse_boolean(raw_value)
                 if bv is None:
-                    print(f"  warning: could not parse boolean for {canonical}: '{raw_value}'", file=sys.stderr)
-                    continue
+                    # The user expressed an intent we cannot parse; treat as a
+                    # configuration error rather than silently dropping the row,
+                    # which would re-introduce the silent-default behavior the
+                    # bare-flag rewrite was meant to eliminate.
+                    print(
+                        f"ERROR: could not parse boolean for {canonical}: '{raw_value}' (expected true/false)",
+                        file=sys.stderr,
+                    )
+                    sys.exit(1)
                 epc_observations.append((bv, source, raw_param))
             continue
 

--- a/.claude/skills/sim2real-bootstrap/generate_from_config.py
+++ b/.claude/skills/sim2real-bootstrap/generate_from_config.py
@@ -54,6 +54,9 @@ PARAMETER_ALIASES = {
     "max_model_len": {"max_model_len", "--max-model-len", "max_seq_len"},
     "enable_chunked_prefill": {"enable_chunked_prefill", "--enable-chunked-prefill"},
     "enable_prefix_caching": {"enable_prefix_caching", "--enable-prefix-caching"},
+    # Negative bare flag: presence (with empty value column) means caching OFF.
+    # Folded into enable_prefix_caching at the end of extract_fields.
+    "__no_enable_prefix_caching__": {"--no-enable-prefix-caching"},
     "replicas": {"number of pods", "instances", "replicas", "num_instances"},
     "dtype": {"dtype", "--dtype"},
     "pipeline_parallel_size": {"pipeline_parallel_size", "--pipeline-parallel-size"},
@@ -245,6 +248,10 @@ def extract_fields(table: TableSection) -> dict[str, ProvenanceValue]:
     if value_col is None:
         return fields
 
+    # Collected enable_prefix_caching observations across all four accepted forms;
+    # reconciled after the row loop.
+    epc_observations: list[tuple[bool, str, str]] = []  # (resolved_bool, source, raw_param)
+
     for row in table.rows:
         raw_param = row.get(param_col, "")
         raw_value = row.get(value_col, "")
@@ -255,10 +262,28 @@ def extract_fields(table: TableSection) -> dict[str, ProvenanceValue]:
 
         source = f'config.md row "{normalize_cell(raw_param)}"'
 
+        # Prefix caching: accept legacy keyed form (enable_prefix_caching=true|false)
+        # AND bare flags (--enable-prefix-caching / --no-enable-prefix-caching with
+        # empty value column). Reconcile after the loop.
+        if canonical == "__no_enable_prefix_caching__":
+            epc_observations.append((False, source, raw_param))
+            continue
+        if canonical == "enable_prefix_caching":
+            if normalize_cell(raw_value) == "":
+                # Bare positive flag: presence implies caching ON.
+                epc_observations.append((True, source, raw_param))
+            else:
+                bv = parse_boolean(raw_value)
+                if bv is None:
+                    print(f"  warning: could not parse boolean for {canonical}: '{raw_value}'", file=sys.stderr)
+                    continue
+                epc_observations.append((bv, source, raw_param))
+            continue
+
         # Parse value based on field type
         if canonical in ("model", "hardware", "dtype"):
             value = normalize_cell(raw_value)
-        elif canonical in ("enable_chunked_prefill", "enable_prefix_caching", "enforce_eager"):
+        elif canonical in ("enable_chunked_prefill", "enforce_eager"):
             value = parse_boolean(raw_value)
             if value is None:
                 print(f"  warning: could not parse boolean for {canonical}: '{raw_value}'", file=sys.stderr)
@@ -270,6 +295,23 @@ def extract_fields(table: TableSection) -> dict[str, ProvenanceValue]:
                 value = normalize_cell(raw_value)
 
         fields[canonical] = ProvenanceValue(value=value, source=source, raw_param=raw_param)
+
+    # Reconcile enable_prefix_caching observations.
+    if epc_observations:
+        distinct = {v for v, _, _ in epc_observations}
+        if len(distinct) > 1:
+            joined = "; ".join(f"{s} -> {v}" for v, s, _ in epc_observations)
+            print(
+                f"ERROR: conflicting enable_prefix_caching specifications in config.md ({joined})",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        resolved = next(iter(distinct))
+        first_source = epc_observations[0][1]
+        first_raw = epc_observations[0][2]
+        fields["enable_prefix_caching"] = ProvenanceValue(
+            value=resolved, source=first_source, raw_param=first_raw
+        )
 
     return fields
 
@@ -311,11 +353,15 @@ def build_additional_flags(
         f = fields["enable_chunked_prefill"]
         flags.append(("--enable-chunked-prefill", f.source))
 
-    # Only emit --no-enable-prefix-caching when the user explicitly disabled it.
-    # If unspecified or explicitly enabled, defer to vLLM's default.
+    # Emit a single bare flag matching the user's intent. If the field was not
+    # specified in config.md at all, emit nothing and defer to vLLM's per-model
+    # default (typically ON for generative models).
     epc = fields.get("enable_prefix_caching")
-    if epc is not None and not epc.value:
-        flags.append(("--no-enable-prefix-caching", epc.source))
+    if epc is not None:
+        if epc.value:
+            flags.append(("--enable-prefix-caching", epc.source))
+        else:
+            flags.append(("--no-enable-prefix-caching", epc.source))
 
     if "dtype" in fields and fields["dtype"].value != "auto":
         f = fields["dtype"]

--- a/.claude/skills/sim2real-bootstrap/generate_from_config.py
+++ b/.claude/skills/sim2real-bootstrap/generate_from_config.py
@@ -311,13 +311,11 @@ def build_additional_flags(
         f = fields["enable_chunked_prefill"]
         flags.append(("--enable-chunked-prefill", f.source))
 
-    # Always emit --no-enable-prefix-caching UNLESS explicitly True
+    # Only emit --no-enable-prefix-caching when the user explicitly disabled it.
+    # If unspecified or explicitly enabled, defer to vLLM's default.
     epc = fields.get("enable_prefix_caching")
-    if epc is None:
-        flags.append(("--no-enable-prefix-caching", "default (not specified in config.md)"))
-    elif not epc.value:
+    if epc is not None and not epc.value:
         flags.append(("--no-enable-prefix-caching", epc.source))
-    # If epc.value is True: don't emit the flag (caching enabled)
 
     if "dtype" in fields and fields["dtype"].value != "auto":
         f = fields["dtype"]

--- a/.claude/skills/sim2real-bootstrap/tests/test_generate_from_config.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_generate_from_config.py
@@ -1,0 +1,176 @@
+"""Tests for generate_from_config.py — prefix-caching input + output contract.
+
+Covers the acceptance criteria from issue #293:
+  - Legacy keyed input (enable_prefix_caching | true|false)
+  - Bare positive flag input (--enable-prefix-caching, empty value column)
+  - Bare negative flag input (--no-enable-prefix-caching, empty value column)
+  - Field absent → no flag emitted
+  - Contradictory specifications → sys.exit(1)
+  - Unparseable boolean → sys.exit(1)
+  - Duplicate same-value rows → reconciled silently
+  - Sentinel __no_enable_prefix_caching__ never leaks into the returned fields
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parents[1]))
+import generate_from_config as gfc
+
+
+def make_table(rows: list[dict]) -> gfc.TableSection:
+    """Build a TableSection that find_vllm_table-style code expects."""
+    return gfc.TableSection(heading="vLLM Pod Configuration", rows=rows, line_number=0)
+
+
+def epc_flag(fields: dict[str, gfc.ProvenanceValue]) -> str | None:
+    """Return the prefix-caching flag emitted by build_additional_flags, or None."""
+    flags = gfc.build_additional_flags(fields)
+    for flag, _ in flags:
+        if "prefix-caching" in flag:
+            return flag
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Input form parity
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "row,expected_value,expected_flag",
+    [
+        # Legacy keyed form
+        ({"Parameter": "enable_prefix_caching", "Value": "true"}, True, "--enable-prefix-caching"),
+        ({"Parameter": "enable_prefix_caching", "Value": "false"}, False, "--no-enable-prefix-caching"),
+        # Legacy keyed form via --enable-prefix-caching alias
+        ({"Parameter": "--enable-prefix-caching", "Value": "true"}, True, "--enable-prefix-caching"),
+        ({"Parameter": "--enable-prefix-caching", "Value": "false"}, False, "--no-enable-prefix-caching"),
+        # Bare positive flag (empty value column)
+        ({"Parameter": "--enable-prefix-caching", "Value": ""}, True, "--enable-prefix-caching"),
+        # Bare negative flag (empty value column)
+        ({"Parameter": "--no-enable-prefix-caching", "Value": ""}, False, "--no-enable-prefix-caching"),
+    ],
+)
+def test_accepted_input_forms_resolve_correctly(row, expected_value, expected_flag):
+    fields = gfc.extract_fields(make_table([row]))
+    assert "enable_prefix_caching" in fields
+    assert fields["enable_prefix_caching"].value is expected_value
+    assert epc_flag(fields) == expected_flag
+
+
+def test_field_absent_emits_no_flag():
+    """Per #293: when enable_prefix_caching is absent, defer to vLLM (emit nothing)."""
+    fields = gfc.extract_fields(make_table([
+        {"Parameter": "model", "Value": "meta-llama/Llama-3.1-8B"},
+    ]))
+    assert "enable_prefix_caching" not in fields
+    assert epc_flag(fields) is None
+
+
+def test_negative_bare_flag_value_column_is_ignored():
+    """`--no-enable-prefix-caching` resolves OFF regardless of value column contents."""
+    fields = gfc.extract_fields(make_table([
+        {"Parameter": "--no-enable-prefix-caching", "Value": "true"},
+    ]))
+    assert fields["enable_prefix_caching"].value is False
+    assert epc_flag(fields) == "--no-enable-prefix-caching"
+
+
+# ---------------------------------------------------------------------------
+# Reconciliation: duplicates vs conflicts
+# ---------------------------------------------------------------------------
+
+def test_duplicate_agreeing_rows_reconcile_silently():
+    """Multiple rows asserting the same value collapse to one observation."""
+    fields = gfc.extract_fields(make_table([
+        {"Parameter": "enable_prefix_caching", "Value": "true"},
+        {"Parameter": "--enable-prefix-caching", "Value": ""},
+    ]))
+    assert fields["enable_prefix_caching"].value is True
+    assert epc_flag(fields) == "--enable-prefix-caching"
+
+
+def test_contradictory_bare_flags_exit_1(capsys):
+    """Both --enable-prefix-caching and --no-enable-prefix-caching present is an error."""
+    table = make_table([
+        {"Parameter": "--enable-prefix-caching", "Value": ""},
+        {"Parameter": "--no-enable-prefix-caching", "Value": ""},
+    ])
+    with pytest.raises(SystemExit) as exc:
+        gfc.extract_fields(table)
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "conflicting enable_prefix_caching" in err
+    # Both source rows should be cited.
+    assert "--enable-prefix-caching" in err
+    assert "--no-enable-prefix-caching" in err
+
+
+def test_contradictory_legacy_and_bare_exit_1():
+    """Legacy false + bare positive is also a conflict."""
+    table = make_table([
+        {"Parameter": "enable_prefix_caching", "Value": "false"},
+        {"Parameter": "--enable-prefix-caching", "Value": ""},
+    ])
+    with pytest.raises(SystemExit) as exc:
+        gfc.extract_fields(table)
+    assert exc.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# Unparseable boolean: must NOT silently drop the row
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("bad_value", ["treu", "on", "enabled", "maybe"])
+def test_unparseable_boolean_exits_1(bad_value, capsys):
+    """An unparseable value column is a configuration error, not a silent skip."""
+    table = make_table([
+        {"Parameter": "enable_prefix_caching", "Value": bad_value},
+    ])
+    with pytest.raises(SystemExit) as exc:
+        gfc.extract_fields(table)
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "could not parse boolean" in err
+    assert bad_value in err
+
+
+# ---------------------------------------------------------------------------
+# Sentinel hygiene
+# ---------------------------------------------------------------------------
+
+def test_sentinel_key_never_appears_in_output_fields():
+    """The internal __no_enable_prefix_caching__ canonical must be folded away."""
+    fields = gfc.extract_fields(make_table([
+        {"Parameter": "--no-enable-prefix-caching", "Value": ""},
+    ]))
+    assert "__no_enable_prefix_caching__" not in fields
+    assert "enable_prefix_caching" in fields
+
+
+def test_sentinel_does_not_skew_vllm_table_detection():
+    """__no_enable_prefix_caching__ must not be in VLLM_INDICATOR_FIELDS."""
+    assert "__no_enable_prefix_caching__" not in gfc.VLLM_INDICATOR_FIELDS
+
+
+# ---------------------------------------------------------------------------
+# Output contract: exact bare flag, never legacy keyed
+# ---------------------------------------------------------------------------
+
+def test_output_uses_bare_form_not_keyed():
+    """build_additional_flags must emit `--enable-prefix-caching`, not `--enable-prefix-caching=true`."""
+    fields = {
+        "enable_prefix_caching": gfc.ProvenanceValue(value=True, source="test", raw_param=""),
+    }
+    flags = gfc.build_additional_flags(fields)
+    flag_strs = [f for f, _ in flags]
+    assert "--enable-prefix-caching" in flag_strs
+    assert not any("=" in f and "prefix-caching" in f for f in flag_strs)
+
+
+def test_output_absent_emits_nothing():
+    """No prefix-caching key in fields → no prefix-caching flag in output."""
+    fields = {}
+    flags = gfc.build_additional_flags(fields)
+    assert not any("prefix-caching" in f for f, _ in flags)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,4 +27,4 @@ jobs:
         run: ruff check pipeline/ .claude/skills/ --select F
 
       - name: Run tests
-        run: python -m pytest pipeline/ .claude/skills/sim2real-analyze/tests/ .claude/skills/sim2real-translate/tests/ -v
+        run: python -m pytest pipeline/ .claude/skills/sim2real-analyze/tests/ .claude/skills/sim2real-bootstrap/tests/ .claude/skills/sim2real-translate/tests/ -v

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ Two checks run in order:
 ruff check pipeline/ .claude/skills/ --select F
 
 # 2. Tests
-python -m pytest pipeline/ .claude/skills/sim2real-analyze/tests/ .claude/skills/sim2real-translate/tests/ -v
+python -m pytest pipeline/ .claude/skills/sim2real-analyze/tests/ .claude/skills/sim2real-bootstrap/tests/ .claude/skills/sim2real-translate/tests/ -v
 ```
 
 Run both locally before pushing. If your change adds a new module, test file location, or skill, update `.github/workflows/test.yml` to include it — CI only covers paths explicitly listed.


### PR DESCRIPTION
## Summary

Expanded scope of #293 after design discussion. The bootstrap script now handles `enable_prefix_caching` symmetrically:

**Input (`config.md`) — accept either form:**

| Row label                        | Value column     | Meaning |
|----------------------------------|------------------|---------|
| `enable_prefix_caching`          | `true` / `false` | Caching ON / OFF (legacy keyed) |
| `--enable-prefix-caching` (alias)| `true` / `false` | Caching ON / OFF (legacy keyed) |
| `--enable-prefix-caching`        | empty            | Caching ON (bare flag) |
| `--no-enable-prefix-caching`     | empty            | Caching OFF (bare flag) |

Multiple agreeing rows are reconciled. Contradictory specifications (e.g. both bare flags present) error with the observed sources.

**Output (scenario YAML) — always a single bare flag:**

| Resolved state | Emitted flag |
|----------------|--------------|
| ON             | `--enable-prefix-caching` |
| OFF            | `--no-enable-prefix-caching` |
| Field absent   | Emit nothing (defer to vLLM's per-model default) |

This brings the script into alignment with vLLM's CLI conventions (see `vllm/engine/arg_utils.py:_set_default_chunked_prefill_and_prefix_caching_args`, which resolves an unset value to `model_config.is_prefix_caching_supported`).

Closes #293

## Test plan

- [x] `ruff check pipeline/ .claude/skills/ --select F` — clean
- [x] `python -m pytest pipeline/ .claude/skills/sim2real-analyze/tests/ .claude/skills/sim2real-translate/tests/ -v` — 940 passed
- [x] Inline behavioral check: legacy true/false, bare positive, bare negative, absent, and agreeing-duplicate cases all produce the expected output flag
- [x] Conflict path: contradictory bare flags exit 1 with a message naming both source rows