### PR TITLE
feat(deploy): replace status RETRIES column with RUNTIME

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -466,6 +466,100 @@ def _delete_pipelinerun(pr_name: str, namespace: str) -> None:
 
 # ── Status command ───────────────────────────────────────────────────────────
 
+# ── Runtime tracking helpers ─────────────────────────────────────────────────
+# Issue #378: progress entries carry `running_since` (ISO-8601 UTC, set on
+# dispatch) and `last_duration` (float seconds, set on terminal transitions).
+# The two are mutually exclusive: a row that's running has running_since set
+# and last_duration None; a row that completed has last_duration set and
+# running_since None. Entries that predate this feature are missing both —
+# helpers and the status renderer treat that as "—".
+
+def _mark_running(entry: dict) -> None:
+    """Stamp ``running_since=now``, clear ``last_duration``. Call on dispatch.
+
+    Pairs with :func:`_finalize_run` (terminal sites) and :func:`_clear_runtime`
+    (reset / requeue sites) to maintain the running_since vs. last_duration
+    invariant: a running entry has running_since set and last_duration None;
+    a terminated entry has the inverse.
+    """
+    import datetime as _dt
+    entry["running_since"] = _dt.datetime.now(_dt.timezone.utc).isoformat()
+    entry["last_duration"] = None
+
+
+def _finalize_run(entry: dict) -> None:
+    """Record the just-ended attempt's duration on terminal transitions.
+
+    Call when status transitions to done / failed / timed-out / stalled. If
+    ``running_since`` is set, computes ``now - running_since`` (seconds) and
+    stores it as ``last_duration``; clears ``running_since`` either way. If
+    ``running_since`` was not set (pair wasn't running, e.g. transitioning
+    from pending → failed), this is a no-op other than ensuring the field
+    stays None.
+    """
+    import datetime as _dt
+    started = entry.get("running_since")
+    if started:
+        try:
+            start_dt = _dt.datetime.fromisoformat(started)
+            now = _dt.datetime.now(_dt.timezone.utc)
+            entry["last_duration"] = (now - start_dt).total_seconds()
+        except (ValueError, TypeError):
+            # Malformed timestamp: just clear without recording.
+            pass
+    entry["running_since"] = None
+
+
+def _clear_runtime(entry: dict) -> None:
+    """Clear both runtime fields. Call on reset / requeue / pending transitions
+    where the previous attempt's duration is being discarded (the next
+    dispatch will start fresh)."""
+    entry["running_since"] = None
+    entry["last_duration"] = None
+
+
+def _fmt_duration(seconds: "float | None") -> str:
+    """Format a duration as a ≤7-char string: 42s / 5m12s / 1h08m / 2d04h.
+
+    Returns "—" for None or negative values (defensive — clock skew, malformed
+    data). Width budget keeps the RUNTIME column at 7 chars without re-flow.
+    """
+    if seconds is None or seconds < 0:
+        return "—"
+    s = int(seconds)
+    if s < 60:
+        return f"{s}s"
+    if s < 3600:
+        return f"{s//60}m{s%60:02d}s"
+    if s < 86400:
+        return f"{s//3600}h{(s%3600)//60:02d}m"
+    return f"{s//86400}d{(s%86400)//3600:02d}h"
+
+
+def _runtime_str(entry: dict) -> str:
+    """RUNTIME column value for the status table.
+
+    - running: live ``now - running_since``, ticks per watch refresh
+    - done / failed / timed-out / stalled: frozen ``last_duration``
+    - pending or any state with missing fields: "—"
+    """
+    import datetime as _dt
+    status = entry.get("status", "")
+    if status == "running":
+        started = entry.get("running_since")
+        if not started:
+            return "—"
+        try:
+            start_dt = _dt.datetime.fromisoformat(started)
+        except (ValueError, TypeError):
+            return "—"
+        now = _dt.datetime.now(_dt.timezone.utc)
+        return _fmt_duration((now - start_dt).total_seconds())
+    if status in ("done", "failed", "timed-out", "stalled"):
+        return _fmt_duration(entry.get("last_duration"))
+    return "—"
+
+
 def _cmd_status(args, run_dir: Path,
                 setup_config: dict | None = None) -> None:
     """Print a snapshot table of all (workload, package) pair statuses."""
