### PR TITLE
fix(deploy): skip orphan progress entries instead of crashing

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -2457,6 +2457,22 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
                          preserve_pipelineruns=preserve_pipelineruns)
     store.save(progress)
 
+    # Orphans: pair_keys in progress (in scope, still active) but absent from
+    # cluster/. Happens when prepare.py is re-run with a different workload set
+    # between stop and the next run. Without this guard, _pending_pairs would
+    # surface them and the dispatch loop's pair_costs[pair_key] would KeyError
+    # at startup (#408).
+    orphans = sorted(
+        k for k, v in progress.items()
+        if _is_pair_key(k) and k in _scope and k not in discovered
+        and v.get("status") in ("pending", "running")
+    )
+    if orphans:
+        warn(f"{len(orphans)} progress entries have no PipelineRun in cluster/ "
+             f"(likely from a prior prepare.py): {orphans}. Skipping. "
+             f"Remove the entries manually or via `deploy.py reset --only <key>` "
+             f"if they should not return.")
+
     # Track which namespace is assigned to which pair
     slots_busy: dict[str, str] = {
         entry["namespace"]: key
@@ -2466,11 +2482,13 @@ def _cmd_run(args, run_dir: Path, setup_config: dict) -> None:
 
     def _pending_pairs() -> list[str]:
         return [k for k, v in progress.items()
-                if _is_pair_key(k) and v.get("status") == "pending" and k in _scope]
+                if _is_pair_key(k) and v.get("status") == "pending"
+                and k in _scope and k in discovered]
 
     def _work_remaining() -> bool:
         return any(v.get("status") in ("pending", "running")
-                   for k, v in progress.items() if _is_pair_key(k) and k in _scope)
+                   for k, v in progress.items()
+                   if _is_pair_key(k) and k in _scope and k in discovered)
 
     timeout_hours = 4
     info(f"Orchestrator: {len(_scope)} pairs in scope, {len(namespaces)} slot(s)")

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -3053,6 +3053,117 @@ def test_free_slot_runs_gpu_probe_and_dispatches(tmp_path, monkeypatch):
     assert "_orchestrator" not in saved_progress
 
 
