### PR TITLE
feat(deploy): show completed_namespace in status SLOT column for done pairs

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -523,7 +523,7 @@ def _cmd_status(args, run_dir: Path,
 
         for key, entry in sorted(pairs.items()):
             status = entry.get("status", "unknown")
-            slot = entry.get("namespace") or "—"
+            slot = entry.get("namespace") or entry.get("completed_namespace") or "—"
             retries = entry.get("retries", 0)
             counts[status] = counts.get(status, 0) + 1
             print(f"{key:<{pair_w}} {status:<{col_status}} {slot:<{col_slot}} {retries}")

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -8,7 +8,7 @@ from pipeline.lib.progress import ConfigMapProgressStore
 
 
 _PROGRESS = {
-    "wl-smoke-baseline":   {"workload": "wl-smoke",  "package": "baseline",   "status": "done",      "namespace": "sim2real-0", "retries": 0},
+    "wl-smoke-baseline":   {"workload": "wl-smoke",  "package": "baseline",   "status": "done",      "namespace": None,         "completed_namespace": "sim2real-0", "retries": 0},
     "wl-smoke-treatment":  {"workload": "wl-smoke",  "package": "treatment",  "status": "running",   "namespace": "sim2real-1", "retries": 0},
     "wl-load-baseline":    {"workload": "wl-load",   "package": "baseline",   "status": "pending",   "namespace": None,         "retries": 0},
     "wl-load-treatment":   {"workload": "wl-load",   "package": "treatment",  "status": "timed-out", "namespace": "sim2real-2", "retries": 1},
@@ -39,6 +39,31 @@ def test_status_output_contains_all_pairs(tmp_path, capsys, monkeypatch):
     for key in _PROGRESS:
         if not key.startswith("_"):
             assert key in out
+
+
+def test_status_done_pair_shows_completed_namespace(tmp_path, capsys, monkeypatch):
+    """Done pair's SLOT column displays completed_namespace, not '—' (issue #366).
+
+    `entry["namespace"]` is cleared by the orchestrator on completion so the
+    slot can be reused; the namespace where the pair ran is preserved under
+    `completed_namespace`. The status display falls back to that field so an
+    operator can see where each completed pair ran.
+    """
+    from pipeline.deploy import _cmd_status
+    _mock_cm(monkeypatch, _PROGRESS)
+
+    class _Args:
+        only = None
+        workload = "wl-smoke"
+        package = "baseline"
+        status = None
+        live = False
+
+    _cmd_status(_Args(), tmp_path, setup_config={"namespace": "sim2real-ns"})
+    out = capsys.readouterr().out
+    done_line = next(line for line in out.splitlines() if "wl-smoke-baseline" in line)
+    assert "sim2real-0" in done_line
+    assert "—" not in done_line
 
 
 def test_status_filter_by_workload(tmp_path, capsys, monkeypatch):


### PR DESCRIPTION
## Summary

`pipeline/deploy.py status` now shows where a done pair ran, in the SLOT column. Previously every done pair printed `—` even though the orchestrator records the run namespace under `entry["completed_namespace"]` (it has to clear `entry["namespace"]` so the slot can be reused — see [`deploy.py:2327-2332`](../blob/main/pipeline/deploy.py#L2327-L2332)).

One-line fix at [`pipeline/deploy.py:526`](../blob/main/pipeline/deploy.py#L526):

```python
slot = entry.get("namespace") or entry.get("completed_namespace") or "—"
```

Closes #366.

## Reviewer attention

- **Failed / stalled / timed-out pairs are unaffected.** Those paths intentionally retain `entry["namespace"]` (per #277, so reset/cleanup can find helm releases). The first lookup wins; behavior unchanged.
- **Test fixture realignment**: `pipeline/tests/test_deploy_run.py:11` previously had an unrealistic `done` entry that retained `namespace=sim2real-0`. Real done entries have `namespace=None` and `completed_namespace` set. The fixture was updated to mirror the real lifecycle, and a new test (`test_status_done_pair_shows_completed_namespace`) asserts the SLOT column displays the namespace rather than `—` for the done row. Existing tests that rely on `_PROGRESS` (status filtering, summary count, key presence) don't depend on the namespace value, so they're untouched.
- No public-API or schema changes; this is a display-only fix.

## Test plan

- [x] `python3 -m pytest pipeline/tests/test_deploy_run.py -v` — 164/164 pass, including the new assertion.
- [x] `ruff check pipeline/ .claude/skills/ --select F` — clean.
- [x] Stale-reference sweep over `docs/`, `pipeline/README.md`, `.claude/skills/`. `deploy.py status` is described only in generic prose; no SLOT-column example or contract docs to update.
- [ ] On a real cluster: complete a deploy, run `deploy.py status`, confirm done pairs show their actual namespace in the SLOT column rather than `—`.