### PR TITLE
fix(setup): adopt clean RBAC pattern after roles.yaml split

### DIFF
--- a/pipeline/setup.py
+++ b/pipeline/setup.py
@@ -369,24 +369,34 @@ def step_namespace(cfg: SetupConfig) -> None:
 # ── Step 3: RBAC ─────────────────────────────────────────────────────
 
 def step_rbac(cfg: SetupConfig) -> None:
-    """Step 3: Apply RBAC roles and OpenShift SCC policies."""
+    """Step 3: Apply RBAC bundles for the helm-installer and sim2real-runner SAs.
+
+    Each SA has a namespaced base (always required) and an optional cluster
+    augment (best-effort). On a kubectl Forbidden reply that specifically
+    targets cluster-scoped RBAC resources (ClusterRole/ClusterRoleBinding),
+    a best-effort file is skipped with a warn and the run continues. Any
+    other failure (network, malformed YAML, SCC/webhook/quota denial
+    unrelated to cluster-scoped RBAC) still aborts the run.
+
+    SCC RoleBindings (restricted, anyuid, privileged) ride along in the
+    namespaced bases — no imperative `oc adm policy add-scc-to-user` calls.
+
+    Degradations when a cluster augment is skipped:
+      - tektonc roles-cluster.yaml: llm-d-benchmark node auto-discovery is
+        unavailable; cross-ns DCGM exec for stream-gpu-stats Phase 2/2.5/3
+        is skipped. Admin-only stack installs are already gated by the
+        install task's `--non-admin` flag (set by llmdbenchmark-standup).
+      - sim2real-runner-cluster.yaml: orchestrator GPU capacity probe
+        (kubectl get nodes/pods) fails; the probe-failure branch of
+        deploy.py's dispatch loop falls through to ungated dispatch with
+        a rate-limited warn.
+    """
     step(3, 8, "RBAC")
     if cfg.no_cluster:
         ok("RBAC (skipped — --no-cluster)"); return
 
     primary_ns = cfg.namespaces[0]
     env = {**os.environ, "NAMESPACE": cfg.namespace, "PRIMARY_NAMESPACE": primary_ns}
-    # Apply RBAC as paired (namespaced base, optional cluster augment) bundles.
-    # Required files exit on failure. Best-effort files exit-gracefully on a
-    # `forbidden` reply (operator lacks cluster-scoped RBAC create) — the
-    # corresponding ClusterRole/ClusterRoleBinding is skipped and downstream
-    # consumers degrade as documented:
-    #   - tektonc roles-cluster.yaml absent → llm-d-benchmark auto-discovery
-    #     unavailable; cross-ns DCGM exec for stream-gpu-stats Phase 2/2.5/3
-    #     skipped (admin-only stack installs already gated by --non-admin).
-    #   - sim2real-runner-cluster.yaml absent → orchestrator GPU capacity
-    #     probe (kubectl get nodes/pods) fails; deploy.py falls through to
-    #     ungated dispatch with a rate-limited warn (deploy.py:2511-2545).
     yaml_paths = [
         (TEKTONC_DIR / "tekton" / "roles-ns.yaml",                          True),
         (TEKTONC_DIR / "tekton" / "roles-cluster.yaml",                     False),
@@ -407,17 +417,24 @@ def step_rbac(cfg: SetupConfig) -> None:
         if result.returncode == 0:
             continue
         combined = (result.stdout + result.stderr).lower()
-        if not required and "forbidden" in combined:
+        # Narrow predicate: only skip when the failure is a Forbidden on
+        # cluster-scoped RBAC resources (clusterrole/clusterrolebinding).
+        # Other Forbidden reasons (SCC admission, webhook denials, quota
+        # exhaustion) signal that the operator's intent isn't being met
+        # and the run should abort.
+        is_cluster_rbac_forbidden = (
+            not required
+            and "forbidden" in combined
+            and "clusterrole" in combined
+        )
+        if result.stderr: print(result.stderr, end="", file=sys.stderr)
+        if is_cluster_rbac_forbidden:
             warn(f"Skipped {yaml_path.name} — user lacks cluster-scoped RBAC. "
                  "Downstream features that depend on this augment will degrade; "
-                 "see step_rbac docstring for which.")
+                 "see step_rbac docstring for the catalog.")
             continue
