### PR TITLE
fix(remote): drop activeDeadlineSeconds from orchestrator Job

### DIFF
--- a/pipeline/lib/remote.py
+++ b/pipeline/lib/remote.py
@@ -86,7 +86,6 @@ def build_orchestrator_job(
         "metadata": {"name": JOB_NAME, "namespace": namespace},
         "spec": {
             "backoffLimit": 0,
-            "activeDeadlineSeconds": 18000,
             "template": {
                 "spec": {
                     "serviceAccountName": SERVICE_ACCOUNT,

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -296,11 +296,11 @@ def test_fmt_duration_invalid_returns_dash(value):
 def test_fmt_duration_width_budget_holds():
     """Every formatted duration in the realistic range fits in 7 chars.
 
-    The realistic upper bound is set by `activeDeadlineSeconds: 18000` (5h)
-    on the orchestrator Job, multiplied by retries — at most a handful of
-    hours, never near a day. The 7-char column budget holds comfortably for
-    anything operators will actually see; values past ~999 days would
-    overflow but cannot occur in practice."""
+    Orchestrator wall time is bounded by per-PipelineRun timeouts
+    (`timeout_hours` × `max_retries`) summed across pairs — at most a
+    handful of days for any practical sweep. The 7-char column budget
+    holds comfortably for anything operators will actually see; values
+    past ~999 days would overflow but cannot occur in practice."""
     from pipeline.deploy import _fmt_duration
     for s in (0, 59, 60, 3599, 3600, 86399, 86400, 86400 * 30):
         assert len(_fmt_duration(s)) <= 7, f"_fmt_duration({s})={_fmt_duration(s)!r} exceeds width"

--- a/pipeline/tests/test_remote.py
+++ b/pipeline/tests/test_remote.py
@@ -249,9 +249,10 @@ def test_job_backoff_limit_zero():
     assert job["spec"]["backoffLimit"] == 0
 
 
-def test_job_active_deadline():
+def test_job_has_no_active_deadline():
+    """No Job-level wall-clock deadline; the orchestrator bounds its own runtime."""
     job = _build_job()
-    assert job["spec"]["activeDeadlineSeconds"] == 18000
+    assert "activeDeadlineSeconds" not in job["spec"]
 
 
 # --- defaults.yaml bundling tests ---


### PR DESCRIPTION
## Summary

Removes the hardcoded `activeDeadlineSeconds: 18000` (5h) from `build_orchestrator_job`. Keeps `backoffLimit: 0` and `restartPolicy: Never`.

## Why

The deadline only fires when the orchestrator has already failed to make progress on its own — and when it fires, it makes the failure worse: the pod is SIGTERMed with no handler, leaving `running` ConfigMap entries stranded until the next `deploy.py run` triggers `_reconcile_on_resume`. Multi-pair sweeps that exceed 5h hit this every time.

The orchestrator's own exit conditions (`_work_remaining()` plus per-PipelineRun `timeout_hours × max_retries` plus `_handle_pending_pods` plus `_check_pod_health`) already bound runtime. The deadline is redundant in the success case and harmful in the failure case.

A no-progress watchdog ("no entry changed state in N hours → exit") would be the right mitigation for an orchestrator that genuinely hangs, but that's a separate enhancement and shouldn't gate this removal. The two related concerns called out in #396 (orchestrator SIGTERM handler; `deploy.py status` reconciling against PR state) are also out of scope here.

## Changes

- `pipeline/lib/remote.py` — drop the `activeDeadlineSeconds` line.
- `pipeline/tests/test_remote.py` — replace `test_job_active_deadline` (which asserted `== 18000`) with `test_job_has_no_active_deadline`, a regression guard against reintroduction.
- `pipeline/tests/test_deploy_run.py` — update the `_fmt_duration` width-budget docstring; the upper bound is no longer the Job deadline but the per-PR timeout × retries × pair count.

## Stale-reference sweep

Grepped `activeDeadlineSeconds`, `18000`, `5h`, and `5 hours` across `pipeline/`, `.claude/skills/`, `docs/`, and READMEs. Only hits were unrelated (a `_fmt_duration` test input and section headers in `sim2real-check/SKILL.md`).

## Test plan

- [x] `python -m pytest pipeline/ .claude/skills/sim2real-analyze/tests/ .claude/skills/sim2real-bootstrap/tests/ .claude/skills/sim2real-translate/tests/` — 1093 passed, 2 xfailed
- [x] `ruff check pipeline/ .claude/skills/ --select F` — clean
- [ ] Smoke test on the next remote sweep that takes >5h (cannot exercise locally)

Closes #396