### PR TITLE
feat: wire stream-epp-logs into pipeline.yaml

### DIFF
--- a/pipeline/pipeline.yaml
+++ b/pipeline/pipeline.yaml
@@ -82,6 +82,19 @@ spec:
         - name: smoketest_delay
           value: "30"
 
+    - name: stream-epp-logs
+      runAfter: ["llmdbenchmark-standup"]
+      taskRef:
+        name: stream-epp-logs
+      workspaces:
+        - name: data
+          workspace: data-storage
+      params:
+        - name: namespace
+          value: "$(params.namespace)"
+        - name: resultsDir
+          value: "$(params.runName)/$(params.phase)/$(params.workloadName)"
+
     - name: run-workload-blis-observe-binary
       runAfter: ["llmdbenchmark-standup", "install-blis"]
       taskRef:

--- a/pipeline/tests/test_pipeline_yaml.py
+++ b/pipeline/tests/test_pipeline_yaml.py
@@ -32,3 +32,61 @@ class TestCollectResultsParams:
         task = self._get_collect_results_task()
         param_names = [p["name"] for p in task["params"]]
         assert "resultsDir" in param_names
+
+
+class TestStreamEppLogsTask:
+    """stream-epp-logs task invocation in pipeline.yaml."""
+
+    def _get_stream_epp_logs_task(self):
+        pipeline = yaml.safe_load(PIPELINE_YAML.read_text())
+        tasks = pipeline["spec"]["tasks"]
+        s = [t for t in tasks if t["name"] == "stream-epp-logs"]
+        assert len(s) == 1, "Expected exactly one stream-epp-logs task"
+        return s[0]
+
+    def test_task_present(self):
+        """stream-epp-logs must be wired into the pipeline."""
+        self._get_stream_epp_logs_task()
+
+    def test_task_ref(self):
+        """taskRef points at the stream-epp-logs Task resource."""
+        task = self._get_stream_epp_logs_task()
+        assert task["taskRef"]["name"] == "stream-epp-logs"
+
+    def test_runs_after_standup(self):
+        """Streamer starts as soon as the model stack is up — in parallel with the workload."""
+        task = self._get_stream_epp_logs_task()
+        assert task["runAfter"] == ["llmdbenchmark-standup"], (
+            "Streamer must start after standup (when EPP pods exist) and "
+            "in parallel with the workload, not after it."
+        )
+
+    def test_data_workspace_bound(self):
+        """data workspace must be bound to data-storage so logs land on the shared PVC."""
+        task = self._get_stream_epp_logs_task()
+        ws = {w["name"]: w["workspace"] for w in task["workspaces"]}
+        assert ws.get("data") == "data-storage"
+
+    def test_has_namespace_param(self):
+        """stream-epp-logs must receive the namespace param."""
+        task = self._get_stream_epp_logs_task()
+        param_names = [p["name"] for p in task["params"]]
+        assert "namespace" in param_names
+
+    def test_has_results_dir_param(self):
+        """stream-epp-logs must receive the resultsDir param so its output sits next to the workload's."""
+        task = self._get_stream_epp_logs_task()
+        param_names = [p["name"] for p in task["params"]]
+        assert "resultsDir" in param_names
+
+    def test_results_dir_matches_workload(self):
+        """The streamer's resultsDir must be identical to the workload's, so they write into the same per-workload subdir."""
+        pipeline = yaml.safe_load(PIPELINE_YAML.read_text())
+        tasks = pipeline["spec"]["tasks"]
+
+        s = next(t for t in tasks if t["name"] == "stream-epp-logs")
+        w = next(t for t in tasks if t["name"] == "run-workload-blis-observe-binary")
+
+        s_rd = next(p["value"] for p in s["params"] if p["name"] == "resultsDir")
+        w_rd = next(p["value"] for p in w["params"] if p["name"] == "resultsDir")
+        assert s_rd == w_rd, f"resultsDir mismatch: streamer={s_rd!r} workload={w_rd!r}"


### PR DESCRIPTION
Closes #308.

