### PR TITLE
fix(deploy): merge discovered into progress before --remote pre-flight

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -3170,7 +3170,20 @@ def _cmd_run_remote(args, run_dir: "Path", setup_config: dict) -> None:
             warn(f"ConfigMap unreachable — skipping pre-flight filter "
                  f"validation: {exc}")
             progress = None
-        if progress:
+        if progress is not None:
+            # Mirror _cmd_run's init loop locally so the pre-flight validator
+            # sees pair_keys that prepare.py added since the last run. The
+            # in-cluster orchestrator independently does its own init from
+            # the ConfigMap and persists; only `workload` and `package` need
+            # to be populated here — those are the fields _apply_run_filters
+            # reads when building valid_workloads / valid_packages (#414).
+            for key, meta in discovered.items():
+                if key not in progress:
+                    progress[key] = {
+                        "workload": meta["workload"],
+                        "package":  meta["package"],
+                        "status":   "pending",
+                    }
             _resolve_scope(progress, args)
 
     _cmd_build(run_dir, namespace=namespace, skip_build=args.skip_build)

--- a/pipeline/tests/test_deploy_remote.py
+++ b/pipeline/tests/test_deploy_remote.py
@@ -593,6 +593,96 @@ def test_run_remote_passes_scoping_flags(monkeypatch, tmp_path):
     assert "wl-smoke" in container_args
 
 
+# ── Pre-flight filter validation merges discovered (#414) ──────────────────
+
+def _write_pr_yaml(cluster_dir, stem, workload, package="baseline"):
+    (cluster_dir / f"pipelinerun-{stem}.yaml").write_text(
+        f"metadata:\n  name: pipelinerun-{stem}\n"
+        f"spec:\n  params:\n"
+        f"  - name: workloadName\n    value: {workload}\n"
+        f"  - name: phase\n    value: {package}\n"
+    )
+
+
+def _existing_progress_entry(workload, package="baseline", status="done"):
+    return {
+        "workload": workload, "package": package, "status": status,
+        "namespace": None, "completed_namespace": None,
+        "retries": 0, "pending_stalls": 0,
+        "pending_since": None, "running_since": None, "last_duration": None,
+    }
+
+
+def test_run_remote_preflight_accepts_newly_discovered_workload(monkeypatch, tmp_path):
+    """Regression for #414. A workload YAML in cluster/ but absent from the
+    progress ConfigMap must pass pre-flight validation — mirrors the
+    init-loop merge _cmd_run does in-cluster."""
+    from pipeline.lib.progress import ConfigMapProgressStore
+    run_dir = _setup_run_dir(tmp_path)
+    cluster_dir = run_dir / "cluster"
+    # Two pair_keys in cluster/: one already known to progress, one newly added.
+    _write_pr_yaml(cluster_dir, "existing-baseline", workload="wl-existing")
+    _write_pr_yaml(cluster_dir, "newwl-baseline", workload="wl-newwl")
+    # Progress only knows about wl-existing — wl-newwl is the newly-added one.
+    monkeypatch.setattr(
+        ConfigMapProgressStore, "load",
+        lambda self: {"wl-existing-baseline": _existing_progress_entry("wl-existing")},
+    )
+    monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)
+    monkeypatch.setattr(mod, "_check_existing_job", lambda ns: None)
+    monkeypatch.setattr(mod, "_cmd_build", lambda *a, **kw: "skip")
+    monkeypatch.setattr(mod, "_wait_for_job_pod", lambda *a, **kw: None)
+
+    apply_inputs = []
+
+    def fake_subprocess_run(cmd, *, input=None, text=True, check=False, capture_output=True, **kw):
+        if input:
+            apply_inputs.append(json.loads(input))
+        return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    with patch("subprocess.run", side_effect=fake_subprocess_run):
+        args = _make_run_args(remote=True, skip_build=True, workload="wl-newwl")
+        setup_config = {"namespaces": ["ns"], "orchestrator_image": "img:latest"}
+        # Must NOT SystemExit at pre-flight.
+        mod._cmd_run_remote(args, run_dir, setup_config)
+
+    # ConfigMap + Job were submitted (we got past pre-flight + image build).
+    assert len(apply_inputs) == 2
+    assert apply_inputs[0]["kind"] == "ConfigMap"
+    assert apply_inputs[1]["kind"] == "Job"
+    # And --workload was forwarded to the in-cluster orchestrator unchanged.
+    container_args = apply_inputs[1]["spec"]["template"]["spec"]["containers"][0]["args"]
+    assert "--workload" in container_args
+    assert "wl-newwl" in container_args
+
+
+def test_run_remote_preflight_still_rejects_truly_unknown_workload(monkeypatch, tmp_path, capsys):
+    """A --workload value that exists neither in progress nor in cluster/ must
+    still be rejected. The #414 fix loosens validation only for keys present
+    in cluster/."""
+    from pipeline.lib.progress import ConfigMapProgressStore
+    run_dir = _setup_run_dir(tmp_path)
+    cluster_dir = run_dir / "cluster"
+    _write_pr_yaml(cluster_dir, "existing-baseline", workload="wl-existing")
+    monkeypatch.setattr(
+        ConfigMapProgressStore, "load",
+        lambda self: {"wl-existing-baseline": _existing_progress_entry("wl-existing")},
+    )
+    monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)
+    monkeypatch.setattr(mod, "_check_existing_job", lambda ns: None)
+    monkeypatch.setattr(mod, "_cmd_build", lambda *a, **kw: "skip")
+
+    args = _make_run_args(remote=True, skip_build=True, workload="wl-bogus")
+    setup_config = {"namespaces": ["ns"], "orchestrator_image": "img:latest"}
+
+    with pytest.raises(SystemExit) as exc_info:
+        mod._cmd_run_remote(args, run_dir, setup_config)
+    assert exc_info.value.code == 1
+    err = capsys.readouterr().err
+    assert "wl-bogus" in err
+    assert "unrecognized" in err.lower()
+
+
 def test_run_remote_no_image_exits(monkeypatch, tmp_path):
     run_dir = _setup_run_dir(tmp_path)
     monkeypatch.setattr(mod, "EXPERIMENT_ROOT", tmp_path)


