### PR TITLE
feat(pipeline): add slicer module for transfer.yaml translation/assembly partition

### DIFF
--- a/pipeline/lib/slicer.py
+++ b/pipeline/lib/slicer.py
@@ -1,0 +1,120 @@
+"""transfer.yaml translation/assembly slice partitioner.
+
+Partitions a loaded v3 ``transfer.yaml`` dict into two slices:
+
+- **Translation slice** — fields that determine the translation result
+  (scenario, component, context, per-algorithm source). Hashed to detect
+  when a re-translation is required.
+- **Assembly slice** — everything else (workloads, baselines, per-algorithm
+  defaults, framework defaults toggles, etc.). Affects how a benchmark run
+  is built, not what gets translated.
+
+Slice membership is design-locked here; future additive manifest fields
+default to the assembly slice unless their stem is added to
+``TRANSLATION_FIELDS``. The first consumer is Step 2's ``translate``
+command (not yet implemented); Step 0 ships this as a ready substrate.
+
+The hash is SHA-256 over canonical (sorted-key, no-whitespace) JSON of
+``translation_slice`` — stable across YAML formatter / writer differences.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+TRANSLATION_FIELDS: list[str] = [
+    "scenario",
+    "component",
+    "context",
+    "algorithms[*].source",
+]
+"""Design-locked list of translation-slice members.
+
+The ``[*]`` suffix denotes per-element projection on a list-valued field.
+``algorithms[*].config`` appears in the 3D proposal but does not exist in
+v3 — it is intentionally omitted. If a Step 2+ consumer surfaces the need,
+it gets added as an additive extension at that time.
+"""
+
+# Top-level keys whose values are projected into the translation slice.
+_TRANSLATION_TOP_KEYS = ("scenario", "component", "context")
+
+# Per-algorithm field projections. ``name`` is included on both sides as
+# identity — without it, the projected entries cannot be tied back to the
+# manifest's algorithms.
+_ALGORITHM_TRANSLATION_KEYS = ("source",)
+_ALGORITHM_ASSEMBLY_KEYS = ("defaults",)
+
+
+def translation_slice(manifest: dict) -> dict:
+    """Return the translation-slice projection of ``manifest``.
+
+    Includes scenario, component, context, and per-algorithm
+    ``{name, source}`` (sorted by name for stability). Omits fields that
+    are absent in the input rather than emitting null defaults — keeps
+    the slice (and its hash) tight against manifest reality.
+    """
+    out: dict[str, Any] = {}
+    for key in _TRANSLATION_TOP_KEYS:
+        if key in manifest:
+            out[key] = manifest[key]
+    algos = manifest.get("algorithms")
+    if algos:
+        out["algorithms"] = [
+            _project_algorithm(a, _ALGORITHM_TRANSLATION_KEYS)
+            for a in _sorted_by_name(algos)
+        ]
+    return out
+
+
+def assembly_slice(manifest: dict) -> dict:
+    """Return the assembly-slice projection of ``manifest``.
+
+    Everything not in the translation slice: ``workloads``, ``baselines``,
+    ``defaults``, ``kind``, ``version``, ``pipeline``, ``blis_observe``,
+    any other top-level field, plus per-algorithm ``{name, defaults}``
+    (sorted by name).
+    """
+    out: dict[str, Any] = {}
+    for key, value in manifest.items():
+        if key in _TRANSLATION_TOP_KEYS or key == "algorithms":
+            continue
+        out[key] = value
+    algos = manifest.get("algorithms")
+    if algos:
+        out["algorithms"] = [
+            _project_algorithm(a, _ALGORITHM_ASSEMBLY_KEYS)
+            for a in _sorted_by_name(algos)
+        ]
+    return out
+
+
+def translation_hash(manifest: dict) -> str:
+    """SHA-256 over canonical JSON of ``translation_slice(manifest)``.
+
+    Canonical = sorted keys at every depth, no whitespace separators.
+    Stable across YAML re-serialization and dict key reordering.
+    """
+    canonical = json.dumps(
+        translation_slice(manifest),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _project_algorithm(algo: dict, keys: tuple[str, ...]) -> dict:
+    out: dict[str, Any] = {}
+    if "name" in algo:
+        out["name"] = algo["name"]
+    for key in keys:
+        if key in algo:
+            out[key] = algo[key]
+    return out
+
+
+def _sorted_by_name(algos: list) -> list:
+    return sorted(algos, key=lambda a: a.get("name", "") if isinstance(a, dict) else "")

--- a/pipeline/tests/test_slicer.py
+++ b/pipeline/tests/test_slicer.py
@@ -1,0 +1,252 @@
+"""Tests for pipeline/lib/slicer.py — transfer.yaml partition + hash."""
+
+import copy
+import re
+
+import yaml
+
+from pipeline.lib import slicer
+
+
+# ── Test fixtures ──────────────────────────────────────────────────────
+
+
+def _full_manifest() -> dict:
+    """A representative v3 manifest with all slice-relevant fields populated."""
+    return {
+        "kind": "sim2real-transfer",
+        "version": 3,
+        "scenario": "admission_control",
+        "component": {
+            "repo": "https://github.com/llm-d/llm-d-inference-scheduler",
+            "kind": "scheduler",
+            "path": "llm-d-inference-scheduler",
+        },
+        "context": {
+            "text": "Some additional context.",
+            "files": ["context.md", "extra.md"],
+        },
+        "algorithms": [
+            {"name": "ac1", "source": "algorithm/ac1.go", "defaults": "b1"},
+            {"name": "ac2", "source": "algorithm/ac2.go", "defaults": "b1"},
+        ],
+        "baselines": [
+            {"name": "b1", "scenario": "baseline.yaml"},
+        ],
+        "workloads": ["workloads/w1.yaml", "workloads/w2.yaml"],
+        "defaults": {"disable": ["rbac"]},
+        "pipeline": {"name": "sim2real", "yaml": "pipeline/pipeline.yaml"},
+    }
+
+
+def _baseline_only_manifest() -> dict:
+    """A v3 manifest with no algorithms (component is optional in this mode)."""
+    return {
+        "kind": "sim2real-transfer",
+        "version": 3,
+        "scenario": "baseline_only",
+        "context": {"text": "", "files": []},
+        "baselines": [
+            {"name": "b1", "scenario": "baseline.yaml"},
+        ],
+        "workloads": [],
+        "defaults": {"disable": []},
+    }
+
+
+# ── translation_slice ──────────────────────────────────────────────────
+
+
+class TestTranslationSlice:
+    def test_full_manifest_projects_expected_top_keys(self):
+        m = _full_manifest()
+        s = slicer.translation_slice(m)
+        assert set(s.keys()) == {"scenario", "component", "context", "algorithms"}
+
+    def test_algorithms_projected_to_name_and_source_only(self):
+        m = _full_manifest()
+        s = slicer.translation_slice(m)
+        assert s["algorithms"] == [
+            {"name": "ac1", "source": "algorithm/ac1.go"},
+            {"name": "ac2", "source": "algorithm/ac2.go"},
+        ]
+
+    def test_algorithms_sorted_by_name(self):
+        m = _full_manifest()
+        m["algorithms"] = list(reversed(m["algorithms"]))
+        s = slicer.translation_slice(m)
+        names = [a["name"] for a in s["algorithms"]]
+        assert names == sorted(names)
+
+    def test_baseline_only_omits_component_and_algorithms(self):
+        s = slicer.translation_slice(_baseline_only_manifest())
+        assert "component" not in s
+        assert "algorithms" not in s
+        assert s["scenario"] == "baseline_only"
+        assert s["context"] == {"text": "", "files": []}
+
+    def test_empty_algorithms_list_omitted(self):
+        m = _full_manifest()
+        m["algorithms"] = []
+        s = slicer.translation_slice(m)
+        assert "algorithms" not in s
+
+    def test_does_not_mutate_input(self):
+        m = _full_manifest()
+        snapshot = copy.deepcopy(m)
+        slicer.translation_slice(m)
+        assert m == snapshot
+
+    def test_excludes_assembly_fields(self):
+        s = slicer.translation_slice(_full_manifest())
+        for excluded in ("workloads", "baselines", "defaults", "pipeline", "kind", "version"):
+            assert excluded not in s
+
+
+# ── assembly_slice ─────────────────────────────────────────────────────
+
+
+class TestAssemblySlice:
+    def test_includes_everything_not_in_translation(self):
+        m = _full_manifest()
+        s = slicer.assembly_slice(m)
+        # All top-level keys except scenario, component, context, algorithms
+        # land in assembly verbatim (algorithms re-appears in projected form).
+        for key in ("kind", "version", "baselines", "workloads", "defaults", "pipeline"):
+            assert key in s, f"missing top-level key: {key}"
+        for key in ("scenario", "component", "context"):
+            assert key not in s, f"translation-only key leaked into assembly: {key}"
+
+    def test_algorithms_projected_to_name_and_defaults_only(self):
+        m = _full_manifest()
+        s = slicer.assembly_slice(m)
+        assert s["algorithms"] == [
+            {"name": "ac1", "defaults": "b1"},
+            {"name": "ac2", "defaults": "b1"},
+        ]
+
+    def test_algorithms_sorted_by_name(self):
+        m = _full_manifest()
+        m["algorithms"] = list(reversed(m["algorithms"]))
+        s = slicer.assembly_slice(m)
+        names = [a["name"] for a in s["algorithms"]]
+        assert names == sorted(names)
+
+    def test_baseline_only_omits_algorithms(self):
+        s = slicer.assembly_slice(_baseline_only_manifest())
+        assert "algorithms" not in s
+        assert s["baselines"] == [{"name": "b1", "scenario": "baseline.yaml"}]
+
+    def test_does_not_mutate_input(self):
+        m = _full_manifest()
+        snapshot = copy.deepcopy(m)
+        slicer.assembly_slice(m)
+        assert m == snapshot
+
+    def test_translation_and_assembly_top_keys_disjoint(self):
+        m = _full_manifest()
+        t_keys = set(slicer.translation_slice(m).keys()) - {"algorithms"}
+        a_keys = set(slicer.assembly_slice(m).keys()) - {"algorithms"}
+        assert t_keys.isdisjoint(a_keys)
+
+
+# ── translation_hash ───────────────────────────────────────────────────
+
+
+_HEX64_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+class TestTranslationHash:
+    def test_format_is_sha256_hex(self):
+        h = slicer.translation_hash(_full_manifest())
+        assert _HEX64_RE.match(h), f"expected 64-char lowercase hex, got: {h!r}"
+
+    def test_deterministic(self):
+        m = _full_manifest()
+        assert slicer.translation_hash(m) == slicer.translation_hash(m)
+
+    def test_stable_across_top_level_key_reordering(self):
+        m1 = _full_manifest()
+        m2 = {k: m1[k] for k in reversed(list(m1.keys()))}
+        assert slicer.translation_hash(m1) == slicer.translation_hash(m2)
+
+    def test_stable_across_nested_key_reordering(self):
+        m1 = _full_manifest()
+        m2 = copy.deepcopy(m1)
+        m2["component"] = {
+            k: m2["component"][k] for k in reversed(list(m2["component"].keys()))
+        }
+        assert slicer.translation_hash(m1) == slicer.translation_hash(m2)
+
+    def test_stable_across_algorithms_list_reordering(self):
+        m1 = _full_manifest()
+        m2 = copy.deepcopy(m1)
+        m2["algorithms"] = list(reversed(m2["algorithms"]))
+        assert slicer.translation_hash(m1) == slicer.translation_hash(m2)
+
+    def test_stable_across_yaml_roundtrip(self):
+        m1 = _full_manifest()
+        m2 = yaml.safe_load(yaml.safe_dump(m1, sort_keys=False))
+        m3 = yaml.safe_load(yaml.safe_dump(m1, sort_keys=True))
+        assert slicer.translation_hash(m1) == slicer.translation_hash(m2)
+        assert slicer.translation_hash(m1) == slicer.translation_hash(m3)
+
+    def test_changes_when_scenario_changes(self):
+        m1 = _full_manifest()
+        m2 = copy.deepcopy(m1)
+        m2["scenario"] = "different_scenario"
+        assert slicer.translation_hash(m1) != slicer.translation_hash(m2)
+
+    def test_changes_when_algorithm_source_changes(self):
+        m1 = _full_manifest()
+        m2 = copy.deepcopy(m1)
+        m2["algorithms"][0]["source"] = "algorithm/renamed.go"
+        assert slicer.translation_hash(m1) != slicer.translation_hash(m2)
+
+    def test_changes_when_context_changes(self):
+        m1 = _full_manifest()
+        m2 = copy.deepcopy(m1)
+        m2["context"]["text"] = "different text"
+        assert slicer.translation_hash(m1) != slicer.translation_hash(m2)
+
+    def test_changes_when_component_changes(self):
+        m1 = _full_manifest()
+        m2 = copy.deepcopy(m1)
+        m2["component"]["ref"] = "v1.2.3"
+        assert slicer.translation_hash(m1) != slicer.translation_hash(m2)
+
+    def test_unchanged_when_only_assembly_fields_change(self):
+        """Editing workloads / baselines / defaults must not bump the hash."""
+        m1 = _full_manifest()
+        m2 = copy.deepcopy(m1)
+        m2["workloads"] = ["workloads/different.yaml"]
+        m2["baselines"][0]["scenario"] = "different_baseline.yaml"
+        m2["defaults"]["disable"] = ["request-id", "verbosity"]
+        m2["pipeline"]["name"] = "renamed"
+        assert slicer.translation_hash(m1) == slicer.translation_hash(m2)
+
+    def test_unchanged_when_only_algorithm_defaults_change(self):
+        """algorithm.defaults is an assembly field, not translation."""
+        m1 = _full_manifest()
+        m2 = copy.deepcopy(m1)
+        # Add a second baseline so defaults can reference a different name
+        m2["baselines"].append({"name": "b2", "scenario": "b2.yaml"})
+        m2["algorithms"][0]["defaults"] = "b2"
+        assert slicer.translation_hash(m1) == slicer.translation_hash(m2)
+
+    def test_baseline_only_manifest_hashes(self):
+        h = slicer.translation_hash(_baseline_only_manifest())
+        assert _HEX64_RE.match(h)
+
+
+# ── TRANSLATION_FIELDS constant ────────────────────────────────────────
+
+
+class TestTranslationFields:
+    def test_constant_lists_declared_members(self):
+        assert slicer.TRANSLATION_FIELDS == [
+            "scenario",
+            "component",
+            "context",
+            "algorithms[*].source",
+        ]


### PR DESCRIPTION
## Summary

Adds `pipeline/lib/slicer.py` — pure code that partitions a loaded v3 `transfer.yaml` dict into:

- **Translation slice** — `scenario`, `component`, `context`, per-algorithm `{name, source}`. Hashed (`translation_hash`) to detect when re-translation is needed.
- **Assembly slice** — everything else, plus per-algorithm `{name, defaults}`. Affects how runs are built, not what gets translated.

Slice membership is design-locked here; future additive manifest fields default to the assembly slice unless their stem is added to `TRANSLATION_FIELDS`. The first consumer is Step 2's `translate` (not yet implemented); Step 0 ships this as a ready substrate.

`translation_hash` = SHA-256 over canonical (sorted-key, no-whitespace) JSON of `translation_slice` — stable across YAML formatter / writer differences, dict key reordering, and `algorithms` list reordering.

No edits to `pipeline/lib/manifest.py` (acceptance criterion: slicer is purely additive).

## Design calls (called out for reviewer attention)

1. **Algorithm identity in slices.** `TRANSLATION_FIELDS` spec is `algorithms[*].source` — but `source` alone is anonymous. The projected algorithm entries include `name` alongside `source` (and alongside `defaults` in the assembly slice) so each entry is identifiable. `name` is identity, not slice content.
2. **Algorithm list ordering.** Algorithm lists are sorted by `name` inside slices for hash stability — same content in a different declaration order produces the same hash. Top-level canonicalization (`sort_keys=True`) already handles dict keys; this extends the same principle to algorithm lists.

If either call is wrong, easy to redirect.

## Acceptance criteria

- [x] `pipeline/lib/slicer.py` created with three functions plus `TRANSLATION_FIELDS`
- [x] `translation_hash` returns SHA-256 over canonical JSON of `translation_slice`
- [x] Hash stability verified across dict key reordering, list reordering, and YAML re-serialization
- [x] `pipeline/tests/test_slicer.py` covers full + baseline-only v3 manifests (27 tests, all pass)
- [x] `ruff check pipeline/lib/slicer.py --select F` clean
- [x] No changes to `pipeline/lib/manifest.py`

Full suite: 1100 passed, 2 xfailed (no regressions from this change). Full CI lint (`ruff check pipeline/ .claude/skills/ --select F`) clean.

## Docs sweep

Grepped `docs/`, `.claude/skills/`, `pipeline/README.md`, `CLAUDE.md`, `README*` for `slicer` / `translation_slice` / `translation_hash` / `assembly_slice` / `TRANSLATION_FIELDS`. Only hits are in `docs/epics/step-0/design.md` and `docs/proposals/incremental-implementation-plan-addendum.md` — both spec documents that already describe this module correctly.

`CLAUDE.md`'s `pipeline/lib/` module table does not currently list `slicer.py` (nor `layout.py` from #427, nor `cluster_ops.py` from #428). Epic #416 punts the table refresh to child issue #425 (`docs: update README, CLAUDE.md, CI for the new flow`), so intentionally not touched here.

## Test plan

- [x] `python -m pytest pipeline/tests/test_slicer.py -v` — 27 pass
- [x] `python -m pytest pipeline/` — 1100 pass, 2 xfailed
- [x] `ruff check pipeline/ .claude/skills/ --select F` — clean

Closes #418

Base: refactor/v2-step-0