## Summary

Wires the restored `stream-epp-logs` Tekton Task into `pipeline/pipeline.yaml` so the cluster actually invokes it during runs. Without this, the Task is registered with the cluster (via #309's submodule bump) but no Pipeline node references it, so EPP logs continue to be lost to kubelet rotation.

The new task entry:

```yaml
- name: stream-epp-logs
  runAfter: ["llmdbenchmark-standup"]
  taskRef:
    name: stream-epp-logs
  workspaces:
    - name: data
      workspace: data-storage
  params:
    - name: namespace
      value: "$(params.namespace)"
    - name: resultsDir
      value: "$(params.runName)/$(params.phase)/$(params.workloadName)"
```

`runAfter: ["llmdbenchmark-standup"]` (without `install-blis`) lets the streamer start as soon as the EPP pods exist — in parallel with `install-blis` and `run-workload-blis-observe-binary`. The streamer exits when `collect-results` writes `${resultsDir}/epp_stream_done` (the sentinel handshake landed in [`inference-sim/tektonc-data-collection#31`](https://github.com/inference-sim/tektonc-data-collection/pull/32)).

`resultsDir` is the same expression the workload and `collect-results` use, so the streamer writes into the same per-workload subdirectory on `data-pvc` (`$(runName)/$(phase)/$(workloadName)/epp_logs/`). This is asserted by the new `test_results_dir_matches_workload` test.

## Files

- **Modified:** `pipeline/pipeline.yaml` (+12 lines, single new task entry; nothing else touched)
- **Modified:** `pipeline/tests/test_pipeline_yaml.py` (+59 lines, new `TestStreamEppLogsTask` class with 7 tests, mirroring the existing `TestCollectResultsParams` pattern)

## Verification

- [x] `pytest pipeline/ .claude/skills/sim2real-{analyze,bootstrap,translate}/tests/ -v` — 976 passed, 2 xfailed (was 969 + 2 before; +7 new tests)
- [x] `ruff check pipeline/ --select F` — clean
- [x] Diff is purely additive; `collect-results` block unchanged
- [ ] Cluster-runtime acceptance (streamer starts after standup, runs in parallel with workload, exits on sentinel; `epp_logs/` contains the full run; no orphaned `kubectl`/`awk` processes) — out of scope for this PR; verifiable by reviewer with `kubectl -n <ns> get pods` during a run and inspecting `epp_logs/` after

## Reviewer attention

1. **Why `runAfter: ["llmdbenchmark-standup"]` and not `["llmdbenchmark-standup", "install-blis"]` like the workload?** The streamer doesn't use `blis` tooling — it only needs running EPP pods, which standup creates. Decoupling from `install-blis` lets streamer Phase 1 (60 s pod-discovery window) overlap with `install-blis` if the latter is slow, reducing the chance of missing early routing-decision logs.

2. **`containerName` and `windowMinutes` not passed.** Both default to `"epp"` and `"2"` respectively in the Task. Defaulting keeps the pipeline params surface minimal and matches `collect-results`'s previous bucket cadence.

3. **Sentinel race with `collect-results` is task-side, not wiring-side.** PR #32's silent-failure-hunter flagged a theoretical race where `collect-results` could write the sentinel before the streamer reaches Phase 2's `rm -f ${SENTINEL}`. Under this `runAfter` graph (`stream-epp-logs` runs in parallel with the workload, `collect-results` runs after the workload), streamer Phase 2 has minutes-to-tens-of-minutes of headroom before `collect-results` runs. If the race ever does fire, it belongs in the Task code (#31), not in this PR.

4. **No removal of dead `epp_log_since` writes.** `run-workload-blis-observe.yaml:45` and `run-workload-blis-observe-binary.yaml:42` still write `${RESULTS_DIR}/epp_log_since`, but its only consumer (the deleted `collect-epp-logs` step in `collect-results`) is gone. That's harmless dead state, and removing it lives in the `tektonc-data-collection` repo, not here. Worth tracking as a separate cleanup if it bothers anyone.