### PR TITLE
feat(prepare): drop the deploy/edit/quit gate prompt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ python pipeline/run.py     --experiment-root ../admission-control switch <run-na
 | 3 | Translate checkpoint | Write `skill_input.json`; exit and wait for `/sim2real-translate` skill |
 | 4 | Assembly | Assemble resolved scenarios from bundles + overlays, generate PipelineRuns |
 | 5 | Summary | Write `run_summary.md` |
-| 6 | Gate | Human review: `[d]eploy / [e]dit / [q]uit` |
+| 6 | Gate | Print summary; mark run `READY TO DEPLOY` |
 
 **`/sim2real-translate`** — AI skill that reads `skill_input.json` and writes `translation_output.json`. Run this after prepare exits at Phase 3, then re-run prepare to continue.
 

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -84,7 +84,7 @@ python pipeline/prepare.py [--force] [--rebuild-context] [--manifest PATH] [--ru
 | 3 | **Translate checkpoint** — write `skill_input.json`, wait (skipped if no algorithm) | resumes on re-run |
 | 4 | Assembly — resolved scenarios, cluster YAMLs, PipelineRuns | on re-run |
 | 5 | Summary — write `run_summary.md` | on re-run |
-| 6 | **Gate** — `[d]eploy / [e]dit / [q]uit` | on re-run |
+| 6 | **Gate** — print summary, mark `READY TO DEPLOY` | on re-run |
 
 **Phase 1 ref validation**: If `component.ref` is set in the manifest, Phase 1 resolves it via `git rev-parse` in the component submodule and compares against HEAD. A mismatch produces a warning (not a hard error) with the expected/actual SHA and a checkout command. Missing submodule or non-git directory with `component.ref` set is a hard error with an init command.
 
@@ -92,7 +92,7 @@ python pipeline/prepare.py [--force] [--rebuild-context] [--manifest PATH] [--ru
 
 **Phase 4 assembly** reads baseline scenario files from the experiment root, merges them with skill-generated overlay files from `generated/`. For multi-algorithm runs, each algorithm's overlay is in `generated/{algo_name}/{algo_name}_config.yaml`. For single-algorithm runs, the overlay may be at `generated/{name}_config.yaml` or `generated/treatment_config.yaml` (legacy). Resolved scenario files are written to `cluster/`. PipelineRuns are generated with a `scenarioContent` param containing the fully resolved scenario YAML. Workloads are loaded from the manifest.
 
-**Phase 6 gate**: `d` marks the run `READY TO DEPLOY` (required by `deploy.py`). `e` drops you back to edit files, then re-displays the summary. `q` marks `abandoned` and exits.
+**Phase 6 gate**: prints `run_summary.md`, appends `**Verdict: READY TO DEPLOY**` to it, and marks the `gate` phase done. Non-interactive — abort the run by Ctrl-C before invoking `deploy.py`. The recorded verdict is surfaced by `run.py list/inspect` but is not enforced by `deploy.py`.
 
 **Subcommands:**
 

--- a/pipeline/prepare.py
+++ b/pipeline/prepare.py
@@ -7,7 +7,7 @@ Phases:
   3. Translate  — checkpoint: write skill_input.json, check for translation_output.json
   4. Assembly   — assemble resolved scenarios, generate PipelineRuns
   5. Summary    — generate run_summary.md
-  6. Gate       — human review: [d]eploy / [e]dit / [q]uit
+  6. Gate       — print summary, mark READY TO DEPLOY
 
 Re-running skips completed phases (tracked in .state.json).
 """
@@ -981,7 +981,7 @@ def _phase_summary(state: StateMachine, manifest: dict, run_dir: Path, resolved:
 # ── Phase 6: Gate ────────────────────────────────────────────────────────────
 
 def _phase_gate(state: StateMachine, run_dir: Path):
-    """Phase 6: Human review gate."""
+    """Phase 6: print run summary and mark the run ready to deploy."""
     step(6, "Gate")
 
     if state.is_done("gate"):
@@ -991,25 +991,10 @@ def _phase_gate(state: StateMachine, run_dir: Path):
 
     summary_path = run_dir / "run_summary.md"
     print("\n" + summary_path.read_text())
-
-    while True:
-        choice = input("\n  [d]eploy / [e]dit / [q]uit: ").strip().lower()
-        if choice in ("d", "deploy"):
-            with open(summary_path, "a") as f:
-                f.write("\n**Verdict: READY TO DEPLOY**\n")
-            state.mark_done("gate", verdict="READY TO DEPLOY")
-            ok("Gate: READY TO DEPLOY")
-            return
-        elif choice in ("e", "edit"):
-            info(f"Edit files in {run_dir}, then press Enter to re-display.")
-            input("  Press Enter when done editing...")
-            print("\n" + summary_path.read_text())
-        elif choice in ("q", "quit"):
-            state.mark_done("gate", verdict="abandoned")
-            warn("Gate: abandoned")
-            sys.exit(0)
-        else:
-            print("  Enter 'd' to deploy, 'e' to edit, or 'q' to quit.")
+    with open(summary_path, "a") as f:
+        f.write("\n**Verdict: READY TO DEPLOY**\n")
+    state.mark_done("gate", verdict="READY TO DEPLOY")
+    ok("Gate: READY TO DEPLOY")
 
 
 # ── Subcommands ──────────────────────────────────────────────────────────────

--- a/pipeline/tests/test_prepare.py
+++ b/pipeline/tests/test_prepare.py
@@ -1348,13 +1348,7 @@ class TestBaselineOnlyNoAlgorithm:
             manifest = None
             rebuild_context = False
 
-        # Mock _phase_gate to avoid interactive input
-        original_gate = mod._phase_gate
-        mod._phase_gate = lambda *a, **kw: None
-        try:
-            mod._cmd_run(Args(), manifest, run_dir)
-        finally:
-            mod._phase_gate = original_gate
+        mod._cmd_run(Args(), manifest, run_dir)
 
         # Verify: translate was skipped, summary was written
         assert (run_dir / "run_summary.md").exists()
@@ -1389,3 +1383,48 @@ class TestBaselineOnlyNoAlgorithm:
         mod._phase_summary(state, manifest, run_dir, resolved)
         summary = (run_dir / "run_summary.md").read_text()
         assert "Source: `N/A`" in summary
+
+
+class TestPhaseGate:
+    def test_gate_is_non_interactive(self, repo):
+        """_phase_gate must complete without reading stdin."""
+        mod = _import_prepare_with_root(repo)
+        run_dir = repo / "workspace" / "runs" / "test-run"
+        run_dir.mkdir(parents=True, exist_ok=True)
+        (run_dir / "run_summary.md").write_text("# Run summary\n")
+
+        state = StateMachine("test-run", "routing", run_dir)
+        state.mark_done("init")
+        state.mark_done("summary")
+
+        # If anything tries to read stdin the test will deadlock; instead, swap
+        # builtins.input for a sentinel that raises.
+        import builtins
+        original_input = builtins.input
+        builtins.input = lambda *a, **kw: (_ for _ in ()).throw(
+            AssertionError("_phase_gate must not call input()")
+        )
+        try:
+            mod._phase_gate(state, run_dir)
+        finally:
+            builtins.input = original_input
+
+        assert state.is_done("gate")
+        assert state.get_phase("gate").get("verdict") == "READY TO DEPLOY"
+        assert "**Verdict: READY TO DEPLOY**" in (run_dir / "run_summary.md").read_text()
+
+    def test_gate_idempotent_on_completed_run(self, repo):
+        """_phase_gate must skip on a run whose gate is already done."""
+        mod = _import_prepare_with_root(repo)
+        run_dir = repo / "workspace" / "runs" / "test-run"
+        run_dir.mkdir(parents=True, exist_ok=True)
+        (run_dir / "run_summary.md").write_text("# Already done\n")
+
+        state = StateMachine("test-run", "routing", run_dir)
+        state.mark_done("init")
+        state.mark_done("summary")
+        state.mark_done("gate", verdict="READY TO DEPLOY")
+
+        # Already-done gate must not re-append the verdict line.
+        mod._phase_gate(state, run_dir)
+        assert (run_dir / "run_summary.md").read_text() == "# Already done\n"


### PR DESCRIPTION
Closes #391

## Summary

Replace `prepare.py` Phase 6's interactive `[d]eploy / [e]dit / [q]uit` prompt with a non-interactive completion that prints the run summary, marks the run `READY TO DEPLOY`, and returns.

## Why

The gate was advisory only. `pipeline/README.md` claimed the verdict was "required by `deploy.py`", but `grep` across `pipeline/deploy.py` and `pipeline/lib/` for `READY TO DEPLOY`, `is_done("gate")`, or `gate.*verdict` returns nothing — `deploy.py` never reads it. The only downstream consumer is `pipeline/lib/run_manager.py`, which surfaces the verdict for human-readable display in `run.py list/inspect` but doesn't branch on its value. So the prompt was UX friction with no operational enforcement.

## Change

`pipeline/prepare.py:_phase_gate`:

```python
def _phase_gate(state: StateMachine, run_dir: Path):
    """Phase 6: print run summary and mark the run ready to deploy."""
    step(6, "Gate")

    if state.is_done("gate"):
        verdict = state.get_phase("gate").get("verdict", "")
        info(f"[skip] Gate already complete: {verdict}")
        return

    summary_path = run_dir / "run_summary.md"
    print("\n" + summary_path.read_text())
    with open(summary_path, "a") as f:
        f.write("\n**Verdict: READY TO DEPLOY**\n")
    state.mark_done("gate", verdict="READY TO DEPLOY")
    ok("Gate: READY TO DEPLOY")
```

Operators who want to abort can Ctrl-C before invoking `deploy.py` — same outcome as the old `q` branch, no ceremony.

## Tests

- New `TestPhaseGate.test_gate_is_non_interactive` — asserts the phase never reads stdin (swaps `builtins.input` for a sentinel that raises).
- New `TestPhaseGate.test_gate_idempotent_on_completed_run` — asserts the already-done branch doesn't re-append the verdict line.
- `TestBaselineOnlyNoAlgorithm.test_cmd_run_baseline_only_no_algorithm` — drop the `mod._phase_gate = lambda *a, **kw: None` monkeypatch; no longer needed since the phase doesn't block on input.

Full suite: `1093 passed, 2 xfailed in 29.48s` (was 1091; +2 new tests). Lint: `ruff check pipeline/ .claude/skills/ --select F` clean.

## Reviewer attention

- **Verdict still recorded in state.** `state.mark_done("gate", verdict="READY TO DEPLOY")` is preserved, so `run_manager._get_verdict` (`pipeline/lib/run_manager.py:92-96`) and the `RunSummary.verdict` field surfaced by `run.py list/inspect` continue to render the same string. `pipeline/tests/test_run_manager.py` exercises this path; all tests still pass.
- **No replacement opt-out flag.** Per the issue, the request was to remove the prompt entirely, not to make it opt-out via a flag like `--no-gate`.
- **`q` and `e` branches are gone, not preserved.** Aborting a prepared run is now `Ctrl-C` before `deploy.py`; editing files between Phase 5 and deploy is just "edit and re-run prepare". The two-second cost of a re-run is cheap compared to maintaining the branches.

## Sweep for stale references

- `grep` across `**/*.md` and `**/*.py` for `[d]eploy`, `[e]dit`, `[q]uit`, `_phase_gate`, `gate.*prompt`, `gate.*human review`: no remaining mentions in the worktree.
- Updated:
  - `pipeline/prepare.py:10` module docstring Phase 6 description.
  - `pipeline/README.md:87` Phase 6 table row.
  - `pipeline/README.md:95` Phase 6 paragraph (rewritten; dropped the false "required by `deploy.py`" claim).
  - `CLAUDE.md:53` Phase 6 table row.