### PR TITLE
feat: collect resource manifests in pipeline results

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -996,7 +996,7 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
                         continue
                     wl_dest = dest_dir / wl_name
                     wl_dest.mkdir(parents=True, exist_ok=True)
-                    for log_dir in (wl_dest / "server_logs", wl_dest / "epp_logs"):
+                    for log_dir in (wl_dest / "server_logs", wl_dest / "epp_logs", wl_dest / "resources"):
                         if log_dir.exists():
                             shutil.rmtree(log_dir)
                     # Copy trace files
@@ -1015,6 +1015,14 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
                             check=False, capture=True)
                     if r.returncode != 0 and "no such file" not in r.stderr.lower():
                         wl_errors.append(f"{wl_name}/epp_logs: {r.stderr.strip()}")
+                    # Copy resources directory
+                    res_src = f"{namespace}/{pod_name}:/data/{run_name}/{phase}/{wl_name}/resources/"
+                    res_dest = wl_dest / "resources"
+                    res_dest.mkdir(exist_ok=True)
+                    r = run(["kubectl", "cp", res_src, str(res_dest), "--retries=3"],
+                            check=False, capture=True)
+                    if r.returncode != 0 and "no such file" not in r.stderr.lower():
+                        wl_errors.append(f"{wl_name}/resources: {r.stderr.strip()}")
                     if wl_errors:
                         phase_errors.extend(wl_errors)
                     if on_workload_done:


### PR DESCRIPTION
## Summary
- Updates tektonc-data-collection submodule to include the new collect-resources step (inference-sim/tektonc-data-collection#34)
- Adds resources/ directory to the skip-logs selective-copy path in deploy.py so manifests are pulled alongside epp_logs during lightweight collection

## Test plan
- [x] Deployed updated task with setup.py --redeploy-tasks and verified it applies
- [ ] Run full pipeline and confirm resources/ is populated in results
- [ ] Run deploy.py collect --skip-logs and confirm resources/ is copied locally