### PR TITLE
fix(sim2real-bootstrap): default to --enable-prefix-caching when config.md is silent

### DIFF
--- a/.claude/skills/sim2real-bootstrap/SKILL.md
+++ b/.claude/skills/sim2real-bootstrap/SKILL.md
@@ -178,7 +178,7 @@ Generate llm-d-benchmark scenario YAML(s) for baseline arm(s).
    The script will:
    - Parse the vLLM configuration table from config.md
    - Apply MODEL_METADATA and HARDWARE_LABELS lookups
-   - Emit a single bare prefix-caching flag matching the user's intent: `--enable-prefix-caching` if explicitly enabled, `--no-enable-prefix-caching` if explicitly disabled, nothing if unspecified in config.md (defers to vLLM's per-model default). Input accepts either the legacy keyed form (`enable_prefix_caching | true|false`) or a bare flag row label (`--enable-prefix-caching` / `--no-enable-prefix-caching` with an empty value column); contradictory specifications error.
+   - Emit a single bare prefix-caching flag matching the user's intent: `--enable-prefix-caching` if explicitly enabled, `--no-enable-prefix-caching` if explicitly disabled, `--enable-prefix-caching` (with a `sim2real-bootstrap default` provenance source) if unspecified in config.md. The deployed vLLM version predates per-model default resolution, so silent → OFF rather than ON; defaulting to ON keeps caching enabled for our scenarios (see issue #295). Input accepts either the legacy keyed form (`enable_prefix_caching | true|false`) or a bare flag row label (`--enable-prefix-caching` / `--no-enable-prefix-caching` with an empty value column); contradictory specifications error.
    - Write YAML with inline provenance comments showing each value's source
    - Error on unknown models/hardware (update lookup tables in the script if needed)
 

