### PR TITLE
feat(manifest): add blis_observe section to transfer.yaml

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -317,6 +317,13 @@ epp_image:                  # optional
 pipeline:                   # optional — defaults applied if absent
   name: sim2real            # Pipeline resource name referenced in PipelineRuns (default: "sim2real")
   yaml: pipeline/pipeline.yaml  # path relative to repo root (default: "pipeline/pipeline.yaml")
+
+blis_observe:               # optional — per-transfer overrides for blis observe tuning
+  maxConcurrency: 10000     # all keys optional; absent keys fall through to the
+  timeout: 1800             # Pipeline-level defaults in pipeline/pipeline.yaml
+  warmupRequests: 50        # (currently 10000 / 1800 / 50 / 60s / "").
+  prewarmDuration: 60s      # Values are emitted as PipelineRun params to override
+  extraArgs: ""             # the Pipeline defaults — Tekton handles the merge.
 ```
 
 All paths are relative to the repo root and validated at Phase 1.

--- a/pipeline/lib/manifest.py
+++ b/pipeline/lib/manifest.py
@@ -237,3 +237,29 @@ def _validate_v3_fields(data: dict) -> None:
         raise ManifestError(
             f"pipeline.yaml must be a relative path, got: {pipeline['yaml']}"
         )
+
+    # blis_observe (optional): per-transfer overrides for the blis-observe
+    # tuning params the sim2real Pipeline accepts (see pipeline/pipeline.yaml).
+    # Absent or partial → omitted keys fall through to Pipeline-level defaults.
+    observe_raw = data.get("blis_observe")
+    if observe_raw is None:
+        data["blis_observe"] = {}
+    elif not isinstance(observe_raw, dict):
+        raise ManifestError("blis_observe must be a mapping")
+    else:
+        _valid_observe_keys = {
+            "maxConcurrency", "timeout", "warmupRequests",
+            "prewarmDuration", "extraArgs",
+        }
+        unknown_observe = set(observe_raw.keys()) - _valid_observe_keys
+        if unknown_observe:
+            raise ManifestError(
+                f"blis_observe contains unknown keys: {sorted(unknown_observe)}. "
+                f"Valid keys: {sorted(_valid_observe_keys)}"
+            )
+        for k, v in observe_raw.items():
+            if not isinstance(v, (str, int, float)) or isinstance(v, bool):
+                raise ManifestError(
+                    f"blis_observe.{k} must be a scalar (string or number)"
+                )
+        data["blis_observe"] = dict(observe_raw)

--- a/pipeline/lib/tekton.py
+++ b/pipeline/lib/tekton.py
@@ -42,6 +42,11 @@ def _apply_workspace_bindings(ws_names: list, bindings: dict) -> list:
     ]
 
 
+_OBSERVE_PARAM_ORDER = (
+    "maxConcurrency", "timeout", "warmupRequests", "prewarmDuration", "extraArgs",
+)
+
+
 def make_pipelinerun_scenario(
     phase: str,
     workload: dict,
@@ -56,6 +61,7 @@ def make_pipelinerun_scenario(
     blis_git_commit: str = "",
     blis_git_repo_url: str = "",
     model: str = "",
+    observe: dict | None = None,
 ) -> dict:
     """Generate a PipelineRun with resolved scenario content."""
     if spec_content is None:
@@ -68,24 +74,32 @@ def make_pipelinerun_scenario(
     wl_spec = {k: v for k, v in workload.items() if k != "workload_name"}
     wl_spec_str = yaml.dump(wl_spec, default_flow_style=True).strip()
 
+    params: list[dict] = [
+        {"name": "experimentId",      "value": run_name},
+        {"name": "runName",           "value": run_name},
+        {"name": "namespace",         "value": namespace},
+        {"name": "phase",             "value": phase},
+        {"name": "scenarioContent",   "value": scenario_content},
+        {"name": "specContent",       "value": spec_content},
+        {"name": "workloadName",      "value": wl_name},
+        {"name": "workloadSpec",      "value": wl_spec_str},
+        {"name": "benchmarkGitRepoUrl", "value": benchmark_git_repo_url},
+        {"name": "benchmarkGitCommit", "value": benchmark_git_commit},
+        {"name": "blisGitRepoUrl",   "value": blis_git_repo_url},
+        {"name": "blisGitCommit",     "value": blis_git_commit},
+        {"name": "model",            "value": model},
+    ]
+    if observe:
+        # Emit only specified keys; omitted ones fall through to Pipeline-level
+        # defaults declared in pipeline/pipeline.yaml. Tekton params are strings.
+        for k in _OBSERVE_PARAM_ORDER:
+            if k in observe:
+                params.append({"name": k, "value": str(observe[k])})
+
     spec: dict = {
         "pipelineRef": {"name": pipeline_name},
         "taskRunTemplate": {"serviceAccountName": "helm-installer"},
-        "params": [
-            {"name": "experimentId",      "value": run_name},
-            {"name": "runName",           "value": run_name},
-            {"name": "namespace",         "value": namespace},
-            {"name": "phase",             "value": phase},
-            {"name": "scenarioContent",   "value": scenario_content},
-            {"name": "specContent",       "value": spec_content},
-            {"name": "workloadName",      "value": wl_name},
-            {"name": "workloadSpec",      "value": wl_spec_str},
-            {"name": "benchmarkGitRepoUrl", "value": benchmark_git_repo_url},
-            {"name": "benchmarkGitCommit", "value": benchmark_git_commit},
-            {"name": "blisGitRepoUrl",   "value": blis_git_repo_url},
-            {"name": "blisGitCommit",     "value": blis_git_commit},
-            {"name": "model",            "value": model},
-        ],
+        "params": params,
         "timeouts": {"pipeline": "4h"},
         "taskRunSpecs": [
             {"pipelineTaskName": name, "timeout": dur}

--- a/pipeline/prepare.py
+++ b/pipeline/prepare.py
@@ -696,6 +696,8 @@ def _phase_assembly(args, state: StateMachine, manifest: dict, run_dir: Path,
     scenarios_list = first_baseline.resolved.get("scenario", [])
     model_name = scenarios_list[0].get("model", {}).get("name", "") if scenarios_list else ""
 
+    observe = manifest.get("blis_observe") or {}
+
     for pkg in packages:
         scenario_content = yaml.dump(pkg.resolved, default_flow_style=False, allow_unicode=True)
         for wl in workloads:
@@ -715,6 +717,7 @@ def _phase_assembly(args, state: StateMachine, manifest: dict, run_dir: Path,
                 blis_git_commit=blis_commit,
                 blis_git_repo_url=blis_repo_url,
                 model=model_name,
+                observe=observe,
             )
             pr_path = cluster_dir / f"pipelinerun-{safe_wl}-{pkg.name}.yaml"
             pr_path.write_text(yaml.dump(pr, default_flow_style=False, allow_unicode=True))

--- a/pipeline/tests/test_manifest.py
+++ b/pipeline/tests/test_manifest.py
@@ -183,6 +183,64 @@ def test_load_valid_v3_minimal(tmp_path):
     assert m["algorithms"][0]["name"] == "treatment"
 
 
+# ── blis_observe section ────────────────────────────────────────────────────
+
+def test_blis_observe_absent_defaults_to_empty(tmp_path):
+    """When absent, blis_observe loads as an empty dict (fall-through to Pipeline defaults)."""
+    path = _write_manifest(tmp_path, MINIMAL_V3)
+    m = load_manifest(path)
+    assert m["blis_observe"] == {}
+
+
+def test_blis_observe_full_section_loaded(tmp_path):
+    data = {**MINIMAL_V3, "blis_observe": {
+        "maxConcurrency": 5000,
+        "timeout": 3600,
+        "warmupRequests": 25,
+        "prewarmDuration": "30s",
+        "extraArgs": "--foo bar",
+    }}
+    path = _write_manifest(tmp_path, data)
+    m = load_manifest(path)
+    assert m["blis_observe"] == {
+        "maxConcurrency": 5000,
+        "timeout": 3600,
+        "warmupRequests": 25,
+        "prewarmDuration": "30s",
+        "extraArgs": "--foo bar",
+    }
+
+
+def test_blis_observe_partial_section_loaded(tmp_path):
+    """Partial sections are preserved; absent keys stay absent (no defaulting in the loader)."""
+    data = {**MINIMAL_V3, "blis_observe": {"timeout": 3600}}
+    path = _write_manifest(tmp_path, data)
+    m = load_manifest(path)
+    assert m["blis_observe"] == {"timeout": 3600}
+
+
+def test_blis_observe_rejects_non_mapping(tmp_path):
+    data = {**MINIMAL_V3, "blis_observe": "not_a_mapping"}
+    path = _write_manifest(tmp_path, data)
+    with pytest.raises(ManifestError, match="blis_observe must be a mapping"):
+        load_manifest(path)
+
+
+def test_blis_observe_rejects_unknown_keys(tmp_path):
+    data = {**MINIMAL_V3, "blis_observe": {"timeout": 3600, "bogus": 1}}
+    path = _write_manifest(tmp_path, data)
+    with pytest.raises(ManifestError, match="blis_observe.*unknown.*bogus"):
+        load_manifest(path)
+
+
+@pytest.mark.parametrize("bad_value", [True, [1, 2], {"nested": 1}, None])
+def test_blis_observe_rejects_non_scalar_values(tmp_path, bad_value):
+    data = {**MINIMAL_V3, "blis_observe": {"timeout": bad_value}}
+    path = _write_manifest(tmp_path, data)
+    with pytest.raises(ManifestError, match="blis_observe.timeout.*scalar"):
+        load_manifest(path)
+
+
 
 
 # ── component section ─────────────────────────────────────────────────────────

--- a/pipeline/tests/test_tekton.py
+++ b/pipeline/tests/test_tekton.py
@@ -172,3 +172,74 @@ def test_workspace_bindings():
     ws = pr["spec"]["workspaces"]
     assert ws[0]["name"] == "data-storage"
     assert ws[0]["persistentVolumeClaim"]["claimName"] == "my-pvc"
+
+
+# ── observe dict → PipelineRun params ─────────────────────────────────────────
+
+_OBSERVE_KEYS = ("maxConcurrency", "timeout", "warmupRequests", "prewarmDuration", "extraArgs")
+
+
+def _names(pr):
+    return [p["name"] for p in pr["spec"]["params"]]
+
+
+def test_observe_absent_emits_no_observe_params():
+    """observe=None (or absent) leaves the PipelineRun param list at its base set."""
+    pr = make_pipelinerun_scenario(
+        phase="baseline", workload={"name": "wl"}, run_name="r",
+        namespace="ns", pipeline_name="sim2real-r",
+        scenario_content="{}",
+    )
+    names = _names(pr)
+    for k in _OBSERVE_KEYS:
+        assert k not in names, f"absent observe leaked {k}"
+
+
+def test_observe_empty_dict_emits_no_observe_params():
+    """observe={} (the manifest default when section is absent) emits nothing."""
+    pr = make_pipelinerun_scenario(
+        phase="baseline", workload={"name": "wl"}, run_name="r",
+        namespace="ns", pipeline_name="sim2real-r",
+        scenario_content="{}",
+        observe={},
+    )
+    names = _names(pr)
+    for k in _OBSERVE_KEYS:
+        assert k not in names
+
+
+def test_observe_partial_emits_only_specified_keys():
+    """Omitted keys are left for Tekton to fall through to Pipeline-level defaults."""
+    pr = make_pipelinerun_scenario(
+        phase="baseline", workload={"name": "wl"}, run_name="r",
+        namespace="ns", pipeline_name="sim2real-r",
+        scenario_content="{}",
+        observe={"timeout": 3600, "maxConcurrency": 5000},
+    )
+    params = {p["name"]: p["value"] for p in pr["spec"]["params"]}
+    assert params["timeout"] == "3600"
+    assert params["maxConcurrency"] == "5000"
+    for k in ("warmupRequests", "prewarmDuration", "extraArgs"):
+        assert k not in params
+
+
+def test_observe_full_dict_emits_all_keys_as_strings():
+    """All five keys flow through; values are coerced to strings for Tekton."""
+    pr = make_pipelinerun_scenario(
+        phase="baseline", workload={"name": "wl"}, run_name="r",
+        namespace="ns", pipeline_name="sim2real-r",
+        scenario_content="{}",
+        observe={
+            "maxConcurrency": 5000,
+            "timeout": 3600,
+            "warmupRequests": 25,
+            "prewarmDuration": "30s",
+            "extraArgs": "--foo bar",
+        },
+    )
+    params = {p["name"]: p["value"] for p in pr["spec"]["params"]}
+    assert params["maxConcurrency"] == "5000"
+    assert params["timeout"] == "3600"
+    assert params["warmupRequests"] == "25"
+    assert params["prewarmDuration"] == "30s"
+    assert params["extraArgs"] == "--foo bar"


### PR DESCRIPTION
## Summary

Closes #337. Threads per-transfer overrides for the five `blis observe` tuning params into the PipelineRuns the orchestrator generates.

Today every PipelineRun uses the Pipeline-level defaults declared in `pipeline/pipeline.yaml` (`maxConcurrency: "10000"`, `timeout: "1800"`, `warmupRequests: "50"`, `prewarmDuration: "60s"`, `extraArgs: ""`) — wired up in PR #338. There has been no way for an experiment bundle to specify different values short of editing the framework's Pipeline definition. This adds:

```yaml
blis_observe:
  maxConcurrency: 5000
  timeout: 3600
  warmupRequests: 25
  prewarmDuration: 30s
  extraArgs: "--foo bar"
