### PR TITLE
fix(deploy): cancel wait-loop waits for terminal reason, not just non-Running

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -391,6 +391,25 @@ def _cmd_build(run_dir: Path, namespace: str, skip_build: bool) -> str:
 
 # ── PipelineRun helpers ──────────────────────────────────────────────────────
 
+# Tekton PipelineRun `.status.conditions[0].reason` values that mean the run is
+# fully done — no further state transitions, finally tasks (including
+# `llmdbenchmark-teardown`) have completed.  `CancelledRunningFinally`,
+# `PipelineRunStopping`, and `PipelineRunStoppingTimeout` are explicitly
+# NOT terminal: they're transient states where finally is still executing,
+# and deleting the PipelineRun while it's in one of those states force-kills
+# the in-flight teardown and orphans its helm releases (issue #412).
+_TERMINAL_PR_REASONS = frozenset({
+    "Cancelled",
+    "PipelineRunCancelled",        # older Tekton versions
+    "Succeeded",
+    "Completed",
+    "Failed",
+    "PipelineRunTimeout",
+    "CreateRunFailed",
+    "Unknown",                     # PR not found → also terminal for our wait
+})
+
+
 def _cancel_and_delete_pipelinerun(pr_name: str, namespace: str) -> bool:
     """If a PipelineRun with the given name exists, cancel it, wait for it to
     finish cancelling, then delete it so a fresh one can be submitted.
@@ -427,10 +446,15 @@ def _cancel_and_delete_pipelinerun(pr_name: str, namespace: str) -> bool:
             warn(f"Failed to patch PipelineRun {pr_name!r} for cancellation"
                  + (f": {detail}" if detail else ""))
         else:
+            # Wait for the PipelineRun to reach a TERMINAL reason — not just
+            # "anything other than Running".  `CancelledRunningFinally` is the
+            # transient state where the finally block (which runs helm uninstall
+            # via llmdbenchmark-teardown) is still executing; breaking on it and
+            # deleting the PR kills the teardown mid-flight.  See issue #412.
             for _ in range(40):  # wait up to 120 s
                 time.sleep(3)
                 current = _check_pipelinerun_status(pr_name, namespace)
-                if current not in ("Running", "Started"):
+                if current in _TERMINAL_PR_REASONS:
                     info(f"PipelineRun {pr_name!r} cancelled (now: {current})")
                     break
             else:

--- a/pipeline/tests/test_deploy_cancel.py
+++ b/pipeline/tests/test_deploy_cancel.py
@@ -98,3 +98,157 @@ def test_cancel_patch_failure_still_attempts_delete(monkeypatch):
     result = mod._cancel_and_delete_pipelinerun("my-pr", "ns-0")
     assert result is True
     assert ["kubectl", "delete", "pipelinerun"] in calls
+
+
+# ─── Issue #412: wait-loop must not break on CancelledRunningFinally ───
+# CancelledRunningFinally is the transient state where Tekton is running the
+# `finally` block (which contains llmdbenchmark-teardown → helm uninstall).
+# Breaking out of the wait loop and deleting the PipelineRun while it's in
+# this state force-kills the teardown TaskRun and orphans helm releases.
+
+def test_cancel_waits_through_cancelled_running_finally(monkeypatch):
+    """Regression for #412: CancelledRunningFinally is NOT terminal.
+
+    Wait loop must keep polling while the finally block executes, and only
+    break when the reason reaches a terminal value (Cancelled here).
+    """
+    poll_counter = []
+
+    # Sequence:
+    #   1st call (line 415, initial check before the patch): "Running"
+    #   2nd-4th calls (wait loop iterations 1-3): "CancelledRunningFinally"
+    #   5th call (wait loop iteration 4): "Cancelled" → terminal, break
+    sequence = [
+        "Running",
+        "CancelledRunningFinally",
+        "CancelledRunningFinally",
+        "CancelledRunningFinally",
+        "Cancelled",
+    ]
+
+    seq_iter = iter(sequence)
+    last_status = ["Running"]
+
+    def fake_status(pr, ns):
+        try:
+            last_status[0] = next(seq_iter)
+        except StopIteration:
+            pass
+        poll_counter.append(last_status[0])
+        return last_status[0]
+
+    cmds = []
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        cmds.append(list(cmd[:3]))
+        class _R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    monkeypatch.setattr(mod, "_check_pipelinerun_status", fake_status)
+    monkeypatch.setattr(mod.time, "sleep", lambda _s: None)
+
+    result = mod._cancel_and_delete_pipelinerun("my-pr", "ns-0")
+
+    assert result is True
+    # The wait loop must have observed CancelledRunningFinally at least once
+    # without breaking — that is the regression guard.
+    transient_observations = [s for s in poll_counter if s == "CancelledRunningFinally"]
+    assert len(transient_observations) >= 3, (
+        f"Wait loop broke prematurely on a transient state; "
+        f"poll history: {poll_counter}"
+    )
+    # And it must have eventually observed the terminal Cancelled.
+    assert "Cancelled" in poll_counter, (
+        f"Wait loop did not reach terminal Cancelled; poll history: {poll_counter}"
+    )
+    # Delete must have been issued exactly once after wait completed.
+    delete_calls = [c for c in cmds if c == ["kubectl", "delete", "pipelinerun"]]
+    assert len(delete_calls) == 1
+
+
+def test_cancel_times_out_when_finally_never_completes(monkeypatch):
+    """Last-resort safety: if the finally block never terminates within 120s
+    (40 polls × 3s), the wait loop must exit, warn, and force-delete the PR.
+
+    This preserves the existing safety property — a stuck teardown cannot pin
+    a slot indefinitely. The fix only widens what counts as "still in flight",
+    it does not remove the timeout escape.
+    """
+    poll_counter = []
+
+    def fake_status(pr, ns):
+        # First call (line 415) returns "Running" to enter the cancel branch.
+        # Every subsequent call returns the transient state — finally never finishes.
+        if not poll_counter:
+            poll_counter.append("Running")
+            return "Running"
+        poll_counter.append("CancelledRunningFinally")
+        return "CancelledRunningFinally"
+
+    cmds = []
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        cmds.append(list(cmd[:3]))
+        class _R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    monkeypatch.setattr(mod, "_check_pipelinerun_status", fake_status)
+    monkeypatch.setattr(mod.time, "sleep", lambda _s: None)
+
+    result = mod._cancel_and_delete_pipelinerun("my-pr", "ns-0")
+
+    assert result is True
+    # The wait loop should have run all 40 iterations (plus the initial check).
+    wait_loop_polls = [s for s in poll_counter if s == "CancelledRunningFinally"]
+    assert len(wait_loop_polls) == 40, (
+        f"Wait loop should have iterated all 40 times; got {len(wait_loop_polls)}"
+    )
+    # And the force-delete must still run as the last-resort safety net.
+    delete_calls = [c for c in cmds if c == ["kubectl", "delete", "pipelinerun"]]
+    assert len(delete_calls) == 1
+
+
+def test_cancel_breaks_on_non_cancel_terminal_reason(monkeypatch):
+    """If the PR independently transitions to Failed (or any other terminal
+    reason) while we're waiting, the wait loop must break promptly — we don't
+    need to keep polling once the PR is done.
+    """
+    poll_counter = []
+
+    sequence = ["Running", "Failed"]
+    seq_iter = iter(sequence)
+
+    def fake_status(pr, ns):
+        v = next(seq_iter, "Failed")
+        poll_counter.append(v)
+        return v
+
+    cmds = []
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        cmds.append(list(cmd[:3]))
+        class _R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+        return _R()
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    monkeypatch.setattr(mod, "_check_pipelinerun_status", fake_status)
+    monkeypatch.setattr(mod.time, "sleep", lambda _s: None)
+
+    result = mod._cancel_and_delete_pipelinerun("my-pr", "ns-0")
+
+    assert result is True
+    # Initial Running + exactly one wait-loop poll observing Failed.
+    assert poll_counter == ["Running", "Failed"]
+    delete_calls = [c for c in cmds if c == ["kubectl", "delete", "pipelinerun"]]
+    assert len(delete_calls) == 1


### PR DESCRIPTION
## Summary

`_cancel_and_delete_pipelinerun`'s wait loop broke on any PR status reason other than `Running`/`Started`. Tekton's `CancelledRunningFinally` matches that predicate but is transient — it means "main tasks cancelled, finally block is currently executing." Breaking out of the wait and force-deleting the PR while it's in that state killed the in-flight `llmdbenchmark-teardown` TaskRun and orphaned helm releases in the slot namespace.

Replace the predicate with an explicit `_TERMINAL_PR_REASONS` set covering Tekton's actually-terminal reasons (`Cancelled`, `PipelineRunCancelled`, `Succeeded`, `Completed`, `Failed`, `PipelineRunTimeout`, `CreateRunFailed`, `Unknown`). `CancelledRunningFinally`, `PipelineRunStopping`, and `PipelineRunStoppingTimeout` are deliberately not in the set — the wait now keeps polling through them.

Closes #412

## Why this matters (verified live)

Soft-reflective run on 2026-06-29 cancelled 16 PipelineRuns via tier-2 pod-health escalation. Every one logged `cancelled (now: CancelledRunningFinally)` and left helm releases behind:

```
$ helm list -n kalantar-0
infra-llmdbench                  kalantar-0  1  deployed  llm-d-infra-v1.4.0
qwen-qwe-079d55ee-wen3-14b-ms    kalantar-0  1  deployed  llm-d-modelservice-v0.4.15
qwen-qwe-079d55ee-wen3-14b-router kalantar-0  1  deployed  llm-d-router-gateway-dev-v0
```

`tkn pr list -n kalantar-0` returned zero PipelineRuns at the same moment — the PRs were force-deleted before their finally tasks could uninstall their charts.

## Test plan (covered)

`test_deploy_cancel.py` adds three regression tests covering exactly the failure shape:

- `test_cancel_waits_through_cancelled_running_finally` — feeds the stateful status mock a `Running → CancelledRunningFinally × 3 → Cancelled` sequence; asserts the wait observes `CancelledRunningFinally` at least 3 times without breaking, then breaks on terminal `Cancelled`, and `kubectl delete` runs exactly once after.
- `test_cancel_times_out_when_finally_never_completes` — finally never terminates; asserts the wait loop runs all 40 iterations, then the force-delete still fires (preserving the existing safety property — a stuck teardown can't pin a slot indefinitely).
- `test_cancel_breaks_on_non_cancel_terminal_reason` — `Running → Failed` short-circuits the wait.

All five existing tests in `test_deploy_cancel.py` still pass. Full suite: 1119 passed (was 1116). Lint clean.

## Reviewer attention

- The `_TERMINAL_PR_REASONS` set includes `Unknown`. Rationale: `_check_pipelinerun_status` returns `Unknown` when the PR is no longer queryable (kubectl error or PR vanished). The original predicate also broke on `Unknown` (anything not `Running`/`Started`), so including it preserves that behavior — a vanished PR is functionally terminal for our wait.
- The fix scope is intentionally narrow: only `_cancel_and_delete_pipelinerun`'s wait loop. Other status-check sites (`_reconcile_on_resume`, `_handle_timeout`) maintain their own inline tuples of terminal reasons; consolidating them onto `_TERMINAL_PR_REASONS` is a follow-up DRY cleanup, deliberately not in this PR.
- The 120s timeout itself isn't changed. If teardown legitimately exceeds that under cluster load, the orchestrator still force-deletes; that's a separate hardening item.

## Sweep

`grep` for `CancelledRunningFinally`, `CancelledRunFinally`, "cancel wait", "wait cancel" across `docs/`, `pipeline/`, `.claude/skills/`, `README*` — no stale doc references touching the cancel-wait state machine.

## Out of scope (filed separately or deferred)

- Cleaning up the orphan helm releases that have already accumulated in `kalantar-0` from this run. Fix the upstream first; existing orphans can be cleared with `deploy.py reset` or manual `helm uninstall`.
- The downstream tier-2 triage policy that cancels a pair when an unrelated leftover pod is stuck Pending in the slot ns. That's a larger design question.