### PR TITLE
fix(deploy): use server-side apply for run-inputs ConfigMap and orchestrator Job

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -2972,9 +2972,12 @@ def _cmd_run_remote(args, run_dir: "Path", setup_config: dict) -> None:
         sys.exit(1)
     # subprocess.run used directly because the module's run() helper doesn't
     # support stdin input, which kubectl apply -f - requires.
+    # --server-side avoids writing the kubectl.kubernetes.io/last-applied-configuration
+    # annotation, which is capped at 256 KiB and overflowed once the run-inputs
+    # ConfigMap accumulated enough cluster--*.yaml entries.
     info("Applying run-inputs ConfigMap")
     result = subprocess.run(
-        ["kubectl", "apply", "-f", "-"],
+        ["kubectl", "apply", "--server-side", "--force-conflicts", "-f", "-"],
         input=json.dumps(cm), text=True, check=False, capture_output=True,
     )
     if result.returncode != 0:
@@ -2992,7 +2995,7 @@ def _cmd_run_remote(args, run_dir: "Path", setup_config: dict) -> None:
     )
     info("Applying orchestrator Job")
     result = subprocess.run(
-        ["kubectl", "apply", "-f", "-"],
+        ["kubectl", "apply", "--server-side", "--force-conflicts", "-f", "-"],
         input=json.dumps(job), text=True, check=False, capture_output=True,
     )
     if result.returncode != 0:

--- a/pipeline/tests/test_deploy_remote.py
+++ b/pipeline/tests/test_deploy_remote.py
@@ -503,6 +503,32 @@ def test_run_remote_creates_configmap_and_job(monkeypatch, tmp_path):
     assert apply_inputs[1]["kind"] == "Job"
 
 
+def test_run_remote_uses_server_side_apply(monkeypatch, tmp_path):
+    """ConfigMap and Job apply use --server-side to avoid the 256 KiB last-applied-configuration cap."""
+    run_dir = _setup_run_dir(tmp_path)
+    monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)
+    monkeypatch.setattr(mod, "_check_existing_job", lambda ns: None)
+    monkeypatch.setattr(mod, "_cmd_build", lambda *a, **kw: "skip")
+    monkeypatch.setattr(mod, "_wait_for_job_pod", lambda *a, **kw: None)
+
+    apply_cmds = []
+
+    def fake_subprocess_run(cmd, *, input=None, text=True, check=False, capture_output=True, **kw):
+        if input:
+            apply_cmds.append(cmd)
+        return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    with patch("subprocess.run", side_effect=fake_subprocess_run):
+        args = _make_run_args(remote=True, skip_build=True)
+        setup_config = {"namespaces": ["ns"], "orchestrator_image": "img:latest"}
+        mod._cmd_run_remote(args, run_dir, setup_config)
+
+    assert len(apply_cmds) == 2
+    for cmd in apply_cmds:
+        assert "--server-side" in cmd
+        assert "--force-conflicts" in cmd
+
+
 def test_run_remote_job_uses_initcontainer_and_emptydir(monkeypatch, tmp_path):
     """Job uses initContainer to copy ConfigMap to a writable emptyDir."""
     run_dir = _setup_run_dir(tmp_path)


### PR DESCRIPTION
## Summary

Closes #326.

`deploy.py run --remote` was failing with `metadata.annotations: Too long: may not be more than 262144 bytes` once a run accumulated enough `cluster--*.yaml` entries (observed at ~290 KiB serialized — 36 PipelineRuns plus `defaults.yaml`). The cause is client-side `kubectl apply -f -` mirroring the entire submitted manifest into the `kubectl.kubernetes.io/last-applied-configuration` annotation, which has a 256 KiB per-object annotations cap distinct from the ~1 MiB ConfigMap `data` cap.

Switch both applies in `_cmd_run_remote` (run-inputs ConfigMap and orchestrator Job) to server-side apply with `--force-conflicts`. SSA tracks ownership in `metadata.managedFields` instead of the annotation, so the 256 KiB cap no longer applies.

## Reviewer attention

- Why `--force-conflicts`: this code is the sole intentional manager of these objects. Without `--force-conflicts`, SSA would refuse to overwrite fields previously owned by client-side apply on existing objects, surfacing as conflict errors on re-runs against any pre-SSA-era ConfigMap. With it, the orchestrator unconditionally takes ownership.
- Object size is still bounded by etcd's ~1 MiB object cap. At ~290 KiB data + some `managedFields` overhead we have headroom; issue #326 captures the longer-term split direction (shard `cluster--*.yaml` across ConfigMaps, stage via PVC, or compress) for when we approach the cap.
- One regression test added that asserts both kubectl invocations include `--server-side` and `--force-conflicts`.

## Ripples considered

`/pr-ripples` reported only the diff itself (no graphify graph in repo). Manual sweep of `**/*.md` and `pipeline/README.md` for references to client-side apply or `sim2real-run-inputs`: no stale refs. The README describes `--remote` at a level that is invariant to client-side vs server-side apply.

## Test plan

- [x] `python -m pytest pipeline/ .claude/skills/*/tests/ -q` — 1007 passed, 2 xfailed
- [x] `ruff check pipeline/ .claude/skills/ --select F` — clean
- [x] New test `test_run_remote_uses_server_side_apply` passes
- [ ] End-to-end: re-run the failing `deploy.py run --remote --workload code_generation_4` command on the `soft-reflective` experiment and confirm the ConfigMap apply succeeds