@@ -514,9 +608,9 @@ def _cmd_status(args, run_dir: Path,
         pair_w = max(len(k) for k in pairs) + 2
         col_status = 12
         col_slot = 14
-        col_retries = 7
+        col_runtime = 7
 
-        header = (f"{'PAIR':<{pair_w}} {'STATUS':<{col_status}} {'SLOT':<{col_slot}} {'RETRIES':<{col_retries}}")
+        header = (f"{'PAIR':<{pair_w}} {'STATUS':<{col_status}} {'SLOT':<{col_slot}} {'RUNTIME':<{col_runtime}}")
         print()
         print(header)
         print("-" * len(header))
@@ -533,9 +627,9 @@ def _cmd_status(args, run_dir: Path,
                 slot = entry.get("completed_namespace") or "—"
             else:
                 slot = entry.get("namespace") or "—"
-            retries = entry.get("retries", 0)
+            runtime = _runtime_str(entry)
             counts[status] = counts.get(status, 0) + 1
-            print(f"{key:<{pair_w}} {status:<{col_status}} {slot:<{col_slot}} {retries}")
+            print(f"{key:<{pair_w}} {status:<{col_status}} {slot:<{col_slot}} {runtime}")
 
         print()
 
@@ -669,6 +763,7 @@ def _handle_pending_pods(*, pr_name: str, namespace: str, entry: dict,
         entry["status"] = "failed"
         # Retain namespace so reset/cleanup can find the helm releases (issue #277).
         entry["pending_since"] = None
+        _finalize_run(entry)
         return True
 
     # category == "recoverable"
@@ -699,10 +794,12 @@ def _handle_pending_pods(*, pr_name: str, namespace: str, entry: dict,
         entry["status"] = "stalled"
         # Terminal: retain namespace so reset/cleanup can find releases (issue #277).
         warn(f"[{entry.get('workload', '?')}] reached max pending stalls ({max_pending_stalls}) → stalled")
+        _finalize_run(entry)
     else:
         entry["status"] = "pending"
         # Slot freed for re-dispatch — release the namespace.
         entry["namespace"] = None
+        _clear_runtime(entry)
     return True
 
 
@@ -742,10 +839,12 @@ def _handle_timeout(*, pr_name: str, namespace: str, entry: dict,
         entry["retries"] = retries + 1
         # Slot freed for re-dispatch — release the namespace.
         entry["namespace"] = None
+        _clear_runtime(entry)
     else:
         warn(f"[{entry.get('workload', '?')}] timed out, max retries → timed-out")
         entry["status"] = "timed-out"
         # Terminal: retain namespace so reset/cleanup can find releases (issue #277).
+        _finalize_run(entry)
     entry["pending_since"] = None
     return True
 
@@ -1751,6 +1850,7 @@ def _reset_pair(key: str, entry: dict, discovered: dict, *,
             entry["retries"] = 0
             entry["pending_stalls"] = 0
             entry["pending_since"] = None
+            _clear_runtime(entry)
             # Maintain the invariant: completed_namespace is meaningful only
             # while status == "done". Reset clears it alongside the live slot
             # so subsequent display/diagnostic reads do not surface stale
@@ -1807,6 +1907,7 @@ def _reset_pair(key: str, entry: dict, discovered: dict, *,
             entry["retries"] = 0
             entry["pending_stalls"] = 0
             entry["pending_since"] = None
+            _clear_runtime(entry)
             # See note above: completed_namespace is only meaningful while
             # status == "done" (issue #366).
             entry["completed_namespace"] = None
@@ -1847,6 +1948,7 @@ def _reset_pair(key: str, entry: dict, discovered: dict, *,
     entry["retries"] = 0
     entry["pending_stalls"] = 0
     entry["pending_since"] = None
+    _clear_runtime(entry)
     # See note above: completed_namespace is only meaningful while
     # status == "done" (issue #366).
     entry["completed_namespace"] = None
@@ -2057,6 +2159,7 @@ def _reconcile_on_resume(progress: dict, discovered: dict, *,
                 if actual in ("Succeeded", "Completed"):
                     entry["status"] = "done"
                     entry["pending_since"] = None
+                    _finalize_run(entry)
                     entry["completed_namespace"] = ns
                     if not preserve_pipelineruns:
                         try:
@@ -2072,20 +2175,24 @@ def _reconcile_on_resume(progress: dict, discovered: dict, *,
                     entry["status"] = "failed"
                     # Retain namespace so reset/cleanup can find the resources
                     entry["pending_since"] = None
+                    _finalize_run(entry)
                 elif actual == "Unknown":
                     warn(f"[{key}] PipelineRun not found on cluster → resetting to pending")
                     entry["status"] = "pending"
                     entry["namespace"] = None
                     entry["pending_since"] = None
+                    _clear_runtime(entry)
             else:
                 entry["status"] = "pending"
                 entry["namespace"] = None
                 entry["pending_since"] = None
+                _clear_runtime(entry)
         elif entry["status"] not in _known:
             warn(f"[{key}] unrecognized status '{entry['status']}' → resetting to pending")
             entry["status"] = "pending"
             entry["namespace"] = None
             entry["pending_since"] = None
+            _clear_runtime(entry)
 
 
 def _derive_pair_gpu_costs(
@@ -2314,6 +2421,8 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                 "retries":  0,
                 "pending_stalls": 0,
                 "pending_since": None,
+                "running_since": None,
+                "last_duration": None,
             }
 
     _scope = _resolve_scope(progress, args)
@@ -2382,6 +2491,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
             if status in ("Succeeded", "Completed"):
                 ok(f"[{pair_key}] {status} → done")
                 entry["status"] = "done"
+                _finalize_run(entry)
                 entry["completed_namespace"] = ns
                 entry["namespace"] = None
                 store.save(progress)
@@ -2401,6 +2511,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                             "PipelineRunStoppingTimeout"):
                 warn(f"[{pair_key}] hard failure ({status}) → failed")
                 entry["status"] = "failed"
+                _finalize_run(entry)
                 # Retain namespace so reset/cleanup can find the helm releases
                 # (issue #277). Mirrors _reconcile_on_resume's failure handling.
                 store.save(progress)
@@ -2462,6 +2573,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                     warn(f"[{pair_key}] pod health escalation → cancelling PipelineRun")
                     if _cancel_and_delete_pipelinerun(pr_name, ns):
                         entry["status"] = "failed"
+                        _finalize_run(entry)
                         # Retain namespace so reset/cleanup can find the helm
                         # releases (issue #277).
                         store.save(progress)
@@ -2605,6 +2717,7 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                 entry["status"] = "running"
                 entry["namespace"] = ns
                 entry["pending_since"] = None
+                _mark_running(entry)
                 slots_busy[ns] = pair_key
                 store.save(progress)
                 ok(f"[{pair_key}] → {ns} ({pr_name})")

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -8,11 +8,11 @@ from pipeline.lib.progress import ConfigMapProgressStore
 
 
 _PROGRESS = {
-    "wl-smoke-baseline":   {"workload": "wl-smoke",  "package": "baseline",   "status": "done",      "namespace": None,         "completed_namespace": "sim2real-0", "retries": 0},
-    "wl-smoke-treatment":  {"workload": "wl-smoke",  "package": "treatment",  "status": "running",   "namespace": "sim2real-1", "retries": 0},
+    "wl-smoke-baseline":   {"workload": "wl-smoke",  "package": "baseline",   "status": "done",      "namespace": None,         "completed_namespace": "sim2real-0", "retries": 0, "last_duration": 42.0},
+    "wl-smoke-treatment":  {"workload": "wl-smoke",  "package": "treatment",  "status": "running",   "namespace": "sim2real-1", "retries": 0, "running_since": "2024-01-01T00:00:00+00:00"},
     "wl-load-baseline":    {"workload": "wl-load",   "package": "baseline",   "status": "pending",   "namespace": None,         "retries": 0},
-    "wl-load-treatment":   {"workload": "wl-load",   "package": "treatment",  "status": "timed-out", "namespace": "sim2real-2", "retries": 1},
-    "wl-heavy-baseline":   {"workload": "wl-heavy",  "package": "baseline",   "status": "failed",    "namespace": "sim2real-0", "retries": 0},
+    "wl-load-treatment":   {"workload": "wl-load",   "package": "treatment",  "status": "timed-out", "namespace": "sim2real-2", "retries": 1, "last_duration": 7320.0},
+    "wl-heavy-baseline":   {"workload": "wl-heavy",  "package": "baseline",   "status": "failed",    "namespace": "sim2real-0", "retries": 0, "last_duration": 312.5},
     # Stale-cns pending: simulates a pair that completed in sim2real-3 then
     # was reset by an older orchestrator that didn't clear completed_namespace.
     # The display must show "—" for this row, NOT "sim2real-3" (issue #366).
@@ -261,6 +261,230 @@ def test_status_silent_empty_progress(tmp_path, capsys, monkeypatch):
     out = capsys.readouterr().out
     assert "0 pairs" in out
     assert "PAIR" not in out
+
+
+# ── Issue #378: RUNTIME column tests ────────────────────────────────────────
+
+
+@pytest.mark.parametrize("seconds,expected", [
+    (0, "0s"),
+    (1, "1s"),
+    (42, "42s"),
+    (59, "59s"),
+    (60, "1m00s"),
+    (61, "1m01s"),
+    (312, "5m12s"),
+    (3599, "59m59s"),
+    (3600, "1h00m"),
+    (4080, "1h08m"),
+    (86399, "23h59m"),
+    (86400, "1d00h"),
+    (180000, "2d02h"),
+    (42.7, "42s"),  # truncates float to int seconds
+])
+def test_fmt_duration_formats(seconds, expected):
+    from pipeline.deploy import _fmt_duration
+    assert _fmt_duration(seconds) == expected
+
+
+@pytest.mark.parametrize("value", [None, -1, -0.5])
+def test_fmt_duration_invalid_returns_dash(value):
+    from pipeline.deploy import _fmt_duration
+    assert _fmt_duration(value) == "—"
+
+
+def test_fmt_duration_width_budget_holds():
+    """Every formatted duration in the realistic range fits in 7 chars.
+
+    The realistic upper bound is set by `activeDeadlineSeconds: 18000` (5h)
+    on the orchestrator Job, multiplied by retries — at most a handful of
+    hours, never near a day. The 7-char column budget holds comfortably for
+    anything operators will actually see; values past ~999 days would
+    overflow but cannot occur in practice."""
+    from pipeline.deploy import _fmt_duration
+    for s in (0, 59, 60, 3599, 3600, 86399, 86400, 86400 * 30):
+        assert len(_fmt_duration(s)) <= 7, f"_fmt_duration({s})={_fmt_duration(s)!r} exceeds width"
+
+
+def test_runtime_str_running_shows_live_duration():
+    import datetime as _dt
+    from pipeline.deploy import _runtime_str
+    started = (_dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(minutes=10)).isoformat()
+    entry = {"status": "running", "running_since": started}
+    out = _runtime_str(entry)
+    # ~10 minutes elapsed; allow a few-second window for test execution time.
+    assert out in {"9m59s", "10m00s", "10m01s", "10m02s", "10m03s"}
+
+
+def test_runtime_str_done_shows_frozen_duration():
+    from pipeline.deploy import _runtime_str
+    entry = {"status": "done", "last_duration": 42.0}
+    assert _runtime_str(entry) == "42s"
+
+
+def test_runtime_str_failed_shows_frozen_duration():
+    from pipeline.deploy import _runtime_str
+    entry = {"status": "failed", "last_duration": 312.0}
+    assert _runtime_str(entry) == "5m12s"
+
+
+def test_runtime_str_timed_out_shows_frozen_duration():
+    from pipeline.deploy import _runtime_str
+    entry = {"status": "timed-out", "last_duration": 7200.0}
+    assert _runtime_str(entry) == "2h00m"
+
+
+def test_runtime_str_stalled_shows_frozen_duration():
+    from pipeline.deploy import _runtime_str
+    entry = {"status": "stalled", "last_duration": 90.0}
+    assert _runtime_str(entry) == "1m30s"
+
+
+def test_runtime_str_pending_shows_dash():
+    from pipeline.deploy import _runtime_str
+    assert _runtime_str({"status": "pending"}) == "—"
+
+
+def test_runtime_str_running_missing_field_shows_dash():
+    """Pre-feature data: a running entry with no running_since renders '—' and
+    does not crash. (One-time, self-resolving migration: next dispatch
+    populates the field.)"""
+    from pipeline.deploy import _runtime_str
+    assert _runtime_str({"status": "running"}) == "—"
+
+
+def test_runtime_str_running_malformed_timestamp_shows_dash():
+    from pipeline.deploy import _runtime_str
+    assert _runtime_str({"status": "running", "running_since": "not-a-timestamp"}) == "—"
+
+
+def test_runtime_str_done_missing_field_shows_dash():
+    from pipeline.deploy import _runtime_str
+    assert _runtime_str({"status": "done"}) == "—"
+
+
+def test_runtime_str_unknown_status_shows_dash():
+    from pipeline.deploy import _runtime_str
+    assert _runtime_str({"status": "wat"}) == "—"
+
+
+def test_mark_running_sets_running_since_clears_last_duration():
+    import datetime as _dt
+    from pipeline.deploy import _mark_running
+    entry = {"running_since": None, "last_duration": 99.0}
+    _mark_running(entry)
+    assert entry["running_since"] is not None
+    assert entry["last_duration"] is None
+    # Round-trip: parses as ISO-8601 UTC.
+    parsed = _dt.datetime.fromisoformat(entry["running_since"])
+    assert parsed.tzinfo is not None
+
+
+def test_finalize_run_records_duration_and_clears_running_since():
+    import datetime as _dt
+    from pipeline.deploy import _finalize_run
+    started = (_dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(seconds=30)).isoformat()
+    entry = {"running_since": started, "last_duration": None}
+    _finalize_run(entry)
+    assert entry["running_since"] is None
+    assert entry["last_duration"] is not None
+    assert 29 <= entry["last_duration"] <= 35  # ~30s + test overhead
+
+
+def test_finalize_run_no_running_since_is_noop_on_duration():
+    """If running_since was never stamped (e.g. transition from pending to
+    failed without a running phase), don't fabricate a duration. Just ensure
+    running_since stays None."""
+    from pipeline.deploy import _finalize_run
+    entry = {"running_since": None, "last_duration": None}
+    _finalize_run(entry)
+    assert entry["running_since"] is None
+    assert entry["last_duration"] is None
+
+
+def test_finalize_run_malformed_timestamp_clears_without_recording():
+    from pipeline.deploy import _finalize_run
+    entry = {"running_since": "not-a-timestamp", "last_duration": None}
+    _finalize_run(entry)
+    assert entry["running_since"] is None
+    assert entry["last_duration"] is None
+
+
+def test_clear_runtime_clears_both_fields():
+    from pipeline.deploy import _clear_runtime
+    entry = {"running_since": "2024-01-01T00:00:00+00:00", "last_duration": 42.0}
+    _clear_runtime(entry)
+    assert entry["running_since"] is None
+    assert entry["last_duration"] is None
+
+
+def test_status_table_header_says_runtime_not_retries(tmp_path, capsys, monkeypatch):
+    """The column header is RUNTIME, not RETRIES (issue #378)."""
+    from pipeline.deploy import _cmd_status
+    _mock_cm(monkeypatch, _PROGRESS)
+
+    class _Args:
+        only = None
+        workload = None
+        package = None
+        status = None
+        live = False
+
+    _cmd_status(_Args(), tmp_path, setup_config={"namespace": "sim2real-ns"})
+    out = capsys.readouterr().out
+    assert "RUNTIME" in out
+    assert "RETRIES" not in out
+
+
+def test_status_table_done_row_shows_formatted_duration(tmp_path, capsys, monkeypatch):
+    """Done row's RUNTIME column shows last_duration formatted (issue #378).
+
+    The fixture's wl-smoke-baseline carries last_duration=42.0 → '42s'.
+    """
+    from pipeline.deploy import _cmd_status
+    _mock_cm(monkeypatch, _PROGRESS)
+
+    class _Args:
+        only = None
+        workload = "wl-smoke"
+        package = "baseline"
+        status = None
+        live = False
+
+    _cmd_status(_Args(), tmp_path, setup_config={"namespace": "sim2real-ns"})
+    out = capsys.readouterr().out
+    done_line = next(line for line in out.splitlines() if "wl-smoke-baseline" in line)
+    assert "42s" in done_line
+
+
+def test_status_table_pre_feature_done_row_shows_dash(tmp_path, capsys, monkeypatch):
+    """A done row with no last_duration field (pre-feature data) renders '—'
+    in RUNTIME without crashing (issue #378)."""
+    from pipeline.deploy import _cmd_status
+    fixture = {
+        "wl-old-baseline": {
+            "workload": "wl-old", "package": "baseline",
+            "status": "done", "namespace": None,
+            "completed_namespace": "sim2real-0", "retries": 0,
+            # no running_since, no last_duration — pre-feature shape
+        },
+    }
+    _mock_cm(monkeypatch, fixture)
+
+    class _Args:
+        only = None
+        workload = None
+        package = None
+        status = None
+        live = False
+
+    _cmd_status(_Args(), tmp_path, setup_config={"namespace": "sim2real-ns"})
+    out = capsys.readouterr().out
+    line = next(li for li in out.splitlines() if "wl-old-baseline" in li)
+    # SLOT shows the completed namespace; RUNTIME shows '—'. The line should
+    # contain both: completed namespace AND a dash.
+    assert "sim2real-0" in line
+    assert "—" in line
 
 
 def test_status_silent_unreachable_still_exits(tmp_path, capsys, monkeypatch):


### PR DESCRIPTION
Closes #378.

## Summary

The `RETRIES` column in `deploy.py status` was effectively always `0` (only non-zero on the rare timeout path), so operators kept a separate `watch tkn pr list` open to see how long pairs had been running. This PR folds runtime into the status table directly: live for in-flight rows, frozen at completion duration for terminal rows, `—` for pending or pre-feature data.

## Mechanism

Two new mutually-exclusive fields on each progress entry:
- `running_since` — ISO-8601 UTC timestamp, set on dispatch
- `last_duration` — float seconds, set at terminal transitions

Three small transition helpers (`_mark_running`, `_finalize_run`, `_clear_runtime`) maintain the invariant across the 16 sites where `entry["status"]` is mutated. The status table renders via `_runtime_str` and `_fmt_duration` — no new cluster calls, so `watch deploy.py status` stays cheap.

## Reviewer attention

- **All 16 status-mutation sites covered.** Three categories: dispatch (1 site, `_mark_running`), terminal (8 sites — done×2, failed×4, timed-out, stalled — `_finalize_run`), reset/requeue (8 sites, `_clear_runtime`). Each helper call is a one-liner inserted next to the `entry["status"] = "..."` it accompanies.
- **Pre-feature data renders cleanly.** Entries that predate this feature lack `running_since` / `last_duration`. `_runtime_str` short-circuits to `—` in every "missing field" branch — covered by `test_runtime_str_running_missing_field_shows_dash`, `test_runtime_str_done_missing_field_shows_dash`, `test_status_table_pre_feature_done_row_shows_dash`. One-time, self-resolves on next dispatch.
- **Malformed timestamp handling.** Both `_runtime_str` and `_finalize_run` catch `ValueError` / `TypeError` from `datetime.fromisoformat` — explicitly tested. The bad timestamp gets cleared, no record made; column shows `—`.
- **Width budget.** `_fmt_duration` keeps output ≤ 7 chars for any realistic duration (Job `activeDeadlineSeconds: 18000` caps a single attempt at 5h; even with retries, days-scale is unreachable). `test_fmt_duration_width_budget_holds` enforces this for the realistic range; values past ~999 days would overflow but cannot occur in practice.
- **`retries` field is preserved.** Only the displayed column changes; the `retries` key stays in the JSON entry, so anything inspecting the raw progress ConfigMap or downstream consumers continue to see it.
- **Integration sanity** in test_deploy_run.py: extended the `_PROGRESS` fixture with the new fields so existing `test_status_*` assertions (which check things like SLOT column behavior on done rows) continue to make sense. New explicit assertions: header says `RUNTIME` not `RETRIES`; done row shows the formatted duration.

## Stale-reference sweep

Grepped `RETRIES`, `retries column`, `retries field` across `docs/`, `pipeline/`, `README.md`, `.github/`, `.claude/skills/`. Only hit was `pipeline/tests/test_deploy_run.py` itself (the new RUNTIME tests live there). No external docs reference the column header by name.

## Test plan

- [x] Added: `_fmt_duration` table-driven (15 cases) + width-budget invariant + invalid-input cases.
- [x] Added: `_runtime_str` per branch (running/done/failed/timed-out/stalled/pending), missing-field, malformed-timestamp, unknown-status.
- [x] Added: `_mark_running`, `_finalize_run` (with/without running_since, malformed), `_clear_runtime`.
- [x] Added: status-command integration tests — header text, done row's formatted duration, pre-feature row's dash.
- [x] Existing 173 status / dispatch / reset tests continue to pass.
- [x] `python -m pytest pipeline/ -q`: 985 pass, 2 xfailed (pre-existing).
- [x] `ruff check pipeline/ --select F`: clean.
- [ ] Manual: `watch -n 2 deploy.py status` against an in-flight run shows running rows ticking and completed rows frozen — to verify post-merge against a real cluster.