### PR TITLE
refactor(pipeline): port cluster-field reads in prepare.py + lib/remote.py

### DIFF
--- a/pipeline/lib/remote.py
+++ b/pipeline/lib/remote.py
@@ -7,6 +7,37 @@ JOB_NAME = "sim2real-orchestrator"
 SERVICE_ACCOUNT = "sim2real-runner"
 MOUNT_BASE = "/data"
 
+# ConfigMap key prefix for the per-cluster cluster_config.json. The suffix is
+# the cluster id, so the pod can reconstruct the layout-correct path
+# ``clusters/<cluster_id>/cluster_config.json``. Distinct from ``cluster--``,
+# which is reserved for per-run cluster/*.yaml files.
+_CLUSTER_CONFIG_KEY_PREFIX = "cluster_config--"
+
+
+def _discover_cluster_id(workspace_dir: Path) -> str:
+    """Return the single cluster id under ``workspace_dir/clusters/``.
+
+    Step 0 assumes one cluster per workspace. Raises FileNotFoundError if no
+    cluster is registered (the in-pod orchestrator needs ``namespaces`` from
+    cluster_config) or RuntimeError if more than one is present.
+    """
+    clusters_root = workspace_dir / "clusters"
+    cluster_ids = (
+        sorted(p.name for p in clusters_root.iterdir() if p.is_dir())
+        if clusters_root.is_dir() else []
+    )
+    if not cluster_ids:
+        raise FileNotFoundError(
+            f"No cluster registered under {clusters_root}. "
+            f"Run pipeline/cluster.py provision first."
+        )
+    if len(cluster_ids) > 1:
+        raise RuntimeError(
+            f"Multiple clusters found in workspace ({len(cluster_ids)}); "
+            f"Step 0 assumes a single cluster."
+        )
+    return cluster_ids[0]
+
 
 def build_run_inputs_configmap(
     *, run_dir: Path, workspace_dir: Path, namespace: str, run_name: str,
@@ -20,8 +51,18 @@ def build_run_inputs_configmap(
     if not metadata_path.exists():
         raise FileNotFoundError(f"run_metadata.json not found: {metadata_path}")
 
+    cluster_id = _discover_cluster_id(workspace_dir)
+    cluster_config_path = (
+        workspace_dir / "clusters" / cluster_id / "cluster_config.json"
+    )
+    if not cluster_config_path.exists():
+        raise FileNotFoundError(
+            f"cluster_config.json not found: {cluster_config_path}"
+        )
+
     data = {
         "setup_config.json": setup_path.read_text(),
+        f"{_CLUSTER_CONFIG_KEY_PREFIX}{cluster_id}": cluster_config_path.read_text(),
         "run_metadata.json": metadata_path.read_text(),
     }
 
@@ -55,6 +96,12 @@ def _configmap_items(data: dict, run_name: str) -> list[dict]:
             items.append({"key": key, "path": "defaults.yaml"})
         elif key == "run_metadata.json":
             items.append({"key": key, "path": f"runs/{run_name}/{key}"})
+        elif key.startswith(_CLUSTER_CONFIG_KEY_PREFIX):
+            cluster_id = key[len(_CLUSTER_CONFIG_KEY_PREFIX):]
+            items.append({
+                "key": key,
+                "path": f"clusters/{cluster_id}/cluster_config.json",
+            })
         elif key.startswith("cluster--"):
             filename = key[len("cluster--"):]
             items.append({"key": key, "path": f"runs/{run_name}/cluster/{filename}"})

--- a/pipeline/prepare.py
+++ b/pipeline/prepare.py
@@ -26,6 +26,7 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
+from pipeline.lib import cluster_ops, layout
 from pipeline.lib.manifest import load_manifest, ManifestError
 from pipeline.lib.state_machine import StateMachine
 from pipeline.lib.context_builder import build_context
@@ -99,6 +100,30 @@ def _load_setup_config() -> dict:
     if path.exists():
         return json.loads(path.read_text())
     return {}
+
+
+def _load_cluster_config() -> dict:
+    """Load the single cluster_config.json from the workspace.
+
+    Step 0 assumes one cluster per workspace. Returns ``{}`` when no
+    ``clusters/`` entry exists yet (callers surface the same
+    "no cluster configured" error path they used for an empty
+    setup_config); hard-fails when more than one cluster is present.
+    Mirrors ``deploy.py:_load_cluster_config`` so cluster discovery
+    behaves identically across the two entry points.
+    """
+    layout.set_experiment_root(EXPERIMENT_ROOT)
+    cluster_ids = layout.list_cluster_ids()
+    if not cluster_ids:
+        layout.set_experiment_root(REPO_ROOT)
+        cluster_ids = layout.list_cluster_ids()
+        if not cluster_ids:
+            return {}
+    if len(cluster_ids) > 1:
+        err(f"Multiple clusters found in workspace ({len(cluster_ids)}); "
+            f"Step 0 assumes a single cluster.")
+        sys.exit(1)
+    return cluster_ops.read_cluster_config(cluster_ids[0])
 
 
 def _load_resolved_config(manifest: dict) -> dict:
@@ -606,11 +631,11 @@ def _phase_assembly(args, state: StateMachine, manifest: dict, run_dir: Path,
             info("Skipping baseline EPP injection: no component.path in manifest")
 
     # 4b.6: Inject huggingface.secretName into all packages
-    setup_config = _load_setup_config()
-    if not setup_config:
-        err("setup_config.json not found. Run setup.py first to bootstrap cluster resources.")
+    cluster_config = _load_cluster_config()
+    if not cluster_config:
+        err("No cluster_config.json found. Run pipeline/cluster.py provision first to bootstrap cluster resources.")
         sys.exit(1)
-    hf_secret_name = setup_config.get("hf_secret_name", "hf-secret")
+    hf_secret_name = (cluster_config.get("secret_names") or {}).get("hf_token", "hf-secret")
     for pkg in packages:
         if not inject_hf_secret_name(pkg.resolved, hf_secret_name):
             err(f"{pkg.name} has no 'scenario' entries — huggingface.secretName cannot be injected.")
@@ -656,8 +681,9 @@ def _phase_assembly(args, state: StateMachine, manifest: dict, run_dir: Path,
     pipeline_name = manifest.get("pipeline", {}).get("name", "sim2real")
 
     # 4f: Generate PipelineRuns
-    namespace = setup_config.get("namespace", "default")
-    ws_bindings = setup_config.get("workspaces") or {}
+    namespaces = cluster_config.get("namespaces") or []
+    namespace = namespaces[0] if namespaces else "default"
+    ws_bindings = cluster_config.get("workspaces") or {}
     shas = _get_submodule_shas(manifest.get("component", {}).get("path", ""))
     benchmark_commit = shas.get("llm-d-benchmark", "")
     blis_commit = shas.get("inference-sim", "")

--- a/pipeline/tests/test_deploy_remote.py
+++ b/pipeline/tests/test_deploy_remote.py
@@ -400,6 +400,11 @@ def _setup_run_dir(tmp_path):
     cluster_dir = run_dir / "cluster"
     cluster_dir.mkdir(parents=True)
     (workspace / "setup_config.json").write_text("{}")
+    cluster_config_dir = workspace / "clusters" / "test-cluster"
+    cluster_config_dir.mkdir(parents=True)
+    (cluster_config_dir / "cluster_config.json").write_text(
+        json.dumps({"namespaces": ["ns"]})
+    )
     (run_dir / "run_metadata.json").write_text(json.dumps({
         "component_image": "registry.example.com/epp:latest",
     }))

--- a/pipeline/tests/test_prepare.py
+++ b/pipeline/tests/test_prepare.py
@@ -1084,9 +1084,11 @@ class TestBaselineOnlyAssembly:
         run_dir = repo / "workspace" / "runs" / "test-run"
         run_dir.mkdir(parents=True, exist_ok=True)
 
-        # setup_config.json (written by setup.py)
-        setup_config = {"namespace": "sim2real-test", "workspaces": {}}
-        (repo / "workspace" / "setup_config.json").write_text(json.dumps(setup_config))
+        # cluster_config.json (written by cluster.py provision)
+        cluster_dir = repo / "workspace" / "clusters" / "test-cluster"
+        cluster_dir.mkdir(parents=True, exist_ok=True)
+        cluster_config = {"namespaces": ["sim2real-test"], "workspaces": {}}
+        (cluster_dir / "cluster_config.json").write_text(json.dumps(cluster_config))
 
         # baseline.yaml bundle (experiment root)
         baseline_bundle = {
@@ -1328,16 +1330,16 @@ class TestBaselineOnlyNoAlgorithm:
         """Full _cmd_run succeeds with no algorithm — baseline-only flow."""
         mod = _import_prepare_with_root(repo)
         manifest = self._no_algo_manifest()
-        # Empty workloads to skip PipelineRun generation (avoids setup_config dep)
+        # Empty workloads to skip PipelineRun generation (avoids cluster_config dep)
         manifest["workloads"] = []
 
         # baseline.yaml must exist for assembly (needs scenario list for HF injection)
         (repo / "baseline.yaml").write_text(yaml.dump({"scenario": [{"name": "test", "model": {"name": "test"}}]}))
 
-        # setup_config.json required for HF secret injection
-        ws_dir = repo / "workspace"
-        ws_dir.mkdir(parents=True, exist_ok=True)
-        (ws_dir / "setup_config.json").write_text(json.dumps({"namespace": "default"}))
+        # cluster_config.json required for HF secret injection
+        cluster_dir = repo / "workspace" / "clusters" / "test-cluster"
+        cluster_dir.mkdir(parents=True, exist_ok=True)
+        (cluster_dir / "cluster_config.json").write_text(json.dumps({"namespaces": ["default"]}))
 
         run_dir = repo / "workspace" / "runs" / "test-run"
         run_dir.mkdir(parents=True, exist_ok=True)

--- a/pipeline/tests/test_prepare.py
+++ b/pipeline/tests/test_prepare.py
@@ -1134,6 +1134,53 @@ class TestBaselineOnlyAssembly:
         # Should NOT produce cluster/treatment.yaml
         assert not (cluster_dir / "treatment.yaml").exists()
 
+    def test_assembly_propagates_custom_hf_token_from_cluster_config(self, repo):
+        """A custom ``secret_names.hf_token`` in cluster_config must be injected
+        as ``huggingface.secretName`` on every scenario entry.
+
+        Guards the nested key path ``cluster_config["secret_names"]["hf_token"]``
+        against silent fallback to ``"hf-secret"`` — a typo at either layer of
+        the traversal would let the default win, and every other assembly test
+        uses a cluster_config that omits ``secret_names`` (so they all go
+        through the fallback branch).
+        """
+        mod = _import_prepare_with_root(repo)
+        run_dir = self._setup_baseline_only_repo(repo)
+
+        # Override the cluster_config with the nested secret_names shape.
+        cluster_config = {
+            "namespaces": ["sim2real-test"],
+            "workspaces": {},
+            "secret_names": {"hf_token": "my-custom-hf-secret"},
+        }
+        (repo / "workspace" / "clusters" / "test-cluster" / "cluster_config.json").write_text(
+            json.dumps(cluster_config)
+        )
+
+        manifest = dict(MINIMAL_MANIFEST)
+        resolved = mod._load_resolved_config(manifest)
+        state = StateMachine("test-run", "routing", run_dir)
+        state.mark_done("init")
+
+        class Args:
+            force = False
+
+        mod._phase_assembly(Args(), state, manifest, run_dir, resolved)
+
+        # The resolved baseline scenario must carry the custom secret name,
+        # not the "hf-secret" default.
+        baseline_yaml = (run_dir / "cluster" / "baseline.yaml").read_text()
+        baseline_resolved = yaml.safe_load(baseline_yaml)
+        secret_names = {
+            entry["huggingface"]["secretName"]
+            for entry in baseline_resolved["scenario"]
+        }
+        assert secret_names == {"my-custom-hf-secret"}, (
+            f"Expected huggingface.secretName == 'my-custom-hf-secret' on every "
+            f"scenario entry; got {secret_names}. The nested cluster_config key "
+            f"path secret_names.hf_token likely fell back to the default."
+        )
+
     def test_assembly_baseline_only_skips_epp_validation(self, repo):
         """When run_metadata.json has NO registry key but no translation_output.json
         exists, _phase_assembly should still succeed (EPP validation skipped).

--- a/pipeline/tests/test_remote.py
+++ b/pipeline/tests/test_remote.py
@@ -23,9 +23,20 @@ def workspace(tmp_path):
     return workspace_dir, run_dir
 
 
+CLUSTER_ID = "test-cluster"
+
+
+def _write_cluster_config(workspace_dir, cluster_id=CLUSTER_ID, payload=None):
+    cluster_dir = workspace_dir / "clusters" / cluster_id
+    cluster_dir.mkdir(parents=True, exist_ok=True)
+    body = payload if payload is not None else {"namespaces": ["ns"]}
+    (cluster_dir / "cluster_config.json").write_text(json.dumps(body))
+
+
 def _write_defaults(workspace_dir, run_dir):
     setup = {"namespace": "ns", "pipeline_name": "p"}
     (workspace_dir / "setup_config.json").write_text(json.dumps(setup))
+    _write_cluster_config(workspace_dir)
     meta = {"run_name": "test-run"}
     (run_dir / "run_metadata.json").write_text(json.dumps(meta))
     (run_dir / "cluster" / "pipelinerun-smoke-baseline.yaml").write_text("kind: PipelineRun")
@@ -90,11 +101,38 @@ def test_missing_run_metadata(workspace):
         )
 
 
+def test_missing_cluster_config_raises(workspace):
+    """No clusters/ directory raises FileNotFoundError with provision hint."""
+    workspace_dir, run_dir = workspace
+    (workspace_dir / "setup_config.json").write_text("{}")
+    (run_dir / "run_metadata.json").write_text("{}")
+    with pytest.raises(FileNotFoundError, match="No cluster registered"):
+        build_run_inputs_configmap(
+            run_dir=run_dir, workspace_dir=workspace_dir,
+            namespace="ns", run_name="test-run",
+        )
+
+
+def test_multiple_clusters_raises(workspace):
+    """More than one cluster directory raises RuntimeError (Step 0 single-cluster)."""
+    workspace_dir, run_dir = workspace
+    (workspace_dir / "setup_config.json").write_text("{}")
+    (run_dir / "run_metadata.json").write_text("{}")
+    _write_cluster_config(workspace_dir, cluster_id="cluster-a")
+    _write_cluster_config(workspace_dir, cluster_id="cluster-b")
+    with pytest.raises(RuntimeError, match="Multiple clusters"):
+        build_run_inputs_configmap(
+            run_dir=run_dir, workspace_dir=workspace_dir,
+            namespace="ns", run_name="test-run",
+        )
+
+
 def test_empty_cluster_dir_raises(workspace):
     """Empty cluster/ directory raises FileNotFoundError."""
     workspace_dir, run_dir = workspace
     (workspace_dir / "setup_config.json").write_text("{}")
     (run_dir / "run_metadata.json").write_text("{}")
+    _write_cluster_config(workspace_dir)
     with pytest.raises(FileNotFoundError, match="No cluster YAML"):
         build_run_inputs_configmap(
             run_dir=run_dir, workspace_dir=workspace_dir,
@@ -110,11 +148,25 @@ def test_missing_cluster_dir_raises(tmp_path):
     run_dir.mkdir(parents=True)
     (workspace_dir / "setup_config.json").write_text("{}")
     (run_dir / "run_metadata.json").write_text("{}")
+    _write_cluster_config(workspace_dir)
     with pytest.raises(FileNotFoundError, match="No cluster YAML"):
         build_run_inputs_configmap(
             run_dir=run_dir, workspace_dir=workspace_dir,
             namespace="ns", run_name="test-run",
         )
+
+
+def test_cluster_config_packed(workspace):
+    """cluster_config.json content is keyed under the cluster id."""
+    workspace_dir, run_dir = workspace
+    _write_defaults(workspace_dir, run_dir)
+    cm = build_run_inputs_configmap(
+        run_dir=run_dir, workspace_dir=workspace_dir,
+        namespace="ns", run_name="test-run",
+    )
+    key = f"cluster_config--{CLUSTER_ID}"
+    assert key in cm["data"]
+    assert json.loads(cm["data"][key]) == {"namespaces": ["ns"]}
 
 
 # --- _configmap_items tests ---
@@ -143,6 +195,16 @@ def test_configmap_items_cluster_yaml_nested():
     assert "runs/exp-1/cluster/pipelinerun-a.yaml" in paths
 
 
+def test_configmap_items_cluster_config_under_clusters():
+    """cluster_config--<id> maps to clusters/<id>/cluster_config.json."""
+    data = {"cluster_config--ocp-east": "{}"}
+    items = _configmap_items(data, "run1")
+    assert {
+        "key": "cluster_config--ocp-east",
+        "path": "clusters/ocp-east/cluster_config.json",
+    } in items
+
+
 def test_configmap_items_raises_on_unrecognized_key():
     """Unrecognized keys raise ValueError (producer/consumer mismatch)."""
     data = {"setup_config.json": "{}", "unknown_file.txt": "data"}
@@ -157,6 +219,7 @@ NAMESPACE = "sim2real"
 IMAGE = "ghcr.io/inference-sim/sim2real-orchestrator:latest"
 SAMPLE_DATA = {
     "setup_config.json": "{}",
+    "cluster_config--test-cluster": "{}",
     "run_metadata.json": "{}",
     "cluster--baseline.yaml": "x",
 }
@@ -221,6 +284,7 @@ def test_job_configmap_volume_is_read_only():
     items = cfg_vol["configMap"]["items"]
     paths = {i["path"] for i in items}
     assert "setup_config.json" in paths
+    assert "clusters/test-cluster/cluster_config.json" in paths
     assert f"runs/{RUN_NAME}/run_metadata.json" in paths
     assert f"runs/{RUN_NAME}/cluster/baseline.yaml" in paths
 


### PR DESCRIPTION
## Summary

Continues the cluster_config.json migration started in #431 (deploy.py). With this change, every Step-0-scoped consumer of `setup_config.json` cluster fields now reads through `cluster_ops.read_cluster_config()`.

Base: `refactor/v2-step-0`. Parent epic: #416.

## Changes

### `pipeline/prepare.py`

`_phase_assembly` previously read three cluster fields from `setup_config.json`:

| Old | New |
|---|---|
| `setup_config.get(\"hf_secret_name\", \"hf-secret\")` | `cluster_config[\"secret_names\"][\"hf_token\"]` (with same `hf-secret` default) |
| `setup_config.get(\"namespace\", \"default\")` | `cluster_config[\"namespaces\"][0]` (falls back to `\"default\"` when empty) |
| `setup_config.get(\"workspaces\")` | `cluster_config[\"workspaces\"]` |

Adds `_load_cluster_config()` mirroring `deploy.py:_load_cluster_config` — same single-cluster discovery via `layout.list_cluster_ids()`, same legacy in-repo workspace fallback, same multi-cluster hard-fail.

The `current_run` reads at lines 258, 1310, 1311 stay on `setup_config` per design (workspace-scoped).

### `pipeline/lib/remote.py`

`build_run_inputs_configmap` now also packs `cluster_config.json` into the orchestrator ConfigMap. After #431, the in-pod `deploy.py` reads cluster fields from `cluster_config.json` via the layout module; without this update, `--remote` mode would break because the pod never sees the file.

- New `_discover_cluster_id()` walks `workspace_dir/clusters/` and returns the single registered cluster (Step 0 invariant). Errors cleanly on zero clusters (\"Run pipeline/cluster.py provision first\") or multiple clusters.
- ConfigMap key: `cluster_config--<cluster_id>` (distinct from `cluster--<filename>` which is the existing scheme for `runs/<run>/cluster/*.yaml`).
- In-pod path mapping: `clusters/<cluster_id>/cluster_config.json` — matches `layout.cluster_config_path()` so the in-pod orchestrator finds it via the same layout helper as the operator side.

### `pipeline/run.py`, `pipeline/lib/run_manager.py`

**No code changes.** Grep confirms these touch `setup_config.json` only for the workspace-scoped `current_run` tracking field, which stays per the Step 0 design.

## Tests

- `pipeline/tests/test_prepare.py` — two fixtures (TestBaselineOnlyAssembly setup; TestBaselineOnlyNoAlgorithm.test_cmd_run_baseline_only_no_algorithm) now write `clusters/test-cluster/cluster_config.json` instead of `setup_config.json` with cluster-shaped fields.
- `pipeline/tests/test_remote.py` — new `_write_cluster_config` helper. New tests: `test_cluster_config_packed`, `test_missing_cluster_config_raises`, `test_multiple_clusters_raises`, `test_configmap_items_cluster_config_under_clusters`. `_configmap_volume_is_read_only` now asserts the `clusters/<id>/cluster_config.json` path is wired through to the Job spec.
- `pipeline/tests/test_deploy_remote.py` — `_setup_run_dir` helper now writes a cluster_config so the 8 `_cmd_run_remote` tests still reach their assertions after the new precondition.
- `test_run.py` and `test_run_manager.py` exercise no cluster fields; no fixture changes.

Local run:
- `python -m pytest pipeline/` — 1154 passed, 2 xfailed
- CI parity (`pipeline/ + .claude/skills/{sim2real-analyze,sim2real-bootstrap,sim2real-translate}/tests/`) — 1249 passed, 2 xfailed
- `ruff check pipeline/ .claude/skills/ --select F` — clean

## Stale-reference sweep

- `docs/epics/step-0/design.md` line 390 lists `prepare.py:659` as an identified callsite in the design's historical record — left as-is (the table introduction is explicit that it documents callsites identified during design).
- `pipeline/README.md` lines 66, 68 — references to namespace and workspaces being in `setup_config.json` became stale as of #431. Tracked separately by **#425** (\"docs: update README, CLAUDE.md, CI for the new flow\") per the Step 0 epic plan; not touched here to keep PRs single-purpose.
- Earlier-period `docs/superpowers/plans/*.md` snapshots reference old code paths but are immutable historical artifacts.

## Acceptance criteria

- [x] All cluster-field reads in prepare.py, lib/remote.py go through `cluster_ops.read_cluster_config()`.
- [x] No remaining `setup_config.get(\"namespaces\")` / `setup_config.get(\"namespace\"` patterns in these files for cluster-field purposes (verified by grep).
- [x] Test fixtures updated where needed.
- [x] All existing tests pass.
- [x] `ruff check pipeline/prepare.py pipeline/run.py pipeline/lib/remote.py pipeline/lib/run_manager.py --select F` is clean.

## Test plan

- [x] `python -m pytest pipeline/` passes locally
- [x] `python -m pytest pipeline/tests/test_remote.py pipeline/tests/test_deploy_remote.py pipeline/tests/test_prepare.py -v` passes locally
- [x] `ruff check pipeline/ .claude/skills/ --select F` clean

Closes #423