### PR TITLE
fix(setup): handle non-admin OpenShift probes; drop hardcoded storageClass

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -50,6 +50,7 @@ python pipeline/setup.py [flags]
 | `--registry-user USER` | `REGISTRY_USER` | interactive |
 | `--registry-token TOKEN` | `REGISTRY_TOKEN` | interactive |
 | `--run NAME` | — | `sim2real-YYYY-MM-DD` |
+| `--storage-class SC` | — | cluster default |
 | `--no-cluster` | — | false |
 | `--pipeline-yaml PATH` | — | `pipeline/pipeline.yaml` |
 | `--redeploy-tasks` | — | false |

--- a/pipeline/setup.py
+++ b/pipeline/setup.py
@@ -77,7 +77,7 @@ Examples:
                                                         help="Registry repository name [llm-d-inference-scheduler]")
     p.add_argument("--registry-user",  metavar="USER",  help="Registry username")
     p.add_argument("--registry-token", metavar="TOKEN", help="Registry token")
-    p.add_argument("--storage-class",  metavar="SC",    help="PVC storageClassName (auto-detected for OpenShift)")
+    p.add_argument("--storage-class",  metavar="SC",    help="PVC storageClassName (default: cluster default)")
     p.add_argument("--run",            metavar="NAME",  help="Run name [sim2real-YYYY-MM-DD]")
     p.add_argument("--experiment-root", metavar="PATH", dest="experiment_root",
                    help="Root of the experiment repo (default: framework directory)")
@@ -146,25 +146,11 @@ def _detect_container_runtime() -> str:
     return next((rt for rt in ["podman", "docker"] if which(rt)), "")
 
 
-def _resolve_storage_class(args: argparse.Namespace, is_openshift: bool) -> str:
-    """Resolve storage class: flag > OpenShift auto-detect > interactive prompt."""
-    if args.storage_class:
-        return args.storage_class
-    if is_openshift:
-        sc = "ibm-spectrum-scale-fileset"
-        info(f"OpenShift detected — using storageClass: {sc}")
-        return sc
-    if not args.no_cluster:
-        result = run(["kubectl", "get", "storageclass", "--no-headers"],
-                     check=False, capture=True)
-        if result.returncode == 0 and result.stdout.strip():
-            info("Available storage classes:")
-            for line in result.stdout.strip().splitlines():
-                parts = line.split()
-                marker = "  [default]" if "(default)" in line else ""
-                print(f"  • {parts[0]}{marker}")
-    return prompt("storage_class",
-                  "Enter PVC storageClassName (leave blank for cluster default)", default="")
+def _resolve_storage_class(args: argparse.Namespace) -> str:
+    """Resolve storage class: flag overrides; otherwise leave empty so the
+    cluster's default StorageClass applies (annotation
+    `storageclass.kubernetes.io/is-default-class: "true"`)."""
+    return args.storage_class or ""
 
 
 def _resolve_run_name(args: argparse.Namespace) -> tuple[str, Path]:
@@ -203,6 +189,12 @@ def check_cluster_reachable() -> None:
 
     combined = (result.stdout + result.stderr).lower()
 
+    # A `forbidden` reply proves the API server responded and we're authenticated;
+    # the user just lacks permission for whatever cluster-info probed (e.g. listing
+    # services in kube-system). Treat as reachable.
+    if "forbidden" in combined:
+        return
+
     # Classify the failure and give an actionable suggestion
     if "no such host" in combined or "name resolution" in combined or "lookup" in combined:
         reason = "DNS resolution failed — the cluster hostname is not reachable."
@@ -213,7 +205,7 @@ def check_cluster_reachable() -> None:
     elif "i/o timeout" in combined or "timeout" in combined:
         reason = "Connection timed out — the cluster API server did not respond."
         hint   = "Check your VPN or firewall; the cluster may be stopped or unreachable."
-    elif "unauthorized" in combined or "forbidden" in combined:
+    elif "unauthorized" in combined:
         reason = "Authentication failed — your credentials or kubeconfig may be expired."
         hint   = "Try: kubectl config view  or re-run your cluster login command."
     elif "no configuration" in combined or "no such file" in combined:
@@ -286,7 +278,7 @@ def collect_config(args: argparse.Namespace) -> tuple[SetupConfig, Path, str]:
     is_openshift = detect_openshift()
 
     # Storage class
-    storage_class = _resolve_storage_class(args, is_openshift)
+    storage_class = _resolve_storage_class(args)
 
     # Run name + directory
     run_name, run_dir = _resolve_run_name(args)
@@ -350,8 +342,12 @@ def step_namespace(cfg: SetupConfig) -> None:
         ok(f"Namespace {cfg.namespace} (skipped — --no-cluster)"); return
 
     check_cluster_reachable()
