### PR TITLE
feat(pipeline): add layout module for new workspace path helpers

### DIFF
--- a/pipeline/lib/layout.py
+++ b/pipeline/lib/layout.py
@@ -1,0 +1,102 @@
+"""Path helpers for the sim2real workspace layout.
+
+Pure path-only module. Filesystem-aware operations (Path.exists,
+Path.iterdir) are permitted; content reads (JSON parsing, YAML parsing)
+are not. Consumers that need to read or write workspace files use this
+module to compute the path and a separate IO layer to touch the content.
+
+Experiment root
+---------------
+
+Today's pipeline modules each carry a private ``EXPERIMENT_ROOT`` global,
+mutated in ``main()`` from the ``--experiment-root`` CLI flag and falling
+back to ``Path.cwd()``. This module consolidates that resolution so other
+modules can ``layout.set_experiment_root(args.experiment_root)`` once and
+use the helpers below without re-implementing the rule.
+
+Helpers default to ``Path.cwd()`` at use time when the experiment root has
+not been set explicitly, matching the documented "omit --experiment-root
+to default to cwd" backward-compat behavior.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+_EXPERIMENT_ROOT: Path | None = None
+
+
+def set_experiment_root(arg: str | Path | None) -> Path:
+    """Set the module-level experiment root from a CLI-arg-style value.
+
+    Mirrors the resolution rule that today lives inline in
+    ``pipeline/setup.py``, ``pipeline/prepare.py``, and
+    ``pipeline/deploy.py``: a non-empty ``arg`` is resolved to an absolute
+    Path; an empty / None ``arg`` falls back to ``Path.cwd()``.
+
+    Returns the resolved Path so callers can use it directly.
+    """
+    global _EXPERIMENT_ROOT
+    _EXPERIMENT_ROOT = Path(arg).resolve() if arg else Path.cwd()
+    return _EXPERIMENT_ROOT
+
+
+def experiment_root() -> Path:
+    """Return the current experiment root.
+
+    If ``set_experiment_root`` has not been called, returns ``Path.cwd()``
+    evaluated at call time (so a subsequent ``chdir`` is reflected).
+    """
+    return _EXPERIMENT_ROOT if _EXPERIMENT_ROOT is not None else Path.cwd()
+
+
+def workspace_dir() -> Path:
+    """``<experiment-root>/workspace/``"""
+    return experiment_root() / "workspace"
+
+
+def clusters_dir() -> Path:
+    """``workspace/clusters/``"""
+    return workspace_dir() / "clusters"
+
+
+def cluster_dir(cluster_id: str) -> Path:
+    """``workspace/clusters/<cluster_id>/``"""
+    return clusters_dir() / cluster_id
+
+
+def cluster_config_path(cluster_id: str) -> Path:
+    """``workspace/clusters/<cluster_id>/cluster_config.json``"""
+    return cluster_dir(cluster_id) / "cluster_config.json"
+
+
+def list_cluster_ids() -> list[str]:
+    """Return sorted directory names under ``workspace/clusters/``.
+
+    Returns ``[]`` if the directory does not exist or is empty. Files at
+    that level are ignored — only subdirectories are reported.
+    """
+    base = clusters_dir()
+    if not base.is_dir():
+        return []
+    return sorted(p.name for p in base.iterdir() if p.is_dir())
+
+
+def runs_dir() -> Path:
+    """``workspace/runs/``"""
+    return workspace_dir() / "runs"
+
+
+def translations_dir() -> Path:
+    """``workspace/translations/``"""
+    return workspace_dir() / "translations"
+
+
+def setup_config_path() -> Path:
+    """``workspace/setup_config.json``
+
+    Legacy file: post-Step-0 it holds workspace-scoped fields only
+    (cluster-scoped fields move to ``cluster_config.json``).
+    """
+    return workspace_dir() / "setup_config.json"

--- a/pipeline/tests/test_layout.py
+++ b/pipeline/tests/test_layout.py
@@ -1,0 +1,197 @@
+"""Tests for pipeline/lib/layout.py — path helpers + experiment-root resolution."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from pipeline.lib import layout
+
+
+@pytest.fixture(autouse=True)
+def _reset_experiment_root():
+    """Each test starts with the module-level state cleared.
+
+    layout._EXPERIMENT_ROOT is mutated by set_experiment_root(); restore
+    None after every test so tests don't leak state into each other.
+    """
+    layout._EXPERIMENT_ROOT = None
+    yield
+    layout._EXPERIMENT_ROOT = None
+
+
+# ── set_experiment_root / experiment_root ─────────────────────────────
+
+
+class TestSetExperimentRoot:
+    def test_none_falls_back_to_cwd(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        resolved = layout.set_experiment_root(None)
+        assert resolved == tmp_path
+        assert layout.experiment_root() == tmp_path
+
+    def test_empty_string_falls_back_to_cwd(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        resolved = layout.set_experiment_root("")
+        assert resolved == tmp_path
+        assert layout.experiment_root() == tmp_path
+
+    def test_absolute_string_resolved_to_path(self, tmp_path):
+        resolved = layout.set_experiment_root(str(tmp_path))
+        assert resolved == tmp_path
+        assert layout.experiment_root() == tmp_path
+
+    def test_path_object_resolved(self, tmp_path):
+        resolved = layout.set_experiment_root(tmp_path)
+        assert resolved == tmp_path
+        assert layout.experiment_root() == tmp_path
+
+    def test_relative_path_resolved_absolutely(self, tmp_path, monkeypatch):
+        sub = tmp_path / "experiment"
+        sub.mkdir()
+        monkeypatch.chdir(tmp_path)
+        resolved = layout.set_experiment_root("experiment")
+        assert resolved.is_absolute()
+        assert resolved == sub
+
+    def test_resolves_symlinks_and_dots(self, tmp_path, monkeypatch):
+        target = tmp_path / "real"
+        target.mkdir()
+        link = tmp_path / "link"
+        try:
+            link.symlink_to(target)
+        except (OSError, NotImplementedError):
+            pytest.skip("filesystem does not support symlinks")
+        monkeypatch.chdir(tmp_path)
+        resolved = layout.set_experiment_root("./link/../link")
+        # .resolve() resolves both symlinks and .. segments.
+        assert resolved == target.resolve()
+
+
+class TestExperimentRoot:
+    def test_defaults_to_cwd_when_unset(self, tmp_path, monkeypatch):
+        # Fresh module state (per autouse fixture); no set_experiment_root call.
+        monkeypatch.chdir(tmp_path)
+        assert layout.experiment_root() == tmp_path
+
+    def test_cwd_fallback_is_lazy(self, tmp_path, monkeypatch):
+        first = tmp_path / "one"
+        second = tmp_path / "two"
+        first.mkdir()
+        second.mkdir()
+        monkeypatch.chdir(first)
+        assert layout.experiment_root() == first
+        os.chdir(second)
+        assert layout.experiment_root() == second
+
+    def test_explicit_set_overrides_cwd(self, tmp_path, monkeypatch):
+        other = tmp_path / "other"
+        other.mkdir()
+        monkeypatch.chdir(tmp_path)
+        layout.set_experiment_root(str(other))
+        # cwd is tmp_path, but experiment_root sticks to the set value.
+        assert layout.experiment_root() == other
+
+
+# ── Workspace path helpers ────────────────────────────────────────────
+
+
+class TestWorkspacePaths:
+    def test_workspace_dir(self, tmp_path):
+        layout.set_experiment_root(tmp_path)
+        assert layout.workspace_dir() == tmp_path / "workspace"
+
+    def test_clusters_dir(self, tmp_path):
+        layout.set_experiment_root(tmp_path)
+        assert layout.clusters_dir() == tmp_path / "workspace" / "clusters"
+
+    def test_cluster_dir(self, tmp_path):
+        layout.set_experiment_root(tmp_path)
+        assert layout.cluster_dir("ocp-east") == (
+            tmp_path / "workspace" / "clusters" / "ocp-east"
+        )
+
+    def test_cluster_config_path(self, tmp_path):
+        layout.set_experiment_root(tmp_path)
+        assert layout.cluster_config_path("ocp-east") == (
+            tmp_path / "workspace" / "clusters" / "ocp-east" / "cluster_config.json"
+        )
+
+    def test_runs_dir(self, tmp_path):
+        layout.set_experiment_root(tmp_path)
+        assert layout.runs_dir() == tmp_path / "workspace" / "runs"
+
+    def test_translations_dir(self, tmp_path):
+        layout.set_experiment_root(tmp_path)
+        assert layout.translations_dir() == tmp_path / "workspace" / "translations"
+
+    def test_setup_config_path(self, tmp_path):
+        layout.set_experiment_root(tmp_path)
+        assert layout.setup_config_path() == tmp_path / "workspace" / "setup_config.json"
+
+    def test_helpers_track_experiment_root_changes(self, tmp_path):
+        first = tmp_path / "first"
+        second = tmp_path / "second"
+        first.mkdir()
+        second.mkdir()
+        layout.set_experiment_root(first)
+        assert layout.workspace_dir() == first / "workspace"
+        layout.set_experiment_root(second)
+        assert layout.workspace_dir() == second / "workspace"
+
+
+# ── list_cluster_ids ──────────────────────────────────────────────────
+
+
+class TestListClusterIds:
+    def test_returns_empty_when_clusters_dir_absent(self, tmp_path):
+        layout.set_experiment_root(tmp_path)
+        # No workspace/clusters/ created.
+        assert layout.list_cluster_ids() == []
+
+    def test_returns_empty_when_clusters_dir_empty(self, tmp_path):
+        layout.set_experiment_root(tmp_path)
+        layout.clusters_dir().mkdir(parents=True)
+        assert layout.list_cluster_ids() == []
+
+    def test_returns_sorted_subdir_names(self, tmp_path):
+        layout.set_experiment_root(tmp_path)
+        clusters = layout.clusters_dir()
+        clusters.mkdir(parents=True)
+        (clusters / "ocp-west").mkdir()
+        (clusters / "ocp-east").mkdir()
+        (clusters / "kind-local").mkdir()
+        assert layout.list_cluster_ids() == ["kind-local", "ocp-east", "ocp-west"]
+
+    def test_ignores_files_at_clusters_level(self, tmp_path):
+        layout.set_experiment_root(tmp_path)
+        clusters = layout.clusters_dir()
+        clusters.mkdir(parents=True)
+        (clusters / "ocp-east").mkdir()
+        (clusters / "stray.json").write_text("{}")
+        assert layout.list_cluster_ids() == ["ocp-east"]
+
+    def test_returns_empty_when_clusters_dir_is_a_file(self, tmp_path):
+        layout.set_experiment_root(tmp_path)
+        layout.workspace_dir().mkdir(parents=True)
+        # Adversarial: workspace/clusters exists but as a file, not a directory.
+        clusters_path = layout.clusters_dir()
+        clusters_path.write_text("not a directory")
+        assert layout.list_cluster_ids() == []
+
+
+# ── No content I/O ────────────────────────────────────────────────────
+
+
+class TestNoContentIO:
+    """layout.py is a pure path module — no JSON/YAML imports, no opens."""
+
+    def test_no_json_yaml_imports(self):
+        source = Path(layout.__file__).read_text()
+        assert "import json" not in source
+        assert "import yaml" not in source
+        # Permitted filesystem ops; ensure none of these are accidentally
+        # content-reading helpers (.read_text / .read_bytes / open()).
+        assert ".read_text(" not in source
+        assert ".read_bytes(" not in source
+        assert "open(" not in source


### PR DESCRIPTION
## Summary

Adds `pipeline/lib/layout.py` — pure path-helper module for the Step 0 workspace layout. Centralizes the `EXPERIMENT_ROOT` resolution rule that today is duplicated inline across `setup.py`, `prepare.py`, and `deploy.py`. First child of Epic #416; consumed by Children #419, #422, #423, #424.

## Implementation

Public API per design (`docs/epics/step-0/design.md`, ## `layout.py` path helpers):

- `set_experiment_root(arg)` — resolves a CLI-arg-style value (None / empty → cwd; absolute or relative path → `.resolve()`) and stores it in module state. Returns the resolved Path.
- `experiment_root()` — returns the current root, falling back lazily to `Path.cwd()` at call time when never set explicitly (so `chdir` is honored).
- `workspace_dir()`, `clusters_dir()`, `cluster_dir(id)`, `cluster_config_path(id)`, `runs_dir()`, `translations_dir()`, `setup_config_path()` — path composition.
- `list_cluster_ids()` — sorted directory names under `workspace/clusters/`, `[]` if absent, ignores non-directories.

No JSON/YAML imports, no `.read_text` / `.read_bytes` / `open(` calls — enforced by a guard test (`TestNoContentIO`). Only `Path.is_dir` and `Path.iterdir` for the enumeration helper, per the design's explicit "filesystem-aware operations allowed; content reads disallowed" carve-out.

## Tests

`pipeline/tests/test_layout.py` — 23 tests covering:
- Three `EXPERIMENT_ROOT` resolution paths: `None`, `""`, explicit path (str + Path object), relative path resolved absolutely, symlinks + `..` segments.
- Lazy cwd fallback before `set_experiment_root` is called.
- All 7 path helpers against a fresh `tmp_path` root.
- `list_cluster_ids` edge cases: dir absent, dir empty, sorted dirs only, files ignored, `clusters/` is a file.
- No content I/O (asserts source has no `import json`, `import yaml`, `read_text`, `read_bytes`, or `open(`).

## Acceptance (from #417)

- [x] `pipeline/lib/layout.py` created with every function in design.
- [x] `EXPERIMENT_ROOT` resolution centralized (current scatter across `setup.py:788`, `prepare.py:1275`, `deploy.py:3381`).
- [x] No JSON/YAML content I/O in the module.
- [x] `pipeline/tests/test_layout.py` with full coverage.
- [x] `ruff check pipeline/lib/layout.py --select F` clean.
- [x] `python -m pytest pipeline/ ...` — 1144 passed, 2 xfailed (no regressions).

## Stale-reference sweep

Grepped `docs/`, `.claude/skills/`, README, CLAUDE.md for `layout`. One hit in `docs/proposals/incremental-implementation-plan-addendum.md` referencing the name choice between `layout.py` / `workspace.py`; design landed on `layout.py`. No updates needed in this PR — README / CLAUDE.md narrative updates are #425's deliverable.

## Notes for reviewer

- The module-level `_EXPERIMENT_ROOT` defaults to `None`, with `experiment_root()` falling back to `Path.cwd()` evaluated lazily at call time. This matches today's behavior in setup/prepare/deploy where `EXPERIMENT_ROOT` is overridden in `main()`. Consumers will migrate to `layout.set_experiment_root(args.experiment_root)` in later epic children (#422–#424).
- Port of consumers (`deploy.py`, `prepare.py`, etc.) to use these helpers is explicitly out of scope per #417 — that's #422 / #423.

Base: `refactor/v2-step-0`
Parent epic: #416
Closes #417