```

at the top level of `transfer.yaml`. All keys optional; omitted keys fall through to the Pipeline-level defaults. Section absent → today's behavior, byte-identical.

## Changes

- **`pipeline/lib/manifest.py`** — new optional `blis_observe:` validator at the end of `_validate_v3_fields`. Mirrors the `defaults:` validator's style (default value when absent, mapping type-check, unknown-key rejection, per-key scalar type-check). Booleans are explicitly rejected (otherwise `isinstance(True, int) == True` would let them through).
- **`pipeline/lib/tekton.py`** — `make_pipelinerun_scenario` gains an `observe: dict | None = None` kwarg. Emits one PipelineRun `params` entry per specified key, in a stable order (`_OBSERVE_PARAM_ORDER`), with `str()` coercion so YAML ints (`timeout: 3600`) become Tekton param strings (`"3600"`).
- **`pipeline/prepare.py`** — Phase 4 reads `manifest.get("blis_observe") or {}` once and passes it to every `make_pipelinerun_scenario` call in the `(packages × workloads)` loop.
- **`pipeline/tests/test_manifest.py`** — six new cases: absent, full, partial, non-mapping, unknown key, non-scalar value (parametrized over bool/list/dict/None).
- **`pipeline/tests/test_tekton.py`** — four new cases: absent kwarg, empty dict, partial dict, full dict.
- **`pipeline/README.md`** — adds the new section to the v3 schema block.

## Reviewer attention

- **Compat guarantee.** Existing manifests that don't have `blis_observe:` are unaffected. The validator defaults it to `{}`; `make_pipelinerun_scenario` with `observe={}` emits no new param entries; Tekton falls through to Pipeline defaults. Verified with `test_observe_absent_emits_no_observe_params` and `test_observe_empty_dict_emits_no_observe_params`.
- **No Pipeline.yaml change.** The Pipeline-level params declared in PR #338 stay as-is. They remain the defaults for any field a transfer doesn't specify.
- **Bool rejection.** `isinstance(True, int)` is `True` in Python; the validator explicitly checks `isinstance(v, bool)` to keep booleans out of the type-accepts-scalar branch. Tested via the parametrized `test_blis_observe_rejects_non_scalar_values`.
- **Tekton TaskRun ceiling.** The new `timeout:` field is passed to `blis observe` as its `--timeout` flag (workload duration). The outer TaskRun wall-clock ceiling is still hardcoded to `90m` in `pipeline/lib/tekton.py:11-14`. A `--timeout` value > the TaskRun ceiling minus setup/teardown overhead would be silently truncated by Tekton. Flagged as out-of-scope in the #337 decision comment; worth a separate validator check if it becomes a real issue.
- **README schema block.** The surrounding v3 schema block already has unrelated drift from PR #109 (target/config/epp_image vs the current `component:` section) — tracked in #402. This PR only adds the new section; it doesn't try to fix the surrounding drift.

## Stale-reference sweep

Grepped `blis_observe`, `make_pipelinerun_scenario`, and the five param names across `pipeline/`, `.claude/skills/`, `docs/`. Every hit is either new code I just wrote, the existing Pipeline-level wiring in `pipeline/pipeline.yaml` (which this PR complements, not invalidates), or unchanged test names. The bootstrap-skill side (parsing config.md → emitting `blis_observe:` in the generated bundle) is tracked separately in #403.

## Test plan

- [x] `python -m pytest pipeline/ .claude/skills/sim2real-{analyze,bootstrap,translate}/tests/ -q` — 1109 passed, 2 xfailed (pre-existing)
- [x] `ruff check pipeline/ .claude/skills/ --select F` — clean
- [ ] Manual: an experiment with `blis_observe: {timeout: 3600}` in its transfer.yaml produces a PipelineRun with `timeout: "3600"` in `spec.params` and no other observe entries (so Tekton applies Pipeline defaults for the other four).
- [ ] Manual: an experiment without `blis_observe:` produces PipelineRuns with no observe entries (compat — identical to pre-PR behavior).

## Related

- Closes #337
- Depends on #338 (Pipeline-level params, merged)
- Parallel: #402 (README schema drift), #403 (bootstrap-skill emission from config.md)