### PR TITLE
feat(pipeline): cluster_ops provision_namespace + apply_cluster_resources

### DIFF
--- a/pipeline/lib/cluster_ops.py
+++ b/pipeline/lib/cluster_ops.py
@@ -11,18 +11,36 @@ is split into two slices:
 * kubectl/oc primitives — :func:`provision_namespace` (per-namespace
   resources: namespace, RBAC, secrets, PVCs, Tekton tasks) and
   :func:`apply_cluster_resources` (Tekton Pipeline definition). Each
-  primitive is idempotent: a step that's already correct is a no-op, a
-  step that diverges is surfaced as a structured failure on
-  :class:`ProvisionResult` rather than silently overwriting.
+  primitive is idempotent in the ``kubectl apply``/``oc new-project``
+  sense: applying the same manifest twice converges on the same cluster
+  state, and an already-existing object is not an error. Note that
+  ``kubectl apply`` server-side merges — this module does NOT compare
+  the live object's contents to the supplied manifest, so drift between
+  a cluster-mutated resource and the source-of-truth manifest is
+  reconciled silently. Per-step outcomes are reported via
+  :class:`ProvisionResult` (see "outcome reporting" below).
 
-Error-handling convention (per design):
+Outcome reporting:
 
-* Idempotent applies that succeed: silent.
-* Idempotent applies that surface a name collision with different content:
-  structured failure entry on ``ProvisionResult.steps_failed``.
-* Hard failures (auth, network): exceptions propagate to the caller —
-  :class:`ClusterUnreachableError` for connectivity issues,
-  ``subprocess.CalledProcessError`` for unexpected non-zero exits.
+* Successful sub-step (apply returned zero, or pre-check said
+  already-exists): recorded on ``ProvisionResult.steps_ok``.
+* Intentional suppression (caller-supplied ``skip``) or operator
+  prerequisites not provided (e.g. absent secret value + no
+  pre-installed Secret) or best-effort YAMLs that hit a tolerated
+  permission error (cluster-scoped RBAC Forbidden): recorded on
+  ``ProvisionResult.steps_skipped``. Soft divergence — flips
+  :attr:`ProvisionResult.diverged` to True without anything in
+  ``steps_failed``.
+* Non-zero exit from kubectl/oc, missing required YAML, or malformed
+  config: recorded on ``ProvisionResult.steps_failed``. Hard divergence.
+
+Hard failures (auth, network) that prevent reasoning about per-step
+outcomes raise instead — :class:`ClusterUnreachableError` for
+connectivity issues (from :func:`check_cluster_reachable`), and
+``subprocess.CalledProcessError`` from :func:`apply_cluster_resources`'s
+per-namespace applies. No exception ever escapes
+:func:`provision_namespace`: every sub-step lands in exactly one of
+``steps_ok`` / ``steps_skipped`` / ``steps_failed``.
 """
 
 from __future__ import annotations

--- a/pipeline/lib/cluster_ops.py
+++ b/pipeline/lib/cluster_ops.py
@@ -434,9 +434,9 @@ def _step_secrets(
             else:
                 skipped.append(f"{key}({name})")
             continue
-        manifest = _build_secret_manifest(key, name, namespace, value)
+        manifest, reason = _build_secret_manifest(key, name, namespace, value)
         if manifest is None:
-            return ("failed", f"unknown secret key '{key}' — no manifest builder")
+            return ("failed", f"secret '{key}' ({name}): {reason}")
         proc = _run(
             ["kubectl", "apply", "-f", "-"],
             input=manifest, check=False, capture=True,
@@ -454,52 +454,68 @@ def _build_secret_manifest(
     name: str,
     namespace: str,
     value: object,
-) -> str | None:
+) -> tuple[str | None, str | None]:
     """Render a Kubernetes Secret manifest YAML via ``kubectl create
     secret ... --dry-run=client -o yaml``.
 
-    Returns ``None`` if the key is unrecognised — caller surfaces as a
-    structured failure. The four conventional keys are:
+    Returns ``(manifest, None)`` on success and ``(None, reason)`` on any
+    failure — unknown key, incomplete docker-creds dict, or a non-zero
+    ``kubectl create --dry-run`` exit. The caller surfaces ``reason`` on
+    ``ProvisionResult.steps_failed`` so distinct failure modes get
+    distinct operator-facing messages.
+
+    The four conventional keys are:
 
     * ``hf_token`` / ``github_token`` — generic Secret with a single
       string field (``HF_TOKEN`` / ``token``).
     * ``registry_creds`` / ``dockerhub_creds`` — docker-registry Secret;
       value is a dict with ``server``, ``user``, ``token``.
+
+    All ``_run`` calls pass ``check=False`` so a non-zero dry-run is
+    reported through the return value rather than raised — provision_namespace
+    must never let a sub-step bypass :class:`ProvisionResult`.
     """
     if key == "hf_token":
-        return _run(
+        proc = _run(
             ["kubectl", "create", "secret", "generic", name,
              f"--namespace={namespace}",
              f"--from-literal=HF_TOKEN={value}",
              "--dry-run=client", "-o", "yaml"],
-            capture=True,
-        ).stdout
+            check=False, capture=True,
+        )
+        if proc.returncode != 0:
+            return None, f"kubectl create --dry-run failed: {(proc.stderr or proc.stdout).strip()}"
+        return proc.stdout, None
     if key == "github_token":
-        return _run(
+        proc = _run(
             ["kubectl", "create", "secret", "generic", name,
              f"--namespace={namespace}",
              f"--from-literal=token={value}",
              "--dry-run=client", "-o", "yaml"],
-            capture=True,
-        ).stdout
+            check=False, capture=True,
+        )
+        if proc.returncode != 0:
+            return None, f"kubectl create --dry-run failed: {(proc.stderr or proc.stdout).strip()}"
+        return proc.stdout, None
     if key in ("registry_creds", "dockerhub_creds"):
         if not isinstance(value, dict):
-            return None
-        server = value.get("server", "")
-        user = value.get("user", "")
-        token = value.get("token", "")
-        if not (server and user and token):
-            return None
-        return _run(
+            return None, f"value is not a dict (expected {{server, user, token}}, got {type(value).__name__})"
+        missing = [field for field in ("server", "user", "token") if not value.get(field)]
+        if missing:
+            return None, f"value is missing required fields: {', '.join(missing)}"
+        proc = _run(
             ["kubectl", "create", "secret", "docker-registry", name,
              f"--namespace={namespace}",
-             f"--docker-server={server}",
-             f"--docker-username={user}",
-             f"--docker-password={token}",
+             f"--docker-server={value['server']}",
+             f"--docker-username={value['user']}",
+             f"--docker-password={value['token']}",
              "--dry-run=client", "-o", "yaml"],
-            capture=True,
-        ).stdout
-    return None
+            check=False, capture=True,
+        )
+        if proc.returncode != 0:
+            return None, f"kubectl create --dry-run failed: {(proc.stderr or proc.stdout).strip()}"
+        return proc.stdout, None
+    return None, f"unknown secret key '{key}' — no manifest builder"
 
 
 def _step_pvc(

--- a/pipeline/lib/cluster_ops.py
+++ b/pipeline/lib/cluster_ops.py
@@ -1,21 +1,37 @@
-"""File-system primitives for ``clusters/<cluster_id>/cluster_config.json``.
+"""Cluster-config file primitives + kubectl/oc primitives for per-cluster setup.
 
 Step 0 carves cluster-side responsibilities out of ``pipeline/setup.py`` into
-a new ``pipeline/cluster.py`` entry point backed by this library. This module
-is the first slice: read/write/update of the per-cluster config file. The
-kubectl/oc primitives (``provision_namespace``, ``apply_cluster_resources``)
-land in a separate child.
+a new ``pipeline/cluster.py`` entry point backed by this library. The module
+is split into two slices:
 
-Writes are atomic (tmpfile + ``Path.replace``) so a concurrent reader either
-sees the previous full content or the new full content, never a torn write.
-Path resolution is delegated to :mod:`pipeline.lib.layout` — no string
-mashing of workspace paths in this module.
+* File-system primitives — :func:`read_cluster_config`,
+  :func:`write_cluster_config`, :func:`update_cluster_config`. Atomic writes
+  (tmpfile + ``Path.replace``); path resolution delegated to
+  :mod:`pipeline.lib.layout`.
+* kubectl/oc primitives — :func:`provision_namespace` (per-namespace
+  resources: namespace, RBAC, secrets, PVCs, Tekton tasks) and
+  :func:`apply_cluster_resources` (Tekton Pipeline definition). Each
+  primitive is idempotent: a step that's already correct is a no-op, a
+  step that diverges is surfaced as a structured failure on
+  :class:`ProvisionResult` rather than silently overwriting.
+
+Error-handling convention (per design):
+
+* Idempotent applies that succeed: silent.
+* Idempotent applies that surface a name collision with different content:
+  structured failure entry on ``ProvisionResult.steps_failed``.
+* Hard failures (auth, network): exceptions propagate to the caller —
+  :class:`ClusterUnreachableError` for connectivity issues,
+  ``subprocess.CalledProcessError`` for unexpected non-zero exits.
 """
 
 from __future__ import annotations
 
 import json
