### PR TITLE
feat(pipeline): expose blis observe tuning params on the sim2real Pipeline (closes #234)

### DIFF
--- a/pipeline/pipeline.yaml
+++ b/pipeline/pipeline.yaml
@@ -33,6 +33,21 @@ spec:
     - name: skipTeardown
       type: string
       default: "false"
+    - name: maxConcurrency
+      type: string
+      default: "10000"
+    - name: timeout
+      type: string
+      default: "1800"
+    - name: warmupRequests
+      type: string
+      default: "50"
+    - name: prewarmDuration
+      type: string
+      default: "60s"
+    - name: extraArgs
+      type: string
+      default: ""
   workspaces:
     - name: source
     - name: data-storage
@@ -113,6 +128,16 @@ spec:
           value: "$(params.workloadSpec)"
         - name: resultsDir
           value: "$(params.runName)/$(params.phase)/$(params.workloadName)"
+        - name: maxConcurrency
+          value: "$(params.maxConcurrency)"
+        - name: timeout
+          value: "$(params.timeout)"
+        - name: warmupRequests
+          value: "$(params.warmupRequests)"
+        - name: prewarmDuration
+          value: "$(params.prewarmDuration)"
+        - name: extraArgs
+          value: "$(params.extraArgs)"
 
     - name: collect-results
       runAfter: ["run-workload-blis-observe-binary"]


### PR DESCRIPTION
## Summary

Closes #234.

This is **PR B** of a two-PR plan:
- **PR A** ([tektonc-data-collection#37](https://github.com/inference-sim/tektonc-data-collection/pull/37), merged at `acf4055`): added params to the `run-workload-blis-observe-binary` Task itself.
- **PR B** (this one): bumps the submodule pointer to PR A's merge SHA and threads matching Pipeline-level params so PipelineRuns can override without touching the Task YAML.

## Changes

**`pipeline/pipeline.yaml`** — adds five Pipeline-level params with defaults matching the Task's, and threads them through the `run-workload-blis-observe-binary` task invocation:

| Param | Default | Source flag | Notes |
|---|---|---|---|
| `maxConcurrency` | `"10000"` | `--max-concurrency` | |
| `timeout` | `"1800"` | `--timeout` | seconds |
| `warmupRequests` | `"50"` | `--warmup-requests` | |
| `prewarmDuration` | `"60s"` | `--prewarm-duration` | `0s` disables priming entirely |
| `extraArgs` | `""` | catch-all | appended verbatim to the `blis observe` command line |

**`tektonc-data-collection`** — submodule pointer bumped from `d33fa35` → `acf4055` (PR #37 merge commit).

## What this PR does NOT do

Per #234's Scope and the cross-reference to #337, **scenario-config-driven values are not threaded** in this PR. `pipeline/lib/tekton.py:make_pipelinerun_scenario()` is unchanged — generated PipelineRuns do not emit the new params, so Tekton uses the Pipeline-level defaults (which match the previously hardcoded Task values). That keeps behavior identical for existing callers.

The follow-up that wires these from `transfer.yaml` / scenario / workload through to PipelineRun param values is tracked in #337. Once #337 resolves the manifest-hierarchy question, the threading can land in a focused PR.

## Reviewer attention

- **Default parity.** The Pipeline defaults (`"10000"` / `"1800"` / `"50"` / `"60s"` / `""`) intentionally mirror the Task defaults from PR #37. Drifting them apart would silently change behavior — keep them in sync until #337 lands a manifest-driven source.
- **`extraArgs` shell behavior.** The Task script appends `$(params.extraArgs)` unquoted on its own continuation line. With the empty default, POSIX `\<newline>` line-joining produces trailing whitespace which the shell discards — verified with `bash -c` repro before pushing PR A.
- **Tests.** `pipeline/tests/test_tekton.py` (9 tests) still pass — they assert presence of specific PipelineRun params, not absence of others, so adding new Pipeline-level params with default-passthrough doesn't break anything.

## Stale-reference sweep

Grepped `**/*.md`, `**/*.py`, `**/*.yaml` for the previous hardcoded values (`max-concurrency`, `--timeout 1800`, `warmup-requests 50`, `prewarm-duration 60s`, `extraArgs`). The only hits are this PR's diff in `pipeline/pipeline.yaml`. No docs, comments, or skill prompts referenced the old hardcoded values.

## Test plan

- [x] `python -m pytest pipeline/ .claude/skills/sim2real-{analyze,bootstrap,translate}/tests/ -q` — 1007 passed, 2 xfailed (pre-existing)
- [x] `ruff check pipeline/ .claude/skills/ --select F` — clean
- [ ] Manual: a PipelineRun without overrides should reproduce current behavior identically (defaults flow Pipeline → Task).
- [ ] Manual: a PipelineRun overriding `prewarmDuration: "0s"` should skip the prewarm phase entirely (per `inference-sim/cmd/observe_cmd.go:478-480`).

## Related

- Closes #234
- Depends on tektonc-data-collection#37 (merged)
- Blocks (in spirit) #337 — the manifest-hierarchy decision can now land cleanly because the Pipeline already accepts the values.