### PR TITLE
ci(orchestrator-image): make smoke test self-maintaining and surface failures

### DIFF
--- a/.github/workflows/orchestrator-image.yml
+++ b/.github/workflows/orchestrator-image.yml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      issues: write
 
     steps:
       - uses: actions/checkout@v4
@@ -58,7 +59,67 @@ jobs:
           docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} --help
           docker run --rm --entrypoint kubectl ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} version --client
           docker run --rm --entrypoint helm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} version --short
-          docker run --rm --entrypoint python ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} -c "from pipeline.lib import assemble, backoff, capacity, context_builder, epp, health, manifest, pod_pending, progress, run_manager, state_machine, tekton, values; print('OK')"
+          docker run --rm --entrypoint python ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} -c "
+          import pkgutil, importlib, pipeline.lib as p
+          failures = []
+          for m in pkgutil.iter_modules(p.__path__):
+              try:
+                  importlib.import_module(f'pipeline.lib.{m.name}')
+              except Exception as e:
+                  failures.append(f'{m.name}: {type(e).__name__}: {e}')
+          if failures:
+              raise SystemExit(chr(10).join(failures))
+          print('OK: all pipeline.lib modules imported')
+          "
 
       - name: Push
         run: docker push --all-tags ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Notify on failure
+        if: failure() && github.event_name == 'push'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = ['ci-broken', 'orchestrator-image'];
+            const colors = { 'ci-broken': 'd93f0b', 'orchestrator-image': 'c5def5' };
+
+            // Idempotent label creation: 422 = already exists, anything else propagates.
+            for (const name of labels) {
+              try {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name,
+                  color: colors[name],
+                });
+              } catch (e) {
+                if (e.status !== 422) throw e;
+              }
+            }
+
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: labels.join(','),
+            });
+
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = `Run [${context.runId}](${runUrl}) failed on \`${context.sha.slice(0, 7)}\`.`;
+
+            if (existing.length === 0) {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: 'CI: Build Orchestrator Image is failing on main',
+                body,
+                labels,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing[0].number,
+                body,
+              });
+            }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # sim2real
 
+[![Build Orchestrator Image](https://github.com/inference-sim/sim2real/actions/workflows/orchestrator-image.yml/badge.svg)](https://github.com/inference-sim/sim2real/actions/workflows/orchestrator-image.yml)
+
 Pipeline for transferring simulation-discovered routing algorithms from [inference-sim](inference-sim/) to production [llm-d](https://github.com/llm-d/llm-d).
 
 ## Install


### PR DESCRIPTION
Closes #374.

## Summary

The post-build smoke test in `.github/workflows/orchestrator-image.yml` hardcoded a literal list of `pipeline.lib` modules to import. When PR #282 deleted `pipeline/lib/backoff.py`, the list wasn't updated, so every push to `main` since 2026-06-04 has built the image, failed at the smoke test with `ImportError: cannot import name 'backoff' from 'pipeline.lib'`, and never reached the Push step. `:latest` on GHCR sat stale for ~19 days while merges piled up — caught when a user hit PR #373's missing `_refresh_namespaces` in a running pod.

## Changes

1. **Smoke test is now self-maintaining.** Replace the literal import list with `pkgutil.iter_modules(pipeline.lib.__path__)` + `importlib.import_module`. Modules added/removed under `pipeline/lib/` are picked up automatically. All import failures are collected and reported, not just the first.
2. **README workflow status badge.** Added at the top of `README.md` so a stale build is visible to anyone glancing at the repo. Passive layer.
3. **`Notify on failure` step.** Opens a labeled tracking issue (or comments on the existing one) when the workflow fails on a `push` event. Labels `ci-broken` and `orchestrator-image` are created idempotently inside the step (catches 422 = already exists). `workflow_dispatch` recovery reruns are intentionally excluded so they don't pile new comments onto the open issue. Active layer.

`permissions:` block gains `issues: write` to enable the new step (already had `contents: read`, `packages: write`).

## Reviewer attention

- **Python heredoc inside YAML.** The smoke-test `run:` step uses a YAML literal-block `|` with a `docker run -c "..."` whose argument spans multiple lines. YAML strips the common leading indent before passing the script to bash; bash preserves the embedded newlines through to `python -c`. The Python code uses `chr(10)` rather than `'\n'` to dodge any escape-sequence ambiguity. Verified by parsing the YAML with `yaml.safe_load` and by running the same Python snippet locally against the current `pipeline/lib/`.
- **Idempotent `createLabel`.** The `Notify on failure` step creates both labels via `github.rest.issues.createLabel`, swallowing only HTTP 422 (label exists) and re-throwing anything else. So the first failure on `main` provisions the labels; subsequent failures find them present and proceed. No out-of-band label management needed.
- **`failure() && github.event_name == 'push'` guard.** `failure()` is true if any prior step in the job failed (Build, Smoke test, or Push). `push` excludes `workflow_dispatch` so manual recoveries don't comment on the tracking issue. Implication: if a `workflow_dispatch` rerun fails, no notification fires; that's intentional — the operator triggering it knows it failed.
- **Org policy on workflow `issues: write`.** Repo's `default_workflow_permissions` is `read`, but per-workflow elevations work (we already use `packages: write`). No org rule visible in `gh api` blocks `issues: write`. If org policy turns out stricter, the symptom will be the `Notify on failure` step itself failing with a 403; the build/smoke/push pipeline is unaffected.

## Test plan (locally verified)

- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/orchestrator-image.yml'))"` — YAML parses.
- [x] Run the new smoke-test Python locally against current `pipeline/lib/` — all 17 modules import, exits 0, prints `OK: all pipeline.lib modules imported`.
- [x] Add `pipeline/lib/_failtest_374.py` containing `raise RuntimeError("simulated module-load failure")`; rerun the snippet — exits 1, output is `_failtest_374: RuntimeError: simulated module-load failure`. Removed.

## Test plan (post-merge, requires running CI)

- [ ] After merge, `:latest` digest on GHCR updates from the pre-2026-06-04 stale digest. Confirm by `oc -n <ns> exec <orchestrator-pod> -- grep _refresh_namespaces /app/pipeline/deploy.py` (after a pod restart) returning hits.
- [ ] README badge renders green on the rendered README.
- [ ] Push a temp commit that breaks a `pipeline/lib/*.py` module on a feature branch → merge → confirm a new issue opens with labels `ci-broken,orchestrator-image`. Push a follow-up still-broken commit → confirm it comments rather than re-creating.

## Out of scope (filed separately if/when needed)

- `--remote` mode `setup_config.json` gap (PR #373's edit-the-file guidance is workstation-only; the in-cluster orchestrator reads from a per-pod emptyDir populated once by an init container).
- Operator-side staleness check in `prepare.py`/`setup.py` (compare orchestrator image's `:<sha>` to local working-tree HEAD).