### PR TITLE
feat(pipeline): apply baseline workarounds via defaults overlay

### DIFF
--- a/.claude/skills/sim2real-bootstrap/SKILL.md
+++ b/.claude/skills/sim2real-bootstrap/SKILL.md
@@ -247,10 +247,32 @@ ls "$EXPERIMENT_ROOT"/workloads/*.yaml
 
 ---
 
+### Task 4b: Copy framework defaults overlay
+
+**action:** shell
+
+Framework workarounds documented in `docs/troubleshooting.md` (EPP llm-d.ai
+RBAC, request-id preservation, EPP/vLLM verbosity) are applied automatically
+by `prepare.py` Phase 4 from `<experiment-root>/baselines/defaults/`. Copy
+the framework templates into the experiment so each experiment is
+self-contained and reproducible.
+
+```bash
+mkdir -p "$EXPERIMENT_ROOT/baselines/defaults"
+cp "$SKILL_DIR/templates/defaults/"*.yaml "$EXPERIMENT_ROOT/baselines/defaults/"
+ls "$EXPERIMENT_ROOT/baselines/defaults/"
+```
+
+Each fragment is a partial scenario YAML — operators can edit individual
+fragments in place to tweak them for the experiment, or list a fragment
+stem under `defaults.disable` in `transfer.yaml` to opt out entirely.
+
+---
+
 ### Task 5: Create transfer.yaml
 
 **action:** derive-and-approve  
-**depends:** task-2, task-3, task-4
+**depends:** task-2, task-3, task-4, task-4b
 
 Assemble transfer manifest from all prior task outputs.
 
@@ -302,6 +324,14 @@ workloads: <list from task-4>
 context:
   text: <derived summary>
   files: <list of context files>
+
+defaults:
+  disable: []
+  # Available fragments (filename stems in baselines/defaults/):
+  #   - llm-d-rbac
+  #   - preserve-request-id
+  #   - epp-verbosity
+  #   - vllm-logging
 ```
 
 **Constraints:**
@@ -347,6 +377,11 @@ Exit code 0 and all fields printed = success.
   transfer.yaml                  <- task-5
   baselines/
     <name>.yaml                  <- task-3
+    defaults/                    <- task-4b
+      llm-d-rbac.yaml
+      preserve-request-id.yaml
+      epp-verbosity.yaml
+      vllm-logging.yaml
   <component-name>/             <- task-2 (submodule)
   algorithms/
     <algorithm>.go               <- pre-existing
@@ -374,3 +409,4 @@ This skill ships with supporting files in its directory. Invoke in place — do 
 | `generate_from_config.py` | Parses `config.md` markdown tables → scenario YAMLs with provenance comments. Preferred for most experiments. Handles hardware normalization, bare-flag prefix-caching input/output, and unknown model/hardware detection. |
 | `generate_scenarios.py` | Converts JSON config (`top3_selection.json`) → scenario YAMLs. Use when JSON input exists. |
 | `generate_scenarios.README.md` | Coverage map for the JSON-input path. Documents field mappings, omission rules, and gaps. |
+| `templates/defaults/*.yaml` | Framework-owned baseline workaround fragments (RBAC, request-id, verbosity). Copied into `<experiment-root>/baselines/defaults/` at task-4b so each experiment is self-contained and reproducible. |

--- a/.claude/skills/sim2real-bootstrap/templates/defaults/epp-verbosity.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/epp-verbosity.yaml
@@ -1,0 +1,7 @@
+# Workaround: bump EPP log verbosity for diagnosability.
+# See docs/troubleshooting.md "Increasing logging verbosity / EPP".
+# scenario[0].name is realigned to the experiment baseline at merge time.
+scenario:
+- name: defaults
+  inferenceExtension:
+    verbosity: "5"

--- a/.claude/skills/sim2real-bootstrap/templates/defaults/llm-d-rbac.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/llm-d-rbac.yaml
@@ -1,0 +1,25 @@
+# Workaround: EPP needs llm-d.ai RBAC to inspect inferenceobjectives.
+# See docs/troubleshooting.md "EPP does not start (missing RBAC for llm-d.ai)".
+# scenario[0].name is realigned to the experiment baseline at merge time.
+scenario:
+- name: defaults
+  extraObjects:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: ${model.idLabel}-gaie-epp-llm-d
+      rules:
+      - apiGroups: ["llm-d.ai"]
+        resources: ["inferenceobjectives", "inferencemodelrewrites"]
+        verbs: ["get", "watch", "list"]
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: ${model.idLabel}-gaie-epp-llm-d
+      subjects:
+      - kind: ServiceAccount
+        name: ${model.idLabel}-gaie-epp
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: ${model.idLabel}-gaie-epp-llm-d

--- a/.claude/skills/sim2real-bootstrap/templates/defaults/preserve-request-id.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/preserve-request-id.yaml
@@ -1,5 +1,5 @@
 # Workaround: preserve external request-id so requests can be correlated to pods/nodes.
-# See docs/troubleshooting.md "Corrolate requests with pods (and hence nodes)".
+# See docs/troubleshooting.md "Correlate requests with pods (and hence nodes)".
 # scenario[0].name is realigned to the experiment baseline at merge time.
 scenario:
 - name: defaults

--- a/.claude/skills/sim2real-bootstrap/templates/defaults/preserve-request-id.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/preserve-request-id.yaml
@@ -1,0 +1,28 @@
+# Workaround: preserve external request-id so requests can be correlated to pods/nodes.
+# See docs/troubleshooting.md "Corrolate requests with pods (and hence nodes)".
+# scenario[0].name is realigned to the experiment baseline at merge time.
+scenario:
+- name: defaults
+  extraObjects:
+    - apiVersion: networking.istio.io/v1alpha3
+      kind: EnvoyFilter
+      metadata:
+        name: preserve-external-request-id
+      spec:
+        workloadSelector:
+          labels:
+            gateway.networking.k8s.io/gateway-name: infra-llmdbench-inference-gateway
+        configPatches:
+          - applyTo: NETWORK_FILTER
+            match:
+              context: GATEWAY
+              listener:
+                filterChain:
+                  filter:
+                    name: envoy.filters.network.http_connection_manager
+            patch:
+              operation: MERGE
+              value:
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                  preserve_external_request_id: true

--- a/.claude/skills/sim2real-bootstrap/templates/defaults/vllm-logging.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/vllm-logging.yaml
@@ -1,0 +1,10 @@
+# Workaround: enable vLLM uvicorn access log + INFO logging for diagnosability.
+# See docs/troubleshooting.md "Increasing logging verbosity / vLLM".
+# scenario[0].name is realigned to the experiment baseline at merge time.
+scenario:
+- name: defaults
+  decode:
+    vllm:
+      additionalFlags:
+      - --no-disable-uvicorn-access-log
+      loggingLevel: INFO

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,13 +158,14 @@ If a fix only exists in `workspace/`, it will be silently lost the next time tha
 **Bundle inputs** (version-controlled in experiment repo):
 - `baseline.yaml` — baseline scenario (model config, baseline scorer EPP config)
 - `treatment.yaml` (optional) — diffs from baseline for the treatment arm
+- `baselines/defaults/*.yaml` (optional) — framework workaround fragments (RBAC, request-id, verbosity); enabled set controlled by `defaults.disable` in `transfer.yaml`. See [`docs/troubleshooting.md`](docs/troubleshooting.md#framework-defaults-overlay).
 
 **Skill-generated overlays** (in `workspace/runs/<run>/generated/`):
 - `baseline_config.yaml` — baseline scorer plugin config overlay
 - `treatment_config.yaml` — evolved treatment scorer plugin config overlay
 
 **Assembly** is performed by `prepare.py` Phase 4 via `pipeline/lib/assemble.py`:
-- `baseline_resolved = deep_merge(baseline_bundle, baseline_overlay)`
-- `treatment_resolved = deep_merge(deep_merge(baseline_resolved, treatment_diffs), treatment_overlay)`
+- `baseline_resolved = deep_merge(deep_merge(framework_defaults, baseline_bundle), baseline_overlay)` (defaults are no-op when `baselines/defaults/` is absent)
+- `treatment_resolved = deep_merge(deep_merge(baseline_resolved, treatment_diffs), treatment_overlay)` (treatment inherits framework defaults transitively through `baseline_resolved`)
 - EPP image injected into treatment scenarios from `run_metadata.json`
 - PipelineRuns generated per workload × {baseline, treatment}

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,6 +2,33 @@
 
 Experiment-config issues operators encounter when running the sim2real pipeline. For pipeline-level recovery operations (rerun failed pairs, stop orchestration, clean up cluster artifacts, wipe data), see [`pipeline/README.md` § Troubleshooting](../pipeline/README.md#troubleshooting).
 
+## Framework defaults overlay
+
+The workarounds below are applied automatically by `prepare.py` Phase 4 via a defaults overlay. `sim2real-bootstrap` copies framework templates into `<experiment-root>/baselines/defaults/` at bootstrap time, and `assemble.py` deep-merges enabled fragments under each baseline (precedence: defaults → experiment baseline → skill overlay). Treatment scenarios inherit transitively through the resolved baseline.
+
+The fragments shipped today:
+
+| Fragment stem | What it adds |
+|---------------|--------------|
+| `llm-d-rbac` | EPP `Role` + `RoleBinding` for `inferenceobjectives.llm-d.ai` |
+| `preserve-request-id` | `EnvoyFilter` that preserves the external request-id |
+| `epp-verbosity` | `inferenceExtension.verbosity: "5"` |
+| `vllm-logging` | `vllm.additionalFlags: [--no-disable-uvicorn-access-log]` + `loggingLevel: INFO` |
+
+**Opt out** by listing fragment stems under `defaults.disable` in `transfer.yaml`:
+
+```yaml
+defaults:
+  disable:
+    - vllm-logging
+```
+
+**Per-experiment customization** is done by editing the file in `<experiment-root>/baselines/defaults/<stem>.yaml` directly — the experiment's copy is what gets merged.
+
+**Removing a workaround framework-wide** (e.g., upstream fix landed): delete the file from `.claude/skills/sim2real-bootstrap/templates/defaults/`. New bootstraps stop including it; existing experiments keep their copy until removed.
+
+The remainder of this document keeps the original snippets so operators can hand-apply or hand-edit them when needed.
+
 ## EPP does not start (missing RBAC for `llm-d.ai`)
 
 The EPP fails because it does not have permission to inspect `inferenceobjectives.llm-d.ai` resources. This can happen if the `llm-d.ai` CRDs are loaded in your cluster and you are using the `main` branch of `llm-d-router`.
@@ -52,4 +79,34 @@ Add to `**.vllm` in `baselines/*.yaml`:
 additionalFlags:
 - --no-disable-uvicorn-access-log
 loggingLevel: INFO
+```
+
+## Correlate requests with pods (and hence nodes)
+
+Add to baseline files:
+
+```yaml
+  extraObjects:
+    - apiVersion: networking.istio.io/v1alpha3
+      kind: EnvoyFilter
+      metadata:
+        name: preserve-external-request-id
+      spec:
+        workloadSelector:
+          labels:
+            gateway.networking.k8s.io/gateway-name: infra-llmdbench-inference-gateway
+        configPatches:
+          - applyTo: NETWORK_FILTER
+            match:
+              context: GATEWAY
+              listener:
+                filterChain:
+                  filter:
+                    name: envoy.filters.network.http_connection_manager
+            patch:
+              operation: MERGE
+              value:
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                  preserve_external_request_id: true
 ```

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -289,6 +289,12 @@ context:
   text: |                   # freeform instructions for translation skill
   files: [<path>, ...]      # files assembled into context document (Phase 2)
 
+defaults:                   # optional — controls framework defaults overlay
+  disable: []               # fragment stems (filename without .yaml) to skip;
+                            # fragments live in <experiment-root>/baselines/defaults/
+                            # and are merged UNDER each baseline at Phase 4. See
+                            # docs/troubleshooting.md#framework-defaults-overlay.
+
 # v3 fields (required unless noted)
 target:
   repo: <path>              # llm-d-inference-scheduler repo path

--- a/pipeline/lib/assemble.py
+++ b/pipeline/lib/assemble.py
@@ -4,6 +4,7 @@ Deep-merges bundle inputs (baseline.yaml, treatment.yaml) with skill-generated
 overlay files (generated/baseline_config.yaml, generated/treatment_config.yaml)
 to produce fully resolved scenario files.
 """
+import copy
 import yaml
 from pathlib import Path
 from typing import NamedTuple
@@ -103,6 +104,25 @@ class Package(NamedTuple):
     resolved: dict
 
 
+def _load_defaults_overlay(defaults_dir: Path | None, disable: list[str]) -> dict:
+    """Load YAML fragments from defaults_dir and deep-merge them into one overlay.
+
+    Fragments are partial scenario YAMLs whose stem (filename without .yaml) is
+    used as the opt-out key. Files whose stem appears in `disable` are skipped.
+    Returns {} when defaults_dir is None or the directory does not exist, so
+    experiments without a baselines/defaults/ directory are unaffected.
+    """
+    if defaults_dir is None or not defaults_dir.exists():
+        return {}
+    disable_set = set(disable or [])
+    merged: dict = {}
+    for fragment in sorted(defaults_dir.glob("*.yaml")):
+        if fragment.stem in disable_set:
+            continue
+        merged = deep_merge(merged, _load_yaml(fragment))
+    return merged
+
+
 def _resolve_overlay(name: str, generated_dir: Path, kind: str) -> dict:
     """Find overlay for a package.
 
@@ -134,14 +154,24 @@ def assemble_packages(
     algorithms: list[dict],
     generated_dir: Path,
     overlays_expected: bool = False,
+    defaults_dir: Path | None = None,
+    defaults_disable: list[str] | None = None,
 ) -> list[Package]:
     """Assemble all packages (baselines + algorithms) into resolved scenarios.
 
     Each baseline entry: {name, scenario_path, defaults_path?}
     Each algorithm entry: {name, scenario_path, defaults (baseline name)}
+
+    When ``defaults_dir`` is provided, YAML fragments under it are merged UNDER
+    each baseline (precedence: framework_defaults → experiment_defaults_path →
+    experiment_baseline → skill_overlay). Treatment scenarios inherit the
+    framework defaults transitively through ``resolved_baselines``. Fragment
+    stems listed in ``defaults_disable`` are skipped.
     """
     resolved_baselines: dict[str, dict] = {}
     packages: list[Package] = []
+
+    framework_defaults = _load_defaults_overlay(defaults_dir, defaults_disable or [])
 
     for bl in baselines:
         name = bl["name"]
@@ -152,6 +182,10 @@ def assemble_packages(
             raw = deep_merge(defaults, scenario)
         else:
             raw = scenario
+
+        if framework_defaults:
+            aligned = _align_overlay_name(raw, copy.deepcopy(framework_defaults))
+            raw = deep_merge(aligned, raw)
 
         overlay = _resolve_overlay(name, generated_dir, "baseline")
         overlay = _align_overlay_name(raw, overlay)

--- a/pipeline/lib/manifest.py
+++ b/pipeline/lib/manifest.py
@@ -123,6 +123,32 @@ def load_manifest(path: "Path | str") -> dict:
         raise ManifestError("context.files must be a list")
     data["context"] = {"text": ctx_text, "files": ctx_files}
 
+    # Defaults section (optional): controls the framework defaults overlay
+    # applied from <experiment-root>/baselines/defaults/. Currently only
+    # 'disable' is recognized (list of fragment stems to skip).
+    defaults_raw = data.get("defaults")
+    if defaults_raw is None:
+        data["defaults"] = {"disable": []}
+    elif not isinstance(defaults_raw, dict):
+        raise ManifestError("defaults must be a mapping")
+    else:
+        _valid_defaults_keys = {"disable"}
+        unknown_defaults = set(defaults_raw.keys()) - _valid_defaults_keys
+        if unknown_defaults:
+            raise ManifestError(
+                f"defaults contains unknown keys: {sorted(unknown_defaults)}. "
+                f"Valid keys: disable"
+            )
+        disable = defaults_raw.get("disable", []) or []
+        if not isinstance(disable, list):
+            raise ManifestError("defaults.disable must be a list")
+        for i, entry in enumerate(disable):
+            if not isinstance(entry, str) or not entry.strip():
+                raise ManifestError(
+                    f"defaults.disable[{i}] must be a non-empty string (fragment stem)"
+                )
+        data["defaults"] = {"disable": disable}
+
     _validate_v3_fields(data)
 
     return data

--- a/pipeline/prepare.py
+++ b/pipeline/prepare.py
@@ -542,12 +542,17 @@ def _phase_assembly(args, state: StateMachine, manifest: dict, run_dir: Path,
     translation_happened = translation_output_path.exists()
     generated_dir = run_dir / "generated"
 
+    defaults_dir = EXPERIMENT_ROOT / "baselines" / "defaults"
+    defaults_disable = (manifest.get("defaults") or {}).get("disable") or []
+
     try:
         packages = assemble_packages(
             baselines=baselines_spec,
             algorithms=algorithms_spec if translation_happened else [],
             generated_dir=generated_dir,
             overlays_expected=translation_happened,
+            defaults_dir=defaults_dir,
+            defaults_disable=defaults_disable,
         )
     except AssemblyError as e:
         err(str(e))

--- a/pipeline/tests/test_assemble.py
+++ b/pipeline/tests/test_assemble.py
@@ -524,6 +524,245 @@ def test_assemble_packages_multi_algo_independent_overlays(tmp_path):
     assert "quintic-shed" not in algo2_plugins
 
 
+# ── Framework defaults overlay tests ───────────────────────────────────────
+
+# Minimal RBAC fragment in the same shape baselines/*.yaml use; scenario name
+# is intentionally a placeholder — _align_overlay_name realigns it at merge time.
+DEFAULTS_RBAC = {
+    "scenario": [{
+        "name": "defaults",
+        "extraObjects": [
+            {"apiVersion": "rbac.authorization.k8s.io/v1", "kind": "Role",
+             "metadata": {"name": "epp-llm-d"},
+             "rules": [{"apiGroups": ["llm-d.ai"], "resources": ["inferenceobjectives"], "verbs": ["get"]}]},
+            {"apiVersion": "rbac.authorization.k8s.io/v1", "kind": "RoleBinding",
+             "metadata": {"name": "epp-llm-d"},
+             "roleRef": {"kind": "Role", "name": "epp-llm-d"}},
+        ],
+    }],
+}
+
+DEFAULTS_VERBOSITY = {
+    "scenario": [{
+        "name": "defaults",
+        "inferenceExtension": {"verbosity": "5"},
+    }],
+}
+
+DEFAULTS_VLLM = {
+    "scenario": [{
+        "name": "defaults",
+        "decode": {"vllm": {
+            "additionalFlags": ["--no-disable-uvicorn-access-log"],
+            "loggingLevel": "INFO",
+        }},
+    }],
+}
+
+
+def test_defaults_overlay_all_enabled_applies_to_baseline(tmp_path):
+    """All fragments in baselines/defaults/ are merged under the experiment baseline."""
+    _write(tmp_path / "b1.yaml", BASELINE)
+    _write(tmp_path / "defaults" / "llm-d-rbac.yaml", DEFAULTS_RBAC)
+    _write(tmp_path / "defaults" / "epp-verbosity.yaml", DEFAULTS_VERBOSITY)
+    _write(tmp_path / "defaults" / "vllm-logging.yaml", DEFAULTS_VLLM)
+
+    pkgs = assemble_packages(
+        baselines=[{"name": "b1", "scenario_path": tmp_path / "b1.yaml"}],
+        algorithms=[],
+        generated_dir=tmp_path / "generated",
+        defaults_dir=tmp_path / "defaults",
+    )
+    sc = pkgs[0].resolved["scenario"][0]
+
+    # Baseline overrides defaults — verbosity from BASELINE wins ("3", not "5")
+    assert sc["inferenceExtension"]["verbosity"] == "3"
+    # vllm-logging fields appear (no conflict in BASELINE)
+    assert sc["decode"]["vllm"]["loggingLevel"] == "INFO"
+    assert "--no-disable-uvicorn-access-log" in sc["decode"]["vllm"]["additionalFlags"]
+    # RBAC manifests survive intact
+    objs = sc["extraObjects"]
+    identities = sorted((o["kind"], o["metadata"]["name"]) for o in objs)
+    assert ("Role", "epp-llm-d") in identities
+    assert ("RoleBinding", "epp-llm-d") in identities
+    # Baseline scenario name preserved
+    assert sc["name"] == "admission-control"
+
+
+def test_defaults_disable_skips_listed_fragments(tmp_path):
+    """A fragment whose stem appears in defaults_disable is not applied."""
+    _write(tmp_path / "b1.yaml", BASELINE)
+    _write(tmp_path / "defaults" / "llm-d-rbac.yaml", DEFAULTS_RBAC)
+    _write(tmp_path / "defaults" / "vllm-logging.yaml", DEFAULTS_VLLM)
+
+    pkgs = assemble_packages(
+        baselines=[{"name": "b1", "scenario_path": tmp_path / "b1.yaml"}],
+        algorithms=[],
+        generated_dir=tmp_path / "generated",
+        defaults_dir=tmp_path / "defaults",
+        defaults_disable=["llm-d-rbac"],
+    )
+    sc = pkgs[0].resolved["scenario"][0]
+
+    # vllm-logging applied
+    assert sc["decode"]["vllm"]["loggingLevel"] == "INFO"
+    # RBAC fragment skipped — Role/RoleBinding not present
+    objs = sc.get("extraObjects", [])
+    kinds = {o.get("kind") for o in objs}
+    assert "Role" not in kinds
+    assert "RoleBinding" not in kinds
+
+
+def test_defaults_missing_dir_is_noop(tmp_path):
+    """A non-existent defaults_dir leaves the baseline unchanged."""
+    _write(tmp_path / "b1.yaml", BASELINE)
+    pkgs_with = assemble_packages(
+        baselines=[{"name": "b1", "scenario_path": tmp_path / "b1.yaml"}],
+        algorithms=[],
+        generated_dir=tmp_path / "generated",
+        defaults_dir=tmp_path / "does_not_exist",
+    )
+    pkgs_without = assemble_packages(
+        baselines=[{"name": "b1", "scenario_path": tmp_path / "b1.yaml"}],
+        algorithms=[],
+        generated_dir=tmp_path / "generated",
+    )
+    assert pkgs_with[0].resolved == pkgs_without[0].resolved
+
+
+def test_defaults_collision_with_experiment_extraobject_experiment_wins(tmp_path):
+    """Baseline-supplied extraObject of the same K8s identity overrides the fragment."""
+    fragment = {
+        "scenario": [{
+            "name": "defaults",
+            "extraObjects": [
+                {"apiVersion": "rbac.authorization.k8s.io/v1", "kind": "Role",
+                 "metadata": {"name": "epp-llm-d"},
+                 "rules": [{"apiGroups": ["llm-d.ai"], "verbs": ["get"]}]},
+            ],
+        }],
+    }
+    experiment_baseline = {
+        "scenario": [{
+            "name": "admission-control",
+            "model": {"name": "Qwen/Qwen3-14B"},
+            "extraObjects": [
+                {"apiVersion": "rbac.authorization.k8s.io/v1", "kind": "Role",
+                 "metadata": {"name": "epp-llm-d"},
+                 "rules": [{"apiGroups": ["llm-d.ai"], "verbs": ["get", "watch", "list"]}]},
+            ],
+        }],
+    }
+    _write(tmp_path / "b1.yaml", experiment_baseline)
+    _write(tmp_path / "defaults" / "llm-d-rbac.yaml", fragment)
+
+    pkgs = assemble_packages(
+        baselines=[{"name": "b1", "scenario_path": tmp_path / "b1.yaml"}],
+        algorithms=[],
+        generated_dir=tmp_path / "generated",
+        defaults_dir=tmp_path / "defaults",
+    )
+    role = next(o for o in pkgs[0].resolved["scenario"][0]["extraObjects"]
+                if o["kind"] == "Role" and o["metadata"]["name"] == "epp-llm-d")
+    # Experiment baseline's wider verbs win
+    assert role["rules"][0]["verbs"] == ["get", "watch", "list"]
+
+
+def test_defaults_edited_in_place_honored(tmp_path):
+    """An edited fragment's content is what gets merged — no framework override."""
+    edited_fragment = {
+        "scenario": [{
+            "name": "defaults",
+            "inferenceExtension": {"verbosity": "9"},  # not "5"
+        }],
+    }
+    _write(tmp_path / "b1.yaml", {"scenario": [{"name": "ac", "model": {"name": "M"}}]})
+    _write(tmp_path / "defaults" / "epp-verbosity.yaml", edited_fragment)
+
+    pkgs = assemble_packages(
+        baselines=[{"name": "b1", "scenario_path": tmp_path / "b1.yaml"}],
+        algorithms=[],
+        generated_dir=tmp_path / "generated",
+        defaults_dir=tmp_path / "defaults",
+    )
+    assert pkgs[0].resolved["scenario"][0]["inferenceExtension"]["verbosity"] == "9"
+
+
+def test_defaults_apply_to_multiple_baselines(tmp_path):
+    """Each baseline picks up the same defaults overlay independently."""
+    _write(tmp_path / "b1.yaml", BASELINE)
+    _write(tmp_path / "b2.yaml", BASELINE_ALT)
+    _write(tmp_path / "defaults" / "vllm-logging.yaml", DEFAULTS_VLLM)
+
+    pkgs = assemble_packages(
+        baselines=[
+            {"name": "b1", "scenario_path": tmp_path / "b1.yaml"},
+            {"name": "b2", "scenario_path": tmp_path / "b2.yaml"},
+        ],
+        algorithms=[],
+        generated_dir=tmp_path / "generated",
+        defaults_dir=tmp_path / "defaults",
+    )
+    for pkg in pkgs:
+        assert pkg.resolved["scenario"][0]["decode"]["vllm"]["loggingLevel"] == "INFO"
+
+
+def test_defaults_inherited_by_treatment_through_baseline(tmp_path):
+    """Treatment scenarios inherit framework defaults transitively via the resolved baseline."""
+    _write(tmp_path / "b1.yaml", BASELINE)
+    _write(tmp_path / "treatment.yaml", TREATMENT_DIFFS)
+    _write(tmp_path / "defaults" / "llm-d-rbac.yaml", DEFAULTS_RBAC)
+    _write(tmp_path / "generated" / "ac1_config.yaml", TREATMENT_OVERLAY)
+
+    pkgs = assemble_packages(
+        baselines=[{"name": "b1", "scenario_path": tmp_path / "b1.yaml"}],
+        algorithms=[{"name": "ac1", "scenario_path": tmp_path / "treatment.yaml", "defaults": "b1"}],
+        generated_dir=tmp_path / "generated",
+        defaults_dir=tmp_path / "defaults",
+        overlays_expected=True,
+    )
+    # Treatment package inherits the defaults' Role/RoleBinding via the resolved baseline.
+    treatment_objs = pkgs[1].resolved["scenario"][0]["extraObjects"]
+    kinds = {o["kind"] for o in treatment_objs}
+    assert "Role" in kinds
+    assert "RoleBinding" in kinds
+
+
+def test_defaults_skill_overlay_overrides_defaults(tmp_path):
+    """Skill-generated overlay wins over framework defaults (precedence: defaults < baseline < overlay)."""
+    _write(tmp_path / "b1.yaml", {"scenario": [{"name": "ac", "model": {"name": "M"}}]})
+    _write(tmp_path / "defaults" / "epp-verbosity.yaml", DEFAULTS_VERBOSITY)
+    overlay = {"scenario": [{"name": "ac", "inferenceExtension": {"verbosity": "1"}}]}
+    _write(tmp_path / "generated" / "b1_config.yaml", overlay)
+
+    pkgs = assemble_packages(
+        baselines=[{"name": "b1", "scenario_path": tmp_path / "b1.yaml"}],
+        algorithms=[],
+        generated_dir=tmp_path / "generated",
+        defaults_dir=tmp_path / "defaults",
+    )
+    # Overlay's "1" beats defaults' "5".
+    assert pkgs[0].resolved["scenario"][0]["inferenceExtension"]["verbosity"] == "1"
+
+
+def test_defaults_empty_directory_is_noop(tmp_path):
+    """An empty defaults/ directory applies no fragments."""
+    _write(tmp_path / "b1.yaml", BASELINE)
+    (tmp_path / "defaults").mkdir()
+    pkgs = assemble_packages(
+        baselines=[{"name": "b1", "scenario_path": tmp_path / "b1.yaml"}],
+        algorithms=[],
+        generated_dir=tmp_path / "generated",
+        defaults_dir=tmp_path / "defaults",
+    )
+    pkgs_baseline = assemble_packages(
+        baselines=[{"name": "b1", "scenario_path": tmp_path / "b1.yaml"}],
+        algorithms=[],
+        generated_dir=tmp_path / "generated",
+    )
+    assert pkgs[0].resolved == pkgs_baseline[0].resolved
+
+
 class TestInjectHfSecretName:
     """inject_hf_secret_name sets huggingface.secretName on all scenario entries."""
 

--- a/pipeline/tests/test_manifest.py
+++ b/pipeline/tests/test_manifest.py
@@ -620,3 +620,54 @@ def test_no_algorithm_no_algorithms_is_baseline_only(tmp_path):
     path = _write_manifest(tmp_path, data)
     m = load_manifest(path)
     assert m.get("algorithms", []) == []
+
+
+# ── defaults block tests ───────────────────────────────────────────────────
+
+def test_defaults_block_absent_normalizes_to_empty_disable(tmp_path):
+    """No defaults: key in manifest → defaults.disable == []."""
+    path = _write_manifest(tmp_path, MINIMAL_V3)
+    m = load_manifest(path)
+    assert m["defaults"] == {"disable": []}
+
+
+def test_defaults_block_explicit_disable_loaded(tmp_path):
+    data = {**MINIMAL_V3, "defaults": {"disable": ["llm-d-rbac", "vllm-logging"]}}
+    path = _write_manifest(tmp_path, data)
+    m = load_manifest(path)
+    assert m["defaults"]["disable"] == ["llm-d-rbac", "vllm-logging"]
+
+
+def test_defaults_block_empty_disable_list(tmp_path):
+    data = {**MINIMAL_V3, "defaults": {"disable": []}}
+    path = _write_manifest(tmp_path, data)
+    m = load_manifest(path)
+    assert m["defaults"] == {"disable": []}
+
+
+def test_defaults_block_must_be_mapping(tmp_path):
+    data = {**MINIMAL_V3, "defaults": "not_a_mapping"}
+    path = _write_manifest(tmp_path, data)
+    with pytest.raises(ManifestError, match="defaults must be a mapping"):
+        load_manifest(path)
+
+
+def test_defaults_disable_must_be_list(tmp_path):
+    data = {**MINIMAL_V3, "defaults": {"disable": "rbac"}}
+    path = _write_manifest(tmp_path, data)
+    with pytest.raises(ManifestError, match="defaults.disable must be a list"):
+        load_manifest(path)
+
+
+def test_defaults_disable_entries_must_be_strings(tmp_path):
+    data = {**MINIMAL_V3, "defaults": {"disable": ["valid", 42]}}
+    path = _write_manifest(tmp_path, data)
+    with pytest.raises(ManifestError, match=r"defaults.disable\[1\]"):
+        load_manifest(path)
+
+
+def test_defaults_block_rejects_unknown_keys(tmp_path):
+    data = {**MINIMAL_V3, "defaults": {"disable": [], "enable": ["foo"]}}
+    path = _write_manifest(tmp_path, data)
+    with pytest.raises(ManifestError, match="defaults contains unknown keys.*enable"):
+        load_manifest(path)


### PR DESCRIPTION
Closes #324.

## Summary

- Adds an automatic defaults overlay to `prepare.py` Phase 4 that applies the workarounds in `docs/troubleshooting.md` mechanically — EPP `llm-d.ai` RBAC, the `preserve-external-request-id` EnvoyFilter, and EPP/vLLM verbosity — so experiments no longer need to paste them into every `baselines/*.yaml`.
- Fragments live inside the experiment bundle (`<experiment-root>/baselines/defaults/`), copied at bootstrap from framework-owned templates in `.claude/skills/sim2real-bootstrap/templates/defaults/`. Each experiment is self-contained and reproducible.
- Per-fragment opt-out via `defaults.disable` in `transfer.yaml`. Missing key / missing directory is a no-op, so existing experiments without `baselines/defaults/` continue to assemble identically.

## Mechanism

`assemble_packages` gains `defaults_dir` + `defaults_disable` params. Enabled YAML fragments are deep-merged into one overlay, name-aligned to each baseline scenario, and merged UNDER the experiment baseline:

```
defaults  →  experiment_defaults_path?  →  experiment_baseline  →  skill_overlay
```

Treatment scenarios inherit framework defaults transitively through `resolved_baselines` — no second application. The existing `_merge_k8s_objects` (issue #278) handles `extraObjects` identity merging cleanly, so RBAC and EnvoyFilter manifests coexist with whatever the experiment supplies.

## Reviewer attention

- `pipeline/lib/assemble.py` — new helper `_load_defaults_overlay`; the new layering inside the baseline loop. The `copy.deepcopy` before `_align_overlay_name` keeps the cached `framework_defaults` dict intact across baselines.
- `pipeline/lib/manifest.py` — top-level `defaults: { disable: [str] }` validation; absent → normalized to `{disable: []}`. Distinct from the existing per-baseline `defaults:` field (a scenario-file path) — different scopes, no collision.
- Fragments use `name: defaults` as a placeholder; `_align_overlay_name` realigns it to each baseline's scenario name at merge time.
- `vllm.additionalFlags` is a list of strings, so by current `_merge_lists` semantics the experiment baseline's value (if specified) replaces the fragment's. The issue acknowledges this; verbosity/RBAC/EnvoyFilter are unaffected.

## Test plan

- [x] `python -m pytest pipeline/ .claude/skills/sim2real-analyze/tests/ .claude/skills/sim2real-bootstrap/tests/ .claude/skills/sim2real-translate/tests/` — 1006 passed, 2 xfailed
- [x] `ruff check pipeline/ .claude/skills/ --select F` — clean
- [x] New unit tests cover: all-enabled merge, per-fragment disable, missing dir / empty dir, identity collision (experiment wins), edited-in-place fragment, multi-baseline, treatment inheritance, skill overlay precedence over defaults, manifest validation (absent / explicit / wrong types / unknown keys)

## Stale-reference sweep

Updated `pipeline/README.md` (transfer.yaml schema), `CLAUDE.md` (Scenario-Based Assembly Architecture section), `docs/troubleshooting.md` (intro section pointing to the auto-application path + new "Correlate requests with pods" subsection that the issue references), and `.claude/skills/sim2real-bootstrap/SKILL.md` (new task 4b, transfer.yaml schema, file tree, bundled-files table).