-        if result.stderr: print(result.stderr, end="", file=sys.stderr)
         sys.exit(result.returncode)
 
-    # SCC bindings are now carried by tekton/roles-ns.yaml (helm-installer-
-    # restricted-scc, helm-installer-anyuid-scc, helm-installer-privileged-scc).
-    # No imperative `oc adm policy add-scc-to-user` calls needed.
     ok("RBAC roles applied")
 
 # ── Step 4: Secrets ──────────────────────────────────────────────────

--- a/pipeline/setup.py
+++ b/pipeline/setup.py
@@ -376,28 +376,48 @@ def step_rbac(cfg: SetupConfig) -> None:
 
     primary_ns = cfg.namespaces[0]
     env = {**os.environ, "NAMESPACE": cfg.namespace, "PRIMARY_NAMESPACE": primary_ns}
-    for yaml_path in [
-        TEKTONC_DIR / "tekton" / "roles.yaml",
-        TEKTONC_DIR / "tekton" / "rbac" / "sim2real-runner.yaml",
-        REPO_ROOT / "pipeline" / "rbac" / "sim2real-runner-cluster.yaml",
-        REPO_ROOT / "pipeline" / "rbac" / "sim2real-runner-ns.yaml",
-    ]:
+    # Apply RBAC as paired (namespaced base, optional cluster augment) bundles.
+    # Required files exit on failure. Best-effort files exit-gracefully on a
+    # `forbidden` reply (operator lacks cluster-scoped RBAC create) — the
+    # corresponding ClusterRole/ClusterRoleBinding is skipped and downstream
+    # consumers degrade as documented:
+    #   - tektonc roles-cluster.yaml absent → llm-d-benchmark auto-discovery
+    #     unavailable; cross-ns DCGM exec for stream-gpu-stats Phase 2/2.5/3
+    #     skipped (admin-only stack installs already gated by --non-admin).
+    #   - sim2real-runner-cluster.yaml absent → orchestrator GPU capacity
+    #     probe (kubectl get nodes/pods) fails; deploy.py falls through to
+    #     ungated dispatch with a rate-limited warn (deploy.py:2511-2545).
+    yaml_paths = [
+        (TEKTONC_DIR / "tekton" / "roles-ns.yaml",                          True),
+        (TEKTONC_DIR / "tekton" / "roles-cluster.yaml",                     False),
+        (TEKTONC_DIR / "tekton" / "rbac" / "sim2real-runner.yaml",          True),
+        (REPO_ROOT / "pipeline" / "rbac" / "sim2real-runner-ns.yaml",       True),
+        (REPO_ROOT / "pipeline" / "rbac" / "sim2real-runner-cluster.yaml",  False),
+    ]
+    for yaml_path, required in yaml_paths:
         if not yaml_path.exists():
             err(f"{yaml_path.name} not found at {yaml_path} — did submodule init fail?"); sys.exit(1)
         subst = subprocess.run(
             ["envsubst", "$NAMESPACE $PRIMARY_NAMESPACE"],
             input=yaml_path.read_text(), capture_output=True, text=True, env=env, check=True,
         )
-        run(["kubectl", "apply", "-f", "-"], input=subst.stdout)
+        result = run(["kubectl", "apply", "-f", "-"], input=subst.stdout,
+                     check=False, capture=True)
+        if result.stdout: print(result.stdout, end="")
+        if result.returncode == 0:
+            continue
+        combined = (result.stdout + result.stderr).lower()
+        if not required and "forbidden" in combined:
+            warn(f"Skipped {yaml_path.name} — user lacks cluster-scoped RBAC. "
+                 "Downstream features that depend on this augment will degrade; "
+                 "see step_rbac docstring for which.")
+            continue
+        if result.stderr: print(result.stderr, end="", file=sys.stderr)
+        sys.exit(result.returncode)
 