+import shutil
+import subprocess
 import tempfile
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from pipeline.lib import layout
@@ -28,6 +44,32 @@ from pipeline.lib.values import deep_merge
 # is a flat string→string dict; ``workspaces`` is a dict of Tekton workspace
 # bindings. Partial updates to either should preserve untouched keys.
 _DEEP_MERGE_KEYS = ("secret_names", "workspaces")
+
+
+# Repo-relative paths used by the kubectl/oc primitives. ``cluster_ops.py``
+# lives at ``pipeline/lib/cluster_ops.py``, so the repo root is two parents up.
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_TEKTONC_DIR = _REPO_ROOT / "tektonc-data-collection"
+_PIPELINE_YAML = _REPO_ROOT / "pipeline" / "pipeline.yaml"
+
+
+# PVC defaults — today's setup.py hardcodes these. ``cluster_config['workspaces']``
+# only stores the Tekton binding (claim name); size + access mode are not part
+# of the schema. If a future scenario needs per-PVC sizing, extend the schema
+# and surface here.
+_DEFAULT_PVC_SIZE = "50Gi"
+_DEFAULT_PVC_ACCESS_MODE = "ReadWriteMany"
+
+
+# Sub-steps for provision_namespace, in execution order. ``skip`` arg values
+# must be drawn from this set.
+_PROVISION_STEPS = ("namespace", "rbac", "secrets", "pvc", "tekton")
+
+
+class ClusterUnreachableError(RuntimeError):
+    """Raised by :func:`check_cluster_reachable` when the API server cannot
+    be contacted. Carries an actionable hint as ``args[1]`` when available.
+    """
 
 
 def read_cluster_config(cluster_id: str) -> dict:
@@ -107,3 +149,467 @@ def update_cluster_config(cluster_id: str, /, **updates) -> dict:
         cfg[key] = value
     write_cluster_config(cluster_id, cfg)
     return cfg
