### PR TITLE
fix(rbac): grant orchestrator pods + events in slot namespaces

### DIFF
--- a/pipeline/rbac/sim2real-runner-ns.yaml
+++ b/pipeline/rbac/sim2real-runner-ns.yaml
@@ -1,5 +1,14 @@
-# Additional namespace-scoped permissions for the sim2real-runner SA:
-# - PVC and Secret read access for orchestrator slot health checks.
+# Namespace-scoped permissions the orchestrator SA needs in each slot ns:
+# - pipelineruns (tekton.dev): create/manage workload PipelineRuns.
+# - persistentvolumeclaims, secrets: slot-readiness checks.
+# - pods: per-PipelineRun pending-pod triage (deploy.py _check_pending_pods)
+#   and broader non-Tekton pod health sweeps (lib/health.py:get_all_pods).
+# - events: triage context for pending/failed pods
+#   (lib/health.py:get_events) — feeds the pod_pending classifier.
+# Granted here rather than via the cluster bundle so the orchestrator
+# works when the operator running setup.py lacks cluster-RBAC privileges
+# (sim2real-runner-cluster.yaml is best-effort and silently skipped in
+# that case — issue #410).
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -12,6 +21,12 @@ rules:
   - apiGroups: [""]
     resources: ["persistentvolumeclaims", "secrets"]
     verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/pipeline/tests/test_setup_pipeline.py
+++ b/pipeline/tests/test_setup_pipeline.py
@@ -607,3 +607,59 @@ class TestStepRbacApply:
         assert exc.value.code == 1
         # No kubectl apply should have been issued.
         assert len(self._apply_calls(mock_run)) == 0
+
+
+class TestSimRealRunnerNsRoleContent:
+    """Content assertions on pipeline/rbac/sim2real-runner-ns.yaml.
+
+    The orchestrator SA needs every rule in this Role to be present in every
+    slot namespace. step_rbac applies the file unmodified (just envsubst), so
+    the rules here ARE the orchestrator's namespaced permission set. If a rule
+    silently disappears, the orchestrator's pod-health polling 403s in slot
+    namespaces — see issue #410 for the failure shape.
+    """
+
+    def _load_role_rules(self):
+        import yaml
+        from pipeline.setup import REPO_ROOT
+        path = REPO_ROOT / "pipeline" / "rbac" / "sim2real-runner-ns.yaml"
+        docs = list(yaml.safe_load_all(path.read_text()))
+        role = next(d for d in docs if d.get("kind") == "Role")
+        return role["rules"]
+
+    def _rule_for(self, rules, api_group, resource):
+        """Return the first rule covering (api_group, resource), or None."""
+        for r in rules:
+            if api_group in r.get("apiGroups", []) and resource in r.get("resources", []):
+                return r
+        return None
+
+    def test_pipelineruns_rule_present(self):
+        """Tekton PipelineRun CRUD — the orchestrator's primary verb set."""
+        rule = self._rule_for(self._load_role_rules(), "tekton.dev", "pipelineruns")
+        assert rule is not None
+        assert set(rule["verbs"]) >= {"create", "get", "watch", "list", "delete", "patch"}
+
+    def test_pvc_secret_get_rule_present(self):
+        """Slot-readiness checks read PVC bind state and HF secret presence."""
+        rules = self._load_role_rules()
+        for resource in ("persistentvolumeclaims", "secrets"):
+            rule = self._rule_for(rules, "", resource)
+            assert rule is not None, f"missing rule for core/{resource}"
+            assert "get" in rule["verbs"]
+
+    def test_pods_rule_present(self):
+        """Issue #410: pods get/list/watch is what _check_pod_health and
+        _check_pending_pods exercise on every poll tick; without it, the
+        orchestrator's health triage silently degrades to no-ops."""
+        rule = self._rule_for(self._load_role_rules(), "", "pods")
+        assert rule is not None, "pods rule missing — orchestrator pod health checks will 403"
+        assert set(rule["verbs"]) >= {"get", "list", "watch"}
+
+    def test_events_rule_present(self):
+        """Issue #410: events get/list feeds get_events(), which provides the
+        warning-event context for pod_pending classification (FailedScheduling,
+        ImagePullBackOff, etc.)."""
+        rule = self._rule_for(self._load_role_rules(), "", "events")
+        assert rule is not None, "events rule missing — pending-pod triage loses event context"
+        assert set(rule["verbs"]) >= {"get", "list"}