-    if cfg.is_openshift:
-        warn("OpenShift: adding SCC policies")
-        for policy_args in [
-            ["add-scc-to-user",          "anyuid",       "-z", "default",        "-n", cfg.namespace],
-            ["add-scc-to-user",          "anyuid",       "-z", "helm-installer", "-n", cfg.namespace],
-            ["add-scc-to-user",          "privileged",   "-z", "helm-installer", "-n", cfg.namespace],
-        ]:
-            run(["oc", "adm", "policy"] + policy_args, check=False)
+    # SCC bindings are now carried by tekton/roles-ns.yaml (helm-installer-
+    # restricted-scc, helm-installer-anyuid-scc, helm-installer-privileged-scc).
+    # No imperative `oc adm policy add-scc-to-user` calls needed.
     ok("RBAC roles applied")
 
 # ── Step 4: Secrets ──────────────────────────────────────────────────

--- a/pipeline/setup.py
+++ b/pipeline/setup.py
@@ -433,6 +433,8 @@ def step_rbac(cfg: SetupConfig) -> None:
                  "Downstream features that depend on this augment will degrade; "
                  "see step_rbac docstring for the catalog.")
             continue
+        err(f"kubectl apply failed for {yaml_path.name} "
+            f"(exit {result.returncode}) — RBAC setup aborted")
         sys.exit(result.returncode)
 
     ok("RBAC roles applied")

--- a/pipeline/tests/test_setup_pipeline.py
+++ b/pipeline/tests/test_setup_pipeline.py
@@ -454,3 +454,129 @@ class TestResolveStorageClass:
         """`--storage-class ""` falls through to empty (cluster default)."""
         from pipeline.setup import _resolve_storage_class
         assert _resolve_storage_class(self._args("")) == ""
