### PR TITLE
fix(translate): remove over-prescriptive InferenceObjective example from pipeline/README.md

### DIFF
--- a/.claude/skills/sim2real-translate/prompts/agent-writer.md
+++ b/.claude/skills/sim2real-translate/prompts/agent-writer.md
@@ -90,7 +90,13 @@ that will be deep-merged onto the experiment's `baseline.yaml` by `prepare.py`.
 - Top-level `scenario:` list with one dict
 - The `name` field MUST match the scenario name in the experiment's baseline file exactly
   (mismatched names cause llmdbenchmark to deploy multiple scenarios instead of merging)
-- InferenceObjectives in `extraObjects` — each MUST include `spec.poolRef.name: ${model.idLabel}-gaie`
+- InferenceObjectives go in `extraObjects`. The only field this format pins is:
+  - `spec.poolRef.name: ${model.idLabel}-gaie` — llm-d-benchmark substitutes
+    `${model.idLabel}` at render time (requires llm-d-benchmark >= PR #1103).
+
+  All other InferenceObjective fields (`apiVersion`, `spec.priority`,
+  `spec.poolRef.group`, etc.) come from the project's context document
+  (typically `config.md`) — copy them from there, not from any example.
 - Plugin config in `inferenceExtension.pluginsCustomConfig` as a YAML-in-YAML string
 - Only include fields you are adding or overriding
 

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -390,24 +390,6 @@ scenario:
     images: {...}
 ```
 
-### InferenceObjective requirements
-
-InferenceObjectives go in `extraObjects`. Each must include `spec.poolRef.name` referencing the InferencePool created by the gaie Helm chart:
-
-```yaml
-extraObjects:
-  - apiVersion: inference.networking.x-k8s.io/v1alpha2
-    kind: InferenceObjective
-    metadata:
-      name: critical
-    spec:
-      poolRef:
-        name: ${model.idLabel}-gaie
-      priority: 100
-```
-
-`${model.idLabel}` is resolved by llm-d-benchmark at render time (requires llm-d-benchmark >= PR #1103).
-
 ### Plugin config
 
 The EPP plugin configuration goes inside `inferenceExtension.pluginsCustomConfig` as a YAML-in-YAML string:

--- a/pipeline/tests/test_assemble.py
+++ b/pipeline/tests/test_assemble.py
@@ -1,4 +1,10 @@
-"""Tests for scenario assembly (baseline/treatment merge logic)."""
+"""Tests for scenario assembly (baseline/treatment merge logic).
+
+Note: the apiVersion/kind fields in these fixtures are illustrative.
+These tests verify deep-merge identity behavior, not the canonical
+apiVersion of any resource. Real apiVersion comes from the project's
+context document at translate time.
+"""
 import pytest
 import yaml
 

--- a/pipeline/tests/test_values.py
+++ b/pipeline/tests/test_values.py
@@ -12,6 +12,11 @@ from pipeline.lib.values import (
 # ── _merge_lists ──────────────────────────────────────────────────────────────
 
 class TestMergeLists:
+    # Note: the apiVersion/kind fields in these fixtures are illustrative.
+    # These tests verify deep-merge identity behavior, not the canonical
+    # apiVersion of any resource. Real apiVersion comes from the project's
+    # context document at translate time.
+
     def test_scalar_list_replaced(self):
         assert _merge_lists(["a", "b"], ["c"]) == ["c"]
 


### PR DESCRIPTION
## Summary

Closes #332.

The translate writer agent was emitting InferenceObjectives with `apiVersion: inference.networking.x-k8s.io/v1alpha2`, which the deployed EPP (watching `llm-d.ai`) silently ignored. Every request fell back to default priority — class-shielding experiments measured nothing meaningful.

Root cause: `pipeline/README.md` carried an InferenceObjective YAML example whose only purpose was to communicate the `spec.poolRef.name: ${model.idLabel}-gaie` rule. The writer copied the entire block — including the wrong apiVersion and a missing `poolRef.group` — overriding the correct values from the project context document.

## Changes

- **Delete** the `### InferenceObjective requirements` section from `pipeline/README.md` (formerly lines 393–409). The poolRef rule survives in the writer prompt, so no rule is lost.
- **Rewrite** the InferenceObjective bullet in `.claude/skills/sim2real-translate/prompts/agent-writer.md` (line 93) to be explicit: only `spec.poolRef.name` is pinned by this format; `apiVersion`, `spec.priority`, `spec.poolRef.group`, etc. come from the project's context document, not from any example.
- **Add disclaimer comments** to `pipeline/tests/test_values.py` (TestMergeLists class) and `pipeline/tests/test_assemble.py` (module docstring): the apiVersion strings in those fixtures are illustrative; the tests verify deep-merge identity behavior, not the canonical apiVersion of any resource. Fixture strings left unchanged.

## Reviewer attention

- Verified `agent-writer.md:93` was the only place outside the deleted README section that stated the `${model.idLabel}-gaie` rule, so no requirement is lost by the deletion.
- Tests still pass with the literal `inference.networking.x-k8s.io/v1alpha2` strings in fixtures — the disclaimer is the only thing distinguishing "what this fixture demonstrates" from "what to copy into a real overlay."

## Stale-reference sweep

Grepped `**/*.md` and Python sources for:
- `InferenceObjective requirements` section title — no remaining cross-refs.
- `x-k8s.io/v1alpha2` in markdown — only in this PR's diff (now gone) and skill prompts (only in code-fenced output examples that don't pin a value).

## Test plan

- [x] `python -m pytest pipeline/ -v` — 912 passed, 2 xfailed (pre-existing)
- [x] `python -m pytest .claude/skills/sim2real-{analyze,bootstrap,translate}/tests/ -v` — 95 passed
- [x] `ruff check pipeline/ .claude/skills/ --select F` — clean