-    exists = run(["kubectl", "get", "ns", cfg.namespace],
-                 check=False, capture=True).returncode == 0
+    if cfg.is_openshift:
+        exists = run(["oc", "get", "project", cfg.namespace],
+                     check=False, capture=True).returncode == 0
+    else:
+        exists = run(["kubectl", "get", "ns", cfg.namespace],
+                     check=False, capture=True).returncode == 0
     if exists:
         ok(f"Namespace {cfg.namespace} already exists")
     else:

--- a/pipeline/setup.py
+++ b/pipeline/setup.py
@@ -611,8 +611,11 @@ def step_pvcs(cfg: SetupConfig) -> None:
             if result.returncode == 0:
                 ok(f"PVC {name} is Bound")
             else:
-                warn(f"PVC {name} not yet Bound — check storageClass: "
-                     f"{cfg.storage_class or '(default)'}")
+                warn(f"PVC {name} not yet Bound after 120s — check storageClass: "
+                     f"{cfg.storage_class or '(cluster default)'}. "
+                     f"If the cluster has no default StorageClass, or the default "
+                     f"is unsuitable, re-run setup.py with --storage-class <name>. "
+                     f"Available classes: kubectl get storageclass")
 
 # ── Step 7: Tekton ───────────────────────────────────────────────────
 

--- a/pipeline/tests/test_setup_pipeline.py
+++ b/pipeline/tests/test_setup_pipeline.py
@@ -431,3 +431,26 @@ class TestRunMetadataIdempotent:
         assert meta["stages"]["prepare"] == {"status": "pending"}
         assert meta["stages"]["deploy"] == {"status": "pending"}
         assert meta["stages"]["results"] == {"status": "pending"}
+
+
+class TestResolveStorageClass:
+    """_resolve_storage_class: flag overrides; otherwise empty (cluster default)."""
+
+    def _args(self, storage_class):
+        from argparse import Namespace
+        return Namespace(storage_class=storage_class)
+
+    def test_default_returns_empty_so_cluster_default_applies(self):
+        """No flag → empty string → PVC writer omits storageClassName entirely."""
+        from pipeline.setup import _resolve_storage_class
+        assert _resolve_storage_class(self._args(None)) == ""
+
+    def test_flag_overrides(self):
+        """Flag value is returned verbatim."""
+        from pipeline.setup import _resolve_storage_class
+        assert _resolve_storage_class(self._args("ibm-spectrum-scale-fileset")) == "ibm-spectrum-scale-fileset"
+
+    def test_empty_flag_treated_as_unset(self):
+        """`--storage-class ""` falls through to empty (cluster default)."""
+        from pipeline.setup import _resolve_storage_class
+        assert _resolve_storage_class(self._args("")) == ""


### PR DESCRIPTION
## Summary

Three independent fixes to `pipeline/setup.py` that bite on non-admin OpenShift clusters but are correct on any cluster:

- **`check_cluster_reachable`**: split `unauthorized` from `forbidden`. A `forbidden` reply to `kubectl cluster-info` proves the API server responded and the user is authenticated; only `unauthorized` (401) means expired/missing creds. Previously misclassified non-admin users as logged-out. (#379)
- **`step_namespace`**: on OpenShift, probe namespace existence with `oc get project <name>` instead of `kubectl get ns <name>`. The latter requires cluster-scope `get namespaces` which regular project users don't have; the OpenShift Project API works with project-scoped access. The `oc new-project` branch directly below already implies OpenShift here. (#379)
- **`_resolve_storage_class`**: drop the hardcoded `ibm-spectrum-scale-fileset` for any cluster `detect_openshift()` returns true on — this was vestigial from one specific cluster. Default to leaving `storageClassName` unset so Kubernetes' default-StorageClass annotation (`storageclass.kubernetes.io/is-default-class: "true"`) drives selection; `--storage-class` keeps working as an override. The PVC writer at `setup.py:615` already conditions on truthiness, so empty produces a clean field-less PVC. (#382)

This intentionally does **not** include the RBAC step changes tracked in #380 — those are a temporary workaround pending the YAML split in inference-sim/tektonc-data-collection#48.

## Test plan

- [x] `ruff check pipeline/ .claude/skills/ --select F` — passed
- [x] `python -m pytest pipeline/ -v` — 985 passed, 2 xfailed (pre-existing)
- [ ] Re-run `python pipeline/setup.py --experiment-root <repo>` against a non-admin OpenShift cluster and confirm Step 2 passes
- [ ] Re-run against an admin cluster (or one with an explicit `--storage-class`) and confirm no behavior regression

Closes #379
Closes #382