+
+
+class TestStepRbacApply:
+    """step_rbac applies five YAMLs with required/best-effort semantics."""
+
+    APPLY_PREFIX = ["kubectl", "apply", "-f", "-"]
+
+    def _apply_calls(self, mock_run):
+        return [c for c in mock_run.call_args_list
+                if c.args and list(c.args[0][:4]) == self.APPLY_PREFIX]
+
+    @patch("pipeline.setup.run")
+    def test_all_succeed(self, mock_run):
+        """Five YAMLs apply cleanly — five kubectl apply calls, no exit."""
+        from pipeline.setup import step_rbac
+        mock_run.return_value.returncode = 0
+        mock_run.return_value.stdout = "role.rbac.../helm-access configured\n"
+        mock_run.return_value.stderr = ""
+        step_rbac(_make_config())
+        assert len(self._apply_calls(mock_run)) == 5
+
+    @patch("pipeline.setup.run")
+    def test_required_failure_aborts(self, mock_run):
+        """Required file with non-zero apply causes sys.exit (no skip path)."""
+        import pytest
+        from pipeline.setup import step_rbac
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stdout = ""
+        mock_run.return_value.stderr = "Error from server: something broke"
+        with pytest.raises(SystemExit) as exc:
+            step_rbac(_make_config())
+        assert exc.value.code == 1
+        # Aborts on the FIRST required file (roles-ns.yaml) — only one apply call.
+        assert len(self._apply_calls(mock_run)) == 1
+
+    @patch("pipeline.setup.run")
+    def test_cluster_rbac_forbidden_skips_with_warn(self, mock_run, capsys):
+        """Best-effort file with Forbidden on clusterrole resource skips and continues."""
+        from pipeline.setup import step_rbac
+        cluster_forbidden = (
+            'Error from server (Forbidden): error when creating "STDIN": '
+            'clusterroles.rbac.authorization.k8s.io is forbidden: User "x" '
+            'cannot create resource "clusterroles" at the cluster scope'
+        )
+        # Indices in the apply order: 0=ns, 1=cluster (best-effort), 2=runner, 3=runner-ns, 4=runner-cluster (best-effort)
+        def side_effect(cmd, *args, **kwargs):
+            r = type("R", (), {})()
+            if list(cmd[:4]) == self.APPLY_PREFIX:
+                idx = len([c for c in mock_run.call_args_list
+                           if c.args and list(c.args[0][:4]) == self.APPLY_PREFIX]) - 1
+                if idx in (1, 4):
+                    r.returncode = 1; r.stdout = ""; r.stderr = cluster_forbidden
+                else:
+                    r.returncode = 0; r.stdout = "ok\n"; r.stderr = ""
+            else:
+                r.returncode = 0; r.stdout = ""; r.stderr = ""
+            return r
+        mock_run.side_effect = side_effect
+        step_rbac(_make_config())
+        # Both best-effort skips should have produced a warn line.
+        captured = capsys.readouterr()
+        assert captured.out.count("Skipped") + captured.err.count("Skipped") >= 2
+        assert len(self._apply_calls(mock_run)) == 5
+
+    @patch("pipeline.setup.run")
+    def test_cluster_augment_non_rbac_forbidden_aborts(self, mock_run):
+        """Best-effort file with Forbidden NOT on a clusterrole resource still aborts."""
+        import pytest
+        from pipeline.setup import step_rbac
+        # Forbidden from an SCC admission webhook — no clusterrole text in error.
+        scc_forbidden = (
+            'Error from server (Forbidden): admission webhook "scc.openshift.io" '
+            'denied the request: pod "x" requires anyuid SCC'
+        )
+        def side_effect(cmd, *args, **kwargs):
+            r = type("R", (), {})()
+            if list(cmd[:4]) == self.APPLY_PREFIX:
+                idx = len([c for c in mock_run.call_args_list
+                           if c.args and list(c.args[0][:4]) == self.APPLY_PREFIX]) - 1
+                if idx == 1:
+                    r.returncode = 1; r.stdout = ""; r.stderr = scc_forbidden
+                else:
+                    r.returncode = 0; r.stdout = "ok\n"; r.stderr = ""
+            else:
+                r.returncode = 0; r.stdout = ""; r.stderr = ""
+            return r
+        mock_run.side_effect = side_effect
+        with pytest.raises(SystemExit) as exc:
+            step_rbac(_make_config())
+        assert exc.value.code == 1
+
+    @patch("pipeline.setup.run")
+    def test_skip_branch_emits_stderr(self, mock_run, capsys):
+        """Forbidden-skip branch prints kubectl's stderr before the warn."""
+        from pipeline.setup import step_rbac
+        cluster_forbidden = "Error from server (Forbidden): clusterroles cannot create"
+        def side_effect(cmd, *args, **kwargs):
+            r = type("R", (), {})()
+            if list(cmd[:4]) == self.APPLY_PREFIX:
+                idx = len([c for c in mock_run.call_args_list
+                           if c.args and list(c.args[0][:4]) == self.APPLY_PREFIX]) - 1
+                if idx in (1, 4):
+                    r.returncode = 1; r.stdout = ""; r.stderr = cluster_forbidden
+                else:
+                    r.returncode = 0; r.stdout = "ok\n"; r.stderr = ""
+            else:
+                r.returncode = 0; r.stdout = ""; r.stderr = ""
+            return r
+        mock_run.side_effect = side_effect
+        step_rbac(_make_config())
+        captured = capsys.readouterr()
+        # The actual kubectl Forbidden text should reach stderr — not be silently swallowed.
+        assert "clusterroles cannot create" in captured.err
+
+    @patch("pipeline.setup.run")
+    def test_required_file_not_found_aborts(self, mock_run, tmp_path, monkeypatch):
+        """Missing required YAML (e.g. submodule init failed) exits before apply."""
+        import pytest
+        import pipeline.setup as setup_mod
+        # Point TEKTONC_DIR at an empty tmp_path — roles-ns.yaml won't exist there.
+        monkeypatch.setattr(setup_mod, "TEKTONC_DIR", tmp_path)
+        with pytest.raises(SystemExit) as exc:
+            setup_mod.step_rbac(_make_config())
+        assert exc.value.code == 1
+        # No kubectl apply should have been issued.
+        assert len(self._apply_calls(mock_run)) == 0

--- a/pipeline/tests/test_setup_pipeline.py
+++ b/pipeline/tests/test_setup_pipeline.py
@@ -457,18 +457,66 @@ class TestResolveStorageClass:
 
 
 class TestStepRbacApply:
