### PR TITLE
fix(sim2real-check): correct §1c/§1d/§1g audit methodology

### DIFF
--- a/.claude/skills/sim2real-check/SKILL.md
+++ b/.claude/skills/sim2real-check/SKILL.md
@@ -93,16 +93,20 @@ When both exist, note any differences (especially `aggregate_rate`) and use the 
 - Show: table with each class — expected %, actual %, difference
 
 **1c. Input Token Distribution**
-- From sim: `input_distribution` params (mean, std_dev, min, max)
-- From real: compute mean, stdev, min, max of `input_tokens` column
-- Tolerance: mean within 5%, stdev within 10%
-- Show: table with expected vs actual for mean, stdev, min, max
+- From sim: `input_distribution` params (e.g. for lognormal: mu, sigma, min, max).
+- From real: compute mean, stdev, min, max of `input_tokens` column.
+- **Expected-moment derivation (critical):** use sample-then-clamp Monte Carlo matching the BLIS sampler semantics (`inference-sim/sim/workload/distribution.go`). For each draw: sample from the configured distribution → round to int → clamp to `[min, max]` when bounds are set → floor at 1. Compute the expected mean and stdev as moments of the clamped samples (N ≥ 100k for stable means).
+  - For lognormal (`LognormalSampler.Sample` at `distribution.go:105`), the closed-form `exp(mu + sigma²/2)` is correct ONLY when no clamp bounds are set. When `min > 0` (the common case — e.g. `code_generation` output at `mu=5.2711, sigma=1.2498, min=50`), a non-trivial below-min mass is piled at `min` by clamping, shifting the mean materially below the closed-form value.
+  - Do not use rejection-sampling truncation (resample if outside `[min, max]`) for expected-moment computation. BLIS clamps; rejection produces a different distribution and a measurably different mean.
+- Tolerance: mean within 5%, stdev within 10%.
+- Show: table with expected vs actual for mean, stdev, min, max. Note the expected-mean derivation (`clamped MC` vs `closed-form`) in the table caption so the reader knows which path was used.
 
 **1d. Output Token Distribution**
-- From sim: `output_distribution` params
-- From real: compute from `output_tokens` column
-- Same tolerances as input
-- Show: same table format as 1c
+- From sim: `output_distribution` params.
+- From real: compute from `output_tokens` column.
+- Use the same sample-then-clamp expected-moment derivation as 1c.
+- Same tolerances as 1c.
+- Show: same table format as 1c.
 
 **1e. Prefix Tokens**
 - From sim: check if any client has `prefix_group` or prefix config
@@ -115,11 +119,15 @@ When both exist, note any differences (especially `aggregate_rate`) and use the 
 - Show: expected vs actual streaming fraction
 
 **1g. Burstiness / Arrival Pattern**
-- From sim: `arrival.process` (poisson, constant, etc.)
-- From real: compute coefficient of variation (CV) of inter-arrival times
-  - Poisson: CV should be ~1.0 (0.8-1.2 acceptable)
-  - Constant: CV should be ~0 (<0.1)
-- Show: expected arrival process, measured CV, interpretation
+- From sim: each client's `arrival.process` (poisson, constant, etc.) — every client carries its own spec.
+- From real: compute coefficient of variation (CV) of inter-arrival times **per `client_id`**, not on the merged stream.
+  - Group `trace_data.csv` by `client_id`. For each group: sort by `arrival_time_us`, take consecutive diffs, compute `CV = stdev / mean`.
+  - Verdict each client against its own configured `arrival.process`:
+    - Poisson: CV ~1.0 (0.8-1.2 acceptable)
+    - Constant: CV ~0 (<0.1)
+- **Why per-client.** Each client's IAT sampler runs independently (`inference-sim/sim/workload/arrival.go`); a `constant` client's per-client CV is 0 exactly. The aggregate stream is `concat(per_client_arrivals).sort_by(arrival_time)` (`sim/workload/generator.go`), so when two `constant` clients run at different rates the merged CV is whatever the deterministic superposition produces (e.g. ~0.5 for streams at 1.2 + 2.8 req/s). Pure Poisson superposition is approached only as N → ∞ (Palm-Khintchine). Gating on aggregate CV produces FAILs on workloads where every client is a perfect metronome.
+- **Aggregate CV (diagnostic only).** Also compute the CV of the fully merged stream and report it for context, but do not pass/fail on it. Label it "merged-stream CV — informational; does not gate verdict."
+- Show: per-`client_id` table — `client_id | configured process | measured CV | verdict` — plus a single-row "merged-stream CV" diagnostic below.
 
 ---
 


### PR DESCRIPTION
## Summary

Two methodology bugs in `sim2real-check` §1 (workload parity) produced false WARN/FAIL on every audit run despite sim/real actually being in agreement:

- **§1c/§1d (token distributions)** — the skill didn't pin how the *expected* mean is computed, and the audit defaulted to rejection-sampling truncation. BLIS samplers (`inference-sim/sim/workload/distribution.go`) **clamp**, not reject. For `code_generation` output (`mu=5.2711, sigma=1.2498, min=50`), ~13.9% of raw samples fall below 50; clamping piles them at 50, rejection discards them. Closed-form mean 425.0, clamp 424.4, reject 471.7, measured 421.8 — every cell tripped a "−10% mean shortfall" WARN that was a definitional mismatch, not workload divergence.

- **§1g (burstiness)** — the skill compared the CV of the merged inter-arrival stream against the spec's `arrival.process`. When a workload has multiple `constant` clients at different rates, each client is independently periodic (per-client CV = 0 exactly) but the merged stream's CV is whatever the deterministic superposition produces (~0.5 for two streams at 1.2 + 2.8 req/s). Baseline `cg_4`: per-client CV 0.000/0.000, aggregate 0.497 → spurious FAIL despite every client being a perfect metronome.

Both are check-correctness issues — sim and real consume the same `workload.GenerateWorkload`, so neither was masking a real divergence.

Closes #385

## Changes

- `.claude/skills/sim2real-check/SKILL.md` §1c/§1d: spec the expected-moment computation as sample-then-clamp Monte Carlo (N ≥ 100k) matching the BLIS sampler semantics. The closed-form `exp(mu + sigma²/2)` is valid only when no clamp bounds are set. Cite `LognormalSampler.Sample` at `distribution.go:105` so the next implementer can verify the algorithm.
- `.claude/skills/sim2real-check/SKILL.md` §1g: spec the CV computation per `client_id`, verdict each client against its own `arrival.process` spec. Aggregate (merged-stream) CV is reported as a diagnostic only. Cite the per-client independence (`arrival.go`) and the merge-sort superposition (`generator.go`).

## Reviewer attention

- The fix is in skill prompt text only — no Python code paths. `sim2real-check` has no `tests/` directory in the CI test set, so no automated tests exist or were added. The "test" is that the next audit run on a known-good run produces a PASS instead of the previously-observed false WARN/FAIL.
- The methodology spec uses pseudocode-style instructions ("group by `client_id`, sort by `arrival_time_us`, take consecutive diffs, compute CV"). That matches how every other audit step in the skill is specified.

## Sweep

`grep` for "coefficient of variation", "inter-arrival", "rejection sampl", "closed-form", "aggregate CV", "merged-stream CV" across `.claude/skills/`, `docs/`, `pipeline/`, `README.md` — only this PR's own edits hit. No stale references elsewhere.

## Test plan

- [x] `ruff check .claude/skills/ pipeline/ --select F` — clean
- [x] Methodology spec compared against actual sampler code at `inference-sim/sim/workload/distribution.go:105-125` and `arrival.go:107-115`.