### PR TITLE
feat(bootstrap): add routing-proxy-resources framework default

### DIFF
--- a/.claude/skills/sim2real-bootstrap/SKILL.md
+++ b/.claude/skills/sim2real-bootstrap/SKILL.md
@@ -252,10 +252,10 @@ ls "$EXPERIMENT_ROOT"/workloads/*.yaml
 **action:** shell
 
 Framework workarounds documented in `docs/troubleshooting.md` (EPP llm-d.ai
-RBAC, request-id preservation, EPP/vLLM verbosity) are applied automatically
-by `prepare.py` Phase 4 from `<experiment-root>/baselines/defaults/`. Copy
-the framework templates into the experiment so each experiment is
-self-contained and reproducible.
+RBAC, request-id preservation, EPP/vLLM verbosity, routing-proxy resource
+requests) are applied automatically by `prepare.py` Phase 4 from
+`<experiment-root>/baselines/defaults/`. Copy the framework templates into
+the experiment so each experiment is self-contained and reproducible.
 
 ```bash
 mkdir -p "$EXPERIMENT_ROOT/baselines/defaults"
@@ -332,6 +332,7 @@ defaults:
   #   - preserve-request-id
   #   - epp-verbosity
   #   - vllm-logging
+  #   - routing-proxy-resources
 ```
 
 **Constraints:**
@@ -382,6 +383,7 @@ Exit code 0 and all fields printed = success.
       preserve-request-id.yaml
       epp-verbosity.yaml
       vllm-logging.yaml
+      routing-proxy-resources.yaml
   <component-name>/             <- task-2 (submodule)
   algorithms/
     <algorithm>.go               <- pre-existing

--- a/.claude/skills/sim2real-bootstrap/templates/defaults/routing-proxy-resources.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/routing-proxy-resources.yaml
@@ -1,0 +1,13 @@
+# Workaround: declare explicit resource requests for the routing proxy sidecar.
+# The chart leaves routing.proxy.resources unset; without requests the proxy
+# can be scheduled with no real CPU/memory budget. See docs/troubleshooting.md
+# "Framework defaults overlay".
+# scenario[0].name is realigned to the experiment baseline at merge time.
+scenario:
+- name: defaults
+  routing:
+    proxy:
+      resources:
+        requests:
+          memory: 16Gi
+          cpu: 4

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -14,6 +14,7 @@ The fragments shipped today:
 | `preserve-request-id` | `EnvoyFilter` that preserves the external request-id |
 | `epp-verbosity` | `inferenceExtension.verbosity: "5"` |
 | `vllm-logging` | `vllm.additionalFlags: [--no-disable-uvicorn-access-log]` + `loggingLevel: INFO` |
+| `routing-proxy-resources` | `routing.proxy.resources.requests` set to `memory: 16Gi`, `cpu: 4` (chart leaves it unset) |
 
 **Opt out** by listing fragment stems under `defaults.disable` in `transfer.yaml`:
 


### PR DESCRIPTION
## Summary
- Adds a fifth fragment (`routing-proxy-resources`) to `.claude/skills/sim2real-bootstrap/templates/defaults/` that sets `routing.proxy.resources.requests` to `memory: 16Gi`, `cpu: 4`.
- The chart leaves `routing.proxy.resources` unset, so without explicit requests the proxy sidecar can be scheduled with no real CPU/memory budget.
- Wires the new fragment into `SKILL.md` (task-4b prose, available-fragments comment, final file tree) and the `docs/troubleshooting.md` "Framework defaults overlay" table.

Operators can opt out per-experiment via `defaults.disable: [routing-proxy-resources]` in `transfer.yaml`, or edit the per-experiment copy after bootstrap if 16Gi/4 doesn't fit their workload.

Closes #358.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.claude/skills/sim2real-bootstrap/templates/defaults/routing-proxy-resources.yaml'))"` — fragment parses to the expected nested structure.
- [x] `ruff check pipeline/ .claude/skills/ --select F` — clean.
- [ ] Run `pipeline/setup.py` + `pipeline/prepare.py` on an experiment that re-bootstraps and confirm `baselines/defaults/routing-proxy-resources.yaml` shows up in the experiment copy and the resolved `cluster/baseline.yaml` carries the new `routing.proxy.resources.requests` block.