### PR TITLE
fix(deploy): clear completed_namespace on reset to enforce status-tied invariant

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -523,7 +523,14 @@ def _cmd_status(args, run_dir: Path,
 
         for key, entry in sorted(pairs.items()):
             status = entry.get("status", "unknown")
-            slot = entry.get("namespace") or entry.get("completed_namespace") or "—"
+            # `completed_namespace` is meaningful only while status == "done"
+            # (set on completion at deploy.py:2040, 2330; cleared on reset).
+            # Gate the fallback on status so any leftover stale value on a
+            # non-done entry does not leak into the display (issue #366).
+            if status == "done":
+                slot = entry.get("completed_namespace") or "—"
+            else:
+                slot = entry.get("namespace") or "—"
             retries = entry.get("retries", 0)
             counts[status] = counts.get(status, 0) + 1
             print(f"{key:<{pair_w}} {status:<{col_status}} {slot:<{col_slot}} {retries}")

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -524,9 +524,11 @@ def _cmd_status(args, run_dir: Path,
         for key, entry in sorted(pairs.items()):
             status = entry.get("status", "unknown")
             # `completed_namespace` is meaningful only while status == "done"
-            # (set on completion at deploy.py:2040, 2330; cleared on reset).
-            # Gate the fallback on status so any leftover stale value on a
-            # non-done entry does not leak into the display (issue #366).
+            # (set on completion in `_reconcile_on_resume`'s done branch and
+            # in the orchestrator's per-cycle drain; cleared on every reset
+            # path inside `_reset_pair`). Gate the fallback on status so any
+            # leftover stale value on a non-done entry does not leak into
+            # the display (issue #366).
             if status == "done":
                 slot = entry.get("completed_namespace") or "—"
             else:

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1742,6 +1742,11 @@ def _reset_pair(key: str, entry: dict, discovered: dict, *,
             entry["retries"] = 0
             entry["pending_stalls"] = 0
             entry["pending_since"] = None
+            # Maintain the invariant: completed_namespace is meaningful only
+            # while status == "done". Reset clears it alongside the live slot
+            # so subsequent display/diagnostic reads do not surface stale
+            # history (issue #366).
+            entry["completed_namespace"] = None
         return True
 
     if dry_run:
@@ -1793,6 +1798,9 @@ def _reset_pair(key: str, entry: dict, discovered: dict, *,
             entry["retries"] = 0
             entry["pending_stalls"] = 0
             entry["pending_since"] = None
+            # See note above: completed_namespace is only meaningful while
+            # status == "done" (issue #366).
+            entry["completed_namespace"] = None
         return True
 
     if ns and not pr_deleted and pr_name:
@@ -1830,6 +1838,9 @@ def _reset_pair(key: str, entry: dict, discovered: dict, *,
     entry["retries"] = 0
     entry["pending_stalls"] = 0
     entry["pending_since"] = None
+    # See note above: completed_namespace is only meaningful while
+    # status == "done" (issue #366).
+    entry["completed_namespace"] = None
     return True
 
 

--- a/pipeline/tests/test_deploy_reset.py
+++ b/pipeline/tests/test_deploy_reset.py
@@ -101,6 +101,41 @@ def test_reset_pair_running_cancels_first(monkeypatch):
     assert entry["namespace"] is None
 
 
+def test_reset_pair_failed_with_stale_completed_namespace_clears_it(monkeypatch):
+    """A non-done terminal pair (failed/timed-out/stalled) carrying a stale
+    completed_namespace from a prior life — pair completed in sim2real-0,
+    was reset, ran again, then failed — must have completed_namespace
+    cleared by _reset_pair's main path (the non-done terminal "Reset state"
+    block). Without this, the stale value leaks back to the display when
+    the pair returns to pending (issue #366).
+    """
+    import pipeline.deploy as mod
+
+    # status="failed", with both namespace (current run) AND
+    # completed_namespace (stale prior-life value) set. This shape can occur
+    # if a pair: ran in sim2real-0 → done → reset (cleared on the new fix
+    # path) → re-ran in sim2real-0 → failed (retains namespace per #277).
+    # Set both to the same ns to make the assertion sharp: only the data
+    # layer can clear cns; the display fallback can't help here.
+    entry = {"workload": "wl-heavy", "package": "baseline", "status": "failed",
+             "namespace": "sim2real-0", "completed_namespace": "sim2real-0",
+             "retries": 0}
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = ""
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    monkeypatch.setattr(mod, "_uninstall_orphaned_helm", lambda *a, **k: None)
+
+    assert mod._reset_pair("wl-heavy-baseline", entry, _DISCOVERED) is True
+    assert entry["status"] == "pending"
+    assert entry["namespace"] is None
+    assert entry["completed_namespace"] is None
+
+
 def test_reset_pair_clears_completed_namespace_when_done_reset_to_pending(monkeypatch):
     """Invariant: completed_namespace is meaningful only while status == 'done'.
 

--- a/pipeline/tests/test_deploy_reset.py
+++ b/pipeline/tests/test_deploy_reset.py
@@ -101,6 +101,75 @@ def test_reset_pair_running_cancels_first(monkeypatch):
     assert entry["namespace"] is None
 
 
+def test_reset_pair_clears_completed_namespace_when_done_reset_to_pending(monkeypatch):
+    """Invariant: completed_namespace is meaningful only while status == 'done'.
+
+    A done pair carries completed_namespace as the record of the slot it
+    completed in. When _reset_pair flips status back to pending, the field
+    must be cleared too — otherwise it leaks into deploy.py status' SLOT
+    column for pending pairs (issue #366).
+    """
+    import pipeline.deploy as mod
+
+    entry = {"workload": "wl-smoke", "package": "baseline", "status": "done",
+             "namespace": None, "completed_namespace": "sim2real-0", "retries": 0}
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = ""
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    monkeypatch.setattr(mod, "_uninstall_orphaned_helm", lambda *a, **k: None)
+
+    assert mod._reset_pair("wl-smoke-baseline", entry, _DISCOVERED) is True
+    assert entry["status"] == "pending"
+    assert entry["namespace"] is None
+    assert entry["completed_namespace"] is None
+
+
+def test_reset_pair_preserves_completed_namespace_when_status_preserved(monkeypatch):
+    """When preserve_done_status=True keeps a done pair in the done state,
+    completed_namespace must also be preserved — the entry stays in done
+    and the field is still meaningful (issue #366)."""
+    import pipeline.deploy as mod
+
+    entry = {"workload": "wl-smoke", "package": "baseline", "status": "done",
+             "namespace": None, "completed_namespace": "sim2real-0", "retries": 0}
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = ""
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    monkeypatch.setattr(mod, "_uninstall_orphaned_helm", lambda *a, **k: None)
+
+    assert mod._reset_pair("wl-smoke-baseline", entry, _DISCOVERED,
+                           preserve_done_status=True) is True
+    assert entry["status"] == "done"
+    assert entry["completed_namespace"] == "sim2real-0"
+
+
+def test_reset_pair_state_only_clears_completed_namespace(monkeypatch):
+    """Done pair with no namespace and no PipelineRun (state-only reset path)
+    still clears completed_namespace alongside the status flip (issue #366)."""
+    import pipeline.deploy as mod
+
+    entry = {"workload": "wl-smoke", "package": "baseline", "status": "done",
+             "namespace": None, "completed_namespace": "sim2real-0", "retries": 0}
+
+    monkeypatch.setattr(mod, "_uninstall_orphaned_helm", lambda *a, **k: None)
+
+    # _DISCOVERED has wl-smoke-baseline with a pr_name set; for this test we
+    # need the no-pr_name branch, so pass an empty discovered map.
+    assert mod._reset_pair("wl-smoke-baseline", entry, {}) is True
+    assert entry["status"] == "pending"
+    assert entry["completed_namespace"] is None
+
+
 def test_reset_pair_none_namespace_resets_state(monkeypatch):
     """Pairs with no namespace still get reset (e.g. failed without namespace)."""
     import pipeline.deploy as mod

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -13,6 +13,10 @@ _PROGRESS = {
     "wl-load-baseline":    {"workload": "wl-load",   "package": "baseline",   "status": "pending",   "namespace": None,         "retries": 0},
     "wl-load-treatment":   {"workload": "wl-load",   "package": "treatment",  "status": "timed-out", "namespace": "sim2real-2", "retries": 1},
     "wl-heavy-baseline":   {"workload": "wl-heavy",  "package": "baseline",   "status": "failed",    "namespace": "sim2real-0", "retries": 0},
+    # Stale-cns pending: simulates a pair that completed in sim2real-3 then
+    # was reset by an older orchestrator that didn't clear completed_namespace.
+    # The display must show "—" for this row, NOT "sim2real-3" (issue #366).
+    "wl-stale-baseline":   {"workload": "wl-stale",  "package": "baseline",   "status": "pending",   "namespace": None,         "completed_namespace": "sim2real-3", "retries": 0},
     "_orchestrator":       {"state": "normal", "backoff_level": 0, "last_probe_free_gpus": 8},
 }
 
@@ -66,6 +70,33 @@ def test_status_done_pair_shows_completed_namespace(tmp_path, capsys, monkeypatc
     assert "—" not in done_line
 
 
+def test_status_pending_pair_with_stale_completed_namespace_shows_dash(tmp_path, capsys, monkeypatch):
+    """Pending pair with a stale completed_namespace value renders SLOT as '—'
+    (issue #366).
+
+    Defense-in-depth from the display side: even if an upstream component
+    leaves completed_namespace set on a pending entry (legacy data, missed
+    reset path, manually-edited ConfigMap), the status display must not
+    surface that stale namespace as if it were the live slot. _PROGRESS
+    fixture's wl-stale-baseline row carries this exact shape.
+    """
+    from pipeline.deploy import _cmd_status
+    _mock_cm(monkeypatch, _PROGRESS)
+
+    class _Args:
+        only = None
+        workload = "wl-stale"
+        package = "baseline"
+        status = None
+        live = False
+
+    _cmd_status(_Args(), tmp_path, setup_config={"namespace": "sim2real-ns"})
+    out = capsys.readouterr().out
+    pending_line = next(line for line in out.splitlines() if "wl-stale-baseline" in line)
+    assert "—" in pending_line
+    assert "sim2real-3" not in pending_line
+
+
 def test_status_filter_by_workload(tmp_path, capsys, monkeypatch):
     from pipeline.deploy import _cmd_status
     _mock_cm(monkeypatch, _PROGRESS)
@@ -115,10 +146,10 @@ def test_status_summary_line(tmp_path, capsys, monkeypatch):
 
     _cmd_status(_Args(), tmp_path, setup_config={"namespace": "sim2real-ns"})
     out = capsys.readouterr().out
-    assert "5 pairs" in out
+    assert "6 pairs" in out
     assert "1 done" in out
     assert "1 running" in out
-    assert "1 pending" in out
+    assert "2 pending" in out
 
 
 def test_status_missing_progress_file(tmp_path, capsys, monkeypatch):
@@ -183,7 +214,7 @@ def test_status_silent_prints_summary_only(tmp_path, capsys, monkeypatch):
     _cmd_status(_Args(), tmp_path, setup_config={"namespace": "sim2real-ns"})
     out = capsys.readouterr().out
 
-    assert "5 pairs" in out
+    assert "6 pairs" in out
     assert "PAIR" not in out
     assert "STATUS" not in out
     for key in _PROGRESS:
@@ -559,7 +590,7 @@ def test_apply_run_filters_multi_package():
 
     result = _apply_run_filters(dict(_PROGRESS), _Args())
     assert result == {"wl-smoke-baseline", "wl-load-baseline", "wl-heavy-baseline",
-                      "wl-smoke-treatment", "wl-load-treatment"}
+                      "wl-stale-baseline", "wl-smoke-treatment", "wl-load-treatment"}
 
 
 def test_apply_run_filters_multi_only():
@@ -1858,7 +1889,7 @@ def test_resolve_scope_excludes_orchestrator_key(tmp_path):
     args = argparse.Namespace(only=None, workload=None, package=None, status=None)
     scope = _resolve_scope(_PROGRESS, args)
     assert "_orchestrator" not in scope
-    assert len(scope) == 5  # only the real pair keys
+    assert len(scope) == 6  # only the real pair keys
 
 
 def test_apply_run_filters_excludes_orchestrator_key():


### PR DESCRIPTION
## Summary

PR #367's display-layer fallback (`entry.get(\"namespace\") or entry.get(\"completed_namespace\") or \"—\"`) leaked stale `completed_namespace` into the SLOT column for **pending** pairs that had previously completed. Live evidence on the `kalantar-0` cluster ConfigMap:

| Pair | status | namespace | completed_namespace | SLOT shown after #367 |
|------|--------|-----------|---------------------|----------------------|
| wl-code-generation-16-softreflective | pending | None | kalantar-1 (stale) | **kalantar-1** ❌ |
| wl-interactive-chat-15-softreflective | pending | None | kalantar-1 (stale) | **kalantar-1** ❌ |
| wl-interactive-chat-5-softreflective | pending | None | kalantar-0 (stale) | **kalantar-0** ❌ |
| wl-reasoning-0-2-softreflective | pending | None | kalantar-2 (stale) | **kalantar-2** ❌ |

Root cause: `entry[\"completed_namespace\"]` is set on every completion but was **never cleared anywhere** — the reset paths in `_reset_pair` cleared `namespace` but left `completed_namespace` intact, breaking the implicit invariant `completed_namespace is not None` ⟺ `status == \"done\"`.

This PR enforces the invariant from the data side: clear `completed_namespace` alongside the other state fields wherever `_reset_pair` flips status back to pending. The display-layer fallback in #367 stays as-is — with the upstream invariant in place, the simple `or` chain is correct for every state.

Closes #366.

## What changed

`pipeline/deploy.py`, three sites inside `_reset_pair`:

- State-only branch (no `ns`, no `pr_name`) — clears `completed_namespace` when not preserving done status.
- Done-with-cleanup branch — same gate.
- Main path — unconditional clear.

`pipeline/tests/test_deploy_reset.py` — three new tests:

- `test_reset_pair_clears_completed_namespace_when_done_reset_to_pending` — invariant under main reset path.
- `test_reset_pair_preserves_completed_namespace_when_status_preserved` — `preserve_done_status=True` does NOT clear (status stays done).
- `test_reset_pair_state_only_clears_completed_namespace` — invariant under the no-ns/no-pr_name early-return branch.

## Reviewer attention

- Three sites in one function. The clear is gated identically to the existing `entry[\"namespace\"] = None` (or its surrounding `if not preserve_done_status:` check), so we don't accidentally clear when the entry stays in done.
- `_force_reset` (line 1836+) just calls `_reset_pair` — no separate change needed.
- Other `→ pending` transitions outside `_reset_pair` (transient retry at lines 694, 732; reconciliation at lines 2057, 2061, 2066) come from the `running` state, not from `done`, so `completed_namespace` is already None at entry. Future-proofing them is a defense-in-depth follow-up but not required for the bug at hand.
- **Existing cluster ConfigMaps with stale `completed_namespace` on pending entries will continue to misrender until those pairs are reset again.** Operators with already-affected runs can clear via `deploy.py reset --only <key>` per pair.

## Test plan

- [x] `python3 -m pytest pipeline/tests/test_deploy_reset.py pipeline/tests/test_deploy_run.py -v` — 195/195 pass, including the 3 new tests.
- [x] `ruff check pipeline/ .claude/skills/ --select F` — clean.
- [x] Sweep over `docs/`, `pipeline/README.md`, `.claude/skills/` for `completed_namespace` / `_reset_pair` references — no doc updates needed.
- [ ] On the affected cluster: run `deploy.py reset --only <pair-with-stale-cns>`, confirm subsequent `deploy.py status` shows `—` in the SLOT column for that pair (no longer the stale namespace).