### PR TITLE
fix(health): gate startup-probe escalation on event count

### DIFF
--- a/pipeline/lib/health.py
+++ b/pipeline/lib/health.py
@@ -114,6 +114,14 @@ def parse_events(json_str: str) -> list[EventRecord]:
 
 _OOM_MAX_ATTEMPTS = 2  # tier-1 retries before escalating
 
+# Tolerate this many startup-probe Unhealthy events before escalating to
+# Tier 2. vLLM model pods loading from a cold PVC routinely fail the
+# startup probe a few times while weights load; the helm chart's
+# failureThreshold lets the pod recover on its own. k8s coalesces
+# similar events with a ~6-min window, so the count is coarser than
+# wall-clock failures — 10 is generous in coalesced units.
+_STARTUP_PROBE_MIN_EVENT_COUNT = 10
+
 
 def triage_pod(
     pod: PodState,
@@ -202,10 +210,11 @@ def triage_pod(
              if e.reason == "Unhealthy" and "startup probe" in e.message.lower()),
             None,
         )
-        if startup_fail:
+        if startup_fail and startup_fail.count >= _STARTUP_PROBE_MIN_EVENT_COUNT:
             return TriageResult(
                 tier=2, action="suggest", needs_logs=False,
-                message=f"{pod.name}: startup probe failing",
+                message=(f"{pod.name}: startup probe failing "
+                         f"(count={startup_fail.count})"),
                 suggestion=(
                     "Startup probe timing out before model finishes loading.\n"
                     "Increase failureThreshold in "

--- a/pipeline/tests/test_health.py
+++ b/pipeline/tests/test_health.py
@@ -155,9 +155,9 @@ def _make_pod(**kwargs):
     return PodState(**defaults)
 
 
-def _make_event(reason="", message="", involved_object="p"):
+def _make_event(reason="", message="", involved_object="p", count=1):
     from pipeline.lib.health import EventRecord
-    return EventRecord(reason=reason, message=message, count=1,
+    return EventRecord(reason=reason, message=message, count=count,
                        last_timestamp="", involved_object=involved_object)
 
 
@@ -256,11 +256,30 @@ def test_triage_does_not_modify_tracker():
     assert tracker.count("p") == before, "triage_pod must not modify tracker"
 
 
-def test_triage_startup_probe_unhealthy():
+def test_triage_startup_probe_unhealthy_below_threshold_returns_none():
+    """A few early Unhealthy events while a model loads should not escalate.
+
+    vLLM model pods routinely fail the startup probe a few times while
+    weights load from a cold PVC. Escalating on the first event cancels
+    the PipelineRun before the helm chart's failureThreshold gets a
+    chance to recover the pod.
+    """
     from pipeline.lib.health import triage_pod, RemediationTracker
     pod = _make_pod(phase="Running", ready=False)
     events = [_make_event(reason="Unhealthy",
-                          message="Startup probe failed: connection refused")]
+                          message="Startup probe failed: connection refused",
+                          count=1)]
+    assert triage_pod(pod, events, RemediationTracker()) is None
+
+
+def test_triage_startup_probe_unhealthy_at_threshold_escalates():
+    from pipeline.lib.health import (
+        triage_pod, RemediationTracker, _STARTUP_PROBE_MIN_EVENT_COUNT,
+    )
+    pod = _make_pod(phase="Running", ready=False)
+    events = [_make_event(reason="Unhealthy",
+                          message="Startup probe failed: connection refused",
+                          count=_STARTUP_PROBE_MIN_EVENT_COUNT)]
     result = triage_pod(pod, events, RemediationTracker())
     assert result is not None
     assert result.tier == 2


### PR DESCRIPTION
Closes #387

## Summary

`triage_pod` was returning Tier 2 on the first Unhealthy event matching `startup probe`, which propagates through `_check_pod_health → needs_escalation → _cancel_and_delete_pipelinerun`. vLLM model pods loading from a cold PVC routinely produce a few early Unhealthy events while weights load, so the orchestrator was preempting the helm chart's `failureThreshold` and killing runs that would have recovered on their own.

## Change

Add a count-based threshold and gate the escalation on it:

```python
_STARTUP_PROBE_MIN_EVENT_COUNT = 10
...
if startup_fail and startup_fail.count >= _STARTUP_PROBE_MIN_EVENT_COUNT:
    return TriageResult(tier=2, ...)
```

The escalation message now includes the event count so it's visible in the orchestrator's stdout (`pod-name: startup probe failing (count=12)`).

## Why count-based vs. time-based

Issue #387 spelled out two candidates: count-based (`startup_fail.count >= N`) and time-based (`last_timestamp` age > N min). Going with count-based for two reasons:

1. **Working precedent.** The user's local patch used `count >= 10` and was confirmed to unblock the symptom. Time-based would be unproven here.
2. **Symmetry with the OOM gate.** `_OOM_MAX_ATTEMPTS = 2` is also a count-based threshold living in the same module; readers comparing the two paths get the same shape.

The caveat is documented at the constant: k8s coalesces "similar" events on a ~6-min window, so the count is coarser than wall-clock failures. `10` is generous in coalesced units.

## Tests

- `test_triage_startup_probe_unhealthy` (which pinned the buggy behavior) is replaced by two tests:
  - `test_triage_startup_probe_unhealthy_below_threshold_returns_none` — `count=1` event → `triage_pod` returns `None`.
  - `test_triage_startup_probe_unhealthy_at_threshold_escalates` — `count=_STARTUP_PROBE_MIN_EVENT_COUNT` event → returns Tier 2 with the same suggestion as before.
- `_make_event` helper extended with a `count=` kwarg (default 1, matching prior behavior).

Full suite: `1090 passed, 2 xfailed in 28.21s`. Lint: `ruff check pipeline/ .claude/skills/ --select F` clean.

## Reviewer attention

- The escalation message format changed from `pod-name: startup probe failing` to `pod-name: startup probe failing (count=N)`. No code consumes this message programmatically (`grep -r` clean), but worth a sanity check.
- I considered escalating only when both count and a time threshold are crossed (the time-based option from the issue). Decided against it for this PR — the working local patch is count-only and adding wall-clock awareness introduces a second tunable to reason about. If we ever want it, swap to `last_timestamp` age and delete the count constant.

## Sweep for stale references

- `grep` across `**/*.md` and `**/*.py` for `startup probe`, `triage_pod`, `_OOM_MAX_ATTEMPTS`, `startup_fail`: no external doc references; only `deploy.py` consumes `triage_pod`, and the consumer signature is unchanged.
- No CLAUDE.md or README updates needed.