--- a/.claude/skills/sim2real-bootstrap/generate_from_config.py
+++ b/.claude/skills/sim2real-bootstrap/generate_from_config.py
@@ -360,15 +360,22 @@ def build_additional_flags(
         f = fields["enable_chunked_prefill"]
         flags.append(("--enable-chunked-prefill", f.source))
 
-    # Emit a single bare flag matching the user's intent. If the field was not
-    # specified in config.md at all, emit nothing and defer to vLLM's per-model
-    # default (typically ON for generative models).
+    # Emit a single bare flag matching the user's intent. When config.md is
+    # silent on prefix caching, default to --enable-prefix-caching: the
+    # deployed vLLM version predates per-model default resolution
+    # (vllm/engine/arg_utils.py:_set_default_chunked_prefill_and_prefix_caching_args),
+    # so an unset value would otherwise fall back to OFF rather than ON for
+    # supported models. See issue #295.
     epc = fields.get("enable_prefix_caching")
-    if epc is not None:
-        if epc.value:
-            flags.append(("--enable-prefix-caching", epc.source))
-        else:
-            flags.append(("--no-enable-prefix-caching", epc.source))
+    if epc is None:
+        flags.append((
+            "--enable-prefix-caching",
+            "sim2real-bootstrap default (config.md silent; deployed vLLM requires explicit ON)",
+        ))
+    elif epc.value:
+        flags.append(("--enable-prefix-caching", epc.source))
+    else:
+        flags.append(("--no-enable-prefix-caching", epc.source))
 
     if "dtype" in fields and fields["dtype"].value != "auto":
         f = fields["dtype"]

--- a/.claude/skills/sim2real-bootstrap/tests/test_generate_from_config.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_generate_from_config.py
@@ -1,10 +1,11 @@
 """Tests for generate_from_config.py — prefix-caching input + output contract.
 
-Covers the acceptance criteria from issue #293:
+Covers the acceptance criteria from issues #293 and #295:
   - Legacy keyed input (enable_prefix_caching | true|false)
   - Bare positive flag input (--enable-prefix-caching, empty value column)
   - Bare negative flag input (--no-enable-prefix-caching, empty value column)
-  - Field absent → no flag emitted
+  - Field absent → emit --enable-prefix-caching as a sim2real-bootstrap default
+    (deployed vLLM predates per-model default resolution; see #295)
   - Contradictory specifications → sys.exit(1)
   - Unparseable boolean → sys.exit(1)
   - Duplicate same-value rows → reconciled silently
@@ -59,13 +60,16 @@ def test_accepted_input_forms_resolve_correctly(row, expected_value, expected_fl
     assert epc_flag(fields) == expected_flag
 
 
-def test_field_absent_emits_no_flag():
-    """Per #293: when enable_prefix_caching is absent, defer to vLLM (emit nothing)."""
+def test_field_absent_emits_enable_prefix_caching_default():
+    """Per #295: when enable_prefix_caching is absent, emit --enable-prefix-caching
+    as a sim2real-bootstrap default. The deployed vLLM version predates per-model
+    default resolution, so silent would otherwise resolve to OFF."""
     fields = gfc.extract_fields(make_table([
         {"Parameter": "model", "Value": "meta-llama/Llama-3.1-8B"},
     ]))
+    # extract_fields itself does not synthesize the field; only build_additional_flags does.
     assert "enable_prefix_caching" not in fields
-    assert epc_flag(fields) is None
+    assert epc_flag(fields) == "--enable-prefix-caching"
 
 
 def test_negative_bare_flag_value_column_is_ignored():
@@ -169,8 +173,13 @@ def test_output_uses_bare_form_not_keyed():
     assert not any("=" in f and "prefix-caching" in f for f in flag_strs)
 
 
-def test_output_absent_emits_nothing():
-    """No prefix-caching key in fields → no prefix-caching flag in output."""
+def test_output_absent_emits_default_enable_with_bootstrap_provenance():
+    """No prefix-caching key in fields → emit --enable-prefix-caching with a
+    sim2real-bootstrap provenance source (issue #295)."""
     fields = {}
     flags = gfc.build_additional_flags(fields)
-    assert not any("prefix-caching" in f for f, _ in flags)
+    pc_flags = [(f, src) for f, src in flags if "prefix-caching" in f]
+    assert len(pc_flags) == 1
+    flag, source = pc_flags[0]
+    assert flag == "--enable-prefix-caching"
+    assert "sim2real-bootstrap default" in source


### PR DESCRIPTION
## Summary

Closes #295.

The deployed vLLM version predates per-model default resolution for `enable_prefix_caching` (`vllm/engine/arg_utils.py:_set_default_chunked_prefill_and_prefix_caching_args`). PR #294 emitted nothing for an absent `enable_prefix_caching` row in `config.md`, which on the deployed version falls back to OFF rather than ON — not the intent for our scenarios.

This PR flips the absent-field default to `--enable-prefix-caching`. The two explicit forms (legacy keyed and bare flags, both ON and OFF) keep their PR #294 semantics.

| Resolved state | Emitted flag |
|----------------|--------------|
| ON             | `--enable-prefix-caching` (unchanged) |
| OFF            | `--no-enable-prefix-caching` (unchanged) |
| Field absent   | `--enable-prefix-caching` (was: emit nothing) |

## Reviewer attention

- Provenance: the synthesized flag carries the source string `"sim2real-bootstrap default (config.md silent; deployed vLLM requires explicit ON)"` so it's distinguishable in the YAML provenance comments from a flag that came from `config.md`.
- `extract_fields` was deliberately not changed — it still does not synthesize an `enable_prefix_caching` entry when the field is absent. Only `build_additional_flags`'s output differs. This keeps `extract_fields` purely a parser of input and confines the policy choice to the output stage.
- The "Notes" section of #295 flags that this default should be revisited if/when we move to a vLLM version that ships per-model default resolution. The code comment + SKILL.md text both reference #295 so the rationale is discoverable.

## Test plan

- [x] `ruff check pipeline/ .claude/skills/ --select F` — clean
- [x] `python -m pytest pipeline/ .claude/skills/sim2real-analyze/tests/ .claude/skills/sim2real-bootstrap/tests/ .claude/skills/sim2real-translate/tests/` — 964 passed, 2 xfailed
- [x] Two existing absent-field tests flipped to assert the new default; all explicit-form, contradiction, and unparseable-boolean tests unchanged and passing