### PR TITLE
fix(pipeline): wire prepare-results-dir into DAG; bump submodule

### DIFF
--- a/pipeline/pipeline.yaml
+++ b/pipeline/pipeline.yaml
@@ -97,8 +97,18 @@ spec:
         - name: smoketest_delay
           value: "30"
 
+    - name: prepare-results-dir
+      taskRef:
+        name: prepare-results-dir
+      workspaces:
+        - name: data
+          workspace: data-storage
+      params:
+        - name: resultsDir
+          value: "$(params.runName)/$(params.phase)/$(params.workloadName)"
+
     - name: stream-epp-logs
-      runAfter: ["llmdbenchmark-standup"]
+      runAfter: ["llmdbenchmark-standup", "prepare-results-dir"]
       taskRef:
         name: stream-epp-logs
       workspaces:
@@ -111,7 +121,7 @@ spec:
           value: "$(params.runName)/$(params.phase)/$(params.workloadName)"
 
     - name: stream-gpu-stats
-      runAfter: ["llmdbenchmark-standup"]
+      runAfter: ["llmdbenchmark-standup", "prepare-results-dir"]
       taskRef:
         name: stream-gpu-stats
       workspaces:
@@ -124,7 +134,7 @@ spec:
           value: "$(params.runName)/$(params.phase)/$(params.workloadName)"
 
     - name: run-workload-blis-observe-binary
-      runAfter: ["llmdbenchmark-standup", "install-blis"]
+      runAfter: ["llmdbenchmark-standup", "install-blis", "prepare-results-dir"]
       taskRef:
         name: run-workload-blis-observe-binary
       workspaces:

--- a/pipeline/tests/test_pipeline_yaml.py
+++ b/pipeline/tests/test_pipeline_yaml.py
@@ -56,10 +56,19 @@ class TestStreamEppLogsTask:
     def test_runs_after_standup(self):
         """Streamer starts as soon as the model stack is up — in parallel with the workload."""
         task = self._get_stream_epp_logs_task()