+# ── Orphan pair_key handling (issue #408) ────────────────────────────────────
+
+def _orphan_harness(tmp_path, monkeypatch, *, initial_progress):
+    """Boilerplate for the orphan tests: cluster/ has one pair ('a'), progress
+    starts with whatever initial_progress dict the caller provides. Returns the
+    final saved_progress dict and the captured stderr after _cmd_run returns."""
+    import pipeline.deploy as mod
+    from pipeline.lib.progress import ConfigMapProgressStore
+
+    run_dir = tmp_path / "runs" / "test-run"
+    cluster_dir = run_dir / "cluster"
+    cluster_dir.mkdir(parents=True)
+    _write_pr(cluster_dir, "a")
+    (run_dir / "run_metadata.json").write_text(json.dumps({}))
+    setup_config = {"namespaces": ["sim2real-0"], "namespace": "sim2real-0"}
+
+    saved_progress = {}
+
+    def mock_save(self, data):
+        saved_progress.clear()
+        saved_progress.update(data)
+
+    monkeypatch.setattr(ConfigMapProgressStore, "load", lambda self: dict(initial_progress))
+    monkeypatch.setattr(ConfigMapProgressStore, "save", mock_save)
+    monkeypatch.setattr(mod, "_cmd_build", lambda *a, **kw: "skip")
+    monkeypatch.setattr(mod, "_check_slot_ready", lambda ns, **kw: (True, []))
+
+    import pipeline.lib.capacity as _cap_mod
+    monkeypatch.setattr(_cap_mod, "probe_free_gpus", lambda **kw: (8, 8, 0))
+    monkeypatch.setattr(_cap_mod, "load_defaults",
+                        lambda root: {"decode": {"accelerator": {"count": 1}}})
+    monkeypatch.setattr(mod, "_check_pipelinerun_status",
+                        lambda pr_name, ns: "Succeeded")
+
+    def fake_run(cmd, *, check=True, capture=False, input=None, cwd=None):
+        class _R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+        return _R()
+    monkeypatch.setattr(mod, "run", fake_run)
+    monkeypatch.setattr(mod, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)
+
+    mod._cmd_run(_run_args(), run_dir, setup_config)
+    return saved_progress
+
+
+def _pending_entry(workload, package):
+    return {
+        "workload": workload, "package": package, "status": "pending",
+        "namespace": None, "completed_namespace": None,
+        "retries": 0, "pending_stalls": 0,
+        "pending_since": None, "running_since": None, "last_duration": None,
+    }
+
+
+def test_cmd_run_orphan_pending_does_not_crash(tmp_path, monkeypatch, capsys):
+    """Regression for #408: a pending entry in progress with no matching YAML in
+    cluster/ used to KeyError at pair_costs[pair_key]. Now it's skipped with a
+    warning and the in-discovered pair still completes."""
+    initial = {
+        "wl-orphan-baseline": _pending_entry("orphan", "baseline"),
+    }
+    saved = _orphan_harness(tmp_path, monkeypatch, initial_progress=initial)
+
+    # The in-discovered pair completes.
+    assert saved["wl-a-baseline"]["status"] == "done"
+    # The orphan is surfaced but not auto-removed.
+    assert "wl-orphan-baseline" in saved
+    assert saved["wl-orphan-baseline"]["status"] == "pending"
+    # Warning naming the orphan is emitted to stderr.
+    err = capsys.readouterr().out
+    assert "wl-orphan-baseline" in err
+    assert "no PipelineRun in cluster/" in err
+
+
+def test_cmd_run_orphan_running_does_not_block_completion(tmp_path, monkeypatch, capsys):
+    """An orphan with status=running (left over from a prior run whose YAML was
+    removed) must not keep _work_remaining alive. _reconcile_on_resume already
+    resets it to pending when discovered[k]['pr_name'] is missing; the new gate
+    then ensures it's skipped from dispatch consideration."""
+    initial = {
+        "wl-orphan-baseline": {
+            **_pending_entry("orphan", "baseline"),
+            "status": "running", "namespace": "sim2real-9", "running_since": None,
+        },
+    }
+    saved = _orphan_harness(tmp_path, monkeypatch, initial_progress=initial)
+
+    assert saved["wl-a-baseline"]["status"] == "done"
+    # Reconcile resets orphan running → pending (pr_name absent in discovered);
+    # the gate then keeps it out of dispatch. The entry stays for operator review.
+    assert saved["wl-orphan-baseline"]["status"] == "pending"
+    err = capsys.readouterr().out
+    assert "wl-orphan-baseline" in err
+
+
+def test_cmd_run_no_orphan_no_warning(tmp_path, monkeypatch, capsys):
+    """Negative control: when every progress key is in discovered, no orphan
+    warning fires."""
+    initial = {
+        "wl-a-baseline": _pending_entry("a", "baseline"),
+    }
+    saved = _orphan_harness(tmp_path, monkeypatch, initial_progress=initial)
+
+    assert saved["wl-a-baseline"]["status"] == "done"
+    err = capsys.readouterr().out
+    assert "no PipelineRun in cluster/" not in err
+
+
 # ── Live-loop failure paths retain namespace (issue #277) ───────────────────
 
 


### PR DESCRIPTION
## Summary

Closes #408. Observed three times in `kalantar-0`: orchestrator pod crashes at startup with `KeyError: 'wl-interactive-chat-5-softreflective'` (or similar) at `pipeline/deploy.py:2673`.

## Root cause

`_cmd_run` has two sets of pair_keys that can drift:

- `progress` — loaded from the ConfigMap; carries every entry ever initialized for this run.
- `discovered = _load_pairs(cluster_dir)` — scanned fresh from `cluster/pipelinerun-*.yaml` on every invocation.

