### PR TITLE
feat(deploy): collect resolved llm-d-benchmark plan YAMLs per phase

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -193,6 +193,8 @@ python pipeline/deploy.py pairs   [flags]   # list available pair keys, workload
 
 **`deploy.py collect`** — extracts results from the cluster PVC and writes to `workspace/runs/<run>/results/{phase}/<workload>/`. Repeated collects are incremental: each workload's remote `trace_data.csv` mtime is probed and skipped if the local copy is already up to date. If the mtime probe fails (e.g., pod not running), collection falls back to a full copy — this is the expected degradation path.
 
+Per phase, the resolved llm-d-benchmark plan YAMLs are also pulled into `workspace/runs/<run>/results/{phase}/plans/{flow}/*.yaml` (top-level numbered manifests + `config.yaml`, no `helm/` subdir). Plans are workload-invariant within a phase, so collect picks one workload's latest `root-*` render to source the phase's plans. Plan extraction is best-effort and non-fatal — failures warn but do not block trace collection.
+
 | Flag | Description |
 |------|-------------|
 | `--only PAIR…` | Scope to specific pair keys — narrows both workload and package (comma or space-separated, `wl-` prefix optional; takes precedence over `--workload`) |

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1101,12 +1101,144 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
                     if on_workload_done:
                         on_workload_done(phase, wl_name, namespace, wl_exc)
                 errors[phase] = RuntimeError("; ".join(phase_errors)) if phase_errors else None
+
+            # Pull resolved llm-d-benchmark plan YAMLs alongside trace data.
+            # Best-effort and non-fatal; multi-slot dedup via mtime skip.
+            try:
+                _extract_phase_plans(pod_name, run_name, phase, namespace, run_dir)
+            except Exception as exc:
+                warn(f"[{phase}/plans] extraction failed: {exc}")
     finally:
         run(["kubectl", "delete", "pod", pod_name, "-n", namespace,
              "--ignore-not-found", "--force", "--grace-period=0"],
             check=False, capture=True)
 
     return errors
