### PR TITLE
feat(deploy): redact Secret data in collected plans and resource manifests

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -50,6 +50,7 @@ def _c(code: str, text: str) -> str:
 
 
 from pipeline.lib.log import info, ok, warn, err
+from pipeline.lib.redact import redact_yaml_file, redact_yaml_tree
 
 
 def _is_pair_key(key: str) -> bool:
@@ -1023,6 +1024,8 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
                             check=False, capture=True)
                     if r.returncode != 0 and "no such file" not in r.stderr.lower():
                         wl_errors.append(f"{wl_name}/resources: {r.stderr.strip()}")
+                    else:
+                        redact_yaml_tree(res_dest)
                     if wl_errors:
                         phase_errors.extend(wl_errors)
                     if on_workload_done:
@@ -1243,6 +1246,7 @@ def _extract_phase_plans(pod_name: str, run_name: str, phase: str,
                 copy_errors.append(f"{yaml_name}: {cp_result.stderr.strip()}")
             else:
                 copied += 1
+                redact_yaml_file(local_path)
         if copy_errors:
             warn(f"[{phase}/plans/{flow}] copy errors: {'; '.join(copy_errors)}")
         if copied or skipped:

--- a/pipeline/lib/redact.py
+++ b/pipeline/lib/redact.py
@@ -1,0 +1,124 @@
+"""YAML redaction for collected plan files.
+
+Stubs out sensitive field values in Kubernetes objects whose `kind`
+matches a denylist, so collected plan YAMLs do not carry credentials
+into developer laptops or shared run dirs.
+
+Behavior:
+  - `data` and `stringData` values in matching docs are replaced with
+    the literal string ``REDACTED``. Key names are preserved.
+  - Multi-doc YAML files are processed per-document; non-matching docs
+    pass through unchanged.
+  - Files without any matching docs are not rewritten.
+  - Unreadable / unparseable files are left untouched (warning logged).
+  - Writes go through a sibling tmp file + atomic ``os.replace`` so a
+    process crash mid-write cannot leave a half-redacted file on disk.
+"""
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+
+from pipeline.lib.log import warn
+
+REDACTED = "REDACTED"
+
+DEFAULT_REDACT_KINDS: frozenset[str] = frozenset({"Secret"})
+
+
+def _stub_data_fields(doc: dict) -> bool:
+    """Replace every value under data/stringData with REDACTED in-place.
+
+    Returns True if any value was actually changed. Already-redacted
+    values are left as-is and do not count as a change (so an
+    already-redacted file produces a 0-count pass and skips rewrite).
+    """
+    changed = False
+    for field in ("data", "stringData"):
+        section = doc.get(field)
+        if not isinstance(section, dict):
+            continue
+        for key, value in list(section.items()):
+            if value != REDACTED:
+                section[key] = REDACTED
+                changed = True
+    return changed
+
+
+def _format_header(counts: Counter) -> str:
+    parts = []
+    for kind, n in sorted(counts.items()):
+        suffix = "s" if n != 1 else ""
+        parts.append(f"{n} {kind}{suffix} stubbed")
+    return f"# REDACTED by sim2real collect: {', '.join(parts)}\n"
+
+
+def redact_yaml_file(path: Path, kinds: Iterable[str] | None = None) -> int:
+    """Redact data/stringData values for kind-matching docs in `path`.
+
+    Returns the count of docs that were redacted. Returns 0 (without
+    rewriting the file) for: files with no matching docs, files that
+    aren't valid YAML, or files that can't be read.
+    """
+    redact_set = frozenset(kinds) if kinds is not None else DEFAULT_REDACT_KINDS
+
+    try:
+        text = path.read_text()
+    except OSError as e:
+        warn(f"redact: could not read {path}: {e}")
+        return 0
+
+    try:
+        docs = list(yaml.safe_load_all(text))
+    except yaml.YAMLError as e:
+        warn(f"redact: skipping unparseable YAML {path.name}: {e}")
+        return 0
+
+    counts: Counter = Counter()
+    for doc in docs:
+        if not isinstance(doc, dict):
+            continue
+        kind = doc.get("kind")
+        if kind in redact_set and _stub_data_fields(doc):
+            counts[kind] += 1
+
+    total = sum(counts.values())
+    if total == 0:
+        return 0
+
+    body = yaml.safe_dump_all(docs, sort_keys=False, default_flow_style=False)
+    output = _format_header(counts) + body
+
+    tmp = path.with_suffix(path.suffix + ".redact.tmp")
+    try:
+        tmp.write_text(output)
+        tmp.replace(path)
+    except OSError as e:
+        warn(f"redact: write failed for {path}: {e}")
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        return 0
+
+    return total
+
+
+def redact_yaml_tree(root: Path, kinds: Iterable[str] | None = None) -> int:
+    """Run ``redact_yaml_file`` over every ``*.yaml`` / ``*.yml`` under root.
+
+    Recursive. Non-yaml files are ignored. A missing root directory is a
+    silent no-op (returns 0). Returns the total count of docs redacted
+    across all files.
+    """
+    if not root.is_dir():
+        return 0
+    total = 0
+    for path in sorted(root.rglob("*.yaml")):
+        total += redact_yaml_file(path, kinds=kinds)
+    for path in sorted(root.rglob("*.yml")):
+        total += redact_yaml_file(path, kinds=kinds)
+    return total

--- a/pipeline/tests/test_deploy_collect_plans.py
+++ b/pipeline/tests/test_deploy_collect_plans.py
@@ -232,3 +232,58 @@ def test_setup_dir_filtered_from_flows(tmp_path):
     assert setup_stats == [], "should not have stat'd files under plan/setup"
     cp_calls = [c for c in router.calls if c[:2] == ["kubectl", "cp"]]
     assert len(cp_calls) == 1
+
+
+def test_secret_redacted_after_copy(tmp_path, monkeypatch):
+    """End-to-end: cp lands a Secret YAML; local file is redacted in-place."""
+    run_name = "demo-run"
+    phase = "baseline"
+    plans_root = f"/data/{run_name}/plans/{phase}"
+    workload = "balanced_20"
+    wl_path = f"{plans_root}/{workload}"
+    root = "root-20260101-120000-000"
+    plan_dir = f"{wl_path}/{root}/plan"
+    flow = "flow-control-baseline"
+    flow_dir = f"{plan_dir}/{flow}"
+
+    run_dir = tmp_path / "workspace" / "runs" / run_name
+    run_dir.mkdir(parents=True)
+
+    secret_yaml = (
+        "apiVersion: v1\n"
+        "kind: Secret\n"
+        "metadata:\n"
+        "  name: hf-token\n"
+        "  namespace: jchen4\n"
+        "type: Opaque\n"
+        "data:\n"
+        "  token: aGZfYWJjMTIzZGVmNDU2\n"
+    )
+
+    from pathlib import Path as _P
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:2] == ["kubectl", "cp"]:
+            dest = _P(cmd[3])
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_text(secret_yaml)
+            return _cp_result()
+        if _is_ls(cmd, plans_root):
+            return _cp_result(stdout=f"{workload}\n")
+        if _is_ls(cmd, wl_path):
+            return _cp_result(stdout=f"{root}\n")
+        if _is_find_dirs(cmd, plan_dir):
+            return _cp_result(stdout=f"{plan_dir}/{flow}\n")
+        if _is_find_yaml_stat(cmd, flow_dir):
+            return _cp_result(stdout=f"100 {flow_dir}/secret.yaml\n")
+        return _cp_result()
+
+    monkeypatch.setattr(deploy, "run", fake_run)
+    deploy._extract_phase_plans("pod-x", run_name, phase, "ns-0", run_dir)
+
+    local = run_dir / "results" / phase / "plans" / flow / "secret.yaml"
+    assert local.exists()
+    text = local.read_text()
+    assert text.startswith("# REDACTED by sim2real collect: 1 Secret stubbed\n")
+    assert "REDACTED" in text
+    assert "aGZfYWJjMTIzZGVmNDU2" not in text

