### PR TITLE
fix(translate): require verbatim field-level copy of config.md InferenceObjective fields

### DIFF
--- a/.claude/skills/sim2real-translate/prompts/agent-writer.md
+++ b/.claude/skills/sim2real-translate/prompts/agent-writer.md
@@ -85,13 +85,18 @@ that will be deep-merged onto the experiment's `baseline.yaml` by `prepare.py`.
 - Top-level `scenario:` list with one dict
 - The `name` field MUST match the scenario name in the experiment's baseline file exactly
   (mismatched names cause llmdbenchmark to deploy multiple scenarios instead of merging)
-- InferenceObjectives go in `extraObjects`. The only field this format pins is:
-  - `spec.poolRef.name: ${model.idLabel}-gaie` — llm-d-benchmark substitutes
-    `${model.idLabel}` at render time (requires llm-d-benchmark >= PR #1103).
+- InferenceObjectives go in `extraObjects`. The format pins one rule:
+  - `spec.poolRef.name` MUST equal `${model.idLabel}-gaie` so llm-d-benchmark
+    substitutes `${model.idLabel}` at render time (requires llm-d-benchmark
+    >= PR #1103).
 
-  All other InferenceObjective fields (`apiVersion`, `spec.priority`,
-  `spec.poolRef.group`, etc.) come from the project's context document
-  (typically `config.md`) — copy them from there, not from any example.
+  Everything else MUST be copied verbatim from the project's context document
+  (typically `config.md`) at the field level. In particular: copy the entire
+  `spec.poolRef` block (including `group`, `name`, and any other keys), not
+  just `name`. Same applies to `apiVersion`, `metadata`, `spec.priority`, and
+  any other nested fields the project's `config.md` declares — if it's in
+  config.md's InferenceObjective, it MUST appear in the generated output.
+  Do not paraphrase or selectively include fields.
 - Plugin config in `inferenceExtension.pluginsCustomConfig` as a YAML-in-YAML string
 - Only include fields you are adding or overriding
 


### PR DESCRIPTION
Closes #343.

## Summary

The translation writer was paraphrasing the InferenceObjective rule rather than enforcing it. The post-#332 wording in `agent-writer.md:88-94` said *"All other InferenceObjective fields … come from the project's context document"* — ambient language a writer can reasonably read as "use config.md if you choose to include these fields," not "every field config.md declares MUST appear in the generated output."

That softer reading is consistent with the observed bug: the writer copied `spec.poolRef.name` from `config.md` but dropped `spec.poolRef.group`. The runtime impact (verified across three replicates of `workspace/runs/sr-mk/results.{1,2,3}`): every InferenceObjective lookup fails — `datastore.ObjectiveGet` returns nil because the EPP can't match the objective to the deployed `InferencePool` without a properly-grouped `poolRef` — and treatment/control/baseline collapse to identical admission behavior. ~96K `"No associated InferenceObjective found, using default"` lines per replicate.

This PR replaces the wording with a forcing rule: `spec.poolRef.name` MUST equal the template literal; everything else MUST be copied verbatim from the context document at the field level. The wording explicitly calls out the entire `spec.poolRef` block (including `group`, `name`, and any other keys), not just `name`. Same for `apiVersion`, `metadata`, `spec.priority`, and any other nested fields the project's `config.md` declares.

## What changed

`.claude/skills/sim2real-translate/prompts/agent-writer.md` lines 88-94 — one paragraph rewritten. No code changes, no test changes.

## Reviewer attention

- **Wording strength.** The new text uses "MUST" and "verbatim" repeatedly. That's deliberate — the prior bug class is the writer paraphrasing or selectively including fields, so the rule is written to forbid both behaviors. If the wording feels heavy, the alternative (a programmatic field-level diff guard) is tracked in #341/#339; this PR is the lightweight prompt-only fix.
- **Scope.** The rule applies to InferenceObjectives in `extraObjects`. It does not extend to other artifacts (e.g., the EPP plugin config), which haven't shown the same drop pattern.

## Sweep

Per the implement-issue Step 6 sweep:

- `pipeline/README.md` — no longer carries the over-prescriptive InferenceObjective example (#332's fix landed in #334). Generic structural mentions at lines 388/418/425 are unaffected.
- `.claude/skills/sim2real-translate/prompts/agent-expert.md` and `agent-reviewer.md` — no parallel paragraph requiring updates.
- `.claude/skills/sim2real-check/SKILL.md` — already references `spec.poolRef.group` as a field to validate in Step 2d (#341's static check). Consistent with this PR's direction.
- `pipeline/tests/test_values.py` / `test_assemble.py` — fixtures use illustrative `inference.networking.x-k8s.io/v1alpha2` strings, already noted as illustrative per #332's plan. They don't contradict the new rule (which governs translator output, not test fixtures).
- Phase-3 line at `agent-writer.md:138` ("Do NOT repeat `extraObjects` …") — unrelated; that's about deep-merge propagation, not field copying.

## Verification

Per the issue's recipe (manual, since this is a prompt change without automated guards):

1. Re-translate against `soft-reflective`'s `transfer.yaml` and confirm the new `generated/baseline_config.yaml` carries `spec.poolRef.group: inference.networking.k8s.io` on both InferenceObjective entries.
2. Apply the regenerated configmap and run one workload at v=3.
3. `grep -c "No associated InferenceObjective found" results.<n>/*/*/epp_logs/*.log` should be 0.

Local pre-push checks:
- `python -m pytest pipeline/ -v` — 920 passed, 2 xfailed.
- `ruff check pipeline/ --select F` — clean.
- `git -C <parent-repo> status` — only the worktree shows changes; no leakage.

## Related

- #332 — first instance of this drop pattern (`apiVersion` field), fixed in #334.
- #333 — dead `{BASELINE_*}` reference cleanup, fixed in #336 (independent).
- #339/#341 — sim2real-check additions that automate the equivalent field-level diff at config-time. This PR is the immediate prompt-only fix; #341 (now landed) is the structural defense for future drops.