### PR TITLE
feat(pipeline): cluster_ops file-system primitives

### DIFF
--- a/pipeline/lib/cluster_ops.py
+++ b/pipeline/lib/cluster_ops.py
@@ -1,0 +1,109 @@
+"""File-system primitives for ``clusters/<cluster_id>/cluster_config.json``.
+
+Step 0 carves cluster-side responsibilities out of ``pipeline/setup.py`` into
+a new ``pipeline/cluster.py`` entry point backed by this library. This module
+is the first slice: read/write/update of the per-cluster config file. The
+kubectl/oc primitives (``provision_namespace``, ``apply_cluster_resources``)
+land in a separate child.
+
+Writes are atomic (tmpfile + ``Path.replace``) so a concurrent reader either
+sees the previous full content or the new full content, never a torn write.
+Path resolution is delegated to :mod:`pipeline.lib.layout` — no string
+mashing of workspace paths in this module.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+from pipeline.lib import layout
+from pipeline.lib.values import deep_merge
+
+
+# Top-level keys in cluster_config.json whose contents are merged into the
+# existing value rather than wholesale-replaced. Per design (see
+# docs/epics/step-0/design.md, "cluster_config.json schema"): ``secret_names``
+# is a flat string→string dict; ``workspaces`` is a dict of Tekton workspace
+# bindings. Partial updates to either should preserve untouched keys.
+_DEEP_MERGE_KEYS = ("secret_names", "workspaces")
+
+
+def read_cluster_config(cluster_id: str) -> dict:
+    """Read ``clusters/<cluster_id>/cluster_config.json``.
+
+    Returns the parsed JSON object as a dict. Returns ``{}`` if the file does
+    not exist — callers that need a not-yet-provisioned cluster to fail loudly
+    should check the result themselves.
+    """
+    path = layout.cluster_config_path(cluster_id)
+    if not path.exists():
+        return {}
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def write_cluster_config(cluster_id: str, config: dict) -> None:
+    """Atomically write ``clusters/<cluster_id>/cluster_config.json``.
+
+    Creates the cluster directory if it does not exist. Uses tmpfile +
+    ``Path.replace`` so a concurrent reader never observes a partially
+    written file: the rename is atomic on POSIX (and Windows) for paths on
+    the same filesystem, and the tmpfile is created in the same directory.
+    """
+    path = layout.cluster_config_path(cluster_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=".cluster_config-", suffix=".json.tmp")
+    try:
+        with open(fd, "w", encoding="utf-8") as f:
+            json.dump(config, f, indent=2, sort_keys=True)
+            f.write("\n")
+        Path(tmp).replace(path)
+    except BaseException:
+        Path(tmp).unlink(missing_ok=True)
+        raise
+
+
+def update_cluster_config(cluster_id: str, /, **updates) -> dict:
+    """Read-modify-write of ``cluster_config.json``. Returns the new config.
+
+    Update semantics, per design:
+
+    - Keys ``secret_names`` and ``workspaces`` are **deep-merged** into the
+      existing values when the caller passes a dict. Keys not mentioned in
+      the update are preserved.
+    - All other top-level keys are **fully replaced** by the supplied value.
+
+    Examples::
+
+        # Replace the namespaces list wholesale.
+        update_cluster_config("ocp-east", namespaces=["a", "b"])
+
+        # Merge a new secret name in; existing entries are preserved.
+        update_cluster_config("ocp-east", secret_names={"hf_token": "hf-2"})
+
+        # Add a workspace binding; existing bindings are preserved.
+        update_cluster_config(
+            "ocp-east",
+            workspaces={"new-wks": {"persistentVolumeClaim": {"claimName": "new-pvc"}}},
+        )
+
+    Operates on the read result of ``read_cluster_config`` — an absent file
+    is treated as ``{}``, so this function can be used to initialise a
+    cluster_config from scratch as well as to mutate an existing one.
+
+    The write step is atomic; the read-modify-write sequence as a whole is
+    not (no inter-process locking). Concurrent updaters are not expected.
+    """
+    cfg = read_cluster_config(cluster_id)
+    for key, value in updates.items():
+        if key in _DEEP_MERGE_KEYS and isinstance(value, dict):
+            existing = cfg.get(key)
+            if isinstance(existing, dict):
+                cfg[key] = deep_merge(existing, value)
+                continue
+        cfg[key] = value
+    write_cluster_config(cluster_id, cfg)
+    return cfg

--- a/pipeline/tests/test_cluster_ops.py
+++ b/pipeline/tests/test_cluster_ops.py
@@ -1,0 +1,301 @@
+"""Tests for pipeline/lib/cluster_ops.py — file-system primitives."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from pipeline.lib import cluster_ops, layout
+
+
+@pytest.fixture(autouse=True)
+def _isolated_experiment_root(tmp_path, monkeypatch):
+    """Every test starts with a fresh workspace rooted at tmp_path.
+
+    cluster_ops resolves paths via layout.cluster_config_path(), which reads
+    from layout._EXPERIMENT_ROOT. We set that to tmp_path so cluster files
+    land under tmp_path/workspace/clusters/<id>/ without touching the real
+    filesystem.
+    """
+    layout._EXPERIMENT_ROOT = tmp_path
+    yield
+    layout._EXPERIMENT_ROOT = None
+
+
+# ── read_cluster_config ────────────────────────────────────────────────
+
+
+class TestReadClusterConfig:
+    def test_returns_empty_dict_when_file_absent(self):
+        assert cluster_ops.read_cluster_config("ocp-east") == {}
+
+    def test_returns_empty_dict_when_cluster_dir_absent(self):
+        # Different cluster id, never written to.
+        assert cluster_ops.read_cluster_config("never-provisioned") == {}
+
+    def test_returns_parsed_dict_when_file_present(self, tmp_path):
+        path = layout.cluster_config_path("ocp-east")
+        path.parent.mkdir(parents=True)
+        path.write_text(json.dumps({"cluster_id": "ocp-east", "namespaces": ["a", "b"]}))
+        assert cluster_ops.read_cluster_config("ocp-east") == {
+            "cluster_id": "ocp-east",
+            "namespaces": ["a", "b"],
+        }
+
+    def test_round_trip_via_write(self):
+        cluster_ops.write_cluster_config("ocp-east", {"cluster_id": "ocp-east"})
+        assert cluster_ops.read_cluster_config("ocp-east") == {"cluster_id": "ocp-east"}
+
+
+# ── write_cluster_config ───────────────────────────────────────────────
+
+
+class TestWriteClusterConfig:
+    def test_creates_cluster_directory_if_absent(self, tmp_path):
+        cluster_ops.write_cluster_config("ocp-east", {"cluster_id": "ocp-east"})
+        assert layout.cluster_dir("ocp-east").is_dir()
+        assert layout.cluster_config_path("ocp-east").is_file()
+
+    def test_writes_json_content(self, tmp_path):
+        config = {
+            "cluster_id": "ocp-east",
+            "namespaces": ["a", "b"],
+            "secret_names": {"hf_token": "hf-secret"},
+        }
+        cluster_ops.write_cluster_config("ocp-east", config)
+        path = layout.cluster_config_path("ocp-east")
+        assert json.loads(path.read_text()) == config
+
+    def test_overwrites_existing_file(self):
+        cluster_ops.write_cluster_config("ocp-east", {"version": 1})
+        cluster_ops.write_cluster_config("ocp-east", {"version": 2})
+        assert cluster_ops.read_cluster_config("ocp-east") == {"version": 2}
+
+    def test_tmpfile_cleaned_up_after_success(self, tmp_path):
+        cluster_ops.write_cluster_config("ocp-east", {"cluster_id": "ocp-east"})
+        # Only cluster_config.json should remain — no stray .tmp file.
+        contents = list(layout.cluster_dir("ocp-east").iterdir())
+        assert contents == [layout.cluster_config_path("ocp-east")]
+
+    def test_tmpfile_cleaned_up_on_failure(self, monkeypatch):
+        layout.cluster_dir("ocp-east").mkdir(parents=True)
+
+        def boom(*_a, **_kw):
+            raise RuntimeError("simulated dump failure")
+
+        monkeypatch.setattr(cluster_ops.json, "dump", boom)
+        with pytest.raises(RuntimeError, match="simulated dump failure"):
+            cluster_ops.write_cluster_config("ocp-east", {"x": 1})
+        # No .tmp file lingers in the cluster dir, and the real config was
+        # never written.
+        contents = list(layout.cluster_dir("ocp-east").iterdir())
+        assert contents == []
+
+    def test_atomic_rename_no_torn_write(self, monkeypatch):
+        # Seed with a valid prior config; simulate a write failure mid-dump
+        # and verify the prior config is intact (the rename never happened).
+        prior = {"cluster_id": "ocp-east", "version": "prior"}
+        cluster_ops.write_cluster_config("ocp-east", prior)
+
+        def boom(*_a, **_kw):
+            raise RuntimeError("simulated dump failure")
+
+        monkeypatch.setattr(cluster_ops.json, "dump", boom)
+        with pytest.raises(RuntimeError):
+            cluster_ops.write_cluster_config("ocp-east", {"version": "broken"})
+        # Concurrent reader sees only the prior content, never a torn write.
+        assert cluster_ops.read_cluster_config("ocp-east") == prior
+
+    def test_tmpfile_in_same_directory(self, monkeypatch, tmp_path):
+        # The tmpfile must be created in the same directory as the target so
+        # that Path.replace() is an atomic rename (POSIX requires same fs).
+        captured = {}
+        real_mkstemp = cluster_ops.tempfile.mkstemp
+
+        def spy(*args, **kwargs):
+            captured["dir"] = kwargs.get("dir")
+            return real_mkstemp(*args, **kwargs)
+
+        monkeypatch.setattr(cluster_ops.tempfile, "mkstemp", spy)
+        cluster_ops.write_cluster_config("ocp-east", {"x": 1})
+        assert captured["dir"] == layout.cluster_dir("ocp-east")
+
+
+# ── update_cluster_config ──────────────────────────────────────────────
+
+
+class TestUpdateClusterConfig:
+    def test_starts_from_empty_when_file_absent(self):
+        result = cluster_ops.update_cluster_config("new-cluster", cluster_id="new-cluster")
+        assert result == {"cluster_id": "new-cluster"}
+        assert cluster_ops.read_cluster_config("new-cluster") == {"cluster_id": "new-cluster"}
+
+    def test_returns_new_config(self):
+        cluster_ops.write_cluster_config("ocp-east", {"cluster_id": "ocp-east"})
+        result = cluster_ops.update_cluster_config("ocp-east", namespaces=["a", "b"])
+        assert result == {"cluster_id": "ocp-east", "namespaces": ["a", "b"]}
+
+    def test_full_replace_for_namespaces_list(self):
+        cluster_ops.write_cluster_config(
+            "ocp-east",
+            {"cluster_id": "ocp-east", "namespaces": ["old-1", "old-2", "old-3"]},
+        )
+        cluster_ops.update_cluster_config("ocp-east", namespaces=["new"])
+        assert cluster_ops.read_cluster_config("ocp-east")["namespaces"] == ["new"]
+
+    def test_full_replace_for_top_level_scalar(self):
+        cluster_ops.write_cluster_config(
+            "ocp-east",
+            {"cluster_id": "ocp-east", "storage_class": "gp3"},
+        )
+        cluster_ops.update_cluster_config("ocp-east", storage_class="gp2")
+        assert cluster_ops.read_cluster_config("ocp-east")["storage_class"] == "gp2"
+
+    def test_deep_merge_secret_names_preserves_existing(self):
+        cluster_ops.write_cluster_config(
+            "ocp-east",
+            {
+                "secret_names": {
+                    "hf_token": "hf-secret",
+                    "registry_creds": "registry-creds",
+                    "github_token": "github-token",
+                },
+            },
+        )
+        cluster_ops.update_cluster_config(
+            "ocp-east",
+            secret_names={"dockerhub_creds": "dockerhub-creds"},
+        )
+        assert cluster_ops.read_cluster_config("ocp-east")["secret_names"] == {
+            "hf_token": "hf-secret",
+            "registry_creds": "registry-creds",
+            "github_token": "github-token",
+            "dockerhub_creds": "dockerhub-creds",
+        }
+
+    def test_deep_merge_secret_names_overrides_present_keys(self):
+        cluster_ops.write_cluster_config(
+            "ocp-east",
+            {"secret_names": {"hf_token": "old-name", "registry_creds": "reg-old"}},
+        )
+        cluster_ops.update_cluster_config(
+            "ocp-east",
+            secret_names={"hf_token": "new-name"},
+        )
+        assert cluster_ops.read_cluster_config("ocp-east")["secret_names"] == {
+            "hf_token": "new-name",
+            "registry_creds": "reg-old",
+        }
+
+    def test_deep_merge_workspaces_preserves_existing(self):
+        cluster_ops.write_cluster_config(
+            "ocp-east",
+            {
+                "workspaces": {
+                    "data-storage": {"persistentVolumeClaim": {"claimName": "data-pvc"}},
+                    "source": {"persistentVolumeClaim": {"claimName": "source-pvc"}},
+                },
+            },
+        )
+        cluster_ops.update_cluster_config(
+            "ocp-east",
+            workspaces={"cache": {"persistentVolumeClaim": {"claimName": "cache-pvc"}}},
+        )
+        assert cluster_ops.read_cluster_config("ocp-east")["workspaces"] == {
+            "data-storage": {"persistentVolumeClaim": {"claimName": "data-pvc"}},
+            "source": {"persistentVolumeClaim": {"claimName": "source-pvc"}},
+            "cache": {"persistentVolumeClaim": {"claimName": "cache-pvc"}},
+        }
+
+    def test_deep_merge_workspaces_recurses_into_nested_dict(self):
+        cluster_ops.write_cluster_config(
+            "ocp-east",
+            {
+                "workspaces": {
+                    "data-storage": {
+                        "persistentVolumeClaim": {"claimName": "old-pvc"},
+                        "extra": "keep-me",
+                    },
+                },
+            },
+        )
+        cluster_ops.update_cluster_config(
+            "ocp-east",
+            workspaces={"data-storage": {"persistentVolumeClaim": {"claimName": "new-pvc"}}},
+        )
+        # The deep merge updates claimName but preserves the sibling "extra".
+        assert cluster_ops.read_cluster_config("ocp-east")["workspaces"] == {
+            "data-storage": {
+                "persistentVolumeClaim": {"claimName": "new-pvc"},
+                "extra": "keep-me",
+            },
+        }
+
+    def test_multiple_updates_in_single_call(self):
+        cluster_ops.write_cluster_config(
+            "ocp-east",
+            {
+                "cluster_id": "ocp-east",
+                "namespaces": ["a"],
+                "secret_names": {"hf_token": "hf-secret"},
+            },
+        )
+        cluster_ops.update_cluster_config(
+            "ocp-east",
+            namespaces=["a", "b"],
+            secret_names={"github_token": "github-token"},
+            storage_class="gp3",
+        )
+        assert cluster_ops.read_cluster_config("ocp-east") == {
+            "cluster_id": "ocp-east",
+            "namespaces": ["a", "b"],
+            "secret_names": {
+                "hf_token": "hf-secret",
+                "github_token": "github-token",
+            },
+            "storage_class": "gp3",
+        }
+
+    def test_deep_merge_key_with_non_dict_existing_is_replaced(self):
+        # Defensive: if the existing value for a deep-merge key is somehow
+        # not a dict (corrupted config), the update should fall back to
+        # full replace rather than crash.
+        path = layout.cluster_config_path("ocp-east")
+        path.parent.mkdir(parents=True)
+        path.write_text(json.dumps({"secret_names": "wrong-type"}))
+        cluster_ops.update_cluster_config(
+            "ocp-east",
+            secret_names={"hf_token": "hf-secret"},
+        )
+        assert cluster_ops.read_cluster_config("ocp-east")["secret_names"] == {
+            "hf_token": "hf-secret",
+        }
+
+    def test_deep_merge_key_with_non_dict_update_is_full_replace(self):
+        # If the caller passes a non-dict value for a deep-merge key, full
+        # replace (no attempt to merge a string into an existing dict).
+        cluster_ops.write_cluster_config(
+            "ocp-east",
+            {"secret_names": {"hf_token": "hf-secret"}},
+        )
+        cluster_ops.update_cluster_config("ocp-east", secret_names=None)
+        assert cluster_ops.read_cluster_config("ocp-east")["secret_names"] is None
+
+    def test_uses_layout_for_path_resolution(self):
+        # Acceptance: "Uses pipeline/lib/layout.py for path resolution (no
+        # path string-mashing)." Update should write to the path produced
+        # by layout.cluster_config_path, no other location.
+        cluster_ops.update_cluster_config("ocp-east", cluster_id="ocp-east")
+        assert layout.cluster_config_path("ocp-east").exists()
+
+    def test_cluster_id_kwarg_does_not_collide_with_positional(self):
+        # The positional cluster_id arg is positional-only (def(..., /, **updates)).
+        # A caller can pass cluster_id="..." in **updates without TypeError;
+        # the kwarg lands in the config payload as the cluster_id FIELD.
+        result = cluster_ops.update_cluster_config(
+            "ocp-east",
+            cluster_id="ocp-east",
+            namespaces=["a"],
+        )
+        assert result == {"cluster_id": "ocp-east", "namespaces": ["a"]}