--- a/pipeline/tests/test_redact.py
+++ b/pipeline/tests/test_redact.py
@@ -1,0 +1,248 @@
+"""Tests for pipeline.lib.redact."""
+from pathlib import Path
+
+import yaml
+
+from pipeline.lib.redact import REDACTED, redact_yaml_file
+
+
+def test_redacts_standalone_secret(tmp_path: Path):
+    src = (
+        "apiVersion: v1\n"
+        "kind: Secret\n"
+        "metadata:\n"
+        "  name: hf-token\n"
+        "  namespace: jchen4\n"
+        "type: Opaque\n"
+        "data:\n"
+        "  token: aGZfYWJjMTIzZGVmNDU2\n"
+        "  other: dG9wc2VjcmV0\n"
+    )
+    p = tmp_path / "secret.yaml"
+    p.write_text(src)
+    assert redact_yaml_file(p) == 1
+    out = p.read_text()
+    assert out.startswith("# REDACTED by sim2real collect: 1 Secret stubbed\n")
+    d = list(yaml.safe_load_all(out))[0]
+    assert d["kind"] == "Secret"
+    assert d["metadata"]["name"] == "hf-token"
+    assert d["metadata"]["namespace"] == "jchen4"
+    assert d["type"] == "Opaque"
+    assert d["data"]["token"] == REDACTED
+    assert d["data"]["other"] == REDACTED
+
+
+def test_multi_doc_only_stubs_matching_kinds(tmp_path: Path):
+    src = (
+        "apiVersion: v1\n"
+        "kind: ConfigMap\n"
+        "metadata:\n"
+        "  name: cm\n"
+        "data:\n"
+        "  foo: bar\n"
+        "---\n"
+        "apiVersion: v1\n"
+        "kind: Secret\n"
+        "metadata:\n"
+        "  name: s\n"
+        "type: Opaque\n"
+        "data:\n"
+        "  token: aGY=\n"
+    )
+    p = tmp_path / "mix.yaml"
+    p.write_text(src)
+    assert redact_yaml_file(p) == 1
+    docs = list(yaml.safe_load_all(p.read_text()))
+    cm = next(d for d in docs if d["kind"] == "ConfigMap")
+    sec = next(d for d in docs if d["kind"] == "Secret")
+    assert cm["data"]["foo"] == "bar"
+    assert sec["data"]["token"] == REDACTED
+
+
+def test_secret_with_string_data_only(tmp_path: Path):
+    src = (
+        "apiVersion: v1\n"
+        "kind: Secret\n"
+        "metadata:\n"
+        "  name: hf\n"
+        "type: Opaque\n"
+        "stringData:\n"
+        "  token: hf_xyz\n"
+    )
+    p = tmp_path / "s.yaml"
+    p.write_text(src)
+    assert redact_yaml_file(p) == 1
+    d = list(yaml.safe_load_all(p.read_text()))[0]
+    assert d["stringData"]["token"] == REDACTED
+
+
+def test_secret_with_no_data_fields_unchanged(tmp_path: Path):
+    src = (
+        "apiVersion: v1\n"
+        "kind: Secret\n"
+        "metadata:\n"
+        "  name: empty\n"
+        "type: Opaque\n"
+    )
+    p = tmp_path / "empty.yaml"
+    p.write_text(src)
+    assert redact_yaml_file(p) == 0
+    assert p.read_text() == src
+
+
+def test_file_without_kind_is_passthrough(tmp_path: Path):
+    src = "domain: example.com\nreplicas: 3\nflags:\n  enabled: true\n"
+    p = tmp_path / "values.yaml"
+    p.write_text(src)
+    assert redact_yaml_file(p) == 0
+    assert p.read_text() == src
+
+
+def test_unparseable_file_is_untouched(tmp_path: Path):
+    src = "{ this is not valid yaml"
+    p = tmp_path / "bogus.yaml"
+    p.write_text(src)
+    assert redact_yaml_file(p) == 0
+    assert p.read_text() == src
+
+
+def test_metadata_and_data_key_names_preserved(tmp_path: Path):
+    src = (
+        "apiVersion: v1\n"
+        "kind: Secret\n"
+        "metadata:\n"
+        "  name: hf\n"
+        "  namespace: jchen4\n"
+        "  labels:\n"
+        "    app: scorer\n"
+        "  annotations:\n"
+        "    note: keep\n"
+        "type: Opaque\n"
+        "data:\n"
+        "  token: aGY=\n"
+        "  ca.crt: bXk=\n"
+    )
+    p = tmp_path / "s.yaml"
+    p.write_text(src)
+    assert redact_yaml_file(p) == 1
+    d = list(yaml.safe_load_all(p.read_text()))[0]
+    assert d["metadata"]["labels"] == {"app": "scorer"}
+    assert d["metadata"]["annotations"] == {"note": "keep"}
+    assert set(d["data"].keys()) == {"token", "ca.crt"}
+
+
+def test_idempotent_on_already_redacted(tmp_path: Path):
+    src = (
+        "apiVersion: v1\n"
+        "kind: Secret\n"
+        "metadata:\n"
+        "  name: hf\n"
+        "type: Opaque\n"
+        "data:\n"
+        "  token: aGY=\n"
+    )
+    p = tmp_path / "s.yaml"
+    p.write_text(src)
+    assert redact_yaml_file(p) == 1
+    after_first = p.read_text()
+    assert redact_yaml_file(p) == 0
+    assert p.read_text() == after_first
+
+
+def test_custom_kinds_set(tmp_path: Path):
+    src = (
+        "apiVersion: v1\n"
+        "kind: ConfigMap\n"
+        "metadata:\n"
+        "  name: cm\n"
+        "data:\n"
+        "  hf-token: hf_abc\n"
+    )
+    p = tmp_path / "cm.yaml"
+    p.write_text(src)
+    assert redact_yaml_file(p, kinds={"ConfigMap"}) == 1
+    d = list(yaml.safe_load_all(p.read_text()))[0]
+    assert d["data"]["hf-token"] == REDACTED
+
+
+def test_multi_kind_header_combines_counts(tmp_path: Path):
+    src = (
+        "apiVersion: v1\n"
+        "kind: Secret\n"
+        "metadata: {name: a}\n"
+        "type: Opaque\n"
+        "data: {x: y}\n"
+        "---\n"
+        "apiVersion: v1\n"
+        "kind: Secret\n"
+        "metadata: {name: b}\n"
+        "type: Opaque\n"
+        "data: {x: y}\n"
+        "---\n"
+        "apiVersion: v1\n"
+        "kind: ConfigMap\n"
+        "metadata: {name: c}\n"
+        "data: {x: y}\n"
+    )
+    p = tmp_path / "multi.yaml"
+    p.write_text(src)
+    assert redact_yaml_file(p, kinds={"Secret", "ConfigMap"}) == 3
+    text = p.read_text()
+    assert text.startswith(
+        "# REDACTED by sim2real collect: 1 ConfigMap stubbed, 2 Secrets stubbed\n"
+    )
+
+
+def test_default_kind_set_is_secret_only(tmp_path: Path):
+    """ConfigMap is NOT in the default redact set; default-call leaves it alone."""
+    src = (
+        "apiVersion: v1\n"
+        "kind: ConfigMap\n"
+        "metadata: {name: cm}\n"
+        "data: {token: hf_abc}\n"
+    )
+    p = tmp_path / "cm.yaml"
+    p.write_text(src)
+    assert redact_yaml_file(p) == 0
+    assert p.read_text() == src
+
+
+def test_tree_walks_yaml_and_yml_recursively(tmp_path: Path):
+    """redact_yaml_tree visits *.yaml and *.yml at any depth, skips others."""
+    from pipeline.lib.redact import redact_yaml_tree
+
+    secret = (
+        "apiVersion: v1\n"
+        "kind: Secret\n"
+        "metadata: {name: s}\n"
+        "type: Opaque\n"
+        "data: {token: aGY=}\n"
+    )
+    plain = "key: value\n"
+
+    nested = tmp_path / "deep" / "nested"
+    nested.mkdir(parents=True)
+    (tmp_path / "top.yaml").write_text(secret)
+    (tmp_path / "deep" / "mid.yml").write_text(secret)
+    (nested / "leaf.yaml").write_text(plain)
+    (tmp_path / "ignore.txt").write_text(secret)
+    (tmp_path / "config.json").write_text("{}")
+
+    assert redact_yaml_tree(tmp_path) == 2
+    assert "REDACTED" in (tmp_path / "top.yaml").read_text()
+    assert "REDACTED" in (tmp_path / "deep" / "mid.yml").read_text()
+    assert (nested / "leaf.yaml").read_text() == plain
+    assert (tmp_path / "ignore.txt").read_text() == secret  # untouched
+    assert (tmp_path / "config.json").read_text() == "{}"
+
+
+def test_tree_on_empty_or_missing_dir(tmp_path: Path):
+    """Empty / nonexistent root returns 0 with no errors."""
+    from pipeline.lib.redact import redact_yaml_tree
+
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    assert redact_yaml_tree(empty) == 0
+
+    missing = tmp_path / "does-not-exist"
+    assert redact_yaml_tree(missing) == 0


