### PR TITLE
feat(pipeline): wire stream-gpu-stats and pull gpu_logs/ during deploy.py collect

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,7 @@ All artifacts live under `<experiment-root>/workspace/` (gitignored). When no `-
 | `runs/<run>/cluster/pipelinerun-*.yaml` | `prepare.py` Phase 4 | `deploy.py run` |
 | `runs/<run>/run_summary.md` | `prepare.py` Phase 5 | human review |
 | `runs/<run>/results/{phase}/` | `deploy.py collect` | `/sim2real-analyze` skill, `deploy.py wipe` |
+| `runs/<run>/results/{phase}/<workload>/gpu_logs/<node>.log` | `deploy.py collect` (pulled from PVC) | analysis / debugging |
 | ConfigMap `sim2real-progress-{run}` | `deploy.py run`, `deploy.py reset` | All `deploy.py` subcommands |
 | `runs/<run>/plans/<phase>/<workload>/` | `deploy.py run` | workload tasks |
 | `context/{scenario}/{hash}.md` | `prepare.py` Phase 2 | `prepare.py` Phase 2 (cache) |

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -997,12 +997,12 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
                         continue
                     wl_dest = dest_dir / wl_name
                     wl_dest.mkdir(parents=True, exist_ok=True)
-                    for log_dir in (wl_dest / "server_logs", wl_dest / "epp_logs", wl_dest / "resources"):
+                    for log_dir in (wl_dest / "server_logs", wl_dest / "epp_logs", wl_dest / "gpu_logs", wl_dest / "resources"):
                         if log_dir.exists():
                             shutil.rmtree(log_dir)
                     # Copy trace files
                     wl_errors = []
-                    for fname in ("trace_data.csv", "trace_header.yaml", "epp_stream_done"):
+                    for fname in ("trace_data.csv", "trace_header.yaml", "epp_stream_done", "gpu_stream_done"):
                         src = f"{namespace}/{pod_name}:/data/{run_name}/{phase}/{wl_name}/{fname}"
                         r = run(["kubectl", "cp", src, str(wl_dest / fname), "--retries=3"],
                                 check=False, capture=True)
@@ -1016,6 +1016,14 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
                             check=False, capture=True)
                     if r.returncode != 0 and "no such file" not in r.stderr.lower():
                         wl_errors.append(f"{wl_name}/epp_logs: {r.stderr.strip()}")
+                    # Copy gpu_logs directory
+                    gpu_src = f"{namespace}/{pod_name}:/data/{run_name}/{phase}/{wl_name}/gpu_logs/"
+                    gpu_dest = wl_dest / "gpu_logs"
+                    gpu_dest.mkdir(exist_ok=True)
+                    r = run(["kubectl", "cp", gpu_src, str(gpu_dest), "--retries=3"],
+                            check=False, capture=True)
+                    if r.returncode != 0 and "no such file" not in r.stderr.lower():
+                        wl_errors.append(f"{wl_name}/gpu_logs: {r.stderr.strip()}")
                     # Copy resources directory
                     res_src = f"{namespace}/{pod_name}:/data/{run_name}/{phase}/{wl_name}/resources/"
                     res_dest = wl_dest / "resources"

--- a/pipeline/pipeline.yaml
+++ b/pipeline/pipeline.yaml
@@ -110,6 +110,19 @@ spec:
         - name: resultsDir
           value: "$(params.runName)/$(params.phase)/$(params.workloadName)"
 
+    - name: stream-gpu-stats
+      runAfter: ["llmdbenchmark-standup"]
+      taskRef:
+        name: stream-gpu-stats
+      workspaces:
+        - name: data
+          workspace: data-storage
+      params:
+        - name: namespace
+          value: "$(params.namespace)"
+        - name: resultsDir
+          value: "$(params.runName)/$(params.phase)/$(params.workloadName)"
+
     - name: run-workload-blis-observe-binary
       runAfter: ["llmdbenchmark-standup", "install-blis"]
       taskRef:

--- a/pipeline/tests/test_deploy_collect.py
+++ b/pipeline/tests/test_deploy_collect.py
@@ -1514,7 +1514,7 @@ def test_collect_per_workload_clears_stale_files(tmp_path, monkeypatch):
 
 
 def test_collect_skip_logs_clears_stale_log_dirs(tmp_path, monkeypatch):
-    """--skip-logs path removes stale server_logs/ and epp_logs/ before copying."""
+    """--skip-logs path removes stale server_logs/, epp_logs/, and gpu_logs/ before copying."""
     from pipeline import deploy
     import subprocess
 
@@ -1530,6 +1530,10 @@ def test_collect_skip_logs_clears_stale_log_dirs(tmp_path, monkeypatch):
     stale_epp = results_dir / "epp_logs" / "stale.log"
     stale_epp.parent.mkdir(parents=True)
     stale_epp.write_text("stale epp log")
+
+    stale_gpu = results_dir / "gpu_logs" / "stale.log"
+    stale_gpu.parent.mkdir(parents=True)
+    stale_gpu.write_text("stale gpu log")
 
     data = {
         "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
@@ -1553,6 +1557,45 @@ def test_collect_skip_logs_clears_stale_log_dirs(tmp_path, monkeypatch):
     assert not stale_server.exists()
     assert not (results_dir / "server_logs").exists()
     assert not stale_epp.exists()
+    assert not stale_gpu.exists()
+
+
+def test_collect_skip_logs_invokes_gpu_logs_copy(tmp_path, monkeypatch):
+    """--skip-logs path issues a kubectl cp for gpu_logs/ alongside epp_logs/."""
+    from pipeline import deploy
+    import subprocess
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+
+    data = {
+        "wl-smoke-baseline": {"workload": "smoke", "package": "baseline", "status": "done", "completed_namespace": "ns-0"},
+    }
+    _mock_cm(monkeypatch, data)
+
+    cp_targets = []
+
+    def mock_run(cmd, **kwargs):
+        mock = MagicMock(returncode=0, stdout="", stderr="")
+        cmd_list = cmd if isinstance(cmd, list) else cmd.split()
+        cmd_str = " ".join(cmd_list)
+        if "exec" in cmd_str and "ls" in cmd_str:
+            mock.stdout = "wl-smoke"
+        if "exec" in cmd_str and "stat" in cmd_str:
+            mock.stdout = ""
+        if "cp" in cmd_list and len(cmd_list) >= 4:
+            cp_targets.append(cmd_list[2])  # the source spec, e.g. ns/pod:/path/...
+        return mock
+
+    monkeypatch.setattr(subprocess, "run", mock_run)
+
+    deploy._extract_phases_from_pvc(
+        ["baseline"], "test-run", "ns-0", run_dir, skip_logs=True)
+
+    sources = " ".join(cp_targets)
+    assert "/wl-smoke/gpu_logs/" in sources, f"no gpu_logs/ copy issued; saw: {cp_targets}"
+    assert "/wl-smoke/epp_logs/" in sources, f"sanity: epp_logs/ copy still issued; saw: {cp_targets}"
+    assert "/wl-smoke/gpu_stream_done" in sources, f"no gpu_stream_done sentinel copy; saw: {cp_targets}"
 
 
 def test_collect_idempotent_no_stale_accumulation(tmp_path, monkeypatch):

--- a/pipeline/tests/test_pipeline_yaml.py
+++ b/pipeline/tests/test_pipeline_yaml.py
@@ -90,3 +90,61 @@ class TestStreamEppLogsTask:
         s_rd = next(p["value"] for p in s["params"] if p["name"] == "resultsDir")
         w_rd = next(p["value"] for p in w["params"] if p["name"] == "resultsDir")
         assert s_rd == w_rd, f"resultsDir mismatch: streamer={s_rd!r} workload={w_rd!r}"
+
+
+class TestStreamGpuStatsTask:
+    """stream-gpu-stats task invocation in pipeline.yaml."""
+
+    def _get_stream_gpu_stats_task(self):
+        pipeline = yaml.safe_load(PIPELINE_YAML.read_text())
+        tasks = pipeline["spec"]["tasks"]
+        s = [t for t in tasks if t["name"] == "stream-gpu-stats"]
+        assert len(s) == 1, "Expected exactly one stream-gpu-stats task"
+        return s[0]
+
+    def test_task_present(self):
+        """stream-gpu-stats must be wired into the pipeline."""
+        self._get_stream_gpu_stats_task()
+
+    def test_task_ref(self):
+        """taskRef points at the stream-gpu-stats Task resource."""
+        task = self._get_stream_gpu_stats_task()
+        assert task["taskRef"]["name"] == "stream-gpu-stats"
+
+    def test_runs_after_standup(self):
+        """Streamer starts as soon as the model stack is up — in parallel with the workload."""
+        task = self._get_stream_gpu_stats_task()
+        assert task["runAfter"] == ["llmdbenchmark-standup"], (
+            "Streamer must start after standup (when vLLM pods exist) and "
+            "in parallel with the workload, not after it."
+        )
+
+    def test_data_workspace_bound(self):
+        """data workspace must be bound to data-storage so logs land on the shared PVC."""
+        task = self._get_stream_gpu_stats_task()
+        ws = {w["name"]: w["workspace"] for w in task["workspaces"]}
+        assert ws.get("data") == "data-storage"
+
+    def test_has_namespace_param(self):
+        """stream-gpu-stats must receive the namespace param."""
+        task = self._get_stream_gpu_stats_task()
+        param_names = [p["name"] for p in task["params"]]
+        assert "namespace" in param_names
+
+    def test_has_results_dir_param(self):
+        """stream-gpu-stats must receive the resultsDir param so its output sits next to the workload's."""
+        task = self._get_stream_gpu_stats_task()
+        param_names = [p["name"] for p in task["params"]]
+        assert "resultsDir" in param_names
+
+    def test_results_dir_matches_workload(self):
+        """The streamer's resultsDir must be identical to the workload's, so they write into the same per-workload subdir."""
+        pipeline = yaml.safe_load(PIPELINE_YAML.read_text())
+        tasks = pipeline["spec"]["tasks"]
+
+        s = next(t for t in tasks if t["name"] == "stream-gpu-stats")
+        w = next(t for t in tasks if t["name"] == "run-workload-blis-observe-binary")
+
+        s_rd = next(p["value"] for p in s["params"] if p["name"] == "resultsDir")
+        w_rd = next(p["value"] for p in w["params"] if p["name"] == "resultsDir")
+        assert s_rd == w_rd, f"resultsDir mismatch: streamer={s_rd!r} workload={w_rd!r}"


### PR DESCRIPTION
Closes #340
Parent (now merged): inference-sim/tektonc-data-collection#39

## Summary

Bumps the `tektonc-data-collection` submodule to `3a16c7c` (the merge of #39, which resolves the parent issue #38) and wires the new `stream-gpu-stats` Tekton Task into the sim2real pipeline. After this, every benchmark run will write per-node `nvidia-smi` snapshots to `results/{phase}/<workload>/gpu_logs/<node>.log` and a one-shot pod -> GPU-UUID map to `gpu_logs/<pod>.uuids`, and `deploy.py collect` will pull both into the local results tree.

## Files

- **MODIFIED** `tektonc-data-collection` submodule pointer — `acf4055` → `3a16c7c`. Brings in the new `stream-gpu-stats.yaml` Task, the `pods/exec` RBAC grant on `helm-installer-clusterrole`, and the `gpu_stream_done` sentinel write in `collect-results.yaml`.
- **MODIFIED** `pipeline/pipeline.yaml` — new `stream-gpu-stats` task entry parallel to `stream-epp-logs`, `runAfter: [llmdbenchmark-standup]`, same `data-storage` workspace, same per-workload `resultsDir`. No new pipeline param — relies on the Task's defaults (`intervalSeconds=10s`, etc.).
- **MODIFIED** `pipeline/deploy.py` — `--skip-logs` selective-copy block extended: `gpu_logs/` joins the stale-dir cleanup tuple, `gpu_stream_done` joins the trace-file sentinel list, and a new `kubectl cp` block pulls `gpu_logs/` alongside `epp_logs/`. Non-skip-logs tar path needs no change. `_cmd_wipe` needs no change.
- **NEW TESTS** `pipeline/tests/test_pipeline_yaml.py::TestStreamGpuStatsTask` — 7 cases mirroring `TestStreamEppLogsTask`: task present, taskRef, `runAfter: [llmdbenchmark-standup]`, `data` → `data-storage`, namespace param, resultsDir param, resultsDir matches workload.
- **NEW TEST** `pipeline/tests/test_deploy_collect.py::test_collect_skip_logs_invokes_gpu_logs_copy` — asserts `kubectl cp` is issued for `gpu_logs/` and `gpu_stream_done` under `--skip-logs`. Also extended `test_collect_skip_logs_clears_stale_log_dirs` to assert stale `gpu_logs/` is removed before copy.
- **MODIFIED** `CLAUDE.md` — added one row to the workspace-artifact table for `results/{phase}/<workload>/gpu_logs/<node>.log`. (Issue body said "pipeline/README.md workspace artifact table" but the canonical table actually lives in top-level `CLAUDE.md` — there is no such table in `pipeline/README.md`.)

## Reviewer attention

- **Submodule bump is in the same commit as the wiring**, matching recent precedent (#331 did the same thing for inference-sim + tektonc-data-collection bumps). Splitting them would land a half-functional state on `main` between the two PRs.
- **No new pipeline param.** The issue offered an optional `gpuStatsIntervalSeconds`. Sticking with the Task default keeps the diff minimal — easy to add later from `transfer.yaml` if anyone needs to tune the cadence.
- **Stale-ref sweep:** grepped `*.md` for `epp_logs / server_logs / gpu_logs / stream-epp-logs / stream-gpu-stats`. No hits outside the submodule (which has its own docs we don't own here). Nothing else to update.
- **Documentation file mismatch:** the issue specified `pipeline/README.md` for the artifact-table row, but the canonical workspace-artifact table is in top-level `CLAUDE.md` — `pipeline/README.md` has no such table. Calling this out so the reviewer can confirm.
- **CI parity:** ran the full CI command locally (`pytest pipeline/ .claude/skills/sim2real-analyze/tests/ .claude/skills/sim2real-bootstrap/tests/ .claude/skills/sim2real-translate/tests/`) — 1015 passed, 2 xfailed. Ruff `--select F` clean.

## Test plan

- [x] `ruff check pipeline/ .claude/skills/ --select F` — passes
- [x] `pytest pipeline/ <skill tests>` — 1015 passed (8 new, 1 extended)
- [x] Worktree path-discipline check — parent repo clean of tracked-file changes
- [ ] End-to-end: a real benchmark run on a GPU cluster with the operator. Will verify `gpu_logs/<node>.log` accumulates `nvidia-smi` blocks and `<pod>.uuids` is populated for stock vLLM pods. Out of scope here (no cluster in CI).

## Out of scope (separate follow-ups)

- Parsing/analysis of `gpu_logs/` content (e.g. extracting GPU memory time-series).
- Wiring `gpu_logs/` into `sim2real-check` or `sim2real-analyze` skills. Capture first; analyze separately.