+
+
+def _extract_phase_plans(pod_name: str, run_name: str, phase: str,
+                         namespace: str, run_dir: Path) -> None:
+    """Copy resolved llm-d-benchmark plan YAMLs for one phase from data-pvc.
+
+    PVC layout:
+      /data/{run_name}/plans/{phase}/{workload}/root-<ts>/plan/{flow}/*.yaml
+
+    Workload does not impact system config, so plans are phase-invariant
+    across workloads — pick one workload (lex-first) to source the phase's
+    plans. Multiple roots correspond to render passes (standup, smoketest,
+    teardown) and are expected to be byte-identical; pick the latest by
+    lex-sortable name (root-YYYYMMDD-HHMMSS-mmm).
+
+    Destination: <run_dir>/results/{phase}/plans/{flow}/*.yaml
+
+    Best-effort: errors are warned but never fatal — plan collection must
+    not block trace collection.
+
+    Multi-slot dedup: each namespace slot has its own data-pvc with its own
+    copy of plans. mtime-based skip means the first slot copies, and
+    subsequent slots see local files newer than remote and skip the cp.
+    """
+    plans_root = f"/data/{run_name}/plans/{phase}"
+
+    # Discover workloads under plans/{phase}/
+    ls_wl = run(
+        ["kubectl", "exec", pod_name, f"-n={namespace}", "--",
+         "sh", "-c", f"ls {plans_root} 2>/dev/null"],
+        check=False, capture=True,
+    )
+    if ls_wl.returncode != 0 or not ls_wl.stdout.strip():
+        info(f"[{phase}/plans] no plans directory on PVC — skipping")
+        return
+    workloads = sorted(ls_wl.stdout.strip().split())
+    if not workloads:
+        info(f"[{phase}/plans] no workloads under plans dir — skipping")
+        return
+    workload = workloads[0]
+    wl_path = f"{plans_root}/{workload}"
+
+    # Discover roots, pick latest by lex sort
+    ls_roots = run(
+        ["kubectl", "exec", pod_name, f"-n={namespace}", "--",
+         "sh", "-c", f"ls {wl_path} 2>/dev/null"],
+        check=False, capture=True,
+    )
+    if ls_roots.returncode != 0 or not ls_roots.stdout.strip():
+        warn(f"[{phase}/plans] no contents under {wl_path} — skipping")
+        return
+    roots = sorted(
+        r for r in ls_roots.stdout.strip().split() if r.startswith("root-")
+    )
+    if not roots:
+        warn(f"[{phase}/plans] no root-* dirs under {wl_path} — skipping")
+        return
+    latest_root = roots[-1]
+    plan_dir = f"{wl_path}/{latest_root}/plan"
+
+    # Discover flow dirs (skip the metadata 'setup' dir)
+    ls_flows = run(
+        ["kubectl", "exec", pod_name, f"-n={namespace}", "--",
+         "sh", "-c",
+         f"find {plan_dir} -mindepth 1 -maxdepth 1 -type d 2>/dev/null"],
+        check=False, capture=True,
+    )
+    if ls_flows.returncode != 0 or not ls_flows.stdout.strip():
+        warn(f"[{phase}/plans] no flow dirs under {plan_dir} — skipping")
+        return
+    flows = sorted(
+        Path(p.strip()).name
+        for p in ls_flows.stdout.strip().splitlines()
+        if p.strip() and Path(p.strip()).name != "setup"
+    )
+    if not flows:
+        warn(f"[{phase}/plans] no flow dirs (after filtering) — skipping")
+        return
+
+    dest_root = run_dir / "results" / phase / "plans"
+    for flow in flows:
+        remote_flow = f"{plan_dir}/{flow}"
+        stat_result = run(
+            ["kubectl", "exec", pod_name, f"-n={namespace}", "--",
+             "sh", "-c",
+             f"find {remote_flow} -mindepth 1 -maxdepth 1 -name '*.yaml' "
+             f"-exec stat -c '%Y %n' {{}} \\; 2>/dev/null"],
+            check=False, capture=True,
+        )
+        if stat_result.returncode != 0 or not stat_result.stdout.strip():
+            warn(f"[{phase}/plans/{flow}] no top-level YAMLs found — skipping")
+            continue
+        flow_dest = dest_root / flow
+        flow_dest.mkdir(parents=True, exist_ok=True)
+        copied = 0
+        skipped = 0
+        copy_errors: list[str] = []
+        for line in stat_result.stdout.strip().splitlines():
+            parts = line.split(None, 1)
+            if len(parts) != 2:
+                continue
+            try:
+                remote_mtime = float(parts[0])
+            except ValueError:
+                continue
+            remote_path = parts[1]
+            yaml_name = Path(remote_path).name
+            local_path = flow_dest / yaml_name
+            if _is_up_to_date(local_path, remote_mtime):
+                skipped += 1
+                continue
+            cp_result = run(
+                ["kubectl", "cp",
+                 f"{namespace}/{pod_name}:{remote_path}",
+                 str(local_path), "--retries=3"],
+                check=False, capture=True,
+            )
+            if cp_result.returncode != 0:
+                copy_errors.append(f"{yaml_name}: {cp_result.stderr.strip()}")
+            else:
+                copied += 1
+        if copy_errors:
+            warn(f"[{phase}/plans/{flow}] copy errors: {'; '.join(copy_errors)}")
+        if copied or skipped:
+            info(f"[{phase}/plans/{flow}] copied={copied} skipped={skipped}")
 
 
 def _cmd_collect(args, run_dir: Path, setup_config: dict):