+
+
+# ── Subprocess + tool discovery helpers ──────────────────────────────
+
+
+def _run(
+    cmd: list[str],
+    *,
+    check: bool = True,
+    capture: bool = False,
+    input: str | None = None,
+) -> subprocess.CompletedProcess:
+    """Thin wrapper over ``subprocess.run``. Tests monkeypatch this to
+    intercept every kubectl/oc invocation.
+    """
+    return subprocess.run(cmd, check=check, text=True, capture_output=capture, input=input)
+
+
+def _which(cmd: str) -> bool:
+    return shutil.which(cmd) is not None
+
+
+# ── Relocated support helpers (from setup.py) ────────────────────────
+
+
+def detect_openshift() -> bool:
+    """Return True if the ``oc`` CLI is installed and the user is logged in.
+
+    Mirrors today's ``pipeline/setup.py:177`` logic. ``cluster.py provision``
+    calls this once at startup and records the result on
+    ``cluster_config['is_openshift']``; :func:`provision_namespace` then
+    reads that field rather than re-probing the cluster per namespace.
+    """
+    if not _which("oc"):
+        return False
+    return _run(["oc", "whoami"], check=False, capture=True).returncode == 0
+
+
+def check_cluster_reachable() -> None:
+    """Verify the cluster is reachable via ``kubectl cluster-info``.
+
+    Raises :class:`ClusterUnreachableError` with a classified reason + hint on
+    failure. A 403 "forbidden" reply is treated as reachable (the API server
+    answered and authenticated us; the user simply lacks permission for
+    whatever ``cluster-info`` probed).
+
+    Library convention: this primitive raises rather than calling
+    ``sys.exit`` — the operator-facing CLI (:mod:`pipeline.cluster`) is
+    responsible for translating into a clean exit message.
+    """
+    result = _run(["kubectl", "cluster-info"], check=False, capture=True)
+    if result.returncode == 0:
+        return
+
+    combined = ((result.stdout or "") + (result.stderr or "")).lower()
+    if "forbidden" in combined:
+        return
+
+    if any(s in combined for s in ("no such host", "name resolution", "lookup")):
+        reason = "DNS resolution failed — the cluster hostname is not reachable."
+        hint = "Check your VPN, network connection, or kubeconfig server address."
+    elif "connection refused" in combined:
+        reason = "Connection refused — nothing is listening on the cluster API endpoint."
+        hint = "Ensure the cluster is running and the API server port is accessible."
+    elif "i/o timeout" in combined or "timeout" in combined:
+        reason = "Connection timed out — the cluster API server did not respond."
+        hint = "Check your VPN or firewall; the cluster may be stopped or unreachable."
+    elif "unauthorized" in combined:
+        reason = "Authentication failed — your credentials or kubeconfig may be expired."
+        hint = "Try: kubectl config view  or re-run your cluster login command."
+    elif "no configuration" in combined or "no such file" in combined:
+        reason = "No kubeconfig found — kubectl has no cluster to connect to."
+        hint = "Set KUBECONFIG or run your cluster login command first."
+    else:
+        reason = "kubectl cluster-info failed."
+        hint = (result.stderr or "").strip() or (result.stdout or "").strip()
+
+    raise ClusterUnreachableError(reason, hint)
+
+
+def secret_exists(name: str, namespace: str) -> bool:
+    """Return True if the named Kubernetes secret exists in the namespace."""
+    return _run(
+        ["kubectl", "get", "secret", name, f"-n={namespace}"],
+        check=False, capture=True,
+    ).returncode == 0
+
+
+# ── ProvisionResult + provision_namespace ────────────────────────────
+
+
+@dataclass
+class ProvisionResult:
+    """Structured outcome of :func:`provision_namespace`.
+
+    Follows issue #377's "surface every divergence" convention: every
+    sub-step lands in exactly one of ``steps_ok``, ``steps_skipped``, or
+    ``steps_failed``. ``diverged`` is shorthand for "either skipped or
+    failed any sub-step" — operators use it as a one-line summary signal.
+    """
+
+    namespace: str
+    steps_ok: list[str] = field(default_factory=list)
+    steps_skipped: list[tuple[str, str]] = field(default_factory=list)
+    steps_failed: list[tuple[str, str]] = field(default_factory=list)
+
+    @property
+    def diverged(self) -> bool:
+        return bool(self.steps_skipped or self.steps_failed)
+
+
+def provision_namespace(
+    namespace: str,
+    cluster_config: dict,
+    *,
+    secret_values: dict | None = None,
+    skip: list[str] | tuple[str, ...] = (),
+) -> ProvisionResult:
+    """Provision ONE namespace's cluster-side resources. Idempotent.
+
+    Sub-steps, in order (``skip`` suppresses by name):
+
+    1. ``namespace`` — create via ``oc new-project`` on OpenShift, else
+       ``kubectl create ns``. Already-exists is treated as success.
+    2. ``rbac`` — apply the RBAC YAML bundle (tektonc + pipeline
+       roles-ns / sim2real-runner). Cluster-scoped augments are
+       best-effort: a kubectl Forbidden on a ClusterRole/ClusterRoleBinding
+       is recorded as a structured ``skipped`` entry, not a failure.
+    3. ``secrets`` — for each entry in ``cluster_config['secret_names']``,
+       look up its value in ``secret_values`` (same key). Value present →
+       create/update via ``kubectl apply``. Value absent but Secret exists
+       → leave untouched (idempotent reuse of pre-installed Secrets).
+       Value absent and no existing Secret → structured ``skipped``.
+    4. ``pvc`` — create PVCs per ``cluster_config['workspaces']``. Already
+       existing = success. Size hardcoded to 50Gi, access mode
+       ``ReadWriteMany`` (matches today's setup.py).
+    5. ``tekton`` — apply Tekton step/task YAMLs (tektonc/tekton/steps,
+       tektonc/tekton/tasks). The cluster-wide Pipeline definition is NOT
+       applied here; see :func:`apply_cluster_resources`.
+
+    Args:
+        namespace: target namespace.
+        cluster_config: full cluster config dict. Reads ``is_openshift``,
+            ``secret_names``, ``workspaces``, ``namespaces`` (for the
+            "primary namespace" RBAC envsubst), ``storage_class``.
+        secret_values: resolved secret payloads keyed by the same key used
+            in ``cluster_config['secret_names']``. Shapes:
+              * ``hf_token`` / ``github_token``: str
+              * ``registry_creds`` / ``dockerhub_creds``:
+                ``{"server": str, "user": str, "token": str}``
+            Resolution from CLI flags / env vars / interactive prompts
+            happens in the caller (``cluster.py provision``); this library
+            takes resolved values to keep env-var dependence out of
+            ``pipeline/lib/`` for testability.
+        skip: sub-step names to suppress. Unknown names are ignored
+            (no-op for forward compat).
+
+    Returns:
+        :class:`ProvisionResult` with every attempted sub-step recorded.
+    """
+    skip_set = set(skip or ())
+    result = ProvisionResult(namespace=namespace)
+    secret_values = secret_values or {}
+
+    handlers = {
+        "namespace": _step_namespace,
+        "rbac": _step_rbac,
+        "secrets": _step_secrets,
+        "pvc": _step_pvc,
+        "tekton": _step_tekton,
+    }
+
+    for step in _PROVISION_STEPS:
+        if step in skip_set:
+            result.steps_skipped.append((step, "suppressed by skip arg"))
+            continue
+        status, reason = handlers[step](namespace, cluster_config, secret_values)
+        if status == "ok":
+            result.steps_ok.append(step)
+        elif status == "skipped":
+            result.steps_skipped.append((step, reason))
+        else:
+            result.steps_failed.append((step, reason))
+    return result
+
+
+def _step_namespace(
+    namespace: str,
+    cluster_config: dict,
+    _secret_values: dict,
+) -> tuple[str, str]:
+    is_openshift = bool(cluster_config.get("is_openshift"))
+    # Pre-check: already exists?
+    if is_openshift:
+        exists = _run(
+            ["oc", "get", "project", namespace],
+            check=False, capture=True,
+        ).returncode == 0
+    else:
+        exists = _run(
+            ["kubectl", "get", "ns", namespace],
+            check=False, capture=True,
+        ).returncode == 0
+    if exists:
+        return ("ok", "already exists")
+
+    if is_openshift:
+        proc = _run(["oc", "new-project", namespace], check=False, capture=True)
+    else:
+        proc = _run(["kubectl", "create", "ns", namespace], check=False, capture=True)
+    if proc.returncode == 0:
+        return ("ok", "created")
+    # Race: created in parallel between our pre-check and create — accept.
+    combined = ((proc.stdout or "") + (proc.stderr or "")).lower()
+    if "alreadyexists" in combined or "already exists" in combined:
+        return ("ok", "already exists (race)")
+    return ("failed", (proc.stderr or proc.stdout or "create failed").strip())
+
+
+def _step_rbac(
+    namespace: str,
+    cluster_config: dict,
+    _secret_values: dict,
+) -> tuple[str, str]:
+    namespaces = cluster_config.get("namespaces") or [namespace]
+    primary_ns = namespaces[0]
+    env = {"NAMESPACE": namespace, "PRIMARY_NAMESPACE": primary_ns}
+
+    # Matches today's setup.py:399-406 — same bundle, same required flags.
+    yaml_paths: list[tuple[Path, bool]] = [
+        (_TEKTONC_DIR / "tekton" / "roles-ns.yaml", True),
+        (_TEKTONC_DIR / "tekton" / "roles-cluster.yaml", False),
+        (_TEKTONC_DIR / "tekton" / "rbac" / "sim2real-runner.yaml", True),
+        (_REPO_ROOT / "pipeline" / "rbac" / "sim2real-runner-ns.yaml", True),
+        (_REPO_ROOT / "pipeline" / "rbac" / "sim2real-runner-cluster.yaml", False),
+    ]
+    skipped_names: list[str] = []
+    for yaml_path, required in yaml_paths:
+        if not yaml_path.exists():
+            if required:
+                return ("failed", f"{yaml_path} not found (submodule init?)")
+            continue
+        subst = _envsubst(yaml_path.read_text(), env)
+        proc = _run(
+            ["kubectl", "apply", "-f", "-"],
+            input=subst, check=False, capture=True,
+        )
+        if proc.returncode == 0:
+            continue
+        combined = ((proc.stdout or "") + (proc.stderr or "")).lower()
+        # Narrow predicate (matches setup.py:425-429): only skip a
+        # best-effort YAML when the failure is a Forbidden on cluster-scoped
+        # RBAC. Other Forbidden reasons (SCC, webhook, quota) abort.
+        if (not required) and "forbidden" in combined and "clusterrole" in combined:
+            skipped_names.append(yaml_path.name)
+            continue
+        return ("failed", f"{yaml_path.name}: {(proc.stderr or proc.stdout).strip()}")
+    if skipped_names:
+        return ("skipped", f"cluster-scoped RBAC unavailable: {', '.join(skipped_names)}")
+    return ("ok", "applied")
+
+
+def _step_secrets(
+    namespace: str,
+    cluster_config: dict,
+    secret_values: dict,
+) -> tuple[str, str]:
+    secret_names = cluster_config.get("secret_names") or {}
+    if not secret_names:
+        return ("skipped", "no secret_names configured")
+
+    reused: list[str] = []
+    skipped: list[str] = []
+    for key, name in secret_names.items():
+        if not name:
+            continue
+        value = secret_values.get(key)
+        if value in (None, "", {}):
+            # No value provided. Reuse if a Secret with that name already
+            # exists; otherwise surface as skipped (operator must supply).
+            if secret_exists(name, namespace):
+                reused.append(f"{key}({name})")
+            else:
+                skipped.append(f"{key}({name})")
+            continue
+        manifest = _build_secret_manifest(key, name, namespace, value)
+        if manifest is None:
+            return ("failed", f"unknown secret key '{key}' — no manifest builder")
+        proc = _run(
+            ["kubectl", "apply", "-f", "-"],
+            input=manifest, check=False, capture=True,
+        )
+        if proc.returncode != 0:
+            return ("failed", f"{name}: {(proc.stderr or proc.stdout).strip()}")
+
+    if skipped:
+        return ("skipped", f"no value provided for: {', '.join(skipped)}")
+    return ("ok", "applied" + (f" (reused: {', '.join(reused)})" if reused else ""))
+
+
+def _build_secret_manifest(
+    key: str,
+    name: str,
+    namespace: str,
+    value: object,
+) -> str | None:
+    """Render a Kubernetes Secret manifest YAML via ``kubectl create
+    secret ... --dry-run=client -o yaml``.
+
+    Returns ``None`` if the key is unrecognised — caller surfaces as a
+    structured failure. The four conventional keys are:
+
+    * ``hf_token`` / ``github_token`` — generic Secret with a single
+      string field (``HF_TOKEN`` / ``token``).
+    * ``registry_creds`` / ``dockerhub_creds`` — docker-registry Secret;
+      value is a dict with ``server``, ``user``, ``token``.
+    """
+    if key == "hf_token":
+        return _run(
+            ["kubectl", "create", "secret", "generic", name,
+             f"--namespace={namespace}",
+             f"--from-literal=HF_TOKEN={value}",
+             "--dry-run=client", "-o", "yaml"],
+            capture=True,
+        ).stdout
+    if key == "github_token":
+        return _run(
+            ["kubectl", "create", "secret", "generic", name,
+             f"--namespace={namespace}",
+             f"--from-literal=token={value}",
+             "--dry-run=client", "-o", "yaml"],
+            capture=True,
+        ).stdout
+    if key in ("registry_creds", "dockerhub_creds"):
+        if not isinstance(value, dict):
+            return None
+        server = value.get("server", "")
+        user = value.get("user", "")
+        token = value.get("token", "")
+        if not (server and user and token):
+            return None
+        return _run(
+            ["kubectl", "create", "secret", "docker-registry", name,
+             f"--namespace={namespace}",
+             f"--docker-server={server}",
+             f"--docker-username={user}",
+             f"--docker-password={token}",
+             "--dry-run=client", "-o", "yaml"],
+            capture=True,
+        ).stdout
+    return None
+
+
+def _step_pvc(
+    namespace: str,
+    cluster_config: dict,
+    _secret_values: dict,
+) -> tuple[str, str]:
+    workspaces = cluster_config.get("workspaces") or {}
+    if not workspaces:
+        return ("skipped", "no workspaces configured")
+
+    storage_class = cluster_config.get("storage_class") or ""
+    sc_line = f"  storageClassName: {storage_class}\n" if storage_class else ""
+
+    for ws_name, binding in workspaces.items():
+        claim = (binding or {}).get("persistentVolumeClaim", {}).get("claimName")
+        if not claim:
+            return ("failed", f"workspace '{ws_name}' has no persistentVolumeClaim.claimName")
+        # Already exists?
+        exists = _run(
+            ["kubectl", "get", "pvc", claim, f"-n={namespace}"],
+            check=False, capture=True,
+        ).returncode == 0
+        if exists:
+            continue
+        manifest = (
+            f"apiVersion: v1\nkind: PersistentVolumeClaim\n"
+            f"metadata:\n  name: {claim}\n  namespace: {namespace}\n"
+            f"spec:\n{sc_line}"
+            f"  accessModes:\n    - {_DEFAULT_PVC_ACCESS_MODE}\n"
+            f"  resources:\n    requests:\n      storage: {_DEFAULT_PVC_SIZE}\n"
+        )
+        proc = _run(
+            ["kubectl", "apply", "-f", "-"],
+            input=manifest, check=False, capture=True,
+        )
+        if proc.returncode != 0:
+            return ("failed", f"PVC {claim}: {(proc.stderr or proc.stdout).strip()}")
+    return ("ok", "applied")
+
+
+def _step_tekton(
+    namespace: str,
+    _cluster_config: dict,
+    _secret_values: dict,
+) -> tuple[str, str]:
+    # Apply step/task YAMLs from tektonc-data-collection. Pipeline definition
+    # is cluster-wide and lives in apply_cluster_resources.
+    applied = 0
+    for subdir in ("steps", "tasks"):
+        tekton_dir = _TEKTONC_DIR / "tekton" / subdir
+        if not tekton_dir.exists():
+            continue
+        for yaml_file in sorted(tekton_dir.glob("*.yaml")):
+            proc = _run(
+                ["kubectl", "apply", "-f", str(yaml_file), f"-n={namespace}"],
+                check=False, capture=True,
+            )
+            if proc.returncode != 0:
+                return ("failed", f"{yaml_file.name}: {(proc.stderr or proc.stdout).strip()}")
+            applied += 1
+    if applied == 0:
+        return ("skipped", "no tekton step/task YAMLs found")
+    return ("ok", f"applied {applied} task/step YAML(s)")
+
+
+def _envsubst(text: str, env: dict[str, str]) -> str:
+    """Substitute ``$VAR`` and ``${VAR}`` from ``env`` in ``text``.
+
+    Pure-Python replacement for the ``envsubst`` shell tool so this library
+    doesn't depend on a system binary. Unset / missing keys are left as
+    ``$VAR`` (matches ``envsubst`` default-without-flags behavior).
+    """
+    import re
+
+    def _sub(match: re.Match) -> str:
+        name = match.group(1) or match.group(2)
+        return env.get(name, match.group(0))
+
+    return re.sub(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)", _sub, text)
+
+
+# ── apply_cluster_resources ──────────────────────────────────────────
+
+
+def apply_cluster_resources(cluster_id: str) -> None:
+    """Apply cluster-wide Tekton resources (the Pipeline definition).
+
+    Reads ``cluster_config['namespaces']`` and applies
+    ``pipeline/pipeline.yaml`` to each. Tekton ``Pipeline`` is a namespaced
+    resource in upstream Tekton, so "cluster-wide" here means "the same
+    definition across every namespace registered for this cluster" — it is
+    NOT part of the per-namespace flow because the source YAML is one
+    cluster-level artifact, not a per-namespace one.
+
+    Idempotent: ``kubectl apply`` is a no-op when the live object matches
+    the supplied manifest; subsequent invocations succeed silently.
+
+    Raises ``FileNotFoundError`` if ``pipeline/pipeline.yaml`` is missing.
+    Per-namespace apply failures raise ``subprocess.CalledProcessError`` so
+    the caller can surface the first failure rather than silently
+    continuing.
+    """
+    if not _PIPELINE_YAML.exists():
+        raise FileNotFoundError(f"Pipeline YAML not found at {_PIPELINE_YAML}")
+
+    cfg = read_cluster_config(cluster_id)
+    namespaces = cfg.get("namespaces") or []
+    for ns in namespaces:
+        _run(
+            ["kubectl", "apply", "-f", str(_PIPELINE_YAML), f"-n={ns}"],
+            check=True, capture=True,
+        )

