### PR TITLE
fix(translate): remove dead {BASELINE_SIM_CONFIG} / {BASELINE_REAL_CONFIG} / {BASELINE_REAL_NOTES} references from agent prompts

### DIFF
--- a/.claude/skills/sim2real-translate/SKILL.md
+++ b/.claude/skills/sim2real-translate/SKILL.md
@@ -138,7 +138,7 @@ python3 -c "
 import json, sys
 si = json.load(open('$RUN_DIR/skill_input.json'))
 required = ['run_name', 'run_dir', 'scenario', 'context_path', 'manifest_path',
-            'algorithm_source', 'baseline_sim_config',
+            'algorithm_source',
             'target', 'build_commands', 'config_kind', 'context',
             'current_algorithm']
 missing = [f for f in required if f not in si]
@@ -169,9 +169,6 @@ TARGET_REPO=$EXPERIMENT_ROOT/$(python3 -c "import json; print(json.load(open('$R
 CONFIG_KIND=$(python3 -c "import json; print(json.load(open('$RUN_DIR/skill_input.json'))['config_kind'])")
 CURRENT_ALGORITHM=$(python3 -c "import json; print(json.load(open('$RUN_DIR/skill_input.json'))['current_algorithm'])")
 CONTEXT_TEXT=$(python3 -c "import json; print(json.load(open('$RUN_DIR/skill_input.json')).get('context', {}).get('text', ''))")
-BASELINE_SIM_CONFIG=$(python3 -c "import json; v=json.load(open('$RUN_DIR/skill_input.json'))['baseline_sim_config']; print('$EXPERIMENT_ROOT/' + v if v else '')")
-BASELINE_REAL_CONFIG=$(python3 -c "import json; v=json.load(open('$RUN_DIR/skill_input.json')).get('baseline_real_config'); print('$EXPERIMENT_ROOT/' + v if v else 'null')")
-BASELINE_REAL_NOTES=$(python3 -c "import json; print(json.load(open('$RUN_DIR/skill_input.json')).get('baseline_real_notes', ''))")
 ```
 
 Verify source files exist:
@@ -361,9 +358,6 @@ corresponding shell variables:
 - `{CONTEXT_PATH}` → `$CONTEXT_PATH`
 - `{ALGO_SOURCE}` → `$ALGO_SOURCE`
 - `{ALGO_CONFIG}` → `$ALGO_CONFIG`
-- `{BASELINE_SIM_CONFIG}` → `$BASELINE_SIM_CONFIG`
-- `{BASELINE_REAL_CONFIG}` → `$BASELINE_REAL_CONFIG`
-- `{BASELINE_REAL_NOTES}` → `$BASELINE_REAL_NOTES`
 - `{EXPERT_AGENT_NAME}` → `"expert"`
 - `{TARGET_REPO}` → `$TARGET_REPO`
 - `{CONFIG_KIND}` → `$CONFIG_KIND`

--- a/.claude/skills/sim2real-translate/prompts/agent-expert.md
+++ b/.claude/skills/sim2real-translate/prompts/agent-expert.md
@@ -31,9 +31,7 @@ Read the following to build your foundation:
 1. Read `{EXPERIMENT_ROOT}/transfer.yaml` — understand scenario, algorithm, baseline, context
 2. Read `{ALGO_SOURCE}` — the simulation algorithm being translated
 3. If `{ALGO_CONFIG}` is non-empty: read it — algorithm weights and thresholds (ground truth)
-4. If `{BASELINE_SIM_CONFIG}` is non-empty: read it — the simulation baseline policy
-5. If `{BASELINE_REAL_CONFIG}` is not null: read it — real config template
-6. Read all files in context.files (listed in transfer.yaml)
+4. Read all files in context.files (listed in transfer.yaml)
 
 Then do targeted exploration of the target repo:
 

--- a/.claude/skills/sim2real-translate/prompts/agent-reviewer.md
+++ b/.claude/skills/sim2real-translate/prompts/agent-reviewer.md
@@ -28,8 +28,7 @@ Read and hold in context:
    available plugin types and their type strings
 2. **Algorithm source** `{ALGO_SOURCE}` — the simulation Go file being translated
 3. If `{ALGO_CONFIG}` is non-empty: read it — weights and thresholds (ground truth)
-4. If `{BASELINE_REAL_CONFIG}` is non-null: read it — the real config structure for reference
-5. **Pipeline overlay format** `{REPO_ROOT}/pipeline/README.md` — "Scenario Overlay Format"
+4. **Pipeline overlay format** `{REPO_ROOT}/pipeline/README.md` — "Scenario Overlay Format"
    section defines valid overlay structure
 
 You will read the generated plugin files and treatment config fresh on each review request.

--- a/.claude/skills/sim2real-translate/prompts/agent-writer.md
+++ b/.claude/skills/sim2real-translate/prompts/agent-writer.md
@@ -76,12 +76,7 @@ SendMessage({MAIN_SESSION_NAME}, "baseline-ready: {RUN_DIR}/generated/baseline_c
 ```
 and wait for "continue". Baseline config is shared across algorithms.
 
-Read:
-1. `{REPO_ROOT}/pipeline/README.md` — the "Scenario Overlay Format" section defines the
-   required output structure. Follow it exactly.
-2. `{BASELINE_SIM_CONFIG}` (if non-null) — the sim baseline policy
-3. `{BASELINE_REAL_CONFIG}` (if not null) — a reference real config (for guidance, not literal copy)
-4. `{BASELINE_REAL_NOTES}` — translation hints describing what the baseline should contain
+Use the inputs listed in the upfront "Inputs — Read These Now" table.
 
 Your goal: produce `{RUN_DIR}/generated/baseline_config.yaml` — a **llmdbenchmark scenario overlay**
 that will be deep-merged onto the experiment's `baseline.yaml` by `prepare.py`.
@@ -101,12 +96,9 @@ that will be deep-merged onto the experiment's `baseline.yaml` by `prepare.py`.
 - Only include fields you are adding or overriding
 
 **Content rules:**
-- Use `{BASELINE_REAL_NOTES}`, `{BASELINE_SIM_CONFIG}`, and the context document to
-  determine what plugin config and priorities to include
+- Use `{CONTEXT_PATH}` to determine what plugin config and priorities to include
 - Map sim concepts to real plugin type strings via the signal mapping in `{CONTEXT_PATH}`
 - Ask the Expert if you are unsure about any plugin type string or config field name
-- If `{BASELINE_REAL_CONFIG}` is null and `{BASELINE_SIM_CONFIG}` is null, derive content
-  entirely from the context document and Expert
 
 Create the `generated/` directory if needed, then write `{RUN_DIR}/generated/baseline_config.yaml`.
 Then send to main session:


### PR DESCRIPTION
## Summary

Closes #333.

Removes the three dead placeholder variables (`{BASELINE_SIM_CONFIG}`, `{BASELINE_REAL_CONFIG}`, `{BASELINE_REAL_NOTES}`) from the translate skill prompts. These variables were referenced as primary writer inputs but are always empty in production: the bootstrap skill never emits `baselines[].sim` / `baselines[].real`, the v3 manifest validator treats both as silently optional, and no real `transfer.yaml` in this workspace populates them. Their misleading phrasing biased the writer to look past the context document, contributing to #332.

## Changes

| File | Change |
|---|---|
| `.claude/skills/sim2real-translate/prompts/agent-writer.md` | Replaced duplicative Phase 2 `Read:` list with a one-liner pointing at the upfront "Inputs — Read These Now" table. Stripped placeholder mentions from the content rules so they lean on `{CONTEXT_PATH}` and the Expert only. |
| `.claude/skills/sim2real-translate/prompts/agent-expert.md` | Dropped the two conditional `BASELINE_SIM_CONFIG` / `BASELINE_REAL_CONFIG` read items. |
| `.claude/skills/sim2real-translate/prompts/agent-reviewer.md` | Dropped the conditional `BASELINE_REAL_CONFIG` read item. |
| `.claude/skills/sim2real-translate/SKILL.md` | Removed `'baseline_sim_config'` from the `required = [...]` allowlist, deleted the three bash exports, deleted the three substitution-table entries. |

## Reviewer attention

- **Why touch SKILL.md L141 (the allowlist)?** It was the asymmetric piece: only `baseline_sim_config` was required, not the other two. After this PR, the skill's prompt surface no longer consumes the value, so requiring it in the allowlist would just HALT future runs once #335 (pipeline-side cleanup) lands. Removing it here keeps both PRs self-contained.
- **Pipeline emission untouched.** `pipeline/prepare.py:177-184, 431-439, 453-455` still produce these fields in `skill_input.json`; `pipeline/tests/test_prepare.py:657-738` still pin them. That cleanup is tracked in #335 and now unblocked.

## Stale-reference sweep

After the diff, grepped the entire repo for `BASELINE_SIM_CONFIG`, `BASELINE_REAL_CONFIG`, `BASELINE_REAL_NOTES`, `baseline_sim_config`, `baseline_real_config`, `baseline_real_notes`, and the unprefixed `sim_config` / `real_config` / `real_notes` keys. The only remaining hits are in `pipeline/prepare.py` and `pipeline/tests/test_prepare.py` — both deferred to #335. No skill, prompt, or doc residue.

## Test plan

- [x] `python -m pytest pipeline/ .claude/skills/sim2real-{analyze,bootstrap,translate}/tests/ -q` — 1007 passed, 2 xfailed (pre-existing)
- [x] `ruff check pipeline/ .claude/skills/ --select F` — clean
- [x] Acceptance criteria from #333: writer prompt no longer references the dead variables; SKILL.md bash exports gone; SKILL.md required-fields allowlist no longer requires `'baseline_sim_config'`; `skill_input.json` still contains the three fields (pipeline emission intact pending #335).

## Related

- Closes #333
- Unblocks #335
- Follow-up to #332