-    """step_rbac applies five YAMLs with required/best-effort semantics."""
+    """step_rbac applies five YAMLs with required/best-effort semantics.
+
+    Tests stub out the five YAML paths under tmp_path so they don't depend
+    on the tektonc-data-collection submodule being checked out — CI runs
+    with `submodules: false`.
+    """
 
     APPLY_PREFIX = ["kubectl", "apply", "-f", "-"]
+    _STUB_YAML = (
+        "apiVersion: v1\n"
+        "kind: ServiceAccount\n"
+        "metadata:\n"
+        "  name: stub\n"
+        "  namespace: $NAMESPACE\n"
+    )
+    _STUB_RELPATHS = [
+        "tekton/roles-ns.yaml",
+        "tekton/roles-cluster.yaml",
+        "tekton/rbac/sim2real-runner.yaml",
+        "pipeline/rbac/sim2real-runner-ns.yaml",
+        "pipeline/rbac/sim2real-runner-cluster.yaml",
+    ]
+
+    def _stage(self, tmp_path, monkeypatch, *, omit=()):
+        """Create stub YAMLs (omitting any in `omit`) and patch path constants."""
+        import pipeline.setup as setup_mod
+        for relpath in self._STUB_RELPATHS:
+            if relpath in omit:
+                continue
+            target = tmp_path / relpath
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(self._STUB_YAML)
+        monkeypatch.setattr(setup_mod, "TEKTONC_DIR", tmp_path)
+        monkeypatch.setattr(setup_mod, "REPO_ROOT", tmp_path)
 
     def _apply_calls(self, mock_run):
         return [c for c in mock_run.call_args_list
                 if c.args and list(c.args[0][:4]) == self.APPLY_PREFIX]
 
+    def _index_aware_side_effect(self, mock_run, fail_indices, fail_stderr):
+        """Build a side_effect that returns Forbidden on the given apply indices."""
+        def side_effect(cmd, *args, **kwargs):
+            r = type("R", (), {})()
+            if list(cmd[:4]) == self.APPLY_PREFIX:
+                idx = len([c for c in mock_run.call_args_list
+                           if c.args and list(c.args[0][:4]) == self.APPLY_PREFIX]) - 1
+                if idx in fail_indices:
+                    r.returncode = 1; r.stdout = ""; r.stderr = fail_stderr
+                else:
+                    r.returncode = 0; r.stdout = "ok\n"; r.stderr = ""
+            else:
+                r.returncode = 0; r.stdout = ""; r.stderr = ""
+            return r
+        return side_effect
+
     @patch("pipeline.setup.run")
-    def test_all_succeed(self, mock_run):
+    def test_all_succeed(self, mock_run, tmp_path, monkeypatch):
         """Five YAMLs apply cleanly — five kubectl apply calls, no exit."""
         from pipeline.setup import step_rbac
+        self._stage(tmp_path, monkeypatch)
         mock_run.return_value.returncode = 0
         mock_run.return_value.stdout = "role.rbac.../helm-access configured\n"
         mock_run.return_value.stderr = ""
@@ -476,42 +524,37 @@ class TestStepRbacApply:
         assert len(self._apply_calls(mock_run)) == 5
 
     @patch("pipeline.setup.run")
-    def test_required_failure_aborts(self, mock_run):
-        """Required file with non-zero apply causes sys.exit (no skip path)."""
+    def test_required_failure_aborts(self, mock_run, tmp_path, monkeypatch, capsys):
+        """Required file with non-zero apply causes sys.exit, with file name in stderr."""
         import pytest
         from pipeline.setup import step_rbac
+        self._stage(tmp_path, monkeypatch)
         mock_run.return_value.returncode = 1
         mock_run.return_value.stdout = ""
-        mock_run.return_value.stderr = "Error from server: something broke"
+        mock_run.return_value.stderr = "Error from server: something broke\n"
         with pytest.raises(SystemExit) as exc:
             step_rbac(_make_config())
         assert exc.value.code == 1
         # Aborts on the FIRST required file (roles-ns.yaml) — only one apply call.
         assert len(self._apply_calls(mock_run)) == 1