### PR DESCRIPTION
Closes #312

## Summary

- Adds `pipeline/lib/redact.py`: a YAML-aware redactor that stubs `data`/`stringData` values in every doc whose `kind` is in `DEFAULT_REDACT_KINDS` (currently `{"Secret"}`). Exposes `redact_yaml_file(path)` and `redact_yaml_tree(root)`.
- Wires `redact_yaml_file` into `_extract_phase_plans` (per-yaml call after `kubectl cp` success) — covers the path called out in the issue.
- Wires `redact_yaml_tree` into `_extract_phases_from_pvc` after the resources directory cp (added by #315) — covers the resource manifest tree, which can also contain Secret docs.
- Multi-doc-safe, per-file atomic write, non-fatal on parse / IO failure.

## Reviewer attention

- **Scope expanded beyond the issue text.** Issue #312 was written before #315 shipped the `resources/` collection path. That new path can ship the same kinds of K8s Secret manifests, so this PR redacts both — leaving #315's path leaking would be worse than not having a redactor at all. Mentioned here so reviewers don't get surprised by the second wire-up.
- **Default scope is `{"Secret"}` only.** ConfigMap data redaction is explicitly out of scope per the issue (some configmaps carry tokens, but key-name heuristics are the right tool for that and would over-redact). Adding more kinds is a one-line constant edit.
- **No CLI flag in v1.** The issue lists `--redact-kinds` as optional. Skipped here to minimize surface area; add when a real call site needs it.
- **Idempotency:** a second pass on an already-redacted file changes nothing and does not rewrite (covered by `test_idempotent_on_already_redacted`).
- **Failure mode:** unreadable / unparseable files are logged and skipped — collect never fails because of redaction.
- **Atomic write:** sibling tmp file + `os.replace` ensures no half-redacted files on crash.

## Test plan

- [x] `python -m pytest pipeline/tests/test_redact.py pipeline/tests/test_deploy_collect_plans.py -v` — 19 passed
- [x] `python -m pytest pipeline/ -v` — 895 passed, 2 xfailed
- [x] Full CI command: `python -m pytest pipeline/ .claude/skills/sim2real-analyze/tests/ .claude/skills/sim2real-bootstrap/tests/ .claude/skills/sim2real-translate/tests/` — 990 passed
- [x] `ruff check pipeline/ .claude/skills/ --select F` — clean