-        assert task["runAfter"] == ["llmdbenchmark-standup"], (
+        run_after = task["runAfter"]
+        assert "llmdbenchmark-standup" in run_after, (
             "Streamer must start after standup (when EPP pods exist) and "
             "in parallel with the workload, not after it."
         )
+        assert "run-workload-blis-observe-binary" not in run_after, (
+            "Streamer must run in parallel with the workload, not after it."
+        )
+
+    def test_runs_after_prepare_results_dir(self):
+        """Streamer must wait for prepare-results-dir so RESULTS_DIR exists before it writes."""
+        task = self._get_stream_epp_logs_task()
+        assert "prepare-results-dir" in task["runAfter"]
 
     def test_data_workspace_bound(self):
         """data workspace must be bound to data-storage so logs land on the shared PVC."""
@@ -114,10 +123,19 @@ class TestStreamGpuStatsTask:
     def test_runs_after_standup(self):
         """Streamer starts as soon as the model stack is up — in parallel with the workload."""
         task = self._get_stream_gpu_stats_task()
-        assert task["runAfter"] == ["llmdbenchmark-standup"], (
+        run_after = task["runAfter"]
+        assert "llmdbenchmark-standup" in run_after, (
             "Streamer must start after standup (when vLLM pods exist) and "
             "in parallel with the workload, not after it."
         )
+        assert "run-workload-blis-observe-binary" not in run_after, (
+            "Streamer must run in parallel with the workload, not after it."
+        )
+
+    def test_runs_after_prepare_results_dir(self):
+        """Streamer must wait for prepare-results-dir so RESULTS_DIR exists before it writes."""
+        task = self._get_stream_gpu_stats_task()
+        assert "prepare-results-dir" in task["runAfter"]
 
     def test_data_workspace_bound(self):
         """data workspace must be bound to data-storage so logs land on the shared PVC."""
@@ -148,3 +166,81 @@ class TestStreamGpuStatsTask:
         s_rd = next(p["value"] for p in s["params"] if p["name"] == "resultsDir")
         w_rd = next(p["value"] for p in w["params"] if p["name"] == "resultsDir")
         assert s_rd == w_rd, f"resultsDir mismatch: streamer={s_rd!r} workload={w_rd!r}"
+
+
+class TestPrepareResultsDirTask:
+    """prepare-results-dir is the single owner of RESULTS_DIR creation; every writer must runAfter it."""
+
+    WRITERS = [
+        "stream-epp-logs",
+        "stream-gpu-stats",
+        "run-workload-blis-observe-binary",
+        "collect-results",
+    ]
+
+    def _pipeline(self):
+        return yaml.safe_load(PIPELINE_YAML.read_text())
+
+    def _get(self, name):
+        tasks = self._pipeline()["spec"]["tasks"]
+        matches = [t for t in tasks if t["name"] == name]
+        assert len(matches) == 1, f"Expected exactly one {name} task"
+        return matches[0]
+
+    def test_task_present(self):
+        """prepare-results-dir must be wired into the pipeline."""
+        self._get("prepare-results-dir")
+
+    def test_task_ref(self):
+        """taskRef points at the prepare-results-dir Task resource."""
+        assert self._get("prepare-results-dir")["taskRef"]["name"] == "prepare-results-dir"
+
+    def test_data_workspace_bound(self):
+        """data workspace must be bound to data-storage so the wipe targets the shared PVC."""
+        ws = {w["name"]: w["workspace"] for w in self._get("prepare-results-dir")["workspaces"]}
+        assert ws.get("data") == "data-storage"
+
+    def test_has_results_dir_param(self):
+        """prepare-results-dir must receive resultsDir to know what to wipe."""
+        params = [p["name"] for p in self._get("prepare-results-dir")["params"]]
+        assert "resultsDir" in params
+
+    def test_results_dir_matches_workload(self):
+        """prepare-results-dir's resultsDir must match every writer's resultsDir verbatim."""
+        prep_rd = next(p["value"] for p in self._get("prepare-results-dir")["params"]
+                       if p["name"] == "resultsDir")
+        for w in self.WRITERS:
+            w_rd = next(p["value"] for p in self._get(w)["params"]
+                        if p["name"] == "resultsDir")
+            assert prep_rd == w_rd, f"resultsDir mismatch: prepare={prep_rd!r} {w}={w_rd!r}"
+
+    def test_every_writer_runs_after_prepare(self):
+        """Every task that writes inside RESULTS_DIR must list prepare-results-dir in runAfter, directly or transitively. Direct edges keep the contract self-documenting and survive future re-ordering of upstream dependencies."""
+        tasks_by_name = {t["name"]: t for t in self._pipeline()["spec"]["tasks"]}
+
+        def transitively_after(task_name, target):
+            """Walk runAfter edges; return True if target reachable."""
+            seen = set()
+            frontier = list(tasks_by_name[task_name].get("runAfter", []))
+            while frontier:
+                n = frontier.pop()
+                if n in seen:
+                    continue
+                seen.add(n)
+                if n == target:
+                    return True
+                frontier.extend(tasks_by_name.get(n, {}).get("runAfter", []))
+            return False
+
+        for w in self.WRITERS:
+            assert transitively_after(w, "prepare-results-dir"), (
+                f"{w} must runAfter prepare-results-dir (directly or transitively)"
+            )
+
+    def test_prepare_runs_first(self):
+        """prepare-results-dir itself must not have any runAfter — it owns the RESULTS_DIR creation invariant and must run before every writer."""
+        prep = self._get("prepare-results-dir")
+        assert "runAfter" not in prep or not prep["runAfter"], (
+            "prepare-results-dir must have no runAfter so it runs as early as possible "
+            "in the DAG and the wipe-and-create invariant holds before any writer starts."
+        )


### PR DESCRIPTION
## Summary

- Wires the new `prepare-results-dir` Task into the static Pipeline so `RESULTS_DIR` is wiped-and-created exactly once, before the parallel writer fan-out. Closes the `rm -rf` race that previously let `run-workload-blis-observe-binary` clear `RESULTS_DIR` while `stream-gpu-stats` / `stream-epp-logs` were already writing into subdirs.
- Bumps `tektonc-data-collection` submodule pointer to [`2f22ccd`](https://github.com/inference-sim/tektonc-data-collection/pull/42) — the upstream side of this change (`prepare-results-dir.yaml`, Phase 1.5 stderr capture, new Phase 2.5 per-node UUID/index/bus-id CSV).
- Updates `test_pipeline_yaml.py` to lock the architectural invariant.

## Changes

**`pipeline/pipeline.yaml`**
- New `prepare-results-dir` task (no `runAfter` — runs as early as possible).
- Adds `prepare-results-dir` to the `runAfter` of every writer: `stream-epp-logs`, `stream-gpu-stats`, `run-workload-blis-observe-binary`. `collect-results` inherits via the workload runner.

**`pipeline/tests/test_pipeline_yaml.py`**
- Loosen exact-equality `runAfter` assertions on streamers to membership checks; add `test_runs_after_prepare_results_dir` for both.
- New `TestPrepareResultsDirTask` class: presence, taskRef, workspace binding, `resultsDir` matches every writer, every writer reaches `prepare-results-dir` transitively, prepare itself has empty `runAfter`.

**Submodule**
- `tektonc-data-collection` bumped from `bed0950` → `2f22ccd`.

Closes #348.
Closes inference-sim/tektonc-data-collection#41 once landed.

## Test plan

- [ ] CI green (ruff + pytest)
- [ ] In-cluster run after merge: every workload's `gpu_logs/` contains `<pod>.uuids` or `<pod>.uuids.err`; every node has `<node>.gpus.csv` or `<node>.gpus.csv.err`; no `nonexistent directory` errors from streamers; `gpu_stream_done` and `epp_stream_done` sentinels still written by `collect-results`.