### PR DESCRIPTION
## Summary

Closes #414. `deploy.py run --remote --workload <newly-added>` rejected valid workload names at pre-flight whenever the ConfigMap progress hadn't caught up to the latest `cluster/`. Symmetric with #408 (just resolved): both are progress↔discovered drift, one direction each.

## Root cause

`_cmd_run_remote` does a local pre-flight filter validation at `deploy.py:3161-3174` so bad `--workload`/`--package` filters fail before image build / Job submit:

```python
discovered = _load_pairs(cluster_dir)
if discovered:
    ...
    progress = _load_progress(store, allow_unreachable=True) or None
    ...
    if progress:
        _resolve_scope(progress, args)
```

`_resolve_scope` → `_apply_run_filters` builds `valid_workloads` from `progress` only. The pre-flight never merged `discovered` into `progress`, so pair_keys present in `cluster/pipelinerun-*.yaml` but not yet in the ConfigMap were unknown to the validator.

`_cmd_run` (the in-cluster orchestrator) had no such bug because its init loop at `deploy.py:2443-2459` adds every `key in discovered if key not in progress` to `progress` *before* calling `_resolve_scope`. The asymmetry isn't intentional — the local pre-flight is a *second*, *earlier* validation point that exists purely for fast feedback before Job submit, and the merge was missing from this earlier point.

## Fix

Mirror the in-cluster init merge in the local pre-flight. Minimal `{workload, package, status: pending}` entry per missing key — those are the only fields `_apply_run_filters` reads. The mutation is local; nothing is written to the ConfigMap. The in-cluster orchestrator does its own merge from the authoritative ConfigMap and persists.

```python
if progress is not None:
    for key, meta in discovered.items():
        if key not in progress:
            progress[key] = {
                "workload": meta["workload"],
                "package":  meta["package"],
                "status":   "pending",
            }
    _resolve_scope(progress, args)
```

`if progress:` → `if progress is not None:` is behavior-equivalent given the upstream `_load_progress(...) or None` (an empty dict short-circuits to None), but the new wording matches the new semantics (we now mutate the dict; we want to enter even if it's empty).

## Tests

Two new tests in `pipeline/tests/test_deploy_remote.py`:

- `test_run_remote_preflight_accepts_newly_discovered_workload` — regression for #414. Cluster has YAMLs for `wl-existing` + `wl-newwl`; ConfigMap has only `wl-existing`; `--workload wl-newwl` must pass pre-flight and the ConfigMap+Job pair must be submitted.
- `test_run_remote_preflight_still_rejects_truly_unknown_workload` — defensive. Cluster and progress both lack `wl-bogus`; `--workload wl-bogus` must still SystemExit(1) with the existing "unrecognized values" error. Confirms the fix loosens validation only for keys present in `cluster/`.

**Bisect verification:** Temporarily reverted `pipeline/deploy.py` to the pre-fix state and re-ran the positive test — it failed with the exact error message the user is seeing in production (`--workload: unrecognized values ['wl-newwl']`). Restored, re-runs pass. The test catches the bug.

## Reviewer attention

- **Local-only mutation.** The merged entries live in the in-memory `progress` dict for the duration of the pre-flight; `store.save` is never called from this code path. The ConfigMap is authoritative and gets updated by the in-cluster orchestrator's init loop independently.
- **No change to the in-cluster path.** `_cmd_run` (which runs in the orchestrator Job, and also runs locally for non-`--remote` invocations) is untouched. The merge there is still where it was at `:2443-2459`. The non-`--remote` `run` path is structurally safe because validation already happens after the merge.
- **`if progress:` → `if progress is not None:`.** Behavior-equivalent given the `or None` upstream; updated to match the new mutate-in-place semantics.
- **Field minimality.** Only `workload`, `package`, `status` are populated in the synthetic entry — those are the fields `_apply_run_filters` reads. The other progress-entry fields (`namespace`, `retries`, `pending_since`, etc.) are unset; they don't matter here because the dict is discarded after validation.

## Stale-reference sweep

Grepped `pre-flight`, `_resolve_scope`, `_cmd_run_remote` across `pipeline/`, `docs/`, `.claude/skills/`. Only doc hits describe unrelated pre-flight (image build) or are historical plan documents (`docs/superpowers/plans/2026-05-10-backoff-controller.md`, `2026-05-14-collect-scoping-flags.md`) with line-number references that have been stale long before this PR — left alone.

## Test plan

- [x] `python -m pytest pipeline/ .claude/skills/sim2real-{analyze,bootstrap,translate}/tests/ -q` — 1121 passed, 2 xfailed (pre-existing)
- [x] `ruff check pipeline/ .claude/skills/ --select F` — clean
- [x] Bisect: positive test fails with fix reverted, passes with fix restored — reproduces the user's exact error message
- [ ] Manual verification once merged: `deploy.py run --remote --workload interactive_chat_40,interactive_chat_80,interactive_chat_140` against the `sr-mk` ConfigMap (which still lacks the 80/140 entries) should pass pre-flight and submit.

## Related

- Closes #414
- Symmetric with #408 / #409 (other direction of the same drift)