### PR TITLE
feat(pipeline): retries: 2 on install-llmdbenchmark; consolidate install upstream

### DIFF
--- a/pipeline/pipeline.yaml
+++ b/pipeline/pipeline.yaml
@@ -53,6 +53,7 @@ spec:
     - name: data-storage
   tasks:
     - name: install-llmdbenchmark
+      retries: 2
       taskRef:
         name: install-llmdbenchmark
       workspaces:


### PR DESCRIPTION
## Summary

- Adds `retries: 2` to the `install-llmdbenchmark` pipeline task in `pipeline.yaml`. Tekton spawns a fresh pod and re-runs the whole task on failure, up to 2 retries — covering transient apt mirror / GitHub / PyPI / curl helm / helm plugin install failures.
- Bumps `tektonc-data-collection` submodule to inference-sim/tektonc-data-collection#43, which moves all install-shaped work into `install-llmdbenchmark` and persists the `helm-diff` plugin to a workspace-relative `HELM_DATA_HOME`. This makes the install task ~30s, fully idempotent, and a clean retry target.
- The pre-existing 5-min `llmdbenchmark-standup` task gains a fail-loud preamble that asserts the venv/tool/plugin cache is populated; no retry semantics on it (vllm-deploy/smoketest failures need teardown-then-redo, out of scope, tracked separately).
- The `llmdbenchmark-teardown` task gains the mirrored preamble but exits 0 when the cache is missing (means standup never ran → nothing on-cluster to clean).

Closes #352.

## Why

Today a PipelineRun failed at `step-install-and-standup` with `curl: (35) Recv failure: Connection reset by peer` while downloading Helm. No retry happened — `pipeline.yaml` had no `retries:` and `deploy.py`'s application-level retry only covers PipelineRun timeout and recoverable pod-scheduling. A `Failed` PipelineRun status was terminal.

Tekton has no per-step retries (verified vs. v1 docs); the only Tekton-native scoping is to put `retries: N` on a whole task. Putting it on the existing 5-min standup task is wrong because (a) full-task retry blows 5 min per attempt and (b) vllm-deploy failures (the second-most-common failure) leave half-deployed helm releases that a fresh TaskRun won't clean up.

The submodule PR makes the install task small enough and idempotent enough to be a sensible retry target.

## Sequencing

This PR depends on inference-sim/tektonc-data-collection#43. The submodule pointer here is set to that PR's branch HEAD; once #43 merges, that commit is reachable on the submodule's `main`.

## Test plan

- [x] `ruff check pipeline/ .claude/skills/ --select F` — clean
- [x] `python -m pytest pipeline/ .claude/skills/sim2real-{analyze,bootstrap,translate}/tests/ -v` — 1024 passed, 2 xfailed
- [ ] On a real cluster after submodule PR merges:
  - First-run install-llmdbenchmark performs full install end to end
  - Second-run on same commit fast-skips in <1s
  - Forced curl failure inside install.sh: Tekton retries the task, attempt 2 succeeds, standup runs normally
  - Standup pod sees `${HELM_DATA_HOME}/plugins/helm-diff` populated; `helmfile apply` succeeds

## Sweep

Grepped `install-and-standup`/`install-and-teardown`/`Reusing cached CLI tools`/`LLMDBENCH_VENV_DIR` across `**/*.{py,md,yaml,yml}` in `docs/`, `pipeline/`, `.claude/` — no stale references. `pipeline/README.md` mentions of "retries" all refer to deploy.py's application-level pair retries (unrelated to this PR's Tekton task retry).

## Out of scope

vllm-deploy / smoketest failure recovery. That requires teardown-then-redo of standup, which doesn't fit Tekton task `retries`. Track separately as a `deploy.py`-level reclaim/redispatch case.