`pair_costs` is built only from `discovered ∩ scope` (`deploy.py:2440-2444`). `_pending_pairs()` gates on status + scope but **not** on `discovered` membership. When `prepare.py` is re-run with a different workload set between stop and the next `deploy.py run`, the progress ConfigMap retains entries for workloads no longer present in `cluster/`. Those orphans surface in `_pending_pairs()` but are missing from `pair_costs`, so `pair_costs[pair_key]` at line 2673 raises.

## Fix

Two surgical changes in `_cmd_run`:

1. **Surface orphans at startup.** After `_reconcile_on_resume`, compute the orphan set (in progress + in scope + active status + not in discovered) and warn once with a sorted key list.
2. **Gate `_pending_pairs()` and `_work_remaining()` on `k in discovered`.** Keeps orphans out of dispatch consideration without auto-deleting them — that's left to operator judgment via `deploy.py reset` or manual ConfigMap edit.

```python
orphans = sorted(
    k for k, v in progress.items()
    if _is_pair_key(k) and k in _scope and k not in discovered
    and v.get("status") in ("pending", "running")
)
if orphans:
    warn(f"{len(orphans)} progress entries have no PipelineRun in cluster/ ...")

def _pending_pairs() -> list[str]:
    return [k for k, v in progress.items()
            if _is_pair_key(k) and v.get("status") == "pending"
            and k in _scope and k in discovered]
```

A `running` orphan (status `running` but no YAML in `cluster/`) is handled in two stages: `_reconcile_on_resume` already resets it to `pending` when `discovered[k]["pr_name"]` is missing (`deploy.py:2186-2196`); the new gate then keeps it out of dispatch.

## Tests

Three new end-to-end tests in `pipeline/tests/test_deploy_run.py`:

- `test_cmd_run_orphan_pending_does_not_crash` — regression for #408. Asserts no KeyError, the in-discovered pair completes, the orphan stays in progress (not auto-deleted), and the warning naming the orphan is on stdout.
- `test_cmd_run_orphan_running_does_not_block_completion` — orphan with status `running` in ConfigMap. Verifies reconcile resets it to `pending` and the gate prevents redispatch.
- `test_cmd_run_no_orphan_no_warning` — negative control: when every progress key is in discovered, no orphan warning fires.

## Reviewer attention

- **No state change for non-orphan pairs.** The gate only adds a condition (`and k in discovered`); the existing branches are unchanged. Verified by the 209 pre-existing tests in `test_deploy_run.py` still passing.
- **Out of scope: auto-removal.** The fix surfaces orphans, it doesn't delete them. The issue body argues for surface-don't-delete because the operator should decide whether the orphan represents abandoned work or a transient `cluster/` regeneration.
- **Bait-and-switch capsys streams.** During implementation an earlier `replace_all` on `capsys.readouterr().err` → `.out` accidentally rewrote four pre-existing tests (`test_apply_run_filters_*_aborts`) whose local variable `err` correctly held stderr content. The mass-rewrite was reverted; only the orphan tests use `.out` (because `warn()` in `pipeline/lib/log.py:17` writes via `print(...)` to stdout, not stderr). Worth noting because the two log helpers have a non-obvious split: `warn` → stdout, `err` → stderr.

## Stale-reference sweep

Grepped `_pending_pairs`, `_work_remaining`, `pair_costs[` across `pipeline/`, `docs/`, `.claude/skills/`. Only hit outside the diff is a historical plan document (`docs/superpowers/plans/2026-05-10-backoff-controller.md`) with line-number references that have been stale since long before this PR — left alone.

## Test plan

- [x] `python -m pytest pipeline/ .claude/skills/sim2real-{analyze,bootstrap,translate}/tests/ -q` — 1112 passed, 2 xfailed (pre-existing)
- [x] `ruff check pipeline/ .claude/skills/ --select F` — clean
- [x] Manually verified the workaround for the live `kalantar-0` crash: removing three orphan keys from the ConfigMap unblocked the orchestrator. This PR makes that manual edit unnecessary going forward — the orchestrator skips them with a warning.

## Related

- Closes #408
- Related to #399 (broader stop/restart contract; this PR is the minimal crash-prevention slice, not the full design discussion).