### PR TITLE
fix: harden translate-phase completeness, add runtime band check, add reset

### DIFF
--- a/.claude/skills/sim2real-check/SKILL.md
+++ b/.claude/skills/sim2real-check/SKILL.md
@@ -57,6 +57,8 @@ For EVERY check, you MUST show:
 
 For numerical checks, always show a comparison table. For code/config checks, show the relevant snippets side by side.
 
+**Declared-vs-observed principle.** Every "declared X" check must be paired with an "observed X" check whenever X has a runtime expression. Static parity (config matches source) is necessary but not sufficient — wiring can be silently wrong (e.g., a CRD apiVersion that the cluster accepts but the running EPP commit does not watch) and the run will still produce plausible-looking artifacts. If the declared and observed sets disagree, FAIL.
+
 ## Reference Paths (resolved after Step 0)
 
 - **Simulation codebase** (`BLIS`): confirmed by user
@@ -234,6 +236,29 @@ Verify the generated Go plugin dispatches thresholds to the correct priority val
 Cross-check against `<sim>/README.md` transfer instructions.
 - Show: the Go switch/case block from the generated plugin, annotated with which tier gets which ramp. Show the GAIE priority definitions as proof. Highlight if the mapping is wrong.
 
+**4e. Priority Bands Registered at Runtime — declared-vs-observed check**
+
+This is the runtime-expression pair for 4d. The bug class it catches: the InferenceObjective CRDs in the generated config are valid YAML and the cluster accepts them, but the running EPP commit watches a *different* API group/version and silently ignores them. The flow controller falls back to a single default band at priority 0; the policy still runs but has only one queue to draw from, so it cannot discriminate between priority classes. The trace looks normal — no errors, all status=ok — but the experiment is invalid: any stratification the algorithm is designed to produce will be invisible.
+
+- **Declared (expected)**: parse all `InferenceObjective` blocks across `<real>/generated/baseline_config.yaml` and any treatment configs; collect each `spec.priority` value into the expected set.
+- **Observed (actual)**: pick any one workload's `epp_logs/*.log` under `<real>/results.*/<scenario>/<workload>/` and run:
+  ```
+  grep -hoE '"flowPriority":-?[0-9]+' <log> | sort -u
+  ```
+  The `flow-controller.sweepFinalizedItems` log line at `processor.go:452` emits one event per registered flow per sweep; its `flowPriority` field is the band's runtime priority value. Build the observed set from these.
+- **Verdict**:
+  - **PASS** if `observed ⊇ expected` (every declared band shows up at runtime).
+  - **FAIL** otherwise. The canonical failure mode is `expected = {100, -50, ...}` and `observed = {0}` — meaning the EPP saw no priorities and is operating on a single default band. **Halt the analysis here and report this first**: no downstream policy comparison (4a–4d, 5d) is meaningful while bands are unregistered.
+- **Show**:
+  ```
+  Declared (baseline_config.yaml InferenceObjective specs): {100, -50}
+  Observed (epp_logs/*.log flowPriority field):             {0}
+  Sample observed line:
+    {"caller":"internal/processor.go:452", "flowKey":"default-flow:0", "flowPriority":0, ...}
+  ```
+  Plus one citation per declared priority showing the file:line in `baseline_config.yaml` where it appears.
+- **Why it matters in plain English**: the EPP's flow controller maintains one queue per priority band. If only one band is registered, every request — regardless of its `slo_class` / `vllm_priority` field — lands in the same queue. There is nothing for the admission policy to prefer. Charts will show critical and sheddable accumulating proportionally, latency will look identical across `slo_class` values, and the experiment cannot validly compare baseline vs treatment. Most likely cause when this fires: an `apiVersion` in the generated YAML (e.g. `inference.networking.x-k8s.io/v1alpha2`) that the chosen component commit doesn't watch (it watches `llm-d.ai/v1alpha2`, or vice versa). Both groups may be installed in the cluster as valid CRDs, so this does not surface as a kubectl error — only as a missing runtime registration.
+
 ---
 
 ### 5. RUNTIME ANALYSIS
@@ -317,7 +342,7 @@ Expected 210 req/s (from workloads/w3.yaml:aggregate_rate), measured 210.4 req/s
 
 Use the Agent tool to parallelize independent checks:
 - Agent 1: Workload parity (trace_data.csv analysis via python3)