### PR DESCRIPTION
## Summary

Add `pods` (get/list/watch) and `events` (get/list) to `pipeline/rbac/sim2real-runner-ns.yaml` so the orchestrator's `sim2real-runner` ServiceAccount can list pods and events in every slot namespace via the namespaced Role+RoleBinding alone — independent of whether the cluster-scoped augment (`sim2real-runner-cluster.yaml`) was applied.

When the operator running `setup.py` lacks cluster-RBAC privileges, `step_rbac` silently skips the cluster augment (`required=False` at `setup.py:405`), and the orchestrator ends up with no `pods`/`events` verb anywhere — symptom is a continuous `[WARN] get_all_pods(...) kubectl failed (rc=1)` from `_check_pod_health` and `[<workload>] pod query failed: ...` from `_check_pending_pods`.

Closes #410

## Scope clarification (vs the original issue body)

The vet step caught that the issue overstated the fix. Issue #410 listed two root causes:

1. **Role is missing `pods`/`events`.** Real. Fixed here.
2. **Namespaced binding only covers the primary ns.** Not real. `main()` at `pipeline/setup.py:825-848` already iterates `cfg.namespaces` and calls `step_rbac(ns_cfg)` per slot, so `sim2real-runner-ns.yaml` lands in every slot ns today. User verified with `kubectl get rolebinding sim2real-runner-ns -n=kalantar-1` — binding exists.

So this PR is YAML-only. No code change in `step_rbac`.

## Changes

- `pipeline/rbac/sim2real-runner-ns.yaml`: add two rules (pods get/list/watch, events get/list) to the existing Role; expand the header comment to document why each rule exists and which orchestrator code path needs it. `watch` is granted on pods even though current callsites only `list` — granting it now costs nothing and prevents a future client-go user from re-tripping this issue.
- `pipeline/tests/test_setup_pipeline.py`: new `TestSimRealRunnerNsRoleContent` class with four tests that parse the actual YAML and assert each expected rule is present with the right verbs. Guards against silent regression — if a rule is dropped, the orchestrator's health triage silently degrades to no-ops.

## Reviewer attention

- The `events` rule is also new — the original symptom called out pods, but `get_events` in `lib/health.py:281` was equally affected (silently returned `[]`, weakening triage of `FailedScheduling`/`ImagePullBackOff` warning events). Bundled here since the fix shape is identical.
- This PR is a stop-gap for #377 (`provision_namespace` per-slot helper). When that lands, it will absorb the file content unchanged.

## Sweep

`grep` for `sim2real-runner-ns`, `sim2real-runner-cluster`, `orchestrator RBAC`, `orchestrator permission` across `pipeline/`, `docs/`, `.claude/`, `README*` — no stale doc references. The only `RBAC` hits in `docs/troubleshooting.md` are about the EPP's RBAC (a different SA), unrelated to the orchestrator's.

## Test plan

- [x] Existing `TestStepRbacApply` tests still pass (6 tests).
- [x] New `TestSimRealRunnerNsRoleContent` tests pass (4 tests).
- [x] Full pytest suite: 1116 passed (was 1112).
- [x] `ruff check pipeline/ .claude/skills/ --select F` — clean.
- [ ] On-cluster smoke once merged: re-run `setup.py`, then `kubectl auth can-i list pods -n=kalantar-1 --as=system:serviceaccount:kalantar-0:sim2real-runner` → expect `yes`. Same for `events`. Then confirm `[WARN] get_all_pods(...) kubectl failed` warns no longer fire on a `deploy.py run --remote`.