### PR DESCRIPTION
## Summary

Adds the first slice of `pipeline/lib/cluster_ops.py` — file-system-only read/write/update of `clusters/<cluster_id>/cluster_config.json`. Second child of Epic #416 (depends on #417 / layout module, just merged). The kubectl/oc primitives (`provision_namespace`, `apply_cluster_resources`) are scoped to #420.

## API (per design)

```
read_cluster_config(cluster_id)              -> dict   # {} when file absent
write_cluster_config(cluster_id, cfg)        -> None   # atomic
update_cluster_config(cluster_id, /, **updates) -> dict
```

## Implementation notes

- **Atomic write** — `tempfile.mkstemp(dir=path.parent, ...)` + `Path.replace`, matching `pipeline/lib/state_machine.py:70-77`. The tmpfile is created in the same directory as the target, so the rename is POSIX-atomic on the same filesystem. A concurrent reader sees either the prior full content or the new full content, never a torn write.

- **Deep-merge for `secret_names` / `workspaces`** — uses the existing `pipeline.lib.values.deep_merge`. For these two top-level keys the merge preserves untouched sub-keys; for all other top-level keys, the update is a full replace. Schema-defensive: if the existing value for a deep-merge key is somehow not a dict (corrupt config), the update falls back to full replace rather than crashing.