+        # The labeled err() should name the file so the operator knows what failed.
+        captured = capsys.readouterr()
+        assert "roles-ns.yaml" in captured.err
 
     @patch("pipeline.setup.run")
-    def test_cluster_rbac_forbidden_skips_with_warn(self, mock_run, capsys):
+    def test_cluster_rbac_forbidden_skips_with_warn(self, mock_run, tmp_path, monkeypatch, capsys):
         """Best-effort file with Forbidden on clusterrole resource skips and continues."""
         from pipeline.setup import step_rbac
+        self._stage(tmp_path, monkeypatch)
         cluster_forbidden = (
             'Error from server (Forbidden): error when creating "STDIN": '
             'clusterroles.rbac.authorization.k8s.io is forbidden: User "x" '
             'cannot create resource "clusterroles" at the cluster scope'
         )
         # Indices in the apply order: 0=ns, 1=cluster (best-effort), 2=runner, 3=runner-ns, 4=runner-cluster (best-effort)
-        def side_effect(cmd, *args, **kwargs):
-            r = type("R", (), {})()
-            if list(cmd[:4]) == self.APPLY_PREFIX:
-                idx = len([c for c in mock_run.call_args_list
-                           if c.args and list(c.args[0][:4]) == self.APPLY_PREFIX]) - 1
-                if idx in (1, 4):
-                    r.returncode = 1; r.stdout = ""; r.stderr = cluster_forbidden
-                else:
-                    r.returncode = 0; r.stdout = "ok\n"; r.stderr = ""
-            else:
-                r.returncode = 0; r.stdout = ""; r.stderr = ""
-            return r
-        mock_run.side_effect = side_effect
+        mock_run.side_effect = self._index_aware_side_effect(
+            mock_run, fail_indices={1, 4}, fail_stderr=cluster_forbidden,
+        )
         step_rbac(_make_config())
         # Both best-effort skips should have produced a warn line.
         captured = capsys.readouterr()
@@ -519,50 +562,34 @@ class TestStepRbacApply:
         assert len(self._apply_calls(mock_run)) == 5
 
     @patch("pipeline.setup.run")
-    def test_cluster_augment_non_rbac_forbidden_aborts(self, mock_run):
+    def test_cluster_augment_non_rbac_forbidden_aborts(self, mock_run, tmp_path, monkeypatch):
         """Best-effort file with Forbidden NOT on a clusterrole resource still aborts."""
         import pytest
         from pipeline.setup import step_rbac
+        self._stage(tmp_path, monkeypatch)
         # Forbidden from an SCC admission webhook — no clusterrole text in error.
         scc_forbidden = (
             'Error from server (Forbidden): admission webhook "scc.openshift.io" '
             'denied the request: pod "x" requires anyuid SCC'
         )
-        def side_effect(cmd, *args, **kwargs):
-            r = type("R", (), {})()
-            if list(cmd[:4]) == self.APPLY_PREFIX:
-                idx = len([c for c in mock_run.call_args_list
-                           if c.args and list(c.args[0][:4]) == self.APPLY_PREFIX]) - 1
-                if idx == 1:
-                    r.returncode = 1; r.stdout = ""; r.stderr = scc_forbidden
-                else:
-                    r.returncode = 0; r.stdout = "ok\n"; r.stderr = ""
-            else:
-                r.returncode = 0; r.stdout = ""; r.stderr = ""
-            return r
-        mock_run.side_effect = side_effect
+        mock_run.side_effect = self._index_aware_side_effect(
+            mock_run, fail_indices={1}, fail_stderr=scc_forbidden,
+        )
         with pytest.raises(SystemExit) as exc:
             step_rbac(_make_config())
         assert exc.value.code == 1
+        # Aborts on the second file (cluster augment) — exactly two apply calls.
+        assert len(self._apply_calls(mock_run)) == 2
 
     @patch("pipeline.setup.run")
-    def test_skip_branch_emits_stderr(self, mock_run, capsys):
+    def test_skip_branch_emits_stderr(self, mock_run, tmp_path, monkeypatch, capsys):
         """Forbidden-skip branch prints kubectl's stderr before the warn."""
         from pipeline.setup import step_rbac
