### PR TITLE
feat(tekton): add per-task timeout overrides to generated PipelineRuns

### DIFF
--- a/pipeline/lib/tekton.py
+++ b/pipeline/lib/tekton.py
@@ -4,6 +4,15 @@ import yaml
 _SPEC_BASE_DIR = "/workspace/source/llm-d-benchmark"
 _SCENARIO_FILE_PATH = "/tmp/llmdbench-config/scenario.yaml"
 
+# Per-pipelineTask timeout overrides. These ride on top of the pipeline-level
+# 4h ceiling and catch a stuck task earlier so the slot frees up. Values must
+# stay below spec.timeouts.pipeline below; Tekton rejects taskRunSpecs entries
+# whose timeout exceeds the enclosing pipeline timeout.
+_TASK_TIMEOUTS: dict[str, str] = {
+    "stream-epp-logs": "2h",
+    "run-workload-blis-observe-binary": "90m",
+}
+
 
 def _default_spec_content(base_dir: str = _SPEC_BASE_DIR,
                           scenario_file: str = _SCENARIO_FILE_PATH) -> str:
@@ -78,6 +87,10 @@ def make_pipelinerun_scenario(
             {"name": "model",            "value": model},
         ],
         "timeouts": {"pipeline": "4h"},
+        "taskRunSpecs": [
+            {"pipelineTaskName": name, "timeout": dur}
+            for name, dur in _TASK_TIMEOUTS.items()
+        ],
     }
 
     if workspace_bindings is not None:

--- a/pipeline/tests/test_tekton.py
+++ b/pipeline/tests/test_tekton.py
@@ -78,6 +78,24 @@ def test_make_pipelinerun_scenario_service_account():
     assert pr["spec"]["taskRunTemplate"]["serviceAccountName"] == "helm-installer"
 
 
+def test_make_pipelinerun_scenario_task_run_specs():
+    """taskRunSpecs entries gate per-task timeouts on the long-running tasks."""
+    from pipeline.lib.tekton import _TASK_TIMEOUTS
+    pr = make_pipelinerun_scenario(
+        phase="baseline", workload={"name": "wl"}, run_name="r",
+        namespace="ns", pipeline_name="sim2real-r",
+        scenario_content="{}",
+        workspace_bindings=_WORKSPACE_BINDINGS,
+    )
+    specs = pr["spec"]["taskRunSpecs"]
+    by_task = {s["pipelineTaskName"]: s["timeout"] for s in specs}
+    assert by_task == _TASK_TIMEOUTS
+    # The override must not collide with the global serviceAccountName or the
+    # pipeline-level timeout — both stay where they are.
+    assert pr["spec"]["taskRunTemplate"]["serviceAccountName"] == "helm-installer"
+    assert pr["spec"]["timeouts"] == {"pipeline": "4h"}
+
+
 def test_make_pipelinerun_scenario_workspace_bindings():
     pr = make_pipelinerun_scenario(
         phase="baseline", workload={"name": "wl"}, run_name="r",


### PR DESCRIPTION
Closes #392

## Summary

Add `spec.taskRunSpecs` entries to every PipelineRun emitted by `prepare.py` Phase 4 so two long-running tasks have tighter ceilings than the shared pipeline-level budget:

```yaml
spec:
  ...
  timeouts:
    pipeline: "4h"
  taskRunSpecs:
    - pipelineTaskName: stream-epp-logs
      timeout: "2h"
    - pipelineTaskName: run-workload-blis-observe-binary
      timeout: "90m"
```

The pipeline-level 4h ceiling stays as the DAG-wide blast budget; per-task timeouts catch a hung task earlier so the slot frees up.

## Change

`pipeline/lib/tekton.py`:

```python
_TASK_TIMEOUTS: dict[str, str] = {
    "stream-epp-logs": "2h",
    "run-workload-blis-observe-binary": "90m",
}
...
spec: dict = {
    ...
    "timeouts": {"pipeline": "4h"},
    "taskRunSpecs": [
        {"pipelineTaskName": name, "timeout": dur}
        for name, dur in _TASK_TIMEOUTS.items()
    ],
}
```

`pipeline/tests/test_tekton.py`: new `test_make_pipelinerun_scenario_task_run_specs` asserts the field is present, contents match `_TASK_TIMEOUTS` exactly, and that adding it didn't disturb `taskRunTemplate.serviceAccountName` or `timeouts.pipeline`.

## Why hardcoded (not in `transfer.yaml`)

Per the issue, configurability is not a current requirement. The constant is a single point to edit; promotion to `transfer.yaml` is a follow-up if per-experiment overrides become real.

## Why these two tasks

- `stream-epp-logs` (`pipeline/pipeline.yaml:111`): a long-running streamer that stops itself only via a sentinel from `collect-results`. A wedged kubectl logs subprocess can run far longer than the experiment.
- `run-workload-blis-observe-binary` (`pipeline/pipeline.yaml:137`): the workload runner. A stuck request loop wastes the GPU slot for the rest of the pipeline budget.

The other long-runners (`llmdbenchmark-standup`, `stream-gpu-stats`, `collect-results`) aren't included here. File separately if needed.

## Reviewer attention

- **Tekton v1 schema constraint:** `taskRunSpecs[].timeout` cannot exceed `spec.timeouts.pipeline`. Both proposed values (2h, 90m) are well under 4h. The constant carries a comment saying so.
- **No consumer-side changes:** the function signature is unchanged. `pipeline/prepare.py:32` is the only non-test consumer; it doesn't pass `_TASK_TIMEOUTS` and doesn't need to.
- **API server validation:** I haven't run `kubectl apply --dry-run=server` against a live cluster as part of this PR. The existing tests cover dict shape; the schema is documented as supported in v1 (verified against `/tektoncd/pipeline` docs).

## Verification

- `python -m pytest pipeline/ .claude/skills/sim2real-analyze/tests/ .claude/skills/sim2real-bootstrap/tests/ .claude/skills/sim2real-translate/tests/` → **1091 passed, 2 xfailed**
- `ruff check pipeline/ .claude/skills/ --select F` → **All checks passed!**

## Sweep for stale references

- `grep` across `**/*.md` and `**/*.py` for `make_pipelinerun_scenario`, `_TASK_TIMEOUTS`, `taskRunSpecs`, `pipelinerun.*timeout`, `stream-epp-logs.*timeout`, `run-workload.*timeout`: nothing in docs; only `prepare.py:32` (unaffected) and tests reference the function.
- No `pipeline/README.md` or `CLAUDE.md` updates needed — neither documents the existing `timeouts.pipeline` field.