### PR TITLE
feat(tekton): pin generated PipelineRun SA to helm-installer

### DIFF
--- a/pipeline/lib/tekton.py
+++ b/pipeline/lib/tekton.py
@@ -61,6 +61,7 @@ def make_pipelinerun_scenario(
 
     spec: dict = {
         "pipelineRef": {"name": pipeline_name},
+        "taskRunTemplate": {"serviceAccountName": "helm-installer"},
         "params": [
             {"name": "experimentId",      "value": run_name},
             {"name": "runName",           "value": run_name},

--- a/pipeline/tests/test_tekton.py
+++ b/pipeline/tests/test_tekton.py
@@ -66,6 +66,18 @@ def test_make_pipelinerun_scenario_spec_content_custom():
     assert params["specContent"] == custom_spec
 
 
+def test_make_pipelinerun_scenario_service_account():
+    """PipelineRun pins taskRunTemplate.serviceAccountName so TaskRuns do not
+    fall back to the namespace `default` SA."""
+    pr = make_pipelinerun_scenario(
+        phase="baseline", workload={"name": "wl"}, run_name="r",
+        namespace="ns", pipeline_name="sim2real-r",
+        scenario_content="{}",
+        workspace_bindings=_WORKSPACE_BINDINGS,
+    )
+    assert pr["spec"]["taskRunTemplate"]["serviceAccountName"] == "helm-installer"
+
+
 def test_make_pipelinerun_scenario_workspace_bindings():
     pr = make_pipelinerun_scenario(
         phase="baseline", workload={"name": "wl"}, run_name="r",


### PR DESCRIPTION
## Summary

`pipeline/lib/tekton.py::make_pipelinerun_scenario` now emits `spec.taskRunTemplate.serviceAccountName: helm-installer` on every generated PipelineRun. Previously the spec omitted any SA, so Tekton fell back to the namespace `default` SA. That worked only because `tektonc-data-collection/tekton/roles.yaml` lists `default` as a subject on both `helm-installer-clusterrole` (ClusterRoleBinding) and `helm-access` (RoleBinding) — silently granting the namespace `default` SA broad install-grade RBAC that any unrelated pod in the namespace inherits.

Pinning to `helm-installer` is correct (the SA those bindings were authored for) and unblocks a follow-up that tightens `default` back down.

Closes #360.

## What changed

- `pipeline/lib/tekton.py` — added `"taskRunTemplate": {"serviceAccountName": "helm-installer"}` to the spec dict in `make_pipelinerun_scenario`.
- `pipeline/tests/test_tekton.py` — new `test_make_pipelinerun_scenario_service_account` asserts the SA is set.

## Reviewer attention

- The SA name is hardcoded inline rather than introducing a config knob (`setup_config.json` / `transfer.yaml`). Per-deployment override was explicitly out of scope per the issue. If a future need lands, the literal becomes a parameter without churning the spec shape.
- All existing tests still pass — the new field is purely additive.
- Stale-reference sweep over `docs/`, `pipeline/README.md`, `.claude/skills/` for `serviceAccountName` / `helm-installer` / "default SA" mentions: nothing actionable. The README's PipelineRun mentions describe lifecycle (Phase 4 assembly, orchestrator polling, cleanup); no SA story to update.

## Follow-up (separate PR, in `tektonc-data-collection`)

After this lands, drop the `default` subject from both bindings in `tektonc-data-collection/tekton/roles.yaml` (lines 76-78 and 160-162). That tightens the namespace `default` SA back to its base perms. Tracked in #360's "Follow-up" section.

## Test plan

- [x] `python3 -m pytest pipeline/tests/test_tekton.py -v` — 10/10 pass, including the new assertion.
- [x] `python3 -m pytest pipeline/ .claude/skills/sim2real-{analyze,bootstrap,translate}/tests/` — 1025 passed, 2 xfailed (full CI suite).
- [x] `ruff check pipeline/ .claude/skills/ --select F` — clean.
- [ ] On a real cluster: re-run `prepare.py` Phase 4 and confirm `workspace/runs/<run>/cluster/pipelinerun-*.yaml` carries the new field; observe `tkn pr describe` reports `Service Account: helm-installer` for spawned TaskRuns.