+        self._stage(tmp_path, monkeypatch)
         cluster_forbidden = "Error from server (Forbidden): clusterroles cannot create"
-        def side_effect(cmd, *args, **kwargs):
-            r = type("R", (), {})()
-            if list(cmd[:4]) == self.APPLY_PREFIX:
-                idx = len([c for c in mock_run.call_args_list
-                           if c.args and list(c.args[0][:4]) == self.APPLY_PREFIX]) - 1
-                if idx in (1, 4):
-                    r.returncode = 1; r.stdout = ""; r.stderr = cluster_forbidden
-                else:
-                    r.returncode = 0; r.stdout = "ok\n"; r.stderr = ""
-            else:
-                r.returncode = 0; r.stdout = ""; r.stderr = ""
-            return r
-        mock_run.side_effect = side_effect
+        mock_run.side_effect = self._index_aware_side_effect(
+            mock_run, fail_indices={1, 4}, fail_stderr=cluster_forbidden,
+        )
         step_rbac(_make_config())
         captured = capsys.readouterr()
         # The actual kubectl Forbidden text should reach stderr — not be silently swallowed.
@@ -573,8 +600,8 @@ class TestStepRbacApply:
         """Missing required YAML (e.g. submodule init failed) exits before apply."""
         import pytest
         import pipeline.setup as setup_mod
-        # Point TEKTONC_DIR at an empty tmp_path — roles-ns.yaml won't exist there.
-        monkeypatch.setattr(setup_mod, "TEKTONC_DIR", tmp_path)
+        # Stage everything EXCEPT the first required file.
+        self._stage(tmp_path, monkeypatch, omit=("tekton/roles-ns.yaml",))
         with pytest.raises(SystemExit) as exc:
             setup_mod.step_rbac(_make_config())
         assert exc.value.code == 1


### PR DESCRIPTION
## Summary

Closes the workaround that PR #383 punted on. Replaces the `MUST CHANGE` block in `step_rbac` with the proper probe-and-augment design now that the YAML split lands in tektonc-data-collection.

`step_rbac` now applies five YAMLs as `(path, required)` tuples — three namespaced bases (always required) and two cluster augments (best-effort on `forbidden`):

| File | Status |
|------|--------|
| `tektonc-data-collection/tekton/roles-ns.yaml` | required |
| `tektonc-data-collection/tekton/roles-cluster.yaml` | best-effort |
| `tektonc-data-collection/tekton/rbac/sim2real-runner.yaml` | required |
| `pipeline/rbac/sim2real-runner-ns.yaml` | required |
| `pipeline/rbac/sim2real-runner-cluster.yaml` | best-effort |

Best-effort means: on a `forbidden` reply (operator lacks cluster-scoped RBAC create), skip the file with a `warn` and continue. Any other failure (network blip, malformed YAML, non-RBAC admission failure) still exits non-zero.

**Drops the imperative `oc adm policy add-scc-to-user` block** (`anyuid -z default`, `anyuid -z helm-installer`, `privileged -z helm-installer`). All three SCC bindings now live in `tektonc-data-collection/tekton/roles-ns.yaml` as RoleBindings to `system:openshift:scc:{restricted,anyuid,privileged}`, so the YAML bundle is the single source of truth — anyone applying the bundle (with or without `setup.py`) gets the same SCC posture.

**Bumps the tektonc-data-collection submodule pin** to pick up the split.

## Dependency

This PR depends on inference-sim/tektonc-data-collection#51 merging first. Marked Draft until then. Once that merges, I'll update the submodule pin to the merge SHA and mark this PR ready.

## Test plan

- [x] `ruff check pipeline/ .claude/skills/ --select F` — passed
- [x] `python -m pytest pipeline/ -v` — 988 passed, 2 xfailed (matches main)
- [ ] Re-run `python pipeline/setup.py --experiment-root <repo>` against a non-admin OpenShift cluster, confirm Step 3 passes with the warn for the cluster augments
- [ ] Re-run against a cluster-admin context, confirm both cluster augments apply cleanly

Closes #380