--- a/pipeline/tests/test_deploy_collect_plans.py
+++ b/pipeline/tests/test_deploy_collect_plans.py
@@ -1,0 +1,234 @@
+"""Tests for _extract_phase_plans in deploy.py."""
+
+import subprocess
+from unittest.mock import patch
+
+from pipeline import deploy
+
+
+def _cp_result(rc=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess(args=[], returncode=rc, stdout=stdout, stderr=stderr)
+
+
+class _RunRouter:
+    """Pattern-route each `run()` call to a canned response.
+
+    Patterns are matched in order; first match wins. Each pattern is
+    `(matcher, result)` where matcher is a callable taking the cmd list and
+    returning bool. Records every call in `.calls` for assertions.
+    """
+
+    def __init__(self, patterns):
+        self.patterns = patterns
+        self.calls: list[list[str]] = []
+
+    def __call__(self, cmd, **kwargs):
+        self.calls.append(list(cmd))
+        for matcher, result in self.patterns:
+            if matcher(cmd):
+                return result
+        # Default: empty success — keeps tests resilient to incidental calls.
+        return _cp_result()
+
+
+def _is_ls(cmd, path):
+    """kubectl exec ... -- sh -c 'ls <path> 2>/dev/null' (exact path match)."""
+    if cmd[:2] != ["kubectl", "exec"]:
+        return False
+    shell = cmd[-1] if cmd[-2:-1] == ["-c"] else ""
+    return shell == f"ls {path} 2>/dev/null"
+
+
+def _is_find_dirs(cmd, path):
+    """kubectl exec ... -- sh -c 'find <path> -mindepth 1 -maxdepth 1 -type d ...'"""
+    if cmd[:2] != ["kubectl", "exec"]:
+        return False
+    shell = cmd[-1] if cmd[-2:-1] == ["-c"] else ""
+    return shell.startswith(f"find {path} ") and "-type d" in shell
+
+
+def _is_find_yaml_stat(cmd, path):
+    """kubectl exec ... -- sh -c 'find <path> ... -name *.yaml -exec stat ...'"""
+    if cmd[:2] != ["kubectl", "exec"]:
+        return False
+    shell = cmd[-1] if cmd[-2:-1] == ["-c"] else ""
+    return (
+        shell.startswith(f"find {path} ")
+        and "-name '*.yaml'" in shell
+        and "stat" in shell
+    )
+
+
+def _is_cp(cmd, remote_suffix):
+    """kubectl cp ... <namespace>/<pod>:<remote_path> <local> ..."""
+    if cmd[:2] != ["kubectl", "cp"]:
+        return False
+    return any(arg.endswith(remote_suffix) for arg in cmd)
+
+
+def test_happy_path_single_root_single_flow(tmp_path):
+    """Single root, single flow → yamls land under plans/{flow}/."""
+    run_name = "demo-run"
+    phase = "baseline"
+    plans_root = f"/data/{run_name}/plans/{phase}"
+    workload = "balanced_20"
+    wl_path = f"{plans_root}/{workload}"
+    root = "root-20260101-120000-000"
+    plan_dir = f"{wl_path}/{root}/plan"
+    flow = "flow-control-baseline"
+    flow_dir = f"{plan_dir}/{flow}"
+
+    run_dir = tmp_path / "workspace" / "runs" / run_name
+    run_dir.mkdir(parents=True)
+
+    router = _RunRouter([
+        (lambda c: _is_ls(c, plans_root), _cp_result(stdout=f"{workload}\n")),
+        (lambda c: _is_ls(c, wl_path), _cp_result(stdout=f"{root}\n")),
+        (lambda c: _is_find_dirs(c, plan_dir), _cp_result(stdout=f"{plan_dir}/{flow}\n")),
+        (lambda c: _is_find_yaml_stat(c, flow_dir),
+         _cp_result(stdout=(
+             f"100 {flow_dir}/01_pvc.yaml\n"
+             f"200 {flow_dir}/config.yaml\n"
+         ))),
+        (lambda c: _is_cp(c, "01_pvc.yaml"), _cp_result()),
+        (lambda c: _is_cp(c, "config.yaml"), _cp_result()),
+    ])
+
+    with patch.object(deploy, "run", router):
+        deploy._extract_phase_plans("pod-x", run_name, phase, "ns-0", run_dir)
+
+    dest = run_dir / "results" / phase / "plans" / flow
+    assert dest.is_dir()
+    cp_calls = [c for c in router.calls if c[:2] == ["kubectl", "cp"]]
+    assert len(cp_calls) == 2
+    assert any("01_pvc.yaml" in arg for c in cp_calls for arg in c)
+    assert any("config.yaml" in arg for c in cp_calls for arg in c)
+
+
+def test_picks_latest_root_by_lex_sort(tmp_path):
+    """When multiple roots exist, latest by lex sort is used."""
+    run_name = "demo-run"
+    phase = "baseline"
+    plans_root = f"/data/{run_name}/plans/{phase}"
+    workload = "balanced_20"
+    wl_path = f"{plans_root}/{workload}"
+    older = "root-20260101-120000-000"
+    newer = "root-20260101-130000-000"
+    plan_dir = f"{wl_path}/{newer}/plan"  # MUST be under newer
+    flow = "flow-control-baseline"
+    flow_dir = f"{plan_dir}/{flow}"
+
+    run_dir = tmp_path / "workspace" / "runs" / run_name
+    run_dir.mkdir(parents=True)
+
+    router = _RunRouter([
+        (lambda c: _is_ls(c, plans_root), _cp_result(stdout=f"{workload}\n")),
+        # ls returns roots out of order to confirm sort
+        (lambda c: _is_ls(c, wl_path), _cp_result(stdout=f"{newer}\n{older}\n")),
+        (lambda c: _is_find_dirs(c, plan_dir), _cp_result(stdout=f"{plan_dir}/{flow}\n")),
+        (lambda c: _is_find_yaml_stat(c, flow_dir),
+         _cp_result(stdout=f"100 {flow_dir}/config.yaml\n")),
+        (lambda c: _is_cp(c, "config.yaml"), _cp_result()),
+    ])
+
+    with patch.object(deploy, "run", router):
+        deploy._extract_phase_plans("pod-x", run_name, phase, "ns-0", run_dir)
+
+    # Confirm find/stat targeted the newer root, not the older
+    find_calls = [c for c in router.calls if _is_find_dirs(c, plan_dir)]
+    assert find_calls, "expected a find under newer root's plan dir"
+
+
+def test_skip_when_local_up_to_date(tmp_path):
+    """Local file with mtime >= remote → no kubectl cp invocation."""
+    run_name = "demo-run"
+    phase = "baseline"
+    plans_root = f"/data/{run_name}/plans/{phase}"
+    workload = "balanced_20"
+    wl_path = f"{plans_root}/{workload}"
+    root = "root-20260101-120000-000"
+    plan_dir = f"{wl_path}/{root}/plan"
+    flow = "flow-control-baseline"
+    flow_dir = f"{plan_dir}/{flow}"
+
+    run_dir = tmp_path / "workspace" / "runs" / run_name
+    flow_dest = run_dir / "results" / phase / "plans" / flow
+    flow_dest.mkdir(parents=True)
+    local_yaml = flow_dest / "config.yaml"
+    local_yaml.write_text("local")
+    # Force a known local mtime well in the future of the remote.
+    import os
+    os.utime(local_yaml, (5000, 5000))
+
+    router = _RunRouter([
+        (lambda c: _is_ls(c, plans_root), _cp_result(stdout=f"{workload}\n")),
+        (lambda c: _is_ls(c, wl_path), _cp_result(stdout=f"{root}\n")),
+        (lambda c: _is_find_dirs(c, plan_dir), _cp_result(stdout=f"{plan_dir}/{flow}\n")),
+        (lambda c: _is_find_yaml_stat(c, flow_dir),
+         _cp_result(stdout=f"100 {flow_dir}/config.yaml\n")),
+    ])
+
+    with patch.object(deploy, "run", router):
+        deploy._extract_phase_plans("pod-x", run_name, phase, "ns-0", run_dir)
+
+    cp_calls = [c for c in router.calls if c[:2] == ["kubectl", "cp"]]
+    assert cp_calls == [], f"expected no kubectl cp calls; got {cp_calls}"
+
+
+def test_missing_plans_dir_returns_gracefully(tmp_path):
+    """No plans/{phase}/ on PVC → return without error or cp call."""
+    run_name = "demo-run"
+    phase = "baseline"
+    plans_root = f"/data/{run_name}/plans/{phase}"
+
+    run_dir = tmp_path / "workspace" / "runs" / run_name
+    run_dir.mkdir(parents=True)
+
+    # ls returns rc=1 (missing dir) and empty stdout
+    router = _RunRouter([
+        (lambda c: _is_ls(c, plans_root), _cp_result(rc=1, stdout="", stderr="")),
+    ])
+
+    with patch.object(deploy, "run", router):
+        deploy._extract_phase_plans("pod-x", run_name, phase, "ns-0", run_dir)
+
+    # No copy attempted; plans dir not created locally
+    cp_calls = [c for c in router.calls if c[:2] == ["kubectl", "cp"]]
+    assert cp_calls == []
+    assert not (run_dir / "results" / phase / "plans").exists()
+
+
+def test_setup_dir_filtered_from_flows(tmp_path):
+    """A 'setup' subdir under plan/ is treated as metadata and not copied."""
+    run_name = "demo-run"
+    phase = "baseline"
+    plans_root = f"/data/{run_name}/plans/{phase}"
+    workload = "balanced_20"
+    wl_path = f"{plans_root}/{workload}"
+    root = "root-20260101-120000-000"
+    plan_dir = f"{wl_path}/{root}/plan"
+    flow = "flow-control-baseline"
+    flow_dir = f"{plan_dir}/{flow}"
+
+    run_dir = tmp_path / "workspace" / "runs" / run_name
+    run_dir.mkdir(parents=True)
+
+    router = _RunRouter([
+        (lambda c: _is_ls(c, plans_root), _cp_result(stdout=f"{workload}\n")),
+        (lambda c: _is_ls(c, wl_path), _cp_result(stdout=f"{root}\n")),
+        # find returns BOTH the flow dir AND a 'setup' dir
+        (lambda c: _is_find_dirs(c, plan_dir),
+         _cp_result(stdout=f"{plan_dir}/setup\n{plan_dir}/{flow}\n")),
+        (lambda c: _is_find_yaml_stat(c, flow_dir),
+         _cp_result(stdout=f"100 {flow_dir}/config.yaml\n")),
+        (lambda c: _is_cp(c, "config.yaml"), _cp_result()),
+    ])
+
+    with patch.object(deploy, "run", router):
+        deploy._extract_phase_plans("pod-x", run_name, phase, "ns-0", run_dir)
+
+    # Confirm we never tried to stat or copy under setup/
+    setup_stats = [c for c in router.calls if _is_find_yaml_stat(c, f"{plan_dir}/setup")]
+    assert setup_stats == [], "should not have stat'd files under plan/setup"
+    cp_calls = [c for c in router.calls if c[:2] == ["kubectl", "cp"]]
+    assert len(cp_calls) == 1


### PR DESCRIPTION
## Summary

- Pulls top-level `*.yaml` files from `/data/{run}/plans/{phase}/{wl}/root-<latest>/plan/{flow}/` on the data-pvc into `<run_dir>/results/{phase}/plans/{flow}/`, alongside the existing trace data.
- Plans are workload-invariant within a phase (workload doesn't impact system config), so collect picks one workload's latest `root-*` render per phase.
- Multi-slot dedup is automatic via the existing mtime-based up-to-date skip — first slot copies, subsequent slots see local files newer than remote and skip.
- Best-effort: plan extraction warns on failure but never blocks trace collection.

Closes #297.

## Reviewer attention

- **Scope discipline.** Only top-level `plan/{flow}/*.yaml` is pulled — explicitly NOT `plan/{flow}/helm/`, `plan/setup/`, `logs/`, `setup/commands/`, or `environment/` at the run-root level. The `setup` flow dir is filtered out as metadata. See `_extract_phase_plans` filtering logic.
- **Latest-root selection** uses lex sort on `root-YYYYMMDD-HHMMSS-mmm` filenames — relies on the timestamp portion being zero-padded fixed width.
- **BusyBox compatibility.** The shell commands inside `kubectl exec` use `find -mindepth -maxdepth -type d` and `stat -c '%Y %n'` — both supported by Alpine 3.19 / BusyBox 1.36 (matches the existing pattern at `_probe_remote_mtimes`). No `-printf` (GNU-only).
- **Non-fatal contract.** Wrapped in `try/except` at the call site so a plan-extraction error never propagates out of `_extract_phases_from_pvc`. Trace collection is unaffected.
- **Open question deferred** — the issue notes that the workload-invariance and root-invariance assumptions need wider validation (treatment vs baseline, retried runs, different specs). The 3-root sample inspected during issue triage was byte-identical, but if any divergence shows up in practice, follow-up to either pull all roots or warn on divergence.

## Test plan

- [x] `python -m pytest pipeline/ .claude/skills/sim2real-analyze/tests/ .claude/skills/sim2real-bootstrap/tests/ .claude/skills/sim2real-translate/tests/` — 969 passed, 2 xfailed
- [x] `ruff check pipeline/ .claude/skills/ --select F` — clean
- [x] New tests cover happy path (single root, single flow), latest-root selection across multiple roots, mtime-based skip when local is up to date, missing-plans-dir graceful return, and `setup` flow filtering
- [ ] Live cluster smoke: run `deploy.py collect` against a real run that has plans on the PVC and confirm `results/{phase}/plans/{flow}/*.yaml` appears with the expected manifests