--- a/pipeline/lib/cluster_ops.py
+++ b/pipeline/lib/cluster_ops.py
@@ -409,7 +409,13 @@ def _step_rbac(
             if required:
                 return ("failed", f"{yaml_path} not found (submodule init?)")
             continue
-        subst = _envsubst(yaml_path.read_text(), env)
+        try:
+            text = yaml_path.read_text()
+        except OSError as e:
+            return ("failed", f"{yaml_path.name}: read failed: {e}")
+        except UnicodeDecodeError as e:
+            return ("failed", f"{yaml_path.name}: not UTF-8 ({e.reason})")
+        subst = _envsubst(text, env)
         proc = _run(
             ["kubectl", "apply", "-f", "-"],
             input=subst, check=False, capture=True,
@@ -587,7 +593,11 @@ def _step_tekton(
         tekton_dir = _TEKTONC_DIR / "tekton" / subdir
         if not tekton_dir.exists():
             continue
-        for yaml_file in sorted(tekton_dir.glob("*.yaml")):
+        try:
+            yaml_files = sorted(tekton_dir.glob("*.yaml"))
+        except OSError as e:
+            return ("failed", f"cannot list {tekton_dir}: {e}")
+        for yaml_file in yaml_files:
             proc = _run(
                 ["kubectl", "apply", "-f", str(yaml_file), f"-n={namespace}"],
                 check=False, capture=True,

--- a/pipeline/tests/test_cluster_ops.py
+++ b/pipeline/tests/test_cluster_ops.py
@@ -1,8 +1,10 @@
-"""Tests for pipeline/lib/cluster_ops.py — file-system primitives."""
+"""Tests for pipeline/lib/cluster_ops.py — file-system + kubectl/oc primitives."""
 
 from __future__ import annotations
 
 import json
+import subprocess
+from types import SimpleNamespace
 
 import pytest
 
@@ -299,3 +301,596 @@ class TestUpdateClusterConfig:
             namespaces=["a"],
         )
         assert result == {"cluster_id": "ocp-east", "namespaces": ["a"]}
+
+
+# ── kubectl/oc invocation harness ─────────────────────────────────────
+
+
+def _completed(returncode: int = 0, stdout: str = "", stderr: str = ""):
+    """Build a stand-in for subprocess.CompletedProcess returned by _run."""
+    return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+class FakeRun:
+    """Records every _run() call; returns canned outputs keyed by command prefix.
+
+    Use ``.set(prefix, return_value)`` to register a response for any command
+    whose argv startswith the prefix list. Unmatched calls return success
+    (returncode=0, stdout=""), which is the right default for kubectl applies
+    where the live state already matches.
+    """
+
+    def __init__(self):
+        self.calls: list[list[str]] = []
+        self.inputs: list[str | None] = []
+        self._responses: list[tuple[list[str], SimpleNamespace]] = []
+
+    def set(self, prefix: list[str], result):
+        self._responses.append((prefix, result))
+
+    def __call__(self, cmd, *, check=True, capture=False, input=None):
+        self.calls.append(list(cmd))
+        self.inputs.append(input)
+        for prefix, response in self._responses:
+            if cmd[: len(prefix)] == prefix:
+                if check and response.returncode != 0:
+                    raise subprocess.CalledProcessError(
+                        response.returncode, cmd, response.stdout, response.stderr,
+                    )
+                return response
+        return _completed(returncode=0, stdout="", stderr="")
+
+
+@pytest.fixture
+def fake_run(monkeypatch):
+    fr = FakeRun()
+    monkeypatch.setattr(cluster_ops, "_run", fr)
+    return fr
+
+
+# ── detect_openshift / check_cluster_reachable / secret_exists ────────
+
+
+class TestDetectOpenshift:
+    def test_returns_false_when_oc_not_installed(self, monkeypatch, fake_run):
+        monkeypatch.setattr(cluster_ops, "_which", lambda cmd: False)
+        assert cluster_ops.detect_openshift() is False
+        # We must NOT invoke oc when it isn't on PATH.
+        assert fake_run.calls == []
+
+    def test_returns_true_when_oc_whoami_succeeds(self, monkeypatch, fake_run):
+        monkeypatch.setattr(cluster_ops, "_which", lambda cmd: True)
+        fake_run.set(["oc", "whoami"], _completed(returncode=0))
+        assert cluster_ops.detect_openshift() is True
+
+    def test_returns_false_when_oc_whoami_fails(self, monkeypatch, fake_run):
+        monkeypatch.setattr(cluster_ops, "_which", lambda cmd: True)
+        fake_run.set(["oc", "whoami"], _completed(returncode=1, stderr="not logged in"))
+        assert cluster_ops.detect_openshift() is False
+
+
+class TestCheckClusterReachable:
+    def test_returns_silently_on_success(self, fake_run):
+        fake_run.set(["kubectl", "cluster-info"], _completed(returncode=0))
+        cluster_ops.check_cluster_reachable()  # no raise
+
+    def test_forbidden_treated_as_reachable(self, fake_run):
+        fake_run.set(["kubectl", "cluster-info"],
+                     _completed(returncode=1, stderr="Error: forbidden"))
+        cluster_ops.check_cluster_reachable()
+
+    @pytest.mark.parametrize("stderr,reason_fragment", [
+        ("dial tcp: lookup foo: no such host", "DNS resolution failed"),
+        ("dial tcp 127.0.0.1:8443: connect: connection refused", "Connection refused"),
+        ("Unable to connect to the server: i/o timeout", "Connection timed out"),
+        ("error: You must be logged in to the server (Unauthorized)", "Authentication failed"),
+        ("error: no configuration has been provided", "No kubeconfig found"),
+        ("something else broke", "kubectl cluster-info failed"),
+    ])
+    def test_classifies_failure_and_raises(self, fake_run, stderr, reason_fragment):
+        fake_run.set(["kubectl", "cluster-info"],
+                     _completed(returncode=1, stderr=stderr))
+        with pytest.raises(cluster_ops.ClusterUnreachableError) as exc:
+            cluster_ops.check_cluster_reachable()
+        assert reason_fragment in exc.value.args[0]
+
+
+class TestSecretExists:
+    def test_returns_true_when_kubectl_get_succeeds(self, fake_run):
+        fake_run.set(["kubectl", "get", "secret", "hf-secret"],
+                     _completed(returncode=0, stdout="hf-secret"))
+        assert cluster_ops.secret_exists("hf-secret", "ns-a") is True
+        # Right namespace flag is on the call.
+        assert "-n=ns-a" in fake_run.calls[0]
+
+    def test_returns_false_when_kubectl_get_fails(self, fake_run):
+        fake_run.set(["kubectl", "get", "secret", "hf-secret"],
+                     _completed(returncode=1, stderr="not found"))
+        assert cluster_ops.secret_exists("hf-secret", "ns-a") is False
+
+
+# ── ProvisionResult dataclass ─────────────────────────────────────────
+
+
+class TestProvisionResult:
+    def test_default_fields(self):
+        r = cluster_ops.ProvisionResult(namespace="ns-a")
+        assert r.namespace == "ns-a"
+        assert r.steps_ok == []
+        assert r.steps_skipped == []
+        assert r.steps_failed == []
+
+    def test_diverged_false_when_all_ok(self):
+        r = cluster_ops.ProvisionResult(namespace="ns-a", steps_ok=["namespace"])
+        assert r.diverged is False
+
+    def test_diverged_true_on_skipped(self):
+        r = cluster_ops.ProvisionResult(
+            namespace="ns-a",
+            steps_ok=["namespace"],
+            steps_skipped=[("secrets", "no value")],
+        )
+        assert r.diverged is True
+
+    def test_diverged_true_on_failed(self):
+        r = cluster_ops.ProvisionResult(
+            namespace="ns-a",
+            steps_failed=[("rbac", "kubectl forbidden")],
+        )
+        assert r.diverged is True
+
+
+# ── provision_namespace ───────────────────────────────────────────────
+
+
+def _baseline_cluster_config(**overrides) -> dict:
+    cfg = {
+        "is_openshift": False,
+        "namespaces": ["ns-a", "ns-b"],
+        "storage_class": "",
+        "secret_names": {
+            "hf_token": "hf-secret",
+            "github_token": "github-token",
+            "registry_creds": "registry-secret",
+        },
+        "workspaces": {
+            "data-storage": {"persistentVolumeClaim": {"claimName": "data-pvc"}},
+            "source": {"persistentVolumeClaim": {"claimName": "source-pvc"}},
+        },
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+def _rbac_yaml_paths_exist(monkeypatch, exists=True):
+    # Pretend the RBAC YAML files exist on disk (cluster_ops reads .text on them).
+    monkeypatch.setattr(cluster_ops.Path, "exists", lambda self: exists)
+    monkeypatch.setattr(cluster_ops.Path, "read_text", lambda self: f"# {self.name}\n")
+
+
+def _tekton_yamls_present(monkeypatch, files=None):
+    """Stub Path.exists/glob so _step_tekton sees a couple of YAMLs."""
+    files = files or ["step-a.yaml", "step-b.yaml"]
+
+    real_path = cluster_ops.Path
+
+    def fake_glob(self, pattern):
+        if pattern == "*.yaml":
+            return [real_path(f"/fake/{name}") for name in files]
+        return []
+
+    monkeypatch.setattr(cluster_ops.Path, "exists", lambda self: True)
+    monkeypatch.setattr(cluster_ops.Path, "read_text", lambda self: "# fake\n")
+    monkeypatch.setattr(cluster_ops.Path, "glob", fake_glob)
+
+
+class TestProvisionNamespace:
+    def test_happy_path_all_steps_ok_kubectl(self, fake_run, monkeypatch):
+        """Default cluster (not OpenShift): namespace + rbac + secrets + pvc + tekton all apply cleanly."""
+        _tekton_yamls_present(monkeypatch)
+        # Namespace doesn't exist yet → create succeeds.
+        fake_run.set(["kubectl", "get", "ns", "ns-a"], _completed(returncode=1))
+        fake_run.set(["kubectl", "create", "ns", "ns-a"], _completed(returncode=0))
+        # PVC pre-checks miss; apply succeeds (default).
+        fake_run.set(["kubectl", "get", "pvc"], _completed(returncode=1))
+
+        result = cluster_ops.provision_namespace(
+            "ns-a",
+            _baseline_cluster_config(),
+            secret_values={
+                "hf_token": "hf-XXX",
+                "github_token": "ghp-XXX",
+                "registry_creds": {"server": "quay.io", "user": "u", "token": "t"},
+            },
+        )
+        assert result.namespace == "ns-a"
+        assert result.steps_ok == ["namespace", "rbac", "secrets", "pvc", "tekton"]
+        assert result.steps_skipped == []
+        assert result.steps_failed == []
+        assert result.diverged is False
+
+    def test_openshift_uses_oc_for_namespace(self, fake_run, monkeypatch):
+        _tekton_yamls_present(monkeypatch)
+        fake_run.set(["oc", "get", "project", "ns-a"], _completed(returncode=1))
+        fake_run.set(["oc", "new-project", "ns-a"], _completed(returncode=0))
+        fake_run.set(["kubectl", "get", "pvc"], _completed(returncode=1))
+
+        cluster_ops.provision_namespace(
+            "ns-a",
+            _baseline_cluster_config(is_openshift=True),
+            secret_values={
+                "hf_token": "v", "github_token": "v",
+                "registry_creds": {"server": "s", "user": "u", "token": "t"},
+            },
+        )
+        # An oc new-project call was issued (and no kubectl create ns).
+        cmds = [tuple(c[:3]) for c in fake_run.calls]
+        assert ("oc", "new-project", "ns-a") in cmds
+        assert ("kubectl", "create", "ns") not in [tuple(c[:3]) for c in fake_run.calls]
+
+    def test_existing_namespace_is_noop(self, fake_run, monkeypatch):
+        _tekton_yamls_present(monkeypatch)
+        # Namespace pre-check returns success → no create attempted.
+        fake_run.set(["kubectl", "get", "ns", "ns-a"], _completed(returncode=0))
+        fake_run.set(["kubectl", "get", "pvc"], _completed(returncode=1))
+
+        cluster_ops.provision_namespace(
+            "ns-a",
+            _baseline_cluster_config(),
+            secret_values={
+                "hf_token": "v", "github_token": "v",
+                "registry_creds": {"server": "s", "user": "u", "token": "t"},
+            },
+        )
+        cmds = [tuple(c[:3]) for c in fake_run.calls]
+        assert ("kubectl", "create", "ns") not in cmds
+
+    def test_namespace_already_exists_race_is_ok(self, fake_run, monkeypatch):
+        _tekton_yamls_present(monkeypatch)
+        fake_run.set(["kubectl", "get", "ns", "ns-a"], _completed(returncode=1))
+        fake_run.set(["kubectl", "create", "ns", "ns-a"],
+                     _completed(returncode=1, stderr='Error from server (AlreadyExists)'))
+        fake_run.set(["kubectl", "get", "pvc"], _completed(returncode=1))
+
+        result = cluster_ops.provision_namespace(
+            "ns-a",
+            _baseline_cluster_config(),
+            secret_values={
+                "hf_token": "v", "github_token": "v",
+                "registry_creds": {"server": "s", "user": "u", "token": "t"},
+            },
+        )
+        assert "namespace" in result.steps_ok
+
+    def test_namespace_create_failure_recorded(self, fake_run, monkeypatch):
+        _tekton_yamls_present(monkeypatch)
+        fake_run.set(["kubectl", "get", "ns", "ns-a"], _completed(returncode=1))
+        fake_run.set(["kubectl", "create", "ns", "ns-a"],
+                     _completed(returncode=1, stderr="quota exceeded"))
+        fake_run.set(["kubectl", "get", "pvc"], _completed(returncode=1))
+
+        result = cluster_ops.provision_namespace(
+            "ns-a",
+            _baseline_cluster_config(),
+            secret_values={
+                "hf_token": "v", "github_token": "v",
+                "registry_creds": {"server": "s", "user": "u", "token": "t"},
+            },
+        )
+        assert ("namespace", "quota exceeded") in result.steps_failed
+        # Later steps still run — provision_namespace doesn't short-circuit
+        # on per-step failures; surfacing every divergence is the design.
+        assert result.diverged is True
+
+    def test_skip_arg_suppresses_named_steps(self, fake_run, monkeypatch):
+        _tekton_yamls_present(monkeypatch)
+        result = cluster_ops.provision_namespace(
+            "ns-a",
+            _baseline_cluster_config(),
+            secret_values={
+                "hf_token": "v", "github_token": "v",
+                "registry_creds": {"server": "s", "user": "u", "token": "t"},
+            },
+            skip=["namespace", "rbac", "secrets", "pvc", "tekton"],
+        )
+        assert result.steps_ok == []
+        assert [s for s, _ in result.steps_skipped] == list(cluster_ops._PROVISION_STEPS)
+        # No kubectl/oc calls were issued — skip suppresses execution.
+        assert fake_run.calls == []
+
+    def test_skip_unknown_step_is_ignored(self, fake_run, monkeypatch):
+        _tekton_yamls_present(monkeypatch)
+        fake_run.set(["kubectl", "get", "ns", "ns-a"], _completed(returncode=0))
+        fake_run.set(["kubectl", "get", "pvc"], _completed(returncode=1))
+        # Unknown step in skip is a no-op — for forward compat with future steps.
+        result = cluster_ops.provision_namespace(
+            "ns-a",
+            _baseline_cluster_config(),
+            secret_values={
+                "hf_token": "v", "github_token": "v",
+                "registry_creds": {"server": "s", "user": "u", "token": "t"},
+            },
+            skip=["nonexistent-step"],
+        )
+        assert "namespace" in result.steps_ok  # known steps still ran
+
+    def test_secret_with_value_is_applied(self, fake_run, monkeypatch):
+        _tekton_yamls_present(monkeypatch)
+        fake_run.set(["kubectl", "get", "ns", "ns-a"], _completed(returncode=0))
+        fake_run.set(["kubectl", "get", "pvc"], _completed(returncode=1))
+        # kubectl create secret --dry-run produces the manifest YAML.
+        fake_run.set(["kubectl", "create", "secret", "generic", "hf-secret"],
+                     _completed(returncode=0, stdout="apiVersion: v1\nkind: Secret\n"))
+
+        cluster_ops.provision_namespace(
+            "ns-a",
+            _baseline_cluster_config(),
+            secret_values={
+                "hf_token": "hf-XXX",
+                "github_token": "ghp-XXX",
+                "registry_creds": {"server": "quay.io", "user": "u", "token": "t"},
+            },
+        )
+        # The --from-literal carries the value through.
+        create_calls = [c for c in fake_run.calls
+                        if c[:4] == ["kubectl", "create", "secret", "generic"]]
+        assert any("--from-literal=HF_TOKEN=hf-XXX" in c for c in create_calls)
+
+    def test_secret_value_absent_but_secret_exists_is_reused(self, fake_run, monkeypatch):
+        _tekton_yamls_present(monkeypatch)
+        fake_run.set(["kubectl", "get", "ns", "ns-a"], _completed(returncode=0))
+        fake_run.set(["kubectl", "get", "pvc"], _completed(returncode=1))
+        # Pre-installed secrets exist:
+        fake_run.set(["kubectl", "get", "secret", "hf-secret"], _completed(returncode=0))
+        fake_run.set(["kubectl", "get", "secret", "github-token"], _completed(returncode=0))
+        fake_run.set(["kubectl", "get", "secret", "registry-secret"], _completed(returncode=0))
+
+        result = cluster_ops.provision_namespace(
+            "ns-a",
+            _baseline_cluster_config(),
+            secret_values={},  # no values supplied
+        )
+        # secrets step is OK (reuse is the idempotent happy path).
+        assert "secrets" in result.steps_ok
+        # No create-secret calls were issued.
+        create_calls = [c for c in fake_run.calls if c[:3] == ["kubectl", "create", "secret"]]
+        assert create_calls == []
+
+    def test_secret_value_absent_and_secret_missing_is_skipped(self, fake_run, monkeypatch):
+        _tekton_yamls_present(monkeypatch)
+        fake_run.set(["kubectl", "get", "ns", "ns-a"], _completed(returncode=0))
+        fake_run.set(["kubectl", "get", "pvc"], _completed(returncode=1))
+        # All secret pre-checks miss.
+        fake_run.set(["kubectl", "get", "secret"], _completed(returncode=1))
+
+        result = cluster_ops.provision_namespace(
+            "ns-a",
+            _baseline_cluster_config(),
+            secret_values={},
+        )
+        skipped_steps = [s for s, _ in result.steps_skipped]
+        assert "secrets" in skipped_steps
+        # The reason mentions every missing secret.
+        secrets_reason = next(reason for s, reason in result.steps_skipped if s == "secrets")
+        assert "hf_token" in secrets_reason
+        assert "github_token" in secrets_reason
+        assert "registry_creds" in secrets_reason
+
+    def test_secret_partial_value_skipped(self, fake_run, monkeypatch):
+        _tekton_yamls_present(monkeypatch)
+        fake_run.set(["kubectl", "get", "ns", "ns-a"], _completed(returncode=0))
+        fake_run.set(["kubectl", "get", "pvc"], _completed(returncode=1))
+        # github-token Secret pre-exists; hf-secret and registry-secret missing.
+        fake_run.set(["kubectl", "get", "secret", "github-token"], _completed(returncode=0))
+        fake_run.set(["kubectl", "get", "secret"], _completed(returncode=1))
+        fake_run.set(["kubectl", "create", "secret", "generic", "hf-secret"],
+                     _completed(returncode=0, stdout="apiVersion: v1\nkind: Secret\n"))
+
+        result = cluster_ops.provision_namespace(
+            "ns-a",
+            _baseline_cluster_config(),
+            secret_values={"hf_token": "hf-XXX"},
+        )
+        # secrets step partially applied: hf applied, github reused, registry missing.
+        skipped_reasons = dict(result.steps_skipped)
+        assert "secrets" in skipped_reasons
+        assert "registry_creds" in skipped_reasons["secrets"]
+
+    def test_rbac_cluster_forbidden_skipped_not_failed(self, fake_run, monkeypatch):
+        _tekton_yamls_present(monkeypatch)
+        fake_run.set(["kubectl", "get", "ns", "ns-a"], _completed(returncode=0))
+        fake_run.set(["kubectl", "get", "pvc"], _completed(returncode=1))
+        # Every kubectl apply -f - call gets a Forbidden mentioning ClusterRole;
+        # the matcher only suppresses on best-effort YAMLs, so the required ones
+        # would normally fail. Force them through by giving required path applies
+        # a 0 and only the optional ones the Forbidden response.
+        applies = []
+
+        def custom_run(cmd, *, check=True, capture=False, input=None):
+            applies.append((list(cmd), input))
+            if cmd[:2] == ["kubectl", "apply"] and input and "roles-cluster" in input:
+                return _completed(returncode=1,
+                                  stderr="Error: forbidden: User cannot create resource clusterrole")
+            if cmd[:2] == ["kubectl", "apply"] and input and "sim2real-runner-cluster" in input:
+                return _completed(returncode=1,
+                                  stderr="Error: forbidden: User cannot create resource clusterrolebinding")
+            return _completed(returncode=0)
+
+        monkeypatch.setattr(cluster_ops, "_run", custom_run)
+        # Also need filesystem stubs:
+        _rbac_yaml_paths_exist(monkeypatch)
+
+        result = cluster_ops.provision_namespace(
+            "ns-a",
+            _baseline_cluster_config(),
+            secret_values={
+                "hf_token": "v", "github_token": "v",
+                "registry_creds": {"server": "s", "user": "u", "token": "t"},
+            },
+        )
+        # rbac is skipped (not failed) because every Forbidden was on a
+        # best-effort cluster-scoped YAML.
+        skipped_reasons = dict(result.steps_skipped)
+        assert "rbac" in skipped_reasons
+        assert "cluster" in skipped_reasons["rbac"].lower()
+
+    def test_rbac_other_failure_is_failed(self, fake_run, monkeypatch):
+        _rbac_yaml_paths_exist(monkeypatch)
+        # Required YAML apply fails for a non-cluster-RBAC reason.
+        def custom_run(cmd, *, check=True, capture=False, input=None):
+            if cmd[:2] == ["kubectl", "apply"] and input:
+                return _completed(returncode=1, stderr="error: quota exceeded")
+            if cmd[:3] == ["kubectl", "get"] and "ns" in cmd[2:]:
+                return _completed(returncode=0)
+            return _completed(returncode=0)
+        monkeypatch.setattr(cluster_ops, "_run", custom_run)
+        # We need _step_tekton not to find any YAMLs to apply for this test.
+        monkeypatch.setattr(cluster_ops.Path, "glob", lambda self, pattern: [])
+
+        result = cluster_ops.provision_namespace(
+            "ns-a",
+            _baseline_cluster_config(),
+            secret_values={
+                "hf_token": "v", "github_token": "v",
+                "registry_creds": {"server": "s", "user": "u", "token": "t"},
+            },
+        )
+        failed_steps = [s for s, _ in result.steps_failed]
+        assert "rbac" in failed_steps
+
+    def test_pvc_existing_skipped(self, fake_run, monkeypatch):
+        _tekton_yamls_present(monkeypatch)
+        fake_run.set(["kubectl", "get", "ns", "ns-a"], _completed(returncode=0))
+        # All PVC pre-checks hit.
+        fake_run.set(["kubectl", "get", "pvc"], _completed(returncode=0))
+
+        cluster_ops.provision_namespace(
+            "ns-a",
+            _baseline_cluster_config(),
+            secret_values={
+                "hf_token": "v", "github_token": "v",
+                "registry_creds": {"server": "s", "user": "u", "token": "t"},
+            },
+        )
+        # No kubectl apply on a manifest containing the PVC kind happened.
+        pvc_applies = [
+            (cmd, inp) for cmd, inp in zip(fake_run.calls, fake_run.inputs)
+            if cmd[:2] == ["kubectl", "apply"] and inp and "PersistentVolumeClaim" in inp
+        ]
+        assert pvc_applies == []
+
+    def test_pvc_creates_with_storage_class(self, fake_run, monkeypatch):
+        _tekton_yamls_present(monkeypatch)
+        fake_run.set(["kubectl", "get", "ns", "ns-a"], _completed(returncode=0))
+        fake_run.set(["kubectl", "get", "pvc"], _completed(returncode=1))
+
+        cluster_ops.provision_namespace(
+            "ns-a",
+            _baseline_cluster_config(storage_class="gp3"),
+            secret_values={
+                "hf_token": "v", "github_token": "v",
+                "registry_creds": {"server": "s", "user": "u", "token": "t"},
+            },
+        )
+        pvc_manifests = [
+            inp for cmd, inp in zip(fake_run.calls, fake_run.inputs)
+            if cmd[:2] == ["kubectl", "apply"] and inp and "PersistentVolumeClaim" in inp
+        ]
+        assert pvc_manifests, "expected at least one PVC apply"
+        for manifest in pvc_manifests:
+            assert "storageClassName: gp3" in manifest
+            assert "ReadWriteMany" in manifest
+            assert "50Gi" in manifest
+
+    def test_tekton_skipped_when_no_yamls_found(self, fake_run, monkeypatch):
+        fake_run.set(["kubectl", "get", "ns", "ns-a"], _completed(returncode=0))
+        fake_run.set(["kubectl", "get", "pvc"], _completed(returncode=1))
+        # tekton dirs don't exist:
+        monkeypatch.setattr(cluster_ops.Path, "exists",
+                            lambda self: "tekton" not in self.parts)
+
+        result = cluster_ops.provision_namespace(
+            "ns-a",
+            _baseline_cluster_config(),
+            secret_values={
+                "hf_token": "v", "github_token": "v",
+                "registry_creds": {"server": "s", "user": "u", "token": "t"},
+            },
+        )
+        skipped = dict(result.steps_skipped)
+        assert "tekton" in skipped
+
+
+# ── apply_cluster_resources ───────────────────────────────────────────
+
+
+class TestApplyClusterResources:
+    def test_applies_pipeline_yaml_to_each_namespace(self, fake_run, monkeypatch, tmp_path):
+        # Stub pipeline.yaml existence.
+        monkeypatch.setattr(cluster_ops.Path, "exists", lambda self: True)
+        cluster_ops.write_cluster_config(
+            "ocp-east", {"namespaces": ["ns-a", "ns-b", "ns-c"]},
+        )
+        cluster_ops.apply_cluster_resources("ocp-east")
+        applies = [c for c in fake_run.calls if c[:3] == ["kubectl", "apply", "-f"]]
+        ns_flags = [c[-1] for c in applies]
+        assert ns_flags == ["-n=ns-a", "-n=ns-b", "-n=ns-c"]
+
+    def test_pipeline_yaml_missing_raises(self, fake_run, monkeypatch):
+        monkeypatch.setattr(cluster_ops.Path, "exists", lambda self: False)
+        with pytest.raises(FileNotFoundError):
+            cluster_ops.apply_cluster_resources("ocp-east")
+
+    def test_idempotent_repeat_invocations_succeed(self, fake_run, monkeypatch):
+        # kubectl apply is idempotent — same call sequence on the second run.
+        monkeypatch.setattr(cluster_ops.Path, "exists", lambda self: True)
+        cluster_ops.write_cluster_config("ocp-east", {"namespaces": ["ns-a"]})
+
+        cluster_ops.apply_cluster_resources("ocp-east")
+        first_run_calls = list(fake_run.calls)
+        cluster_ops.apply_cluster_resources("ocp-east")
+        # Same command issued again.
+        second_run_calls = fake_run.calls[len(first_run_calls):]
+        assert second_run_calls == first_run_calls
+
+    def test_no_namespaces_in_config_is_noop(self, fake_run, monkeypatch):
+        monkeypatch.setattr(cluster_ops.Path, "exists", lambda self: True)
+        cluster_ops.write_cluster_config("ocp-east", {"namespaces": []})
+        cluster_ops.apply_cluster_resources("ocp-east")
+        # No kubectl apply -f calls.
+        applies = [c for c in fake_run.calls if c[:3] == ["kubectl", "apply", "-f"]]
+        assert applies == []
+
+    def test_per_namespace_failure_raises(self, fake_run, monkeypatch):
+        monkeypatch.setattr(cluster_ops.Path, "exists", lambda self: True)
+        cluster_ops.write_cluster_config("ocp-east", {"namespaces": ["ns-a"]})
+
+        def boom(cmd, *, check=True, capture=False, input=None):
+            if cmd[:3] == ["kubectl", "apply", "-f"]:
+                raise subprocess.CalledProcessError(1, cmd, "", "stderr")
+            return _completed(returncode=0)
+        monkeypatch.setattr(cluster_ops, "_run", boom)
+
+        with pytest.raises(subprocess.CalledProcessError):
+            cluster_ops.apply_cluster_resources("ocp-east")
+
+
+# ── _envsubst helper (pure-Python envsubst replacement) ───────────────
+
+
+class TestEnvsubst:
+    def test_substitutes_dollar_var(self):
+        assert cluster_ops._envsubst("ns: $NAMESPACE\n", {"NAMESPACE": "ns-a"}) == "ns: ns-a\n"
+
+    def test_substitutes_braced_var(self):
+        assert cluster_ops._envsubst("ns: ${NAMESPACE}\n", {"NAMESPACE": "ns-a"}) == "ns: ns-a\n"
+
+    def test_missing_key_left_intact(self):
+        assert cluster_ops._envsubst("ns: $UNSET", {}) == "ns: $UNSET"
+
+    def test_multiple_vars(self):
+        out = cluster_ops._envsubst(
+            "primary: $PRIMARY_NAMESPACE\nthis: $NAMESPACE\n",
+            {"PRIMARY_NAMESPACE": "ns-a", "NAMESPACE": "ns-b"},
+        )
+        assert "primary: ns-a" in out and "this: ns-b" in out

--- a/pipeline/tests/test_cluster_ops.py
+++ b/pipeline/tests/test_cluster_ops.py
@@ -873,6 +873,61 @@ class TestProvisionNamespace:
         failed_steps = [s for s, _ in result.steps_failed]
         assert "rbac" in failed_steps
 
+    def test_rbac_read_text_oserror_routed_to_failed(self, fake_run, monkeypatch):
+        # The "no exception escapes provision_namespace" invariant requires
+        # that an OSError on read_text() lands in steps_failed, not propagates.
+        _tekton_yamls_present(monkeypatch)
+        fake_run.set(["kubectl", "get", "ns", "ns-a"], _completed(returncode=0))
+        fake_run.set(["kubectl", "get", "pvc"], _completed(returncode=1))
+
+        def boom_read(self, *_a, **_kw):
+            raise PermissionError(13, "Permission denied", str(self))
+        monkeypatch.setattr(cluster_ops.Path, "read_text", boom_read)
+
+        result = cluster_ops.provision_namespace(
+            "ns-a",
+            _baseline_cluster_config(),
+            secret_values={
+                "hf_token": "v", "github_token": "v",
+                "registry_creds": {"server": "s", "user": "u", "token": "t"},
+            },
+        )
+        failed = dict(result.steps_failed)
+        assert "rbac" in failed
+        assert "read failed" in failed["rbac"]
+        # The dispatch loop kept going — every sub-step is in exactly one list.
+        all_attempted = (
+            set(result.steps_ok)
+            | {s for s, _ in result.steps_skipped}
+            | {s for s, _ in result.steps_failed}
+        )
+        assert all_attempted == set(cluster_ops._PROVISION_STEPS)
+
+    def test_tekton_glob_oserror_routed_to_failed(self, fake_run, monkeypatch):
+        # PermissionError on Path.glob (e.g. submodule dir the operator can't
+        # descend into) must surface as steps_failed, not raise out.
+        fake_run.set(["kubectl", "get", "ns", "ns-a"], _completed(returncode=0))
+        fake_run.set(["kubectl", "get", "pvc"], _completed(returncode=1))
+
+        monkeypatch.setattr(cluster_ops.Path, "exists", lambda self: True)
+        monkeypatch.setattr(cluster_ops.Path, "read_text", lambda self: "# fake\n")
+
+        def boom_glob(self, pattern):
+            raise PermissionError(13, "Permission denied", str(self))
+        monkeypatch.setattr(cluster_ops.Path, "glob", boom_glob)
+
+        result = cluster_ops.provision_namespace(
+            "ns-a",
+            _baseline_cluster_config(),
+            secret_values={
+                "hf_token": "v", "github_token": "v",
+                "registry_creds": {"server": "s", "user": "u", "token": "t"},
+            },
+        )
+        failed = dict(result.steps_failed)
+        assert "tekton" in failed
+        assert "cannot list" in failed["tekton"]
+
     def test_pvc_existing_skipped(self, fake_run, monkeypatch):
         _tekton_yamls_present(monkeypatch)
         fake_run.set(["kubectl", "get", "ns", "ns-a"], _completed(returncode=0))

--- a/pipeline/tests/test_cluster_ops.py
+++ b/pipeline/tests/test_cluster_ops.py
@@ -582,6 +582,47 @@ class TestProvisionNamespace:
         # on per-step failures; surfacing every divergence is the design.
         assert result.diverged is True
 
+    def test_no_short_circuit_on_early_failure(self, fake_run, monkeypatch):
+        """provision_namespace must attempt every sub-step even after an
+        earlier one fails. The invariant is 'every sub-step lands in
+        exactly one of steps_ok / steps_skipped / steps_failed' — a
+        regression that adds an early return on first failure would lose
+        coverage of the later steps in the ProvisionResult.
+        """
+        _tekton_yamls_present(monkeypatch)
+        # Namespace step fails on a non-AlreadyExists error.
+        fake_run.set(["kubectl", "get", "ns", "ns-a"], _completed(returncode=1))
+        fake_run.set(["kubectl", "create", "ns", "ns-a"],
+                     _completed(returncode=1, stderr="quota exceeded"))
+        fake_run.set(["kubectl", "get", "pvc"], _completed(returncode=1))
+
+        result = cluster_ops.provision_namespace(
+            "ns-a",
+            _baseline_cluster_config(),
+            secret_values={
+                "hf_token": "v", "github_token": "v",
+                "registry_creds": {"server": "s", "user": "u", "token": "t"},
+            },
+        )
+        # Every one of the five sub-steps lands in exactly one of the three
+        # lists. No exception escapes provision_namespace.
+        all_attempted = (
+            set(result.steps_ok)
+            | {s for s, _ in result.steps_skipped}
+            | {s for s, _ in result.steps_failed}
+        )
+        assert all_attempted == set(cluster_ops._PROVISION_STEPS)
+        assert (
+            len(result.steps_ok)
+            + len(result.steps_skipped)
+            + len(result.steps_failed)
+            == len(cluster_ops._PROVISION_STEPS)
+        )
+        # The failed step is recorded; later steps did run (rbac apply
+        # default-returns 0, so it lands in steps_ok).
+        assert ("namespace", "quota exceeded") in result.steps_failed
+        assert "rbac" in result.steps_ok
+
     def test_skip_arg_suppresses_named_steps(self, fake_run, monkeypatch):
         _tekton_yamls_present(monkeypatch)
         result = cluster_ops.provision_namespace(

--- a/pipeline/tests/test_cluster_ops.py
+++ b/pipeline/tests/test_cluster_ops.py
@@ -696,6 +696,80 @@ class TestProvisionNamespace:
         assert "secrets" in skipped_reasons
         assert "registry_creds" in skipped_reasons["secrets"]
 
+    def test_unknown_secret_key_distinct_error(self, fake_run, monkeypatch):
+        # cluster_config declares a secret key the builder doesn't know about.
+        # Failure reason must name the key, not conflate with "incomplete dict".
+        _tekton_yamls_present(monkeypatch)
+        fake_run.set(["kubectl", "get", "ns", "ns-a"], _completed(returncode=0))
+        fake_run.set(["kubectl", "get", "pvc"], _completed(returncode=1))
+        cfg = _baseline_cluster_config()
+        cfg["secret_names"] = {"futuristic_token": "future-secret"}
+
+        result = cluster_ops.provision_namespace(
+            "ns-a", cfg,
+            secret_values={"futuristic_token": "some-value"},
+        )
+        failed = dict(result.steps_failed)
+        assert "secrets" in failed
+        assert "unknown secret key 'futuristic_token'" in failed["secrets"]
+
+    def test_incomplete_docker_creds_distinct_error(self, fake_run, monkeypatch):
+        # registry_creds dict is missing 'token'. Operator-facing error must
+        # name the missing field, not say "unknown secret key".
+        _tekton_yamls_present(monkeypatch)
+        fake_run.set(["kubectl", "get", "ns", "ns-a"], _completed(returncode=0))
+        fake_run.set(["kubectl", "get", "pvc"], _completed(returncode=1))
+        cfg = _baseline_cluster_config()
+        cfg["secret_names"] = {"registry_creds": "registry-secret"}
+
+        result = cluster_ops.provision_namespace(
+            "ns-a", cfg,
+            secret_values={"registry_creds": {"server": "quay.io", "user": "u"}},
+        )
+        failed = dict(result.steps_failed)
+        assert "secrets" in failed
+        assert "missing required fields: token" in failed["secrets"]
+        # And NOT the unknown-key message:
+        assert "unknown secret key" not in failed["secrets"]
+
+    def test_non_dict_docker_creds_distinct_error(self, fake_run, monkeypatch):
+        # Operator passes a string when a dict is expected.
+        _tekton_yamls_present(monkeypatch)
+        fake_run.set(["kubectl", "get", "ns", "ns-a"], _completed(returncode=0))
+        fake_run.set(["kubectl", "get", "pvc"], _completed(returncode=1))
+        cfg = _baseline_cluster_config()
+        cfg["secret_names"] = {"registry_creds": "registry-secret"}
+
+        result = cluster_ops.provision_namespace(
+            "ns-a", cfg,
+            secret_values={"registry_creds": "not-a-dict"},
+        )
+        failed = dict(result.steps_failed)
+        assert "secrets" in failed
+        assert "not a dict" in failed["secrets"]
+
+    def test_dry_run_failure_routes_through_provision_result(self, fake_run, monkeypatch):
+        # If kubectl create --dry-run somehow returns non-zero, the failure
+        # must land on ProvisionResult.steps_failed, not raise out as
+        # CalledProcessError. The invariant is "every sub-step lands in
+        # steps_ok|skipped|failed" — no exception escapes.
+        _tekton_yamls_present(monkeypatch)
+        fake_run.set(["kubectl", "get", "ns", "ns-a"], _completed(returncode=0))
+        fake_run.set(["kubectl", "get", "pvc"], _completed(returncode=1))
+        fake_run.set(
+            ["kubectl", "create", "secret", "generic", "hf-secret"],
+            _completed(returncode=1, stderr="dry-run failed for reasons"),
+        )
+        cfg = _baseline_cluster_config()
+        cfg["secret_names"] = {"hf_token": "hf-secret"}
+
+        result = cluster_ops.provision_namespace(
+            "ns-a", cfg, secret_values={"hf_token": "hf-XXX"},
+        )
+        failed = dict(result.steps_failed)
+        assert "secrets" in failed
+        assert "dry-run failed" in failed["secrets"]
+
     def test_rbac_cluster_forbidden_skipped_not_failed(self, fake_run, monkeypatch):
         _tekton_yamls_present(monkeypatch)
         fake_run.set(["kubectl", "get", "ns", "ns-a"], _completed(returncode=0))


### PR DESCRIPTION
## Summary

Adds the kubectl/oc-driven primitives that pair with the file-system slice landed in #428. This is Child 4 of epic #416 (Step 0 — Foundation).

- `ProvisionResult` dataclass — surfaces every divergence per sub-step (`steps_ok`, `steps_skipped`, `steps_failed`, `diverged`).
- `provision_namespace(namespace, cluster_config, *, secret_values=None, skip=())` — five-step namespace bootstrap (`namespace`, `rbac`, `secrets`, `pvc`, `tekton`) in design order. Idempotent: already-correct = no-op. Sub-steps surface as structured failures rather than silently overwriting.
- `apply_cluster_resources(cluster_id)` — applies `pipeline/pipeline.yaml` (Tekton `Pipeline` definition) across every namespace in `cluster_config["namespaces"]`. Idempotent via `kubectl apply`.
- Helpers `detect_openshift`, `check_cluster_reachable`, `secret_exists` are added to `cluster_ops`. `check_cluster_reachable` raises `ClusterUnreachableError` instead of `sys.exit` (library convention). The `setup.py` copies remain in place — they're scheduled for deletion in Child 8 (#424) per the design table.

## Reviewer attention

- **`secret_values` shape.** Design comment shows `registry_creds` as `{user, token}`. I extended to `{server, user, token}` because the docker-registry secret requires a `--docker-server` arg and the registry URL isn't in `cluster_config.json` (it stays in `setup_config.json` per design). Caller (#421 `cluster.py provision`) will resolve `server` from setup_config.
- **PVC defaults.** `cluster_config["workspaces"]` only carries claim names; size + access mode aren't part of the schema. Hardcoded `50Gi` / `ReadWriteMany` to match today's `setup.py`. Documented in the docstring + a module constant.
- **`apply_cluster_resources` namespace scope.** Tekton `Pipeline` is namespaced upstream, so "cluster-wide" here means "the same definition applied across every namespace registered for this cluster" — same wire-level behavior as today's `step_tekton`.
- **Divergence detection scope.** `kubectl apply` merges by default; deep content-divergence detection (e.g. comparing existing Secret bytes against intended) is out of scope for this child. Surfaced failures are `kubectl apply` failures + the structured RBAC cluster-forbidden / secret-absent paths. Documented in the docstring.
- **`_envsubst` is pure-Python.** Drops the system-binary dependency `setup.py` had on the `envsubst` shell tool.

## Verification

```bash
.venv/bin/python -m pytest pipeline/ .claude/skills/sim2real-analyze/tests/ .claude/skills/sim2real-bootstrap/tests/ .claude/skills/sim2real-translate/tests/
# 1210 passed, 2 xfailed in 31.80s

.venv/bin/python -m ruff check pipeline/ .claude/skills/ --select F
# All checks passed!

.venv/bin/python -m ruff check pipeline/lib/cluster_ops.py --select F
# All checks passed! (per issue acceptance)
```

66 tests in `test_cluster_ops.py` (38 new) — `FakeRun` harness intercepts every subprocess call. Coverage: happy path (kubectl + oc), namespace race, skip arg (named + unknown), secret apply / reuse / skip / partial, RBAC cluster-forbidden skipped vs hard failure failed, PVC existing-skipped + storage_class injection, tekton-no-yaml skipped, `apply_cluster_resources` per-namespace fan-out + idempotency + missing-yaml raise.

## Stale-reference sweep

`grep` of `cluster_ops.*` and `ProvisionResult` across `*.md` only hit `docs/epics/step-0/design.md` — and the design doc is the spec being implemented, now matching reality. No README / CI / CLAUDE.md updates needed (no user-facing CLI yet — that lands in #421).

## Acceptance

- [x] `provision_namespace` implements all 5 sub-steps per design contract.
- [x] Secret sub-step honors absent `secret_values` entries: skip with structured entry if no existing Secret; reuse if existing Secret present.
- [x] `ProvisionResult` records `steps_ok` / `steps_skipped` / `steps_failed` accurately.
- [x] `skip` arg suppresses sub-steps named in it; remaining sub-steps proceed.
- [x] `apply_cluster_resources` applies the cluster-wide Pipeline definition idempotently.
- [x] `detect_openshift` / `check_cluster_reachable` / `secret_exists` available from `cluster_ops`.
- [x] `pipeline/tests/test_cluster_ops.py` extended with kubectl/oc mocks for both functions; covers happy path + divergence + skip arg.
- [x] `ruff check pipeline/lib/cluster_ops.py --select F` is clean.

Closes #420
Parent: #416