-- Agent 2: Config + Signal parity (YAML/Go file comparison)
+- Agent 2: Config + Signal + Policy parity (YAML/Go file comparison; includes 4e runtime band-registration grep against epp_logs)
 - Agent 3: Runtime analysis (server log parsing)
 
 Combine results into the final report.

--- a/.claude/skills/sim2real-check/SKILL.md
+++ b/.claude/skills/sim2real-check/SKILL.md
@@ -57,8 +57,6 @@ For EVERY check, you MUST show:
 
 For numerical checks, always show a comparison table. For code/config checks, show the relevant snippets side by side.
 
-**Declared-vs-observed principle.** Every "declared X" check must be paired with an "observed X" check whenever X has a runtime expression. Static parity (config matches source) is necessary but not sufficient — wiring can be silently wrong (e.g., a CRD apiVersion that the cluster accepts but the running EPP commit does not watch) and the run will still produce plausible-looking artifacts. If the declared and observed sets disagree, FAIL.
-
 ## Reference Paths (resolved after Step 0)
 
 - **Simulation codebase** (`BLIS`): confirmed by user
@@ -75,14 +73,18 @@ Run ALL checks below.
 
 ### 1. WORKLOAD PARITY
 
-For each workload in the real bundle, find the matching sim workload YAML in `<sim>/workloads/`.
+For each workload in the real bundle, find the matching workload YAML spec. **Lookup order:**
+1. First check `<real>/workloads/` — if the real bundle contains its own workload YAMLs, use those as the source of truth (they reflect any rate rescaling done during sim2real translation).
+2. If not found there, fall back to `<sim>/workloads/`.
+
+When both exist, note any differences (especially `aggregate_rate`) and use the **real bundle's workload YAML** as the expected value for parity checks.
 
 **1a. Arrival Rate (QPS)**
 - **Intended QPS**: compute from `trace_data.csv` `arrival_time_us` column: `num_requests / (max - min arrival)`. This is the rate the load generator *scheduled* requests at.
 - **Actual QPS**: compute from `trace_data.csv` `send_time_us` column: `num_requests / (max - min send_time)`. This is the rate requests were *actually sent* to the server. If actual QPS << intended QPS, the load generator hit a concurrency ceiling and requests queued client-side.
-- From sim: `aggregate_rate` in workload YAML
-- Tolerance: intended QPS within 5% of sim spec. If actual QPS is more than 5% below intended QPS, emit WARN — this means the load generator couldn't keep up with the schedule (likely concurrency ceiling or server backpressure), so the server saw less load than intended and results are not comparable to simulation.
-- Show: table with sim spec rate, intended QPS, actual QPS — all three columns so the reader can spot concurrency bottlenecks
+- From workload YAML: `aggregate_rate` (prefer `<real>/workloads/`, fall back to `<sim>/workloads/`)
+- Tolerance: intended QPS within 5% of spec. If actual QPS is more than 5% below intended QPS, emit WARN — this means the load generator couldn't keep up with the schedule (likely concurrency ceiling or server backpressure), so the server saw less load than intended and results are not comparable to simulation.
+- Show: table with spec rate (note source: real or sim YAML), intended QPS, actual QPS — all three columns so the reader can spot concurrency bottlenecks
 
 **1b. SLO Class Distribution**
 - From sim: each client's `rate_fraction`
