### PR TITLE
fix(deploy): apply --package as a pair-scope filter in collect

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -202,10 +202,10 @@ Per phase, the resolved llm-d-benchmark plan YAMLs are also pulled into `workspa
 |------|-------------|
 | `--only PAIR…` | Scope to specific pair keys — narrows both workload and package (comma or space-separated, `wl-` prefix optional; takes precedence over `--workload`) |
 | `--workload NAME…` | Scope to pairs matching these workloads (comma or space-separated) |
-| `--package NAME…` | Collect only these packages (comma or space-separated, phase-level filter) |
+| `--package NAME…` | Scope to pairs matching these packages (comma or space-separated). Pass the synthetic value `experiment` to collect every package directory of the scoped pairs. |
 | `--skip-logs` | Skip vLLM and EPP log files, collect only traces |
 
-When `--only` or `--workload` is given, only matching workload subdirectories are pulled from the PVC (instead of entire phase directories). Multiple values within a flag use OR (union): `--workload X Y` matches pairs for workload X or Y. Different flags compose as AND: `--workload X Y --package baseline` pulls workloads X and Y from the baseline phase only. Requires progress data to resolve pairs.
+When `--only` or `--workload` is given, only matching workload subdirectories are pulled from the PVC (instead of entire phase directories). Multiple values within a flag use OR (union): `--workload X Y` matches pairs for workload X or Y. Different flags compose as AND: `--workload X Y --package baseline` scopes to baseline pairs whose workload is X or Y, and pulls those workloads from the baseline phase only — pairs of other packages are not in scope and do not trigger "skipping" warnings. The synthetic `--package experiment` value is the carve-out: it does not narrow the pair set, so it preserves today's "every package of the scoped pairs" behavior. Requires progress data to resolve pairs.
 
 **`deploy.py stop`** — deletes the `sim2real-orchestrator` Kubernetes Job (with cascading pod deletion) in the primary namespace. Only meaningful when the orchestrator runs as an in-cluster Job. Pair state is left as-is. If no remote orchestrator Job exists, prints a message and returns. Use `reset` separately to clear failed/stalled pair state.
 

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1394,9 +1394,10 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
             "cluster.")
         sys.exit(1)
 
-    # ── Pair-level scoping (--only / --workload) ──────────────────────────
+    # ── Pair-level scoping (--only / --workload / --package) ─────────────
     scope_only = getattr(args, "only", None)
     scope_workload = getattr(args, "workload", None)
+    scope_package = _parse_list(getattr(args, "package", None))
     scoped = scope_only is not None or scope_workload is not None
 
     if scoped and not progress:
@@ -1404,13 +1405,19 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
         sys.exit(1)
 
     if scoped and progress:
-        # Build a lightweight args namespace for _resolve_scope with only
-        # pair-level filters (--only, --workload).  Collect's --package is
-        # a phase-level filter (nargs="+") and must NOT be mixed in.
+        # Build a lightweight args namespace for _resolve_scope. --package
+        # acts as a pair-scope filter (cumulative-filter rule) — same as
+        # every other deploy.py subcommand — unless the user passed the
+        # synthetic 'experiment' value, which doesn't name a pair package
+        # and so cannot narrow the pair set. In that case pass None and
+        # let the phase-scope logic below expand 'experiment' to every
+        # package directory of the scoped pairs.
+        _pair_scope_pkg = None if scope_package == ["experiment"] else scope_package
+
         class _ScopeArgs:
             only = scope_only
             workload = scope_workload
-            package = None
+            package = _pair_scope_pkg
             status = None
 
         in_scope = _resolve_scope(progress, _ScopeArgs())
@@ -1432,7 +1439,7 @@ def _cmd_collect(args, run_dir: Path, setup_config: dict):
         if not scoped_phases:
             warn("No done phases for scoped pairs.")
             phases_to_collect: list[str] = []
-        elif (pkg_filter := _parse_list(args.package)):
+        elif (pkg_filter := scope_package):
             valid = set(scoped_phases) | {"experiment"}
             unknown = set(pkg_filter) - valid
             if unknown:

--- a/pipeline/tests/test_deploy_collect.py
+++ b/pipeline/tests/test_deploy_collect.py
@@ -1982,3 +1982,165 @@ def test_extract_phases_kubectl_run_failure_raises_runtime_error(tmp_path, monke
     with pytest.raises(RuntimeError, match="create failed.*quota exceeded"):
         deploy._extract_phases_from_pvc(
             ["baseline"], "test-run", "ns-0", run_dir, skip_logs=False)
+
+
+# ─── Issue 398: --package composes with --workload as a pair-scope filter ───
+# Pair-scope filters (--only, --workload, --package, --status) compose as an
+# intersection across every deploy.py subcommand.  Before the fix, collect
+# silently dropped --package from pair scope and only used it for phase scope,
+# so --workload X --package Y resolved to "every package of X" for pair-scope
+# checks (with spurious warnings about pairs of other packages).
+
+def test_collect_package_baseline_with_workload_no_spurious_warn(tmp_path, monkeypatch):
+    """`--workload X --package baseline` must not warn about non-baseline pairs of X.
+
+    Regression for issue #398. Pre-fix, the synthetic _ScopeArgs dropped
+    --package, so a pending wl-X-treatment pair landed in in_scope and the
+    "skipping" warn loop fired on it even though the user only asked about
+    baseline.
+    """
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    data = {
+        "wl-reason-baseline":  {"workload": "reason", "package": "baseline",
+                                "status": "done", "completed_namespace": "ns-0"},
+        "wl-reason-treatment": {"workload": "reason", "package": "treatment",
+                                "status": "pending"},
+    }
+    _mock_cm(monkeypatch, data)
+
+    class Args:
+        only = None
+        workload = "reason"
+        package = ["baseline"]
+        skip_logs = False
+
+    extract_calls = []
+
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False,
+                     workload=None, allowed_workloads=None, on_workload_done=None):
+        extract_calls.append({"phases": sorted(phases),
+                              "allowed_workloads": allowed_workloads})
+        if on_workload_done and allowed_workloads:
+            for phase in phases:
+                for wl in allowed_workloads.get(phase, set()):
+                    on_workload_done(phase, wl, namespace, None)
+        return {p: None for p in phases}
+
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract), \
+         patch.object(deploy, "warn") as mock_warn:
+        deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
+
+    assert len(extract_calls) == 1
+    assert extract_calls[0]["phases"] == ["baseline"]
+    assert extract_calls[0]["allowed_workloads"] == {"baseline": {"reason"}}
+    # The treatment pair is out of scope (user filtered to --package baseline),
+    # so the "Scoped pair ... skipping" warn must not fire on it.
+    warn_msgs = [str(c) for c in mock_warn.call_args_list]
+    assert not any("wl-reason-treatment" in m for m in warn_msgs), (
+        f"Spurious warn about out-of-scope pair: {warn_msgs}"
+    )
+
+
+def test_collect_package_experiment_with_workload_still_warns_nondone(tmp_path, monkeypatch):
+    """`--package experiment` keeps today's behavior: warns on every non-done pair of X.
+
+    The synthetic 'experiment' value doesn't name a pair package, so it
+    cannot narrow pair scope — the fix's carve-out preserves that.
+    """
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    data = {
+        "wl-reason-baseline":  {"workload": "reason", "package": "baseline",
+                                "status": "done", "completed_namespace": "ns-0"},
+        "wl-reason-treatment": {"workload": "reason", "package": "treatment",
+                                "status": "pending"},
+    }
+    _mock_cm(monkeypatch, data)
+
+    class Args:
+        only = None
+        workload = "reason"
+        package = ["experiment"]
+        skip_logs = False
+
+    extract_calls = []
+
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False,
+                     workload=None, allowed_workloads=None, on_workload_done=None):
+        extract_calls.append({"phases": sorted(phases),
+                              "allowed_workloads": allowed_workloads})
+        if on_workload_done and allowed_workloads:
+            for phase in phases:
+                for wl in allowed_workloads.get(phase, set()):
+                    on_workload_done(phase, wl, namespace, None)
+        return {p: None for p in phases}
+
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract), \
+         patch.object(deploy, "warn") as mock_warn:
+        deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
+
+    assert len(extract_calls) == 1
+    # Only baseline is done, so that's all that gets extracted, but every
+    # package of every scoped pair was in-scope — the warn about the pending
+    # treatment pair must fire.
+    assert extract_calls[0]["phases"] == ["baseline"]
+    warn_msgs = [str(c) for c in mock_warn.call_args_list]
+    assert any("wl-reason-treatment" in m and "pending" in m for m in warn_msgs), (
+        f"Expected warn about pending wl-reason-treatment under --package experiment: {warn_msgs}"
+    )
+
+
+def test_collect_multi_package_with_workload(tmp_path, monkeypatch):
+    """`--workload X --package baseline,softreflective` narrows to those two packages."""
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    data = {
+        "wl-reason-baseline": {"workload": "reason", "package": "baseline",
+                               "status": "done", "completed_namespace": "ns-0"},
+        "wl-reason-softreflective": {"workload": "reason", "package": "softreflective",
+                                     "status": "done", "completed_namespace": "ns-0"},
+        "wl-reason-treatment": {"workload": "reason", "package": "treatment",
+                                "status": "pending"},
+    }
+    _mock_cm(monkeypatch, data)
+
+    class Args:
+        only = None
+        workload = "reason"
+        package = ["baseline", "softreflective"]
+        skip_logs = False
+
+    extract_calls = []
+
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False,
+                     workload=None, allowed_workloads=None, on_workload_done=None):
+        extract_calls.append({"phases": sorted(phases),
+                              "allowed_workloads": allowed_workloads})
+        if on_workload_done and allowed_workloads:
+            for phase in phases:
+                for wl in allowed_workloads.get(phase, set()):
+                    on_workload_done(phase, wl, namespace, None)
+        return {p: None for p in phases}
+
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract), \
+         patch.object(deploy, "warn") as mock_warn:
+        deploy._cmd_collect(Args(), run_dir, {"namespace": "ns-0"})
+
+    assert len(extract_calls) == 1
+    assert extract_calls[0]["phases"] == ["baseline", "softreflective"]
+    assert extract_calls[0]["allowed_workloads"] == {
+        "baseline": {"reason"},
+        "softreflective": {"reason"},
+    }
+    # treatment was excluded from pair scope, so no warn about it.
+    warn_msgs = [str(c) for c in mock_warn.call_args_list]
+    assert not any("wl-reason-treatment" in m for m in warn_msgs), (
+        f"Spurious warn about out-of-scope pair: {warn_msgs}"
+    )


### PR DESCRIPTION
## Summary

`deploy.py collect` built a synthetic `_ScopeArgs` with `package=None` before calling `_resolve_scope`, dropping `--package` from pair scope and violating the cumulative-filter rule that every other `deploy.py` subcommand follows. `--workload X --package baseline` then resolved pair scope to "every pair of workload X," and the follow-on \"Scoped pair _ has status 'pending' — skipping\" warn fired on pairs of other packages the user never asked about.

This treats `--package` as a pair-scope filter on the same footing as every other caller. The synthetic `experiment` value is the documented carve-out: it doesn't name a pair package, so when the user passes `--package experiment` we pass `None` to `_resolve_scope` and let the existing phase-scope logic expand it to every package directory of the scoped pairs.

Closes #398

## Changes

- `pipeline/deploy.py` (`_cmd_collect`): hoist `scope_package = _parse_list(args.package)` above the synthetic `_ScopeArgs` and pass it through as the pair-scope `package` value unless it's the literal `["experiment"]`; reuse the same parsed value at the later phase-scope decision so `args.package` is parsed once.
- `pipeline/tests/test_deploy_collect.py`: three new tests covering `--workload + --package baseline` (no spurious warn on out-of-scope pairs), `--workload + --package experiment` (today's behavior preserved — warn fires on every non-done pair), and `--workload + --package baseline,softreflective`.
- `pipeline/README.md`: refresh the `collect` flag table and prose to describe `--package` as a pair-scope filter with the `experiment` carve-out.

## Reviewer attention

- The carve-out is a literal `scope_package == ["experiment"]` check. Mixing values like `--package experiment baseline` is rejected downstream by `_apply_run_filters` as an unknown package, which is arguably an improvement over the previous quiet acceptance — flagging it here in case reviewers prefer a more permissive `"experiment" in scope_package` check.
- The change is scoped to `_cmd_collect`. The other `_resolve_scope` callsites already pass `args` directly, so no parity work is needed.

## Sweep

Grepped `**/*.md`, `pipeline/`, `docs/`, `.claude/skills/`, and `README*` for `--package`, "phase-level filter", and adjacent terms. Only `pipeline/README.md` documented the old behavior; updated. `docs/superpowers/plans/2026-05-14-collect-scoping-flags.md` is a historical planning artifact and accurately describes the design at the time it was written — left as-is.

## Test plan

- [x] `python -m pytest pipeline/ .claude/skills/sim2real-{analyze,bootstrap,translate}/tests/` — 1096 passed
- [x] `ruff check pipeline/ .claude/skills/ --select F` — clean
- [x] Three new regression tests in `test_deploy_collect.py`