- **Positional-only `cluster_id`** — `def update_cluster_config(cluster_id: str, /, **updates)`. Without `/`, calling `update_cluster_config(\"ocp-east\", cluster_id=\"ocp-east\")` (legitimate on first write — populating the schema field) would raise `TypeError: got multiple values for argument 'cluster_id'`. The positional-only marker routes the kwarg into `**updates`. Test caught this during development.

- **Layout-only path resolution** — every path comes from `pipeline.lib.layout` (no `\"workspace/clusters/\" + cluster_id` mashing). Last bullet of the issue's acceptance.

## Tests

24 tests in `pipeline/tests/test_cluster_ops.py`, organized into three classes:

- `TestReadClusterConfig` — missing-file returns `{}`, missing-dir returns `{}`, parsed-dict round trip.
- `TestWriteClusterConfig` — creates parent dir, writes JSON, overwrites, tmpfile-cleaned-up on success AND on simulated failure, **no torn write** (prior content intact after mid-write failure), tmpfile-in-same-directory (so rename is atomic).
- `TestUpdateClusterConfig` — empty start, return-value, full-replace cases (`namespaces`, scalar), deep-merge cases (`secret_names` preserves / overrides, `workspaces` preserves / recurses), multi-key update in one call, defensive-replace when existing or supplied value isn't a dict, layout-only path resolution, positional-only signature collision-resistance.