@@ -143,6 +145,38 @@ Show: table with each config param — expected (from config.md), actual (from s
 - From sim: `--num-instances` in run commands or config.md
 - From real: count distinct server log files in `server_logs/`
 - Show: expected count vs actual count
+
+**2c. Variant Isolation — CRITICAL CHECK**
+
+The real bundle may contain multiple experiment variants (e.g., `baseline/`, `treatment/` or `quartic/`, `control/`). This check verifies that the variants are **identical in all respects except the flow control policy** — ensuring a clean A/B comparison.
+
+**Locate configs:** Find all EndpointPickerConfig YAMLs in `<real>/generated/` (e.g., `baseline_config.yaml`, `<treatment>/treatment_config.yaml`, `<control>/control_config.yaml`).
+
+**For each pair of configs, diff the following sections and classify:**
+
+| Section | Must be IDENTICAL across all variants | Expected to DIFFER |
+|---------|--------------------------------------|-------------------|
+| `featureGates` | Yes | — |
+| `plugins` (list of plugin types) | Mostly — see below | Only the flow control policy plugin entry |
+| `schedulingProfiles` (scorers, weights, picker) | Yes | — |
+| `flowControl` | — | Yes — this is the independent variable |
+| `extraObjects` (InferenceObjective CRDs) | Yes (priority bands) | — |
+| Instance count (from server_logs) | Yes | — |
+| vLLM config (from server logs) | Yes | — |
+
+**Specifically verify:**
+1. **Routing is identical**: same scorer plugins, same weights, same picker in all variants.
+2. **Priority bands are identical**: same InferenceObjective CRDs (or same priority values) applied to all variants.
+3. **Feature gates are identical**: all variants enable/disable the same gates.
+4. **The ONLY difference is the `flowControl` section**: baseline has `flowControl: {}` (built-in default ceiling 1.0), treatment references a custom policy plugin, control references a plugin that implements the same behavior as baseline (ceiling 1.0) but through the custom plugin registration path.
+
+**Why control exists**: Control uses the same plugin registration mechanism as treatment but with baseline-equivalent logic. Comparing baseline vs control isolates plugin framework overhead. Comparing control vs treatment isolates the algorithm effect.
+
+**Show:**
+- Side-by-side diff of all config YAMLs (redacting identical sections, highlighting differences)
+- Table: for each config section, state whether it matches across variants
+- The generated Go code for each variant's policy plugin — confirm control returns constant 1.0 and treatment implements the sim algorithm
+- Verdict: PASS if only flow control policy differs, FAIL if routing/scheduling/priority/feature-gates diverge
 
 ---
 
@@ -236,29 +270,6 @@ Verify the generated Go plugin dispatches thresholds to the correct priority val
 Cross-check against `<sim>/README.md` transfer instructions.
 - Show: the Go switch/case block from the generated plugin, annotated with which tier gets which ramp. Show the GAIE priority definitions as proof. Highlight if the mapping is wrong.
 
-**4e. Priority Bands Registered at Runtime — declared-vs-observed check**
-
-This is the runtime-expression pair for 4d. The bug class it catches: the InferenceObjective CRDs in the generated config are valid YAML and the cluster accepts them, but the running EPP commit watches a *different* API group/version and silently ignores them. The flow controller falls back to a single default band at priority 0; the policy still runs but has only one queue to draw from, so it cannot discriminate between priority classes. The trace looks normal — no errors, all status=ok — but the experiment is invalid: any stratification the algorithm is designed to produce will be invisible.
-
-- **Declared (expected)**: parse all `InferenceObjective` blocks across `<real>/generated/baseline_config.yaml` and any treatment configs; collect each `spec.priority` value into the expected set.
-- **Observed (actual)**: pick any one workload's `epp_logs/*.log` under `<real>/results.*/<scenario>/<workload>/` and run:
-  ```
-  grep -hoE '"flowPriority":-?[0-9]+' <log> | sort -u
-  ```
-  The `flow-controller.sweepFinalizedItems` log line at `processor.go:452` emits one event per registered flow per sweep; its `flowPriority` field is the band's runtime priority value. Build the observed set from these.
-- **Verdict**:
-  - **PASS** if `observed ⊇ expected` (every declared band shows up at runtime).
-  - **FAIL** otherwise. The canonical failure mode is `expected = {100, -50, ...}` and `observed = {0}` — meaning the EPP saw no priorities and is operating on a single default band. **Halt the analysis here and report this first**: no downstream policy comparison (4a–4d, 5d) is meaningful while bands are unregistered.
-- **Show**:
-  ```
-  Declared (baseline_config.yaml InferenceObjective specs): {100, -50}
-  Observed (epp_logs/*.log flowPriority field):             {0}
-  Sample observed line:
-    {"caller":"internal/processor.go:452", "flowKey":"default-flow:0", "flowPriority":0, ...}
-  ```
-  Plus one citation per declared priority showing the file:line in `baseline_config.yaml` where it appears.
-- **Why it matters in plain English**: the EPP's flow controller maintains one queue per priority band. If only one band is registered, every request — regardless of its `slo_class` / `vllm_priority` field — lands in the same queue. There is nothing for the admission policy to prefer. Charts will show critical and sheddable accumulating proportionally, latency will look identical across `slo_class` values, and the experiment cannot validly compare baseline vs treatment. Most likely cause when this fires: an `apiVersion` in the generated YAML (e.g. `inference.networking.x-k8s.io/v1alpha2`) that the chosen component commit doesn't watch (it watches `llm-d.ai/v1alpha2`, or vice versa). Both groups may be installed in the cluster as valid CRDs, so this does not surface as a kubectl error — only as a missing runtime registration.
-
 ---
 
 ### 5. RUNTIME ANALYSIS
@@ -273,27 +284,53 @@ Extract: model, TP size, max_model_len, gpu_memory_utilization, enable_prefix_ca
 **5b. Instance Health & Request Distribution**
 - Count `/completions` requests per instance by grepping each server log file in `server_logs/` for `/completions` (or `/chat/completions` if chat API). This is the authoritative per-instance request count — `trace_data.csv` does not have an instance identifier column.
 - Compute total served requests (sum across instances), per-instance percentage, and spread (max-min as % of average).
-- Check for even distribution (for random/round-robin routing): no instance should get <10% or >40% of total (for 4 instances, expect ~25% each). Spread should be < 10%.
 - Compare total served vs total sent (from trace_data.csv row count) — the difference is requests shed by admission before reaching any instance.
 - Flag any instance that appears unhealthy (no requests, errors in logs)
-- Show: table with instance name, `/completions` request count, percentage of total served, and a summary row with total served vs total sent and spread %
 
-**5c. Prefix Hit Ratio**
+**Distribution expectation depends on routing policy:**
+- **Even-distribution routers** (`random-picker`, `round-robin`, or load-aware scorers like `queue-scorer` + `kv-cache-utilization-scorer`): expect roughly uniform distribution. Each instance should get approximately `100%/N` of requests. Spread (max−min as % of average) should be < 20%. WARN if > 20%, FAIL if > 40%.
+- **Affinity routers** (`prefix-cache-affinity`, `session-affinity`, `lora-affinity`): expect skewed distribution aligned with the affinity key. Verify that the skew correlates with the affinity signal (e.g., prefix groups cluster on specific instances) rather than random hot-spotting.
+- **Custom/experimental routers**: infer the expected distribution from the routing policy description in `<sim>/README.md` or config, and check whether the real distribution matches. Document the expectation and rationale.
+
+**Run this check for ALL variants** (baseline, treatment, control) × ALL workloads. The distribution should be consistent across variants — if routing config is identical (verified in 2c), the distribution pattern should be similar. Flag any variant that shows significantly different distribution from others at the same workload (this would indicate a deployment issue, not an algorithm effect).
+
+- Show: table with variant/workload, per-instance request count and percentage, total served, spread %, and verdict. One row per variant×workload combination.
+
+**5c. EPP Runtime Proof — Treatment Active**
+
+Verify from EPP logs (`epp_logs/`) that the configured policy is actually executing at runtime. This is the proof that config translation resulted in correct runtime behavior — not just correct YAML.
+
+**For each variant, check:**
+1. **Flow control is active**: grep EPP logs for flow controller messages (e.g., `flow-controller`, `FlowControlAdmissionController`, `enqueued`, `dispatched`). If absent, the feature gate may not have activated despite being in config.
+2. **Priority bands recognized**: grep for priority values in request processing logs. Confirm both configured priorities appear (e.g., priority:100 and priority:-50 for critical/sheddable). If only one priority appears, the InferenceObjective CRDs may not have been applied.
+3. **Policy-specific behavior**: 
+   - For treatment (e.g., quartic): at high saturation, expect some requests to show gating/queueing delays or shed outcomes. At low saturation, all requests dispatched immediately (dormant behavior is valid).
+   - For baseline/control: all requests should be dispatched (ceiling=1.0 means no gating).
+4. **Pod discovery**: confirm the EPP sees all expected pods (extract unique PodNames from scheduling logs). Count should match instance count from 2b.
+5. **Hardware parity**: extract `CacheNumBlocks` and `CacheBlockSize` from EPP endpoint data — must be identical across variants (confirms same GPU memory allocation / model config).
+
+**Cross-variant deployment check:**
+- Note whether variants share the same physical deployment (same pod-template-hash) or use separate deployments. If separate, confirm identical hardware config (CacheNumBlocks, CacheBlockSize, GPU type).
+- Flag if variants run in different namespaces — not a problem per se, but document it as it means separate clusters or separate resource quotas.
+
+- Show: table per variant with: flow control active (yes/no), priorities seen, dispatch outcomes (Dispatched/Shed/Timeout counts), pod count, CacheNumBlocks, deployment hash, namespace.
+
+**5d. Prefix Hit Ratio**
 If `enable_prefix_caching=True`, grep server logs for prefix cache hit metrics.
 If `enable_prefix_caching=False`, confirm no unexpected prefix hits.
 - Show: prefix caching status and any hit/miss metrics found
 
-**5d. Request Status**
+**5e. Request Status**
 - Baseline: expect nearly 100% `status=ok` (no admission shedding)
 - Treatment: check `status` column for rejection patterns. Compute shed rate per SLO class.
 - Verify shed behavior matches algorithm expectations (sheddable shed most, batch shed less, critical/standard never shed)
 - Show: table with SLO class, total requests, ok count, shed count, shed rate %
 
-**5e. Error Analysis**
+**5f. Error Analysis**
 Grep server logs for `ERROR`, `WARNING`, `OOM`, `CUDA`, `timeout` patterns.
 - Show: count of each pattern per log file, and any particularly concerning lines
 
-**5f. KV Cache Utilization**
+**5g. KV Cache Utilization**
 From server logs, look for KV cache size info:
 - `GPU KV cache size: N tokens`
 - `Maximum concurrency for X tokens per request: Y.Zx`
@@ -316,6 +353,7 @@ Structure the report as follows. Every section must have evidence tables/snippet
 |----------|------|------|------|
 | Workload | X | Y | Z |
 | Config   | X | Y | Z |
+| Variant Isolation | X | Y | Z |
 | Signal   | X | Y | Z |
 | Policy   | X | Y | Z |
 | Runtime  | X | Y | Z |
@@ -342,7 +380,7 @@ Expected 210 req/s (from workloads/w3.yaml:aggregate_rate), measured 210.4 req/s
 
 Use the Agent tool to parallelize independent checks:
 - Agent 1: Workload parity (trace_data.csv analysis via python3)
-- Agent 2: Config + Signal + Policy parity (YAML/Go file comparison; includes 4e runtime band-registration grep against epp_logs)
+- Agent 2: Config + Signal parity (YAML/Go file comparison)
 - Agent 3: Runtime analysis (server log parsing)
 
 Combine results into the final report.

--- a/.claude/skills/sim2real-translate/SKILL.md
+++ b/.claude/skills/sim2real-translate/SKILL.md
@@ -486,15 +486,25 @@ python3 -c "print(open('$RUN_DIR/generated/$CURRENT_ALGORITHM/${CURRENT_ALGORITH
 
 Print to user:
 ```
-━━━ Review Passed ━━━
+━━━ Review Passed — ACTION REQUIRED ━━━
 Treatment Config: <contents above>
 Plugin files: <list above>
 
-Provide feedback for another round, or type 'done' to finish.
+⚠ This arm is INCOMPLETE until you reply. Source files have NOT yet been
+  written to generated/<algo>/. Choose one:
+
+  • Reply `done`            → finalize: copy source overlay to generated/<algo>/
+                              and let prepare.py advance to the next algorithm
+  • Reply `feedback: <text>` → iterate one more review round with the feedback
+
+Without a reply, the writer agent will wait indefinitely and the run will
+not progress.
 ```
 
-If feedback: `SendMessage("writer", "feedback: <text>")`
-If "done": `SendMessage("writer", "done")`
+If reply is exactly "done": `SendMessage("writer", "done")`
+If reply starts with "feedback:": `SendMessage("writer", "feedback: <text>")`
+Otherwise: re-print the prompt and wait — do NOT silently treat ambiguous
+input as either branch.
 
 **On "done: ...":**
 

--- a/pipeline/prepare.py
+++ b/pipeline/prepare.py
@@ -14,6 +14,7 @@ Re-running skips completed phases (tracked in .state.json).
 
 import argparse
 import json
+import shutil
 import subprocess
 import sys
 import yaml
@@ -274,6 +275,44 @@ def _phase_context(args, state: StateMachine, manifest: dict, run_dir: Path) -> 
 
 # ── Phase 3: Translation Checkpoint ──────────────────────────────────────────
 
+def _arm_overlay_complete(algo_dir: Path, algo_name: str) -> tuple[bool, str | None]:
+    """Check whether an algorithm's overlay is structurally complete.
+
+    An arm is complete iff `<algo>_output.json` exists, parses as JSON, and
+    every path listed in its `files_created` + `files_modified` arrays exists
+    on disk under `algo_dir`.
+
+    Existence of `<algo>_output.json` alone is not sufficient: the writer
+    agent authors that file before the post-review approval gate, so a half-
+    finished run can leave the JSON behind without the source overlay. See
+    the translate skill's Step 6 (`copy_generated`) — that is the only step
+    that materializes the source overlay, and it only runs after the operator
+    explicitly approves the arm.
+
+    Returns (True, None) when complete, otherwise (False, reason).
+    """
+    algo_output = algo_dir / f"{algo_name}_output.json"
+    if not algo_output.exists():
+        return False, f"{algo_name}_output.json not found"
+    try:
+        o = json.loads(algo_output.read_text())
+    except json.JSONDecodeError as e:
+        return False, f"{algo_name}_output.json is not valid JSON: {e}"
+    expected = list(o.get("files_created", [])) + list(o.get("files_modified", []))
+    missing = [f for f in expected if not (algo_dir / f).exists()]
+    if missing:
+        sample = missing[0]
+        more = f" (and {len(missing) - 1} more)" if len(missing) > 1 else ""
+        return False, (
+            f"overlay incomplete: {len(missing)}/{len(expected)} files listed in "
+            f"{algo_name}_output.json are missing under generated/{algo_name}/ "
+            f"(e.g. {sample}{more}). The /sim2real-translate run for this arm "
+            f"likely never reached Step 6 — re-run the skill and reply 'done' "
+            f"at the post-review prompt to finalize."
+        )
+    return True, None
+
+
 def _phase_translate(args, state: StateMachine, manifest: dict, run_dir: Path,
                      resolved: dict, context_path: Path):
     """Phase 3: Per-algorithm translation checkpoint.
@@ -310,15 +349,24 @@ def _phase_translate(args, state: StateMachine, manifest: dict, run_dir: Path,
             sys.exit(1)
 
         if "per_algorithm" in output:
-            # Per-algorithm index format — check completeness
-            all_present = all(
-                (generated_dir / a["name"] / f"{a['name']}_output.json").exists()
-                for a in algorithms
-            )
-            if all_present:
+            # Per-algorithm index format — check structural completeness of
+            # every arm's overlay, not just existence of <algo>_output.json.
+            incomplete = []
+            for a in algorithms:
+                ok_arm, reason = _arm_overlay_complete(
+                    generated_dir / a["name"], a["name"]
+                )
+                if not ok_arm:
+                    incomplete.append((a["name"], reason))
+            if not incomplete:
                 state.mark_done("translate", algorithms=[a["name"] for a in algorithms])
                 ok(f"All {len(algorithms)} algorithms translated")
                 return
+            for name, reason in incomplete:
+                warn(f"[{name}] {reason}")
+            err(f"{len(incomplete)} of {len(algorithms)} algorithm overlay(s) "
+                f"incomplete. Refusing to mark translate phase done.")
+            sys.exit(1)
         elif "plugin_type" in output:
             # Legacy single-algo format — validate and mark done
             for f in ["plugin_type", "files_created", "files_modified",
@@ -343,14 +391,21 @@ def _phase_translate(args, state: StateMachine, manifest: dict, run_dir: Path,
                 "Delete the file and re-run the /sim2real-translate skill.")
             sys.exit(1)
 
-    # Determine which algorithms still need translation
+    # Determine which algorithms still need translation. An arm only counts
+    # as translated when its overlay is structurally complete — the existence
+    # of <algo>_output.json alone is not sufficient (see _arm_overlay_complete).
     translated = []
     pending = []
     for algo in algorithms:
-        algo_output = generated_dir / algo["name"] / f"{algo['name']}_output.json"
-        if algo_output.exists():
+        algo_dir = generated_dir / algo["name"]
+        ok_arm, reason = _arm_overlay_complete(algo_dir, algo["name"])
+        if ok_arm:
             translated.append(algo)
         else:
+            if (algo_dir / f"{algo['name']}_output.json").exists():
+                # The arm has metadata but is structurally incomplete — surface
+                # this to the operator before silently re-targeting it.
+                warn(f"[{algo['name']}] {reason}")
             pending.append(algo)
 
     if not pending:
@@ -1010,6 +1065,139 @@ def _cmd_validate_assembly(args, manifest, run_dir):
     _validate_assembly(run_dir, resolved, algorithm_packages=algo_names or None)
 
 
+def _cmd_reset(args, manifest, run_dir: Path):
+    """Reset one or more algorithm arms.
+
+    Removes the named arm's translate output and any downstream artifacts that
+    were derived from it, so prepare.py will re-target the arm on the next
+    invocation. Default behavior preserves the arm's `<algo>_config.yaml`
+    (the approved treatment derivation); pass `--full` to wipe that too and
+    force a fresh treatment-derivation pass.
+
+    Removes:
+      - generated/<algo>/<algo>_output.json
+      - generated/<algo>/{cmd,pkg}/  (any partial overlay)
+      - generated/<algo>/<algo>_config.yaml          [only with --full]
+      - translation_output.json
+      - cluster/                       (assembly output)
+      - run_summary.md                 (summary output)
+
+    Resets state phases: translate, assembly, summary, gate
+    Plus treatment_derivation when --full is set.
+    """
+    if not run_dir.exists():
+        err(f"run directory does not exist: {run_dir}")
+        sys.exit(1)
+
+    declared = {a["name"] for a in manifest.get("algorithms", [])}
+    targets: list[str] = list(args.algos)
+    unknown = [a for a in targets if a not in declared]
+    if unknown:
+        err(f"unknown algorithm(s): {', '.join(unknown)}. "
+            f"Manifest declares: {', '.join(sorted(declared)) or '(none)'}")
+        sys.exit(1)
+
+    generated_dir = run_dir / "generated"
+    plan: list[tuple[str, Path]] = []   # (action, path)
+
+    for algo in targets:
+        algo_dir = generated_dir / algo
+        if not algo_dir.exists():
+            warn(f"[{algo}] generated/{algo}/ does not exist — nothing to reset")
+            continue
+        out_json = algo_dir / f"{algo}_output.json"
+        cfg_yaml = algo_dir / f"{algo}_config.yaml"
+        if out_json.exists():
+            plan.append(("rm-file", out_json))
+        for sub in ("cmd", "pkg"):
+            d = algo_dir / sub
+            if d.exists():
+                plan.append(("rm-tree", d))
+        if args.full and cfg_yaml.exists():
+            plan.append(("rm-file", cfg_yaml))
+
+    for shared in ("translation_output.json", "run_summary.md"):
+        p = run_dir / shared
+        if p.exists():
+            plan.append(("rm-file", p))
+    cluster_dir = run_dir / "cluster"
+    if cluster_dir.exists():
+        plan.append(("rm-tree", cluster_dir))
+
+    phases_to_reset = ["translate", "assembly", "summary", "gate"]
+    if args.full:
+        phases_to_reset.append("treatment_derivation")
+
+    print(f"\nReset plan for run: {run_dir}")
+    print(f"  algorithms: {', '.join(targets)}{' (--full)' if args.full else ''}")
+    if plan:
+        for action, path in plan:
+            try:
+                rel = path.relative_to(run_dir)
+                disp = str(rel)
+            except ValueError:
+                disp = str(path)
+            verb = "delete file" if action == "rm-file" else "delete tree"
+            print(f"  {verb:13s} {disp}")
+    else:
+        print("  (no files to delete)")
+    print(f"  state reset:  phases {', '.join(phases_to_reset)}\n")
+
+    if args.dry_run:
+        ok("dry-run complete — no changes made")
+        return
+
+    if not args.yes:
+        try:
+            ans = input("Proceed? [y/N] ").strip().lower()
+        except EOFError:
+            ans = ""
+        if ans not in ("y", "yes"):
+            err("aborted")
+            sys.exit(1)
+
+    for action, path in plan:
+        if action == "rm-file":
+            path.unlink()
+        elif action == "rm-tree":
+            shutil.rmtree(path)
+
+    # Clean up now-empty per-arm dirs.
+    for algo in targets:
+        algo_dir = generated_dir / algo
+        if algo_dir.exists() and not any(algo_dir.iterdir()):
+            algo_dir.rmdir()
+
+    try:
+        state = StateMachine.load(run_dir)
+        for phase in phases_to_reset:
+            state.reset(phase)
+        ok(f"state phases cleared: {', '.join(phases_to_reset)}")
+    except FileNotFoundError:
+        warn("no .state.json found — skipping state rollback")
+
+    ok("reset complete.")
+    info("Note: this command does not touch the target submodule (e.g. llm-d-router).")
+    info("If its working tree contains leftovers from a prior run, reset it manually:")
+    info("  git -C <submodule> reset --hard HEAD && git -C <submodule> clean -fd")
+
+    if args.no_retarget:
+        info(f"Re-target skipped (--no-retarget). Run prepare.py to re-target {', '.join(targets)}.")
+        return
+
+    # Re-run the init → context → translate prefix so the user can immediately
+    # invoke /sim2real-translate without an intermediate `prepare.py` call.
+    # init and context are idempotent when already done; _phase_translate will
+    # write a fresh skill_input.json targeting the first pending arm and exit
+    # with the standard translation-checkpoint output.
+    print()
+    info("Re-targeting translate checkpoint...")
+    state = _phase_init(args, manifest, run_dir)
+    resolved = _load_resolved_config(manifest)
+    context_path = _phase_context(args, state, manifest, run_dir)
+    _phase_translate(args, state, manifest, run_dir, resolved, context_path)
+
+
 def _cmd_status(run_dir):
     """Print current state."""
     try:
@@ -1056,6 +1244,33 @@ def build_parser() -> argparse.ArgumentParser:
     sub.add_parser("validate-assembly", help="Validate assembly consistency (standalone)")
     sub.add_parser("status", help="Show current run state")
 
+    reset = sub.add_parser(
+        "reset",
+        help="Reset one or more algorithm arms (undo translate + downstream)",
+    )
+    reset.add_argument(
+        "algos", nargs="+", metavar="ALGO",
+        help="Algorithm name(s) to reset (must appear in transfer.yaml).",
+    )
+    reset.add_argument(
+        "--full", action="store_true",
+        help="Also remove <algo>_config.yaml and reset treatment_derivation",
+    )
+    reset.add_argument(
+        "--dry-run", action="store_true", dest="dry_run",
+        help="Print the plan without making any changes",
+    )
+    reset.add_argument(
+        "--yes", "-y", action="store_true",
+        help="Skip the interactive confirmation prompt",
+    )
+    reset.add_argument(
+        "--no-retarget", action="store_true", dest="no_retarget",
+        help="Skip the re-run of init/context/translate-checkpoint after cleanup. "
+             "By default `reset` rewrites skill_input.json so /sim2real-translate "
+             "can be invoked immediately.",
+    )
+
     return p
 
 
@@ -1086,6 +1301,8 @@ def main():
         _cmd_assemble(args, manifest, run_dir)
     elif cmd == "validate-assembly":
         _cmd_validate_assembly(args, manifest, run_dir)
+    elif cmd == "reset":
+        _cmd_reset(args, manifest, run_dir)
     else:
         _cmd_run(args, manifest, run_dir)
 


### PR DESCRIPTION
## Summary

Three related changes addressing silent-failure modes in the translate phase, plus the adoption of a teammate's broader `sim2real-check` revisions.

- **`sim2real-check` (#300)** — Initially added a narrow 4e priority-band check. After review, replaced with Mert's broader revisions that cover the same bug class plus more: workload YAML lookup precedence (real over sim), new 2c Variant Isolation (diff baseline/treatment/control configs to confirm only `flowControl` differs), router-aware distribution expectation in 5b, new 5c EPP Runtime Proof (flow control liveness, priority recognition, pod discovery, hardware parity). Bumps the `tektonc-data-collection` submodule to `ac359b7` (PR #28) for `llm-d.ai` RBAC.
- **`sim2real-translate` prompt (#301)** — Post-review prompt now says "ACTION REQUIRED", explicitly tells the operator the arm is incomplete until they reply, and requires `done` (exact) or `feedback: <text>` (prefix) — anything else re-prints. Prevents abandoned runs that leave `<algo>_output.json` on disk without source overlay.
- **`prepare.py` (#302)** — Stricter `_arm_overlay_complete` check (every file in `files_created` + `files_modified` must exist on disk, not just the JSON). New `prepare.py reset <algo>...` subcommand wipes a half-finished arm and re-targets the translate checkpoint, with `--full` / `--dry-run` / `--yes` / `--no-retarget` flags.

Closes #300
Closes #301
Closes #302

## Commit history

This branch contains a small back-and-forth on the `sim2real-check` change (commit 1 added a narrow 4e check; commit 4 swapped it for Mert's broader sweep). Net effect is described above.

## Test plan

- [x] `ruff check pipeline/ .claude/skills/ --select F` — passes
- [x] `pytest pipeline/ .claude/skills/sim2real-{analyze,bootstrap,translate}/tests/` — 969 passed
- [ ] Smoke: trigger the half-finished translate state (Ctrl-C before replying `done`), re-run `prepare.py`, confirm it surfaces the incomplete arm and refuses to advance
- [ ] Smoke: `prepare.py reset <algo> --dry-run` then real run, confirm artifacts removed and translate checkpoint re-armed
- [ ] Smoke: run `sim2real-check` against a run with a known apiVersion mismatch, confirm Mert's 5c #2 surfaces the missing band