## Acceptance (from #419)

- [x] `pipeline/lib/cluster_ops.py` created with the three functions.
- [x] Atomic write verified (tmpfile + rename; no torn writes under simulated mid-write failure — `test_atomic_rename_no_torn_write`).
- [x] `read_cluster_config` returns `{}` for absent file (no exception).
- [x] `update_cluster_config` correctly deep-merges `secret_names` and `workspaces` sub-dicts.
- [x] `pipeline/tests/test_cluster_ops.py` covers all three functions including edge cases.
- [x] `ruff check pipeline/lib/cluster_ops.py --select F` clean.
- [x] Uses `pipeline/lib/layout.py` for path resolution.
- [x] Full CI suite locally: 1168 passed, 2 xfailed (24 new, no regressions).

## Stale-reference sweep

Grepped \`docs/\`, \`.claude/skills/\`, README, CLAUDE.md for \`cluster_ops\` and \`cluster_config.json\`. Only hits are in the design doc and design proposals (historical sources). No README/CLAUDE.md updates in this PR — those are #425's deliverable.

## Notes for reviewer

- The deep-merge contract reuses \`values.deep_merge\` to keep the merge semantics consistent with \`assemble.py\`. For the actual \`cluster_config.json\` schema the inner shapes are dict-of-strings (\`secret_names\`) and dict-of-dicts (\`workspaces\`), so the recursion never reaches \`values._merge_lists\`'s k8s-identity branch.
- Read-modify-write in \`update_cluster_config\` is not inter-process-locked. The design notes no concurrent updaters are expected; later steps that introduce slot-add operations will still need to handle that constraint at the caller level if it ever becomes real.

Base: \`refactor/v2-step-0\`
Parent epic: #416
Depends on: #417 (layout module — merged)
Closes #419