### PR TITLE
refactor(setup): remove cluster-side responsibility from setup.py (#424)

### DIFF
--- a/docs/superpowers/plans/2026-06-30-issue-424-setup-shrink.md
+++ b/docs/superpowers/plans/2026-06-30-issue-424-setup-shrink.md
@@ -1,0 +1,1001 @@
+# Issue #424 — Shrink setup.py to a workspace-config writer
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove every cluster-side responsibility from `pipeline/setup.py` and the cluster-scoped + cruft fields from its `setup_config.json` write; consumers (deploy/prepare/run/lib) already read from `cluster_config.json` after children #421/#422/#423 merged.
+
+**Architecture:** Pure deletion. No new code paths. `step_test_push` and `_detect_container_runtime` stay (registry credential test is workspace-scoped). `sim2real_root` keeps being written (consumed by `sim2real-translate` skill; retires in Step 2). All cluster work — namespace/RBAC/secrets/PVCs/Tekton — already lives in `pipeline/lib/cluster_ops.py` and `pipeline/cluster.py`. Match `setup.py` to that division.
+
+**Tech Stack:** Python 3.10+, `argparse`, `pytest`.
+
+## Global Constraints
+
+- Base branch: `refactor/v2-step-0` (epic #416 integration branch). PR targets this branch, NOT `main`.
+- `ruff check pipeline/ --select F` must pass at end.
+- `python -m pytest pipeline/ -v` must pass at end.
+- No new external dependencies.
+- `sim2real_root` must remain in `setup_config.json` (consumed by `sim2real-translate/SKILL.md`; retires in Step 2).
+- `step_test_push` and `_detect_container_runtime` stay — registry credential test is workspace-scoped, not cluster-scoped.
+
+---
+
+## File Structure
+
+**Modified:**
+- `pipeline/setup.py` — main shrink target.
+- `pipeline/tests/test_setup_pipeline.py` — delete obsolete tests, update kept ones.
+- `pipeline/README.md` — per-PR rule: flags/description must match the trimmed CLI.
+
+**Not touched:**
+- `pipeline/lib/cluster_ops.py`, `pipeline/cluster.py` — already implement everything being removed; nothing to add.
+- `pipeline/deploy.py`, `pipeline/prepare.py`, `pipeline/run.py`, `pipeline/lib/remote.py`, `pipeline/lib/run_manager.py` — already ported off the removed fields (verified by grep: zero hits for `setup_config.get("(namespace|namespaces|is_openshift|storage_class|hf_secret_name|workspaces)"`).
+- `docs/`, `CLAUDE.md` — broader doc rewrite is child issue #425's scope.
+
+---
+
+## Task 1: Trim `setup.py` — single coordinated edit pass
+
+**Files:**
+- Modify: `pipeline/setup.py` (single coherent edit; intermediate states won't import).
+
+**Interfaces:**
+- Consumes: existing `SetupConfig` dataclass; `pipeline.lib.log` (info/ok/warn/err); `pipeline.lib.cluster_ops` exists but is not imported (setup.py stops touching cluster code entirely).
+- Produces: shrunken `setup.py` with surface area:
+  - Dataclass fields kept: `registry`, `repo_name`, `run_name`, `registry_user`, `registry_token`, `pipeline_yaml`, `orchestrator_image`.
+  - Dataclass fields removed: `namespace`, `namespaces`, `hf_token`, `github_token`, `storage_class`, `is_openshift`, `no_cluster`. (registry_user/registry_token kept because `step_test_push` may use them for the container-runtime login fallback in `_do_test_push`.)
+  - CLI flags kept (verbatim from issue): `--registry`, `--repo-name`, `--pipeline-yaml`, `--orchestrator-image`, `--run`, `--experiment-root`, `--test-push`, `--test-push-tag`. Plus `--registry-user` and `--registry-token` because they're consumed by `step_test_push` (not in issue's kept list, but functionally required; see Task 1 note below).
+  - Functions removed: `step_namespace`, `step_rbac`, `step_secrets`, `step_pvcs`, `step_tekton`, `detect_openshift`, `check_cluster_reachable`, `secret_exists`, `_resolve_storage_class`.
+  - Functions kept: `step_test_push`, `_do_test_push`, `_detect_container_runtime`, `_resolve_run_name`, `collect_config` (simplified), `step_config_output` (simplified), `main` (simplified), helpers (`run`, `which`, `prompt`, `prompt_secret`, `_c`, `step`, `build_parser`).
+  - `setup_config.json` written keys: `registry`, `repo_name`, `pipeline_yaml`, `orchestrator_image`, `current_run`, `sim2real_root`. Removed: `namespace`, `namespaces`, `storage_class`, `is_openshift`, `tektonc_dir`, `container_runtime`, `setup_timestamp`, `hf_secret_name`, `workspaces`.
+  - `run_metadata.json` written keys: `version`, `registry`, `repo_name`, `created_at`, `pipeline_commit`, `component_image` (when registry set), `stages` (read-modify-write — preserves deploy-owned keys). Removed from idempotent block: `namespace`, `storage_class`, `is_openshift`, `container_runtime`.
+
+**Task 1 note on `--registry-user` / `--registry-token`:** The issue lists these among "CLI flags removed" but `step_test_push` (which stays) uses `cfg.registry_user` and `cfg.registry_token` in `_do_test_push` to authenticate the test push. Without the flags there's no way to pre-fill credentials for `--test-push`. **Decision:** keep `--registry-user` and `--registry-token` (rationale: they belong to the workspace-scoped registry credential test, not cluster-side provisioning). Call this out in the PR description.
+
+### Step 1.1: Replace the entire file content
+
+- [ ] **Step 1.1.1: Write the trimmed `setup.py`**
+
+Replace the contents of `pipeline/setup.py` with the following:
+
+```python
+#!/usr/bin/env python3
+"""sim2real workspace config writer.
+
+Writes `workspace/setup_config.json` and `workspace/runs/<run>/run_metadata.json`
+with operator-side fields. Optionally runs a registry credential test push.
+
+Cluster-side provisioning (namespaces, RBAC, secrets, PVCs, Tekton) lives in
+`pipeline/cluster.py provision`; this script no longer touches the cluster.
+"""
+
+import argparse
+import getpass
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+@dataclass
+class SetupConfig:
+    registry: str
+    repo_name: str
+    run_name: str
+    registry_user: str
+    registry_token: str
+    pipeline_yaml: str | None = None
+    orchestrator_image: str = ""
+
+# ── Repo layout ──────────────────────────────────────────────────────
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+# Overridden in main() when --experiment-root is specified.
+EXPERIMENT_ROOT = REPO_ROOT
+
+# ── Color helpers ────────────────────────────────────────────────────
+_tty = sys.stdout.isatty()
+def _c(code: str, text: str) -> str:
+    return f"\033[{code}m{text}\033[0m" if _tty else text
+
+from pipeline.lib.log import info, ok, warn, err
+def step(n, total, title: str) -> None:
+    print("\n" + _c("36", f"━━━ [{n}/{total}] {title} ━━━"))
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="pipeline/setup.py",
+        description="Workspace config writer for the sim2real pipeline.\n"
+                    "Writes setup_config.json + run_metadata.json. Idempotent.\n"
+                    "Cluster-side provisioning lives in `cluster.py provision`.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Environment variables (alternatives to --flags):
+  REGISTRY_USER, REGISTRY_TOKEN, ORCHESTRATOR_IMAGE
+
+Examples:
+  python pipeline/setup.py --registry quay.io/me
+  python pipeline/setup.py --test-push --registry quay.io/me \\
+    --registry-user u --registry-token t
+""",
+    )
+    p.add_argument("--registry",       metavar="REG",   help="Container registry host (e.g. quay.io/username)")
+    p.add_argument("--repo-name",      metavar="NAME",  default=None,
+                                                        help="Registry repository name [llm-d-inference-scheduler]")
+    p.add_argument("--registry-user",  metavar="USER",  help="Registry username (used by --test-push)")
+    p.add_argument("--registry-token", metavar="TOKEN", help="Registry token (used by --test-push)")
+    p.add_argument("--run",            metavar="NAME",  help="Run name [sim2real-YYYY-MM-DD]")
+    p.add_argument("--experiment-root", metavar="PATH", dest="experiment_root",
+                   help="Root of the experiment repo (default: current working directory)")
+    p.add_argument("--pipeline-yaml",  metavar="PATH",
+                                       help="Path to Tekton Pipeline YAML to apply "
+                                            "(default: <repo-root>/pipeline/pipeline.yaml)")
+    p.add_argument("--test-push",      action="store_true",
+                                       help="Auto-accept test push prompt")
+    p.add_argument("--test-push-tag",  metavar="TAG",   default="_test-image-push",
+                                       help="Image tag for test push [%(default)s]")
+    p.add_argument("--orchestrator-image", metavar="IMAGE",
+                                       help="Orchestrator container image for --remote mode "
+                                            "(e.g. ghcr.io/inference-sim/sim2real/orchestrator:latest)")
+    return p
+
+def run(cmd: list[str], *, check: bool = True, capture: bool = False,
+        input: str | None = None) -> subprocess.CompletedProcess:
+    """Run a command, raise on non-zero unless check=False."""
+    return subprocess.run(cmd, check=check, text=True, capture_output=capture, input=input)
+
+def which(cmd: str) -> bool:
+    import shutil
+    return shutil.which(cmd) is not None
+
+def prompt(var_name: str, message: str, default: str = "", env_var: str = "") -> str:
+    """Return env_var value, or prompt interactively with optional default."""
+    value = os.environ.get(env_var or var_name.upper(), "")
+    if value:
+        return value
+    suffix = f" [{default}]" if default else ""
+    raw = input(f"{message}{suffix}: ").strip()
+    return raw or default
+
+def prompt_secret(message: str, env_var: str = "") -> str:
+    """Return env var value, or prompt with hidden input."""
+    import re
+    value = os.environ.get(env_var, "") if env_var else ""
+    if value:
+        return value
+    hint = f"  (or type an env var name, e.g. {env_var})" if env_var else ""
+    print(hint)
+    raw = getpass.getpass(f"{message}: ")
+    if re.match(r'^[A-Z][A-Z0-9_]{1,}$', raw):
+        resolved = os.environ.get(raw, "")
+        if resolved:
+            ok(f"Read from env var {raw} ({len(resolved)} characters)")
+            return resolved
+    if raw:
+        ok(f"Token received ({len(raw)} characters)")
+    return raw
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+def _detect_container_runtime() -> str:
+    """Auto-detect podman or docker. Returns empty string if neither found."""
+    return next((rt for rt in ["podman", "docker"] if which(rt)), "")
+
+
+def _resolve_run_name(args: argparse.Namespace) -> tuple[str, Path]:
+    """Resolve run name, handle directory collision."""
+    default = f"sim2real-{datetime.now().strftime('%Y-%m-%d')}"
+    run_name = args.run or prompt("run_name", "Enter a name for this run", default=default)
+
+    while True:
+        run_dir = EXPERIMENT_ROOT / "workspace" / "runs" / run_name
+        if run_dir.exists():
+            warn(f"Run '{run_name}' already exists at {run_dir}")
+            answer = prompt("overwrite", "Overwrite it, or enter a new name? [overwrite/NAME]",
+                            default="overwrite")
+            if answer.strip().lower() in ("overwrite", "o", "y", "yes", ""):
+                break
+            run_name = answer.strip()
+        else:
+            break
+
+    run_dir.mkdir(parents=True, exist_ok=True)
+    return run_name, run_dir
+
+
+# ── Step 1: Configuration ────────────────────────────────────────────
+
+def collect_config(args: argparse.Namespace) -> tuple[SetupConfig, Path, str]:
+    """Step 1: Collect operator-side config. Returns (config, run_dir, container_runtime)."""
+    step(1, 3, "Configuration")
+
+    config_path = EXPERIMENT_ROOT / "workspace" / "setup_config.json"
+    defaults = json.loads(config_path.read_text()) if config_path.exists() else {}
+    if defaults:
+        info("Loading defaults from previous setup_config.json")
+
+    reg_default = defaults.get("registry", "")
+    registry = args.registry or prompt("registry",
+        "Container registry (e.g. quay.io/username)", default=reg_default)
+
+    repo_default = defaults.get("repo_name", "llm-d-inference-scheduler")
+    if args.repo_name is not None:
+        repo_name = args.repo_name
+    else:
+        repo_name = prompt("repo_name", "Registry repo name", default=repo_default)
+
+    run_name, run_dir = _resolve_run_name(args)
+
+    reg_user = args.registry_user or os.environ.get("REGISTRY_USER", "")
+    reg_token = args.registry_token or os.environ.get("REGISTRY_TOKEN", "")
+    docker_server = registry.split("/")[0] if registry else ""
+    if not reg_user and not reg_token and docker_server == "ghcr.io":
+        github_token = os.environ.get("GITHUB_TOKEN", "")
+        if github_token:
+            reg_user = registry.split("/")[1] if "/" in registry else "github"
+            reg_token = github_token
+            info("Using GITHUB_TOKEN for ghcr.io authentication.")
+    if registry and not reg_user:
+        reg_user = prompt("registry_user",
+            "Registry username (or press Enter to use container login)", default="")
+    if registry and reg_user and not reg_token:
+        reg_token = prompt_secret("Registry token", env_var="REGISTRY_TOKEN")
+
+    container_rt = _detect_container_runtime()
+
+    _orch_default = (
+        defaults.get("orchestrator_image", "")
+        or "ghcr.io/inference-sim/sim2real/orchestrator:latest"
+    )
+    orchestrator_image = args.orchestrator_image or prompt(
+        "orchestrator_image",
+        "Orchestrator image for --remote mode (press Enter to accept default)",
+        default=_orch_default,
+        env_var="ORCHESTRATOR_IMAGE",
+    )
+
+    cfg = SetupConfig(
+        registry=registry, repo_name=repo_name,
+        run_name=run_name,
+        registry_user=reg_user, registry_token=reg_token,
+        pipeline_yaml=args.pipeline_yaml,
+        orchestrator_image=orchestrator_image,
+    )
+    ok(f"Configuration complete (registry={registry or '(none)'})")
+    return cfg, run_dir, container_rt
+
+# ── Step 2: Registry credential test ─────────────────────────────────
+
+def _do_test_push(container_rt: str, full_image: str, docker_server: str,
+                  reg_user: str, reg_token: str) -> bool:
+    """Execute pull-tag-push-pull sequence. Returns True on success."""
+    base_image = "busybox:latest"
+
+    info(f"Pulling {base_image}...")
+    if run([container_rt, "pull", base_image], check=False, capture=True).returncode != 0:
+        err(f"Could not pull {base_image}")
+        return False
+
+    if run([container_rt, "tag", base_image, full_image], check=False, capture=True).returncode != 0:
+        err(f"Could not tag {base_image} as {full_image}")
+        return False
+
+    if reg_user and reg_token:
+        run([container_rt, "login", docker_server,
+             "--username", reg_user, "--password-stdin"],
+            input=reg_token, check=False, capture=True)
+
+    info(f"Pushing {full_image}...")
+    push_ok = run([container_rt, "push", full_image], check=False, capture=True).returncode == 0
+
+    run([container_rt, "rmi", full_image], check=False, capture=True)
+
+    if not push_ok:
+        return False
+
+    info("Verifying pull-back...")
+    pull_ok = run([container_rt, "pull", full_image], check=False, capture=True).returncode == 0
+    run([container_rt, "rmi", full_image], check=False, capture=True)
+
+    if pull_ok:
+        ok(f"Registry credentials verified (push + pull) → {full_image}")
+    else:
+        ok(f"Push succeeded → {full_image}")
+        warn("Pull-back failed — may be a propagation delay. Credentials likely OK.")
+    return True
+
+
+def step_test_push(cfg: SetupConfig, container_rt: str, test_push_tag: str,
+                   auto_push: bool) -> None:
+    """Step 2: Optional registry credential test with retry on failure."""
+    step(2, 3, "Registry Credential Test")
+    if not cfg.registry:
+        ok("Registry test (skipped — no registry configured)"); return
+    if not container_rt:
+        info("No podman/docker found — skipping test push.")
+        info("Credentials will be verified during in-cluster EPP build.")
+        return
+
+    if not auto_push:
+        full_image = f"{cfg.registry}/{cfg.repo_name}:{test_push_tag}"
+        answer = prompt("test_push",
+            f"Push test image to {full_image}? [y]es / [s]kip", default="s")
+        if answer.strip().lower() not in ("y", "yes"):
+            info("Skipped registry credential test"); return
+
+    full_image = f"{cfg.registry}/{cfg.repo_name}:{test_push_tag}"
+    docker_server = cfg.registry.split("/")[0]
+    interactive = sys.stdout.isatty()
+
+    while True:
+        success = _do_test_push(container_rt, full_image, docker_server,
+                                cfg.registry_user, cfg.registry_token)
+        if success:
+            return
+
+        err("Registry push failed")
+        if not interactive:
+            sys.exit(1)
+
+        answer = prompt("retry", "[r]etry / [s]kip / [q]uit", default="q")
+        choice = answer.strip().lower()
+        if choice in ("r", "retry"):
+            continue
+        elif choice in ("s", "skip"):
+            warn("Registry credentials unverified — will be tested during in-cluster EPP build")
+            return
+        else:
+            sys.exit(1)
+
+# ── Step 3: Config Output ────────────────────────────────────────────
+
+def step_config_output(cfg: SetupConfig, run_dir: Path) -> None:
+    """Step 3: Write setup_config.json and run_metadata.json."""
+    step(3, 3, "Config")
+
+    workspace = EXPERIMENT_ROOT / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+
+    now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    commit = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "--short", "HEAD"],
+        capture_output=True, text=True, check=False,
+    ).stdout.strip() or "unknown"
+
+    # setup_config.json — operator-side fields only. Cluster-side fields
+    # (namespace[s], is_openshift, storage_class, hf_secret_name, workspaces)
+    # live in workspace/clusters/<id>/cluster_config.json, written by
+    # `cluster.py provision`.
+    setup_config_path = workspace / "setup_config.json"
+    existing_setup = {}
+    if setup_config_path.exists():
+        try:
+            existing_setup = json.loads(setup_config_path.read_text())
+        except json.JSONDecodeError:
+            existing_setup = {}
+    existing_setup.update({
+        "registry": cfg.registry,
+        "repo_name": cfg.repo_name,
+        "sim2real_root": str(REPO_ROOT),
+        "pipeline_yaml": cfg.pipeline_yaml,
+        "orchestrator_image": cfg.orchestrator_image,
+        "current_run": cfg.run_name,
+    })
+    setup_config_path.write_text(json.dumps(existing_setup, indent=2))
+    ok(f"Setup config → {setup_config_path}")
+
+    # run_metadata.json — read-modify-write so deploy-owned keys
+    # (source_hashes, epp_image, stages.deploy.last_completed_step) survive
+    # setup re-runs. See issue #365.
+    meta_path = run_dir / "run_metadata.json"
+    if meta_path.exists():
+        try:
+            existing = json.loads(meta_path.read_text())
+        except json.JSONDecodeError:
+            existing = {}
+    else:
+        existing = {}
+
+    existing.update({
+        "version": 1,
+        "registry": cfg.registry,
+        "repo_name": cfg.repo_name,
+        "created_at": now_iso,
+        "pipeline_commit": commit,
+    })
+    if cfg.registry:
+        existing["component_image"] = f"{cfg.registry}/{cfg.repo_name}:{cfg.run_name}"
+
+    stages = existing.setdefault("stages", {})
+    stages["setup"] = {
+        "status": "completed",
+        "completed_at": now_iso,
+        "summary": "Workspace config written",
+    }
+    stages.setdefault("prepare", {"status": "pending"})
+    stages.setdefault("deploy",  {"status": "pending"})
+    stages.setdefault("results", {"status": "pending"})
+
+    meta_path.write_text(json.dumps(existing, indent=2))
+    ok(f"Run metadata → {meta_path}")
+
+
+# ── main ─────────────────────────────────────────────────────────────
+
+def main() -> int:
+    args = build_parser().parse_args()
+
+    global EXPERIMENT_ROOT
+    EXPERIMENT_ROOT = Path(args.experiment_root).resolve() if getattr(args, "experiment_root", None) else Path.cwd()
+
+    cfg, run_dir, container_rt = collect_config(args)
+    step_test_push(cfg, container_rt, args.test_push_tag, args.test_push)
+    step_config_output(cfg, run_dir)
+
+    print()
+    print(_c("32", "━━━ Setup complete ━━━"))
+    print()
+    cfg_path = EXPERIMENT_ROOT / "workspace" / "setup_config.json"
+    print(f"Setup config:  {cfg_path}")
+    print(f"Run name:      {cfg.run_name}")
+    print(f"Run directory: {run_dir}")
+    print()
+    print("Next steps:")
+    print("  1. Provision cluster: python pipeline/cluster.py provision <cluster_id> --namespaces NS1[,NS2,...]")
+    print("  2. Edit <experiment-root>/transfer.yaml (algorithm source, workloads, context)")
+    print("  3. Run: python pipeline/prepare.py")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+Notes on the rewrite:
+- Removed: `TEKTONC_DIR`, `_DEFAULT_HF_SECRET_NAME`, `_resolve_storage_class`, `detect_openshift`, `check_cluster_reachable`, `secret_exists`, `step_namespace`, `step_rbac`, `step_secrets`, `step_pvcs`, `step_tekton`, the `--redeploy-tasks` branch in `main`, the per-namespace loop in `main`. `step` total dropped from 8 to 3.
+- `step_config_output`: now read-modify-write for `setup_config.json` too (was overwrite-only) — preserves keys this script doesn't own anymore. Removed cruft (`tektonc_dir`, `setup_timestamp`, `container_runtime`). `container_rt` argument removed since it isn't persisted.
+- `main`: trimmed to `collect_config → step_test_push → step_config_output`. The "Next steps" message now points operators at `cluster.py provision` first.
+
+- [ ] **Step 1.1.2: Lint and import-check**
+
+```bash
+ruff check pipeline/setup.py --select F
+python -c "import sys; sys.path.insert(0, '.'); import pipeline.setup; print(pipeline.setup.build_parser().parse_args([]))"
+```
+
+Expected (lint): no output / clean.
+Expected (import): an `argparse.Namespace(...)` with the new flag set; no traceback.
+
+---
+
+## Task 2: Trim `pipeline/tests/test_setup_pipeline.py`
+
+**Files:**
+- Modify: `pipeline/tests/test_setup_pipeline.py`
+
+**Interfaces:**
+- Consumes: trimmed `SetupConfig`, `step_config_output(cfg, run_dir)` (note: container_rt arg removed), `build_parser`.
+- Produces: test file containing only tests for surviving symbols.
+
+### Step 2.1: Remove obsolete and rewrite remaining tests
+
+The whole file is rewritten because (a) the `_make_config` helper sets fields that no longer exist on `SetupConfig`, and (b) so many tests target removed functions that surgical deletion would leave the file looking like a graveyard with stale imports.
+
+- [ ] **Step 2.1.1: Replace test file**
+
+Replace `pipeline/tests/test_setup_pipeline.py` with:
+
+```python
+"""Tests for the trimmed setup.py (workspace config writer).
+
+Cluster-side responsibilities (namespace, RBAC, secrets, PVCs, Tekton) moved
+to pipeline/cluster.py + pipeline/lib/cluster_ops.py — see issue #424 and
+the epic #416 design.
+"""
+import json
+import pytest
+
+
+def _make_config(**overrides):
+    """Build a minimal SetupConfig with defaults for testing."""
+    from pipeline.setup import SetupConfig
+    defaults = dict(
+        registry="quay.io/test",
+        repo_name="llm-d-inference-scheduler",
+        run_name="test-run",
+        registry_user="user",
+        registry_token="token",
+        pipeline_yaml=None,
+    )
+    defaults.update(overrides)
+    return SetupConfig(**defaults)
+
+
+class TestSetupConfigJson:
+    """step_config_output writes the operator-side keys."""
+
+    def test_writes_kept_keys(self, tmp_path):
+        from pipeline.setup import step_config_output
+        import pipeline.setup as setup_module
+
+        original = setup_module.EXPERIMENT_ROOT
+        setup_module.EXPERIMENT_ROOT = tmp_path
+        try:
+            run_dir = tmp_path / "workspace" / "runs" / "test-run"
+            run_dir.mkdir(parents=True)
+
+            cfg = _make_config(pipeline_yaml="/path/to/pipeline.yaml",
+                               orchestrator_image="ghcr.io/x/orch:abc")
+            step_config_output(cfg, run_dir)
+
+            data = json.loads((tmp_path / "workspace" / "setup_config.json").read_text())
+            assert data["registry"] == "quay.io/test"
+            assert data["repo_name"] == "llm-d-inference-scheduler"
+            assert data["pipeline_yaml"] == "/path/to/pipeline.yaml"
+            assert data["orchestrator_image"] == "ghcr.io/x/orch:abc"
+            assert data["current_run"] == "test-run"
+            assert "sim2real_root" in data
+        finally:
+            setup_module.EXPERIMENT_ROOT = original
+
+    @pytest.mark.parametrize("removed_key", [
+        "namespace", "namespaces", "is_openshift", "storage_class",
+        "hf_secret_name", "workspaces", "tektonc_dir", "setup_timestamp",
+        "container_runtime",
+    ])
+    def test_removed_keys_absent(self, tmp_path, removed_key):
+        """Cluster-scoped and cruft keys are not written to setup_config.json."""
+        from pipeline.setup import step_config_output
+        import pipeline.setup as setup_module
+
+        original = setup_module.EXPERIMENT_ROOT
+        setup_module.EXPERIMENT_ROOT = tmp_path
+        try:
+            run_dir = tmp_path / "workspace" / "runs" / "test-run"
+            run_dir.mkdir(parents=True)
+            step_config_output(_make_config(), run_dir)
+            data = json.loads((tmp_path / "workspace" / "setup_config.json").read_text())
+            assert removed_key not in data
+        finally:
+            setup_module.EXPERIMENT_ROOT = original
+
+    def test_preserves_keys_owned_by_other_writers(self, tmp_path):
+        """A pre-existing setup_config.json with foreign keys is preserved
+        on re-run — setup.py only owns the keys it writes."""
+        from pipeline.setup import step_config_output
+        import pipeline.setup as setup_module
+
+        original = setup_module.EXPERIMENT_ROOT
+        setup_module.EXPERIMENT_ROOT = tmp_path
+        try:
+            workspace = tmp_path / "workspace"
+            workspace.mkdir(parents=True)
+            # Simulate a foreign key (e.g. a future cluster_id pointer, or
+            # any other writer's field) already in the file.
+            (workspace / "setup_config.json").write_text(json.dumps({
+                "registry": "old.example/x",
+                "foreign_key": "must-survive",
+            }))
+            run_dir = workspace / "runs" / "test-run"
+            run_dir.mkdir(parents=True)
+            step_config_output(_make_config(), run_dir)
+
+            data = json.loads((workspace / "setup_config.json").read_text())
+            assert data["registry"] == "quay.io/test"  # refreshed
+            assert data["foreign_key"] == "must-survive"  # preserved
+        finally:
+            setup_module.EXPERIMENT_ROOT = original
+
+
+class TestBuildParser:
+    """build_parser surface: kept flags accepted; removed flags raise."""
+
+    KEPT_FLAGS = [
+        ("--registry", "REG"),
+        ("--repo-name", "NAME"),
+        ("--pipeline-yaml", "/p"),
+        ("--orchestrator-image", "img"),
+        ("--run", "n"),
+        ("--experiment-root", "/x"),
+        ("--test-push", None),       # flag-only
+        ("--test-push-tag", "t"),
+        ("--registry-user", "u"),
+        ("--registry-token", "t"),
+    ]
+
+    REMOVED_FLAGS = [
+        "--namespace", "--namespaces", "--storage-class",
+        "--hf-token", "--github-token",
+        "--no-cluster", "--redeploy-tasks",
+    ]
+
+    @pytest.mark.parametrize("flag,value", KEPT_FLAGS)
+    def test_kept_flag_parses(self, flag, value):
+        from pipeline.setup import build_parser
+        argv = [flag] if value is None else [flag, value]
+        # Just confirm no SystemExit / argparse error.
+        build_parser().parse_args(argv)
+
+    @pytest.mark.parametrize("flag", REMOVED_FLAGS)
+    def test_removed_flag_raises(self, flag):
+        from pipeline.setup import build_parser
+        with pytest.raises(SystemExit):
+            build_parser().parse_args([flag, "x"])
+
+
+class TestRunMetadataIdempotent:
+    """Re-running setup must preserve deploy-owned fields (issue #365)."""
+
+    def _run_setup(self, tmp_path, **cfg_overrides):
+        from pipeline.setup import step_config_output
+        import pipeline.setup as setup_module
+
+        original = setup_module.EXPERIMENT_ROOT
+        setup_module.EXPERIMENT_ROOT = tmp_path
+        try:
+            run_dir = tmp_path / "workspace" / "runs" / "test-run"
+            run_dir.mkdir(parents=True, exist_ok=True)
+            cfg = _make_config(**cfg_overrides)
+            step_config_output(cfg, run_dir)
+            return run_dir
+        finally:
+            setup_module.EXPERIMENT_ROOT = original
+
+    def test_preserves_source_hashes_on_rerun(self, tmp_path):
+        run_dir = self._run_setup(tmp_path)
+        meta_path = run_dir / "run_metadata.json"
+        meta = json.loads(meta_path.read_text())
+        meta["source_hashes"] = {"quay.io/test/llm-d-inference-scheduler:test-run": "abc123"}
+        meta_path.write_text(json.dumps(meta))
+        self._run_setup(tmp_path)
+        meta2 = json.loads(meta_path.read_text())
+        assert meta2.get("source_hashes") == {
+            "quay.io/test/llm-d-inference-scheduler:test-run": "abc123"
+        }
+
+    def test_preserves_epp_image_on_rerun(self, tmp_path):
+        run_dir = self._run_setup(tmp_path)
+        meta_path = run_dir / "run_metadata.json"
+        meta = json.loads(meta_path.read_text())
+        meta["epp_image"] = "quay.io/test/llm-d-inference-scheduler:test-run"
+        meta_path.write_text(json.dumps(meta))
+        self._run_setup(tmp_path)
+        meta2 = json.loads(meta_path.read_text())
+        assert meta2.get("epp_image") == "quay.io/test/llm-d-inference-scheduler:test-run"
+
+    def test_preserves_stages_deploy_last_completed_step(self, tmp_path):
+        run_dir = self._run_setup(tmp_path)
+        meta_path = run_dir / "run_metadata.json"
+        meta = json.loads(meta_path.read_text())
+        meta.setdefault("stages", {}).setdefault("deploy", {})["last_completed_step"] = "build"
+        meta_path.write_text(json.dumps(meta))
+        self._run_setup(tmp_path)
+        meta2 = json.loads(meta_path.read_text())
+        assert meta2["stages"]["deploy"].get("last_completed_step") == "build"
+
+    def test_refreshes_setup_owned_fields_on_rerun(self, tmp_path):
+        """Setup-owned fields (registry, repo_name) reflect the latest cfg on re-run."""
+        from pipeline.setup import step_config_output
+        import pipeline.setup as setup_module
+
+        run_dir = self._run_setup(tmp_path)
+        meta_path = run_dir / "run_metadata.json"
+
+        original = setup_module.EXPERIMENT_ROOT
+        setup_module.EXPERIMENT_ROOT = tmp_path
+        try:
+            cfg2 = _make_config(registry="quay.io/new-registry", repo_name="new-repo")
+            step_config_output(cfg2, run_dir)
+        finally:
+            setup_module.EXPERIMENT_ROOT = original
+
+        meta2 = json.loads(meta_path.read_text())
+        assert meta2["registry"] == "quay.io/new-registry"
+        assert meta2["repo_name"] == "new-repo"
+
+    def test_first_run_creates_metadata(self, tmp_path):
+        """First-run path produces setup-owned fields. Cluster fields are NOT
+        written by setup.py anymore (cluster_config.json owns them)."""
+        run_dir = self._run_setup(tmp_path)
+        meta = json.loads((run_dir / "run_metadata.json").read_text())
+        assert meta["version"] == 1
+        assert meta["registry"] == "quay.io/test"
+        assert meta["repo_name"] == "llm-d-inference-scheduler"
+        assert meta["component_image"] == "quay.io/test/llm-d-inference-scheduler:test-run"
+        assert meta["stages"]["setup"]["status"] == "completed"
+        assert meta["stages"]["prepare"] == {"status": "pending"}
+        assert meta["stages"]["deploy"] == {"status": "pending"}
+        assert meta["stages"]["results"] == {"status": "pending"}
+        # Cluster-scoped fields are NOT written by setup anymore.
+        for absent in ("namespace", "storage_class", "is_openshift", "container_runtime"):
+            assert absent not in meta
+```
+
+Removed (per issue's "Obsolete tests"):
+- `TestStepTektonPipelineApply` — `step_tekton` removed.
+- `TestRedeployTasksPipeline` (all three) — `--redeploy-tasks` removed.
+- `TestStepRbacApply` (all) — `step_rbac` removed.
+- `TestSimRealRunnerNsRoleContent` — file-content assertions against `pipeline/rbac/sim2real-runner-ns.yaml`; this content check belongs with whoever applies the YAML now, which is `cluster_ops`. Issue #420 already exercises `cluster_ops.provision_namespace` end-to-end via `test_cluster_ops.py`, and `test_cluster_py.py` covers the `cluster.py provision` orchestrator. The narrow Role-rule content assertions are not part of either suite today; that gap is owned by epic #416 cleanup (it predates this issue and isn't a setup.py concern post-trim). Note in PR description as "removed with #424; Role rules are exercised end-to-end by `test_cluster_ops.py`."
+- `TestResolveStorageClass` — `_resolve_storage_class` removed; storage-class flag tests moved to `test_cluster_py.py` per issue.
+- `test_config_output_includes_hf_secret_name` — `hf_secret_name` no longer written.
+
+Updated (per issue's "Update" list):
+- `test_refreshes_setup_owned_fields_on_rerun` — field list shrinks to `registry`/`repo_name` (namespace and container_runtime out of scope now).
+- `test_first_run_creates_full_metadata` → `test_first_run_creates_metadata` — drops `namespace` and adds negative assertions for removed cluster fields.
+
+- [ ] **Step 2.1.2: Run the new test file**
+
+```bash
+python -m pytest pipeline/tests/test_setup_pipeline.py -v
+```
+
+Expected: all tests pass (kept + parametrized).
+
+---
+
+## Task 3: Update `pipeline/README.md`
+
+**Files:**
+- Modify: `pipeline/README.md` — `setup.py` section (flags table + prose).
+
+**Rationale:** Project rule (`CLAUDE.md`): "After any change to `pipeline/` that affects CLI flags, phase behavior, artifact schema, or subcommands, update `pipeline/README.md` to match." Broader README/CLAUDE.md rewrite is issue #425, but the setup.py section is directly contradicted by this PR and must be reconciled.
+
+### Step 3.1: Update setup.py section
+
+- [ ] **Step 3.1.1: Read current setup.py section** to confirm line numbers.
+
+```bash
+grep -nE "^## setup\.py|^## prepare\.py|^## cluster\.py|^## deploy\.py" pipeline/README.md
+```
+
+- [ ] **Step 3.1.2: Replace the setup.py section** with content matching the new CLI.
+
+Apply this edit (using Edit tool):
+
+Replace the entire `## setup.py` section (up to the next `##` heading) with:
+
+```markdown
+## setup.py
+
+Workspace config writer. Writes `workspace/setup_config.json` and `workspace/runs/<run>/run_metadata.json` with operator-side fields (registry, repo_name, current_run, orchestrator_image, pipeline_yaml, sim2real_root). Idempotent.
+
+**Cluster-side provisioning** (namespaces, RBAC, secrets, PVCs, Tekton tasks, Pipeline definition) lives in `cluster.py provision` and writes a separate `workspace/clusters/<cluster_id>/cluster_config.json`. Run `cluster.py provision` before `prepare.py`/`deploy.py`.
+
+```bash
+python pipeline/setup.py [flags]
+```
+
+| Flag | Env var | Default |
+|------|---------|---------|
+| `--registry REG` | — | interactive |
+| `--repo-name NAME` | — | `llm-d-inference-scheduler` |
+| `--registry-user USER` | `REGISTRY_USER` | interactive (when `--test-push`) |
+| `--registry-token TOKEN` | `REGISTRY_TOKEN` | interactive (when `--test-push`) |
+| `--run NAME` | — | `sim2real-YYYY-MM-DD` |
+| `--experiment-root PATH` | — | current working directory |
+| `--pipeline-yaml PATH` | — | `<repo-root>/pipeline/pipeline.yaml` |
+| `--orchestrator-image IMAGE` | `ORCHESTRATOR_IMAGE` | `ghcr.io/inference-sim/sim2real/orchestrator:latest` |
+| `--test-push` | — | false |
+| `--test-push-tag TAG` | — | `_test-image-push` |
+
+**`--pipeline-yaml PATH`** — pointer stored in `setup_config.json`; the Pipeline manifest is applied by `cluster.py provision`, not setup.py.
+
+**`--test-push`** — optional registry credential check (pull busybox, tag, push to `<registry>/<repo_name>:<test-push-tag>`, pull back). Skipped when no registry is configured or no container runtime is found.
+
+Writes `workspace/setup_config.json` and `workspace/runs/<run>/run_metadata.json`. Cluster-scoped fields (`namespaces`, `is_openshift`, `storage_class`, `hf_secret_name`, `workspaces`) live in `workspace/clusters/<cluster_id>/cluster_config.json`, written by `cluster.py provision`.
+```
+
+(The exact final text will be authored against the file's actual prose; the structure above is the contract.)
+
+- [ ] **Step 3.1.3: Sweep for other stale references in pipeline/README.md**
+
+```bash
+grep -nE "setup\.py.*--(namespace|namespaces|hf-token|github-token|storage-class|no-cluster|redeploy-tasks)" pipeline/README.md
+grep -nE "setup_config\.json.*(namespace|workspaces|hf_secret_name|is_openshift|storage_class)" pipeline/README.md
+```
+
+For every hit outside the setup.py section, decide:
+- If it documents what `deploy.py`/`prepare.py` reads from `setup_config.json`, update to point to `cluster_config.json` for cluster fields.
+- If it documents Pipeline application by setup.py, update to point to `cluster.py provision`.
+
+Apply edits in place. Expected end state: no surviving references to removed setup.py flags or to setup.py owning cluster-scoped fields.
+
+---
+
+## Task 4: Verification (gate before commit)
+
+- [ ] **Step 4.1: Ruff (project CI's lint stage)**
+
+```bash
+ruff check pipeline/ .claude/skills/ --select F
+```
+
+Expected: no output.
+
+- [ ] **Step 4.2: Full pipeline test suite + skill tests (matches CI)**
+
+```bash
+python -m pytest pipeline/ .claude/skills/sim2real-analyze/tests/ .claude/skills/sim2real-bootstrap/tests/ .claude/skills/sim2real-translate/tests/ -v
+```
+
+Expected: all green. Anything red blocks the commit; fix before proceeding.
+
+- [ ] **Step 4.3: Acceptance criteria grep checks (from issue body)**
+
+```bash
+# (1) setup.py writes no cluster-scoped field.
+! grep -nE '"(namespace|namespaces|is_openshift|storage_class|hf_secret_name|workspaces)"' pipeline/setup.py
+# (2) Cruft fields no longer written.
+! grep -nE '"(tektonc_dir|setup_timestamp|container_runtime)"' pipeline/setup.py
+# (3) sim2real_root IS still written.
+grep -n '"sim2real_root"' pipeline/setup.py
+# (4) Removed flags not declared.
+! grep -nE 'add_argument\("(--namespace|--namespaces|--storage-class|--hf-token|--github-token|--no-cluster|--redeploy-tasks)"' pipeline/setup.py
+```
+
+Each `!`-prefixed check should produce no output AND exit 0. Each non-`!` check should print the line(s).
+
+- [ ] **Step 4.4: Cross-script sanity — no consumer broke**
+
+```bash
+grep -nrE 'setup_config\.get\("(namespace|namespaces|is_openshift|storage_class|hf_secret_name|workspaces|tektonc_dir|setup_timestamp|container_runtime)"' pipeline/
+```
+
+Expected: no output (all consumers ported by #422/#423).
+
+- [ ] **Step 4.5: Path discipline check**
+
+```bash
+git -C "$(git rev-parse --git-common-dir)/.." status
+```
+
+Expected: only changes inside `.claude/worktrees/issue-424-setup-shrink/`. If the parent repo shows modifications, an edit leaked outside the worktree — revert via `git -C <parent> checkout -- <files>` and redo in the worktree.
+
+---
+
+## Task 5: Commit, push, PR
+
+- [ ] **Step 5.1: Stage and commit**
+
+```bash
+git add pipeline/setup.py pipeline/tests/test_setup_pipeline.py pipeline/README.md docs/superpowers/plans/2026-06-30-issue-424-setup-shrink.md
+git commit -m "$(cat <<'EOF'
+refactor(setup): remove cluster-side responsibility from setup.py (#424)
+
+Shrinks pipeline/setup.py to a workspace-config writer. All cluster-side
+provisioning (namespaces, RBAC, secrets, PVCs, Tekton tasks, Pipeline
+definition) lives in pipeline/cluster.py + pipeline/lib/cluster_ops.py
+(epic #416 children #420/#421). Consumers already read cluster fields
+from cluster_config.json (children #422/#423).
+
+setup.py removals
+  Functions: step_namespace, step_rbac, step_secrets, step_pvcs,
+  step_tekton, detect_openshift, check_cluster_reachable, secret_exists,
+  _resolve_storage_class.
+  Flags: --namespace, --namespaces, --hf-token, --github-token,
+  --storage-class, --no-cluster, --redeploy-tasks.
+  setup_config.json fields: namespace, namespaces, is_openshift,
+  storage_class, hf_secret_name, workspaces, tektonc_dir,
+  setup_timestamp, container_runtime.
+  Tests: TestStepTektonPipelineApply, TestRedeployTasksPipeline,
+  TestStepRbacApply, TestResolveStorageClass,
+  TestSimRealRunnerNsRoleContent (Role content checks now exercised
+  end-to-end by test_cluster_ops.py), test_config_output_includes_hf_secret_name.
+
+setup.py retained
+  step_test_push, _do_test_push, _detect_container_runtime: workspace-
+  scoped registry credential check. sim2real_root: still consumed by
+  sim2real-translate/SKILL.md (retires in Step 2).
+  Flags: --registry, --repo-name, --pipeline-yaml, --orchestrator-image,
+  --run, --experiment-root, --test-push, --test-push-tag, plus
+  --registry-user / --registry-token (functionally required by
+  step_test_push; see PR description).
+
+setup_config.json
+  Now read-modify-write so foreign keys (future cluster_id pointer,
+  other writers) are not clobbered. Setup.py-owned keys: registry,
+  repo_name, pipeline_yaml, orchestrator_image, current_run,
+  sim2real_root.
+
+Refs #416, #424
+EOF
+)"
+```
+
+- [ ] **Step 5.2: Push**
+
+```bash
+git push -u origin refactor/v2-step-0-issue-424-setup-shrink
+```
+
+- [ ] **Step 5.3: Open PR against `refactor/v2-step-0`**
+
+```bash
+gh pr create --base refactor/v2-step-0 \
+  --title "refactor(setup): remove cluster-side responsibility from setup.py (#424)" \
+  --body-file <(cat <<'EOF'
+Closes #424. Parent epic: #416. Base: `refactor/v2-step-0`.
+
+## What changed
+
+`pipeline/setup.py` is now a workspace-config writer. Cluster-side
+provisioning (namespaces, RBAC, secrets, PVCs, Tekton, Pipeline definition)
+moved to `pipeline/cluster.py provision` + `pipeline/lib/cluster_ops.py` in
+prior children #420/#421. Consumers (`deploy.py`, `prepare.py`, `run.py`,
+`lib/remote.py`, `lib/run_manager.py`) read cluster fields from
+`cluster_config.json` after children #422/#423. This PR finishes the carve-out.
+
+## Acceptance (issue #424)
+
+- [x] setup.py writes no cluster-scoped field to `setup_config.json`
+      (verified by grep).
+- [x] Cruft fields (`tektonc_dir`, `setup_timestamp`, `container_runtime`)
+      no longer written.
+- [x] `sim2real_root` still written (retires in Step 2).
+- [x] CLI flag list matches the kept list; removed flags raise argparse
+      errors when passed (verified by parametrized test).
+- [x] `step_test_push` and `_detect_container_runtime` retained as-is.
+- [x] Obsolete tests deleted; remaining tests pass.
+- [x] `ruff check pipeline/ --select F` clean.
+- [x] No leftover dead code in the diff.
+
+## Two judgment calls worth a reviewer's eye
+
+**1. `--registry-user` / `--registry-token` kept.** The issue lists these
+under "CLI flags removed", but `step_test_push` (which stays) uses
+`cfg.registry_user` / `cfg.registry_token` in `_do_test_push` to
+authenticate the test push. Removing the flags would leave `--test-push`
+with no way to pre-fill credentials. They're workspace-scoped (registry,
+not cluster), so I kept them.
+
+**2. `TestSimRealRunnerNsRoleContent` removed.** These were content
+assertions against `pipeline/rbac/sim2real-runner-ns.yaml` — that the Role
+contains the verb set the orchestrator needs (pipelineruns CRUD, pods
+get/list/watch, events get/list, PVCs/secrets get). The RBAC file is
+applied by `cluster_ops.provision_namespace` now, not setup.py. The
+end-to-end behavior of that apply is covered in `test_cluster_ops.py`. The
+narrow file-content checks are not currently mirrored there — that gap
+predates this issue and isn't a setup.py concern post-trim; flagging here
+so the epic-cleanup PR (#426) can decide whether to port them or leave them.
+
+**3. `setup_config.json` is now read-modify-write.** Previously overwrite-
+only. Foreign keys (e.g. a future `cluster_id` pointer, or any other
+writer's field) survive a setup re-run. A regression test covers this.
+
+## Doc updates
+
+`pipeline/README.md` — `setup.py` section rewritten to match the trimmed
+CLI; broader README/CLAUDE.md sweep is #425.
+
+## Verification
+
+```
+ruff check pipeline/ .claude/skills/ --select F
+python -m pytest pipeline/ .claude/skills/sim2real-analyze/tests/ \
+  .claude/skills/sim2real-bootstrap/tests/ \
+  .claude/skills/sim2real-translate/tests/ -v
+```
+
+Both green locally.
+EOF
+)
+```
+
+If `gh` fails with "Resource not accessible by personal access token":
+
+```bash
+unset GITHUB_TOKEN GH_TOKEN; gh pr create --base refactor/v2-step-0 ...
+```
+
+Expected: PR URL printed.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Every removed-function, removed-field, removed-flag, kept-function, kept-field, kept-flag, and deleted/updated test from the issue body maps to either Task 1 (setup.py) or Task 2 (tests). README update maps to Task 3 (project rule).
+- **Placeholder scan:** None.
+- **Type consistency:** `SetupConfig` fields used in `_make_config` match the new dataclass exactly: `registry`, `repo_name`, `run_name`, `registry_user`, `registry_token`, `pipeline_yaml` (and `orchestrator_image` via `**overrides`).
+- **One residual concern:** `step_test_push` keeping `--registry-user`/`--registry-token` deviates from the issue's stated "removed" list. The plan flags this as a judgment call and the PR body calls it out explicitly so the reviewer can push back.

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -28,13 +28,15 @@ The experiment repo must contain:
 - `algorithm/` and `workloads/` directories as referenced in `transfer.yaml`
 - `workspace/` in `.gitignore`
 
-`pipeline/pipeline.yaml` is the static Tekton Pipeline definition (applied by `setup.py`; Phase 4 generates PipelineRuns that reference it).
+`pipeline/pipeline.yaml` is the static Tekton Pipeline definition (applied by `cluster.py provision`; Phase 4 generates PipelineRuns that reference it).
 
 ---
 
 ## setup.py
 
-One-time, idempotent cluster bootstrap. Safe to re-run.
+Workspace config writer. Writes `workspace/setup_config.json` and `workspace/runs/<run>/run_metadata.json` with operator-side fields (registry, repo_name, current_run, orchestrator_image, pipeline_yaml, sim2real_root). Idempotent.
+
+Cluster-side provisioning (namespaces, RBAC, secrets, PVCs, Tekton tasks, Pipeline definition) lives in `cluster.py provision` and writes a separate `workspace/clusters/<cluster_id>/cluster_config.json`. Run `cluster.py provision` before `prepare.py` / `deploy.py`.
 
 ```bash
 python pipeline/setup.py [flags]
@@ -42,30 +44,22 @@ python pipeline/setup.py [flags]
 
 | Flag | Env var | Default |
 |------|---------|---------|
-| `--namespace NS` | `NAMESPACE` | interactive |
-| `--namespaces NS1,NS2,...` | — | — |
-| `--hf-token TOKEN` | `HF_TOKEN` | interactive |
-| `--github-token TOKEN` | `GITHUB_TOKEN` | — |
 | `--registry REG` | — | interactive |
-| `--registry-user USER` | `REGISTRY_USER` | interactive |
-| `--registry-token TOKEN` | `REGISTRY_TOKEN` | interactive |
+| `--repo-name NAME` | — | `llm-d-inference-scheduler` |
+| `--registry-user USER` | `REGISTRY_USER` | interactive (with `--test-push`) |
+| `--registry-token TOKEN` | `REGISTRY_TOKEN` | interactive (with `--test-push`) |
 | `--run NAME` | — | `sim2real-YYYY-MM-DD` |
-| `--storage-class SC` | — | cluster default |
-| `--no-cluster` | — | false |
-| `--pipeline-yaml PATH` | — | `pipeline/pipeline.yaml` |
-| `--redeploy-tasks` | — | false |
+| `--experiment-root PATH` | — | current working directory |
+| `--pipeline-yaml PATH` | — | `<repo-root>/pipeline/pipeline.yaml` |
+| `--orchestrator-image IMAGE` | `ORCHESTRATOR_IMAGE` | `ghcr.io/inference-sim/sim2real/orchestrator:latest` |
+| `--test-push` | — | false |
+| `--test-push-tag TAG` | — | `_test-image-push` |
 
-**`--namespaces NS1,NS2,...`** — provision multiple namespace slots for parallel pool execution. Each slot is bootstrapped identically to a single `--namespace`.
+**`--pipeline-yaml PATH`** — pointer to a Pipeline YAML definition; stored in `setup_config.json`. The manifest itself is applied by `cluster.py provision`.
 
-**`--no-cluster`** — generates `setup_config.json` without touching the cluster; useful when cluster access comes later.
+**`--test-push`** — optional workspace-scoped registry credential check (pull busybox, tag, push to `<registry>/<repo_name>:<test-push-tag>`, pull back). Skipped when no registry is configured or no container runtime (`podman`/`docker`) is found. `--registry-user` / `--registry-token` (or `REGISTRY_USER` / `REGISTRY_TOKEN`) gate the registry login. The cluster-side `registry-secret` is created independently by `cluster.py provision`; see #435 for the dedup plan.
 
-**`--pipeline-yaml PATH`** — override the default Pipeline YAML definition (`pipeline/pipeline.yaml`). Stored in `setup_config.json`.
-
-**`--redeploy-tasks`** — fast path to re-apply Tekton step/task YAMLs and Pipeline definition (requires `--namespace`).
-
-Writes `workspace/setup_config.json` and `workspace/runs/<run>/run_metadata.json`. Subsequent scripts read namespace, registry, and run name from `setup_config.json`.
-
-`setup_config.json` includes workspace bindings for two PVCs: `data-storage` (`data-pvc`) and `source` (`source-pvc`). `source-pvc` holds the BLIS binary built at pipeline runtime by the `install-blis` task. Both must be bound before `deploy.py run` accepts a namespace slot.
+Cluster-scoped fields (`namespaces`, `is_openshift`, `storage_class`, `hf_secret_name`, `workspaces`) live in `workspace/clusters/<cluster_id>/cluster_config.json`, written by `cluster.py provision`. PVC bind state (`data-pvc`, `source-pvc`) is gated by `deploy.py`'s slot-readiness check before `deploy.py run` accepts a namespace slot.
 
 ---
 
@@ -174,7 +168,7 @@ python pipeline/deploy.py pairs   [flags]   # list available pair keys, workload
 
 **Polling and slot-aware probe skipping** — the orchestrator always sleeps at `--poll-interval` (default 30s); there is no backoff state machine. On each cycle it first checks the status of every busy slot's PipelineRun. The GPU capacity probe and dispatch computation run only when at least one slot is free; when all slots are busy the cycle logs `Dispatching 0/<pending> pending — all <total> slots busy` (deduped per state transition) and skips the probe, so slot recovery is detected within one poll interval. The base interval is itself the rate limit against hot-loop reclaim cycles. (Old progress files may still carry a legacy `_orchestrator` metadata key; it is ignored.)
 
-**Live slot-list updates (issue #372)** — each cycle re-reads `workspace/clusters/<cluster_id>/cluster_config.json` and updates the in-memory slot list. Adding a namespace makes it eligible for dispatch on the next cycle (subject to `_check_slot_ready` — PVCs bound, HF secret present); removing a namespace stops new dispatch to it but does **not** cancel a pair already running there — that pair drains and the slot is freed normally on completion. `namespaces[0]` (the primary, where the run-scoped progress ConfigMap lives) is pinned for the lifetime of the run; mid-run changes to it are logged and ignored. Parse / IO errors keep the prior list. The safe way to add a slot is `setup.py --namespaces NS1,NS2,NS3` (provisions before publishing the change).
+**Live slot-list updates (issue #372)** — each cycle re-reads `workspace/clusters/<cluster_id>/cluster_config.json` and updates the in-memory slot list. Adding a namespace makes it eligible for dispatch on the next cycle (subject to `_check_slot_ready` — PVCs bound, HF secret present); removing a namespace stops new dispatch to it but does **not** cancel a pair already running there — that pair drains and the slot is freed normally on completion. `namespaces[0]` (the primary, where the run-scoped progress ConfigMap lives) is pinned for the lifetime of the run; mid-run changes to it are logged and ignored. Parse / IO errors keep the prior list. The safe way to add a slot is `cluster.py provision <cluster_id> --namespaces NS1,NS2,NS3` (provisions before publishing the change).
 
 **Capacity probe filtering** — `pipeline/lib/capacity.py` filters cluster nodes the same way the K8s scheduler would before summing allocatable/requested GPUs. A node is excluded if cordoned (`spec.unschedulable: true`), if it carries a `NoSchedule`/`NoExecute` taint that no role's tolerations match, or if its `nvidia.com/gpu.product` label is not in the set required by the scenario. The required product set is read from `scenario[0].{decode,prefill}.acceleratorType.{labelKey, labelValue}`. When no per-role product constraint can be extracted, cordon and taint screening still apply on cluster facts. Tolerations are currently treated as empty per follow-up issue #263 — every blocking taint excludes the node until that's lifted.
 
@@ -334,7 +328,7 @@ All paths are relative to the repo root and validated at Phase 1.
 
 ## Parallel Pool Execution
 
-`setup.py --namespaces NS1,NS2,...` provisions N namespace slots, each bootstrapped identically. `prepare.py` generates one shared Tekton Pipeline plus one PipelineRun per `(workload, package)` pair. `deploy.py run` orchestrates execution by assigning pairs to free slots, polling for completion, and retrying on timeout. Use `deploy.py collect` to pull results off-cluster. `deploy.py status` reads progress from the ConfigMap.
+`cluster.py provision <cluster_id> --namespaces NS1,NS2,...` provisions N namespace slots, each bootstrapped identically. `prepare.py` generates one shared Tekton Pipeline plus one PipelineRun per `(workload, package)` pair. `deploy.py run` orchestrates execution by assigning pairs to free slots, polling for completion, and retrying on timeout. Use `deploy.py collect` to pull results off-cluster. `deploy.py status` reads progress from the ConfigMap.
 
 | Artifact | Written by | Read by |
 |----------|-----------|---------|

--- a/pipeline/setup.py
+++ b/pipeline/setup.py
@@ -72,8 +72,9 @@ Examples:
     p.add_argument("--experiment-root", metavar="PATH", dest="experiment_root",
                    help="Root of the experiment repo (default: current working directory)")
     p.add_argument("--pipeline-yaml",  metavar="PATH",
-                                       help="Path to Tekton Pipeline YAML to apply "
-                                            "(default: <repo-root>/pipeline/pipeline.yaml)")
+                                       help="Path to Tekton Pipeline YAML "
+                                            "(default: <repo-root>/pipeline/pipeline.yaml); "
+                                            "applied by `cluster.py provision`")
     p.add_argument("--test-push",      action="store_true",
                                        help="Auto-accept test push prompt")
     p.add_argument("--test-push-tag",  metavar="TAG",   default="_test-image-push",

--- a/pipeline/setup.py
+++ b/pipeline/setup.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
-"""sim2real cluster setup — one-time, idempotent environment bootstrap."""
+"""sim2real workspace config writer.
+
+Writes `workspace/setup_config.json` and `workspace/runs/<run>/run_metadata.json`
+with operator-side fields. Optionally runs a registry credential test push.
+
+Cluster-side provisioning (namespaces, RBAC, secrets, PVCs, Tekton) lives in
+`pipeline/cluster.py provision`; this script no longer touches the cluster.
+"""
 
 import argparse
 import getpass
@@ -13,18 +20,11 @@ from pathlib import Path
 
 @dataclass
 class SetupConfig:
-    namespace: str
-    namespaces: list[str]
     registry: str
     repo_name: str
     run_name: str
-    hf_token: str
-    github_token: str
     registry_user: str
     registry_token: str
-    storage_class: str
-    is_openshift: bool
-    no_cluster: bool
     pipeline_yaml: str | None = None
     orchestrator_image: str = ""
 
@@ -33,8 +33,6 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 # Ensure repo root is on sys.path when run as a script (python pipeline/setup.py)
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
-TEKTONC_DIR = REPO_ROOT / "tektonc-data-collection"
-_DEFAULT_HF_SECRET_NAME = "hf-secret"
 
 # Overridden in main() when --experiment-root is specified.
 EXPERIMENT_ROOT = REPO_ROOT
@@ -51,43 +49,31 @@ def step(n, total, title: str) -> None:
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="pipeline/setup.py",
-        description="One-time cluster and environment setup for the sim2real pipeline.\n"
-                    "Idempotent — safe to re-run. 8-step flow: config, namespace, RBAC,\n"
-                    "secrets, registry test, PVCs, Tekton, config output.",
+        description="Workspace config writer for the sim2real pipeline.\n"
+                    "Writes setup_config.json + run_metadata.json. Idempotent.\n"
+                    "Cluster-side provisioning lives in `cluster.py provision`.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Environment variables (alternatives to --flags):
-  NAMESPACE, HF_TOKEN, REGISTRY_USER, REGISTRY_TOKEN, GITHUB_TOKEN
+  REGISTRY_USER, REGISTRY_TOKEN, ORCHESTRATOR_IMAGE
 
 Examples:
-  python pipeline/setup.py                         # fully interactive
-  python pipeline/setup.py --namespace my-ns \\
-    --hf-token hf_xxx --registry quay.io/me       # pre-fill common values
-  python pipeline/setup.py --no-cluster            # local config only, no kubectl
-  python pipeline/setup.py --redeploy-tasks --namespace my-ns
+  python pipeline/setup.py --registry quay.io/me
+  python pipeline/setup.py --test-push --registry quay.io/me \\
+    --registry-user u --registry-token t
 """,
     )
-    p.add_argument("--namespace",      metavar="NS",    help="Kubernetes namespace")
-    p.add_argument("--namespaces",     metavar="NS1,NS2,...",
-                                       help="Comma-separated list of namespaces to provision (overrides --namespace)")
-    p.add_argument("--hf-token",       metavar="TOKEN", help="HuggingFace API token")
-    p.add_argument("--github-token",   metavar="TOKEN", help="GitHub token for private repo access")
     p.add_argument("--registry",       metavar="REG",   help="Container registry host (e.g. quay.io/username)")
     p.add_argument("--repo-name",      metavar="NAME",  default=None,
                                                         help="Registry repository name [llm-d-inference-scheduler]")
-    p.add_argument("--registry-user",  metavar="USER",  help="Registry username")
-    p.add_argument("--registry-token", metavar="TOKEN", help="Registry token")
-    p.add_argument("--storage-class",  metavar="SC",    help="PVC storageClassName (default: cluster default)")
+    p.add_argument("--registry-user",  metavar="USER",  help="Registry username (used by --test-push)")
+    p.add_argument("--registry-token", metavar="TOKEN", help="Registry token (used by --test-push)")
     p.add_argument("--run",            metavar="NAME",  help="Run name [sim2real-YYYY-MM-DD]")
     p.add_argument("--experiment-root", metavar="PATH", dest="experiment_root",
-                   help="Root of the experiment repo (default: framework directory)")
-    p.add_argument("--no-cluster",      action="store_true",
-                                       help="Skip all kubectl/tkn steps (config + JSON output only)")
+                   help="Root of the experiment repo (default: current working directory)")
     p.add_argument("--pipeline-yaml",  metavar="PATH",
                                        help="Path to Tekton Pipeline YAML to apply "
                                             "(default: <repo-root>/pipeline/pipeline.yaml)")
-    p.add_argument("--redeploy-tasks", action="store_true",
-                                       help="Re-apply Tekton step/task YAMLs only (requires --namespace)")
     p.add_argument("--test-push",      action="store_true",
                                        help="Auto-accept test push prompt")
     p.add_argument("--test-push-tag",  metavar="TAG",   default="_test-image-push",
@@ -129,7 +115,6 @@ def prompt_secret(message: str, env_var: str = "") -> str:
     hint = f"  (or type an env var name, e.g. {env_var})" if env_var else ""
     print(hint)
     raw = getpass.getpass(f"{message}: ")
-    # If input looks like an env var name, try resolving it
     if re.match(r'^[A-Z][A-Z0-9_]{1,}$', raw):
         resolved = os.environ.get(raw, "")
         if resolved:
@@ -144,13 +129,6 @@ def prompt_secret(message: str, env_var: str = "") -> str:
 def _detect_container_runtime() -> str:
     """Auto-detect podman or docker. Returns empty string if neither found."""
     return next((rt for rt in ["podman", "docker"] if which(rt)), "")
-
-
-def _resolve_storage_class(args: argparse.Namespace) -> str:
-    """Resolve storage class: flag overrides; otherwise leave empty so the
-    cluster's default StorageClass applies (annotation
-    `storageclass.kubernetes.io/is-default-class: "true"`)."""
-    return args.storage_class or ""
 
 
 def _resolve_run_name(args: argparse.Namespace) -> tuple[str, Path]:
@@ -174,125 +152,35 @@ def _resolve_run_name(args: argparse.Namespace) -> tuple[str, Path]:
     return run_name, run_dir
 
 
-def detect_openshift() -> bool:
-    if not which("oc"):
-        return False
-    return run(["oc", "whoami"], check=False, capture=True).returncode == 0
-
-
-def check_cluster_reachable() -> None:
-    """Verify the cluster is reachable before running any kubectl commands. Exits with a
-    friendly message on common connectivity failures."""
-    result = run(["kubectl", "cluster-info"], check=False, capture=True)
-    if result.returncode == 0:
-        return
-
-    combined = (result.stdout + result.stderr).lower()
-
-    # A `forbidden` reply proves the API server responded and we're authenticated;
-    # the user just lacks permission for whatever cluster-info probed (e.g. listing
-    # services in kube-system). Treat as reachable.
-    if "forbidden" in combined:
-        return
-
-    # Classify the failure and give an actionable suggestion
-    if "no such host" in combined or "name resolution" in combined or "lookup" in combined:
-        reason = "DNS resolution failed — the cluster hostname is not reachable."
-        hint   = "Check your VPN, network connection, or kubeconfig server address."
-    elif "connection refused" in combined:
-        reason = "Connection refused — nothing is listening on the cluster API endpoint."
-        hint   = "Ensure the cluster is running and the API server port is accessible."
-    elif "i/o timeout" in combined or "timeout" in combined:
-        reason = "Connection timed out — the cluster API server did not respond."
-        hint   = "Check your VPN or firewall; the cluster may be stopped or unreachable."
-    elif "unauthorized" in combined:
-        reason = "Authentication failed — your credentials or kubeconfig may be expired."
-        hint   = "Try: kubectl config view  or re-run your cluster login command."
-    elif "no configuration" in combined or "no such file" in combined:
-        reason = "No kubeconfig found — kubectl has no cluster to connect to."
-        hint   = "Set KUBECONFIG or run your cluster login command first."
-    else:
-        reason = "kubectl cluster-info failed."
-        hint   = result.stderr.strip() or result.stdout.strip()
-
-    err(f"Cluster unreachable: {reason}")
-    print(f"  → {hint}")
-    print()
-    print("  If you meant to run without a cluster, re-run with --no-cluster.")
-    sys.exit(1)
-
-
-def secret_exists(name: str, namespace: str) -> bool:
-    """Return True if the named Kubernetes secret exists in the namespace."""
-    return run(["kubectl", "get", "secret", name, f"-n={namespace}"],
-               check=False, capture=True).returncode == 0
-
 # ── Step 1: Configuration ────────────────────────────────────────────
 
 def collect_config(args: argparse.Namespace) -> tuple[SetupConfig, Path, str]:
-    """Step 1: Collect all config upfront. Returns (config, run_dir, container_runtime).
+    """Step 1: Collect operator-side config. Returns (config, run_dir, container_runtime)."""
+    step(1, 3, "Configuration")
 
-    Three modes:
-    - Fresh install (no setup_config.json): prompt for each value
-    - Reuse (existing setup_config.json): show current values as defaults
-    - Fully scripted (all flags): no prompts
-    """
-    step(1, 8, "Configuration")
-
-    # Load prior config for defaults
     config_path = EXPERIMENT_ROOT / "workspace" / "setup_config.json"
     defaults = json.loads(config_path.read_text()) if config_path.exists() else {}
     if defaults:
         info("Loading defaults from previous setup_config.json")
 
-    # Resolve namespace list
-    namespaces_raw = args.namespaces or os.environ.get("NAMESPACES", "")
-    if namespaces_raw:
-        namespaces = [n.strip() for n in namespaces_raw.split(",") if n.strip()]
-        if not namespaces:
-            err("--namespaces produced an empty list"); sys.exit(1)
-        namespace = namespaces[0]
-    else:
-        ns_default = defaults.get("namespace", "sim2real-" + os.environ.get("USER", "dev"))
-        ns_input = args.namespace or prompt("namespace",
-                                            "Kubernetes namespace(s) (comma-separated for multiple)",
-                                            default=ns_default, env_var="NAMESPACE")
-        if not ns_input:
-            err("NAMESPACE is required"); sys.exit(1)
-        namespaces = [n.strip() for n in ns_input.split(",") if n.strip()]
-        namespace = namespaces[0]
-
-    # Registry
     reg_default = defaults.get("registry", "")
     registry = args.registry or prompt("registry",
         "Container registry (e.g. quay.io/username)", default=reg_default)
 
-    # Repo name (argparse default is None so we can detect "not passed")
     repo_default = defaults.get("repo_name", "llm-d-inference-scheduler")
     if args.repo_name is not None:
         repo_name = args.repo_name
     else:
         repo_name = prompt("repo_name", "Registry repo name", default=repo_default)
 
-    # Detect OpenShift early (feeds storage class + RBAC)
-    is_openshift = detect_openshift()
-
-    # Storage class
-    storage_class = _resolve_storage_class(args)
-
-    # Run name + directory
     run_name, run_dir = _resolve_run_name(args)
 
-    # HuggingFace token — empty string means "reuse existing secret" (checked in step_secrets)
-    hf_token = args.hf_token or prompt_secret("HuggingFace token", env_var="HF_TOKEN")
-
-    # GitHub token — used by install-llmdbenchmark to clone repos
-    gh_token = args.github_token or os.environ.get("GITHUB_TOKEN", "")
-
-    # Registry credentials — resolve from args > env > ghcr.io fallback > prompt
-    docker_server = registry.split("/")[0] if registry else ""
+    # Registry credentials are workspace-scoped (used by step_test_push). The
+    # in-cluster registry-secret is created by cluster.py provision, which
+    # collects credentials independently — see #435 for the dedup plan.
     reg_user = args.registry_user or os.environ.get("REGISTRY_USER", "")
     reg_token = args.registry_token or os.environ.get("REGISTRY_TOKEN", "")
+    docker_server = registry.split("/")[0] if registry else ""
     if not reg_user and not reg_token and docker_server == "ghcr.io":
         github_token = os.environ.get("GITHUB_TOKEN", "")
         if github_token:
@@ -305,10 +193,8 @@ def collect_config(args: argparse.Namespace) -> tuple[SetupConfig, Path, str]:
     if registry and reg_user and not reg_token:
         reg_token = prompt_secret("Registry token", env_var="REGISTRY_TOKEN")
 
-    # Auto-detect container runtime (not prompted)
     container_rt = _detect_container_runtime()
 
-    # Orchestrator image — only required for --remote
     _orch_default = (
         defaults.get("orchestrator_image", "")
         or "ghcr.io/inference-sim/sim2real/orchestrator:latest"
@@ -321,214 +207,16 @@ def collect_config(args: argparse.Namespace) -> tuple[SetupConfig, Path, str]:
     )
 
     cfg = SetupConfig(
-        namespace=namespace, namespaces=namespaces, registry=registry, repo_name=repo_name,
-        run_name=run_name, hf_token=hf_token, github_token=gh_token,
+        registry=registry, repo_name=repo_name,
+        run_name=run_name,
         registry_user=reg_user, registry_token=reg_token,
-        storage_class=storage_class, is_openshift=is_openshift,
-        no_cluster=args.no_cluster,
         pipeline_yaml=args.pipeline_yaml,
         orchestrator_image=orchestrator_image,
     )
-    ns_display = ",".join(namespaces) if len(namespaces) > 1 else namespace
-    ok(f"Configuration complete (namespace={ns_display}, registry={registry or '(none)'})")
+    ok(f"Configuration complete (registry={registry or '(none)'})")
     return cfg, run_dir, container_rt
 
-# ── Step 2: Namespace ────────────────────────────────────────────────
-
-def step_namespace(cfg: SetupConfig) -> None:
-    """Step 2: Create/verify namespace, set kubectl context."""
-    step(2, 8, "Namespace")
-    if cfg.no_cluster:
-        ok(f"Namespace {cfg.namespace} (skipped — --no-cluster)"); return
-
-    check_cluster_reachable()
-    if cfg.is_openshift:
-        exists = run(["oc", "get", "project", cfg.namespace],
-                     check=False, capture=True).returncode == 0
-    else:
-        exists = run(["kubectl", "get", "ns", cfg.namespace],
-                     check=False, capture=True).returncode == 0
-    if exists:
-        ok(f"Namespace {cfg.namespace} already exists")
-    else:
-        if cfg.is_openshift:
-            proc = run(["oc", "new-project", cfg.namespace], check=False, capture=True)
-            if proc.returncode != 0 and "AlreadyExists" not in (proc.stderr or ""):
-                proc.check_returncode()
-        else:
-            run(["kubectl", "create", "ns", cfg.namespace])
-        ok(f"Namespace {cfg.namespace} ready")
-
-    result = run(["kubectl", "config", "set-context", "--current",
-                  f"--namespace={cfg.namespace}"], check=False, capture=True)
-    if result.returncode == 0:
-        ok(f"kubectl context set to namespace {cfg.namespace}")
-    else:
-        warn("Could not set kubectl context namespace")
-
-# ── Step 3: RBAC ─────────────────────────────────────────────────────
-
-def step_rbac(cfg: SetupConfig) -> None:
-    """Step 3: Apply RBAC bundles for the helm-installer and sim2real-runner SAs.
-
-    Each SA has a namespaced base (always required) and an optional cluster
-    augment (best-effort). On a kubectl Forbidden reply that specifically
-    targets cluster-scoped RBAC resources (ClusterRole/ClusterRoleBinding),
-    a best-effort file is skipped with a warn and the run continues. Any
-    other failure (network, malformed YAML, SCC/webhook/quota denial
-    unrelated to cluster-scoped RBAC) still aborts the run.
-
-    SCC RoleBindings (restricted, anyuid, privileged) ride along in the
-    namespaced bases — no imperative `oc adm policy add-scc-to-user` calls.
-
-    Degradations when a cluster augment is skipped:
-      - tektonc roles-cluster.yaml: llm-d-benchmark node auto-discovery is
-        unavailable; cross-ns DCGM exec for stream-gpu-stats Phase 2/2.5/3
-        is skipped. Admin-only stack installs are already gated by the
-        install task's `--non-admin` flag (set by llmdbenchmark-standup).
-      - sim2real-runner-cluster.yaml: orchestrator GPU capacity probe
-        (kubectl get nodes/pods) fails; the probe-failure branch of
-        deploy.py's dispatch loop falls through to ungated dispatch with
-        a rate-limited warn.
-    """
-    step(3, 8, "RBAC")
-    if cfg.no_cluster:
-        ok("RBAC (skipped — --no-cluster)"); return
-
-    primary_ns = cfg.namespaces[0]
-    env = {**os.environ, "NAMESPACE": cfg.namespace, "PRIMARY_NAMESPACE": primary_ns}
-    yaml_paths = [
-        (TEKTONC_DIR / "tekton" / "roles-ns.yaml",                          True),
-        (TEKTONC_DIR / "tekton" / "roles-cluster.yaml",                     False),
-        (TEKTONC_DIR / "tekton" / "rbac" / "sim2real-runner.yaml",          True),
-        (REPO_ROOT / "pipeline" / "rbac" / "sim2real-runner-ns.yaml",       True),
-        (REPO_ROOT / "pipeline" / "rbac" / "sim2real-runner-cluster.yaml",  False),
-    ]
-    for yaml_path, required in yaml_paths:
-        if not yaml_path.exists():
-            err(f"{yaml_path.name} not found at {yaml_path} — did submodule init fail?"); sys.exit(1)
-        subst = subprocess.run(
-            ["envsubst", "$NAMESPACE $PRIMARY_NAMESPACE"],
-            input=yaml_path.read_text(), capture_output=True, text=True, env=env, check=True,
-        )
-        result = run(["kubectl", "apply", "-f", "-"], input=subst.stdout,
-                     check=False, capture=True)
-        if result.stdout: print(result.stdout, end="")
-        if result.returncode == 0:
-            continue
-        combined = (result.stdout + result.stderr).lower()
-        # Narrow predicate: only skip when the failure is a Forbidden on
-        # cluster-scoped RBAC resources (clusterrole/clusterrolebinding).
-        # Other Forbidden reasons (SCC admission, webhook denials, quota
-        # exhaustion) signal that the operator's intent isn't being met
-        # and the run should abort.
-        is_cluster_rbac_forbidden = (
-            not required
-            and "forbidden" in combined
-            and "clusterrole" in combined
-        )
-        if result.stderr: print(result.stderr, end="", file=sys.stderr)
-        if is_cluster_rbac_forbidden:
-            warn(f"Skipped {yaml_path.name} — user lacks cluster-scoped RBAC. "
-                 "Downstream features that depend on this augment will degrade; "
-                 "see step_rbac docstring for the catalog.")
-            continue
-        err(f"kubectl apply failed for {yaml_path.name} "
-            f"(exit {result.returncode}) — RBAC setup aborted")
-        sys.exit(result.returncode)
-
-    ok("RBAC roles applied")
-
-# ── Step 4: Secrets ──────────────────────────────────────────────────
-
-def step_secrets(cfg: SetupConfig, container_rt: str) -> None:
-    """Step 4: Create/update hf-secret and registry-secret."""
-    step(4, 8, "Secrets")
-    if cfg.no_cluster:
-        ok("Secrets (skipped — --no-cluster)"); return
-
-    hf_secret_name = _DEFAULT_HF_SECRET_NAME
-
-    if not cfg.hf_token and secret_exists(hf_secret_name, cfg.namespace):
-        ok(f"{hf_secret_name} already exists (reusing)")
-    elif not cfg.hf_token:
-        err(f"HF_TOKEN is required and {hf_secret_name} does not exist in namespace"); sys.exit(1)
-    else:
-        yaml_out = run(
-            ["kubectl", "create", "secret", "generic", hf_secret_name,
-             f"--namespace={cfg.namespace}",
-             f"--from-literal=HF_TOKEN={cfg.hf_token}",
-             "--dry-run=client", "-o", "yaml"],
-            capture=True,
-        ).stdout
-        run(["kubectl", "apply", "-f", "-"], input=yaml_out)
-        ok(f"{hf_secret_name} created/updated")
-
-    # github-token — used by install-llmdbenchmark to clone private repos
-    github_token = cfg.github_token
-    if not github_token and secret_exists("github-token", cfg.namespace):
-        ok("github-token already exists (reusing)")
-    elif not github_token:
-        warn("GITHUB_TOKEN not set and github-token secret does not exist — "
-             "install-llmdbenchmark will fail if repo requires auth")
-    else:
-        yaml_out = run(
-            ["kubectl", "create", "secret", "generic", "github-token",
-             f"--namespace={cfg.namespace}",
-             f"--from-literal=token={github_token}",
-             "--dry-run=client", "-o", "yaml"],
-            capture=True,
-        ).stdout
-        run(["kubectl", "apply", "-f", "-"], input=yaml_out)
-        ok("github-token created/updated")
-
-    # registry-secret
-    if not cfg.registry:
-        warn("No registry — skipping registry-secret"); return
-
-    docker_server = cfg.registry.split("/")[0]
-    if cfg.registry_user and cfg.registry_token:
-        yaml_out = run(
-            ["kubectl", "create", "secret", "docker-registry", "registry-secret",
-             f"--namespace={cfg.namespace}",
-             f"--docker-server={docker_server}",
-             f"--docker-username={cfg.registry_user}",
-             f"--docker-password={cfg.registry_token}",
-             "--dry-run=client", "-o", "yaml"],
-            capture=True,
-        ).stdout
-        run(["kubectl", "apply", "-f", "-"], input=yaml_out)
-        ok("registry-secret created/updated")
-    else:
-        if not container_rt:
-            warn("No container runtime and no registry credentials — skipping registry-secret")
-            return
-        info(f"Falling back to container runtime login ({container_rt})...")
-        result = run([container_rt, "login", docker_server], check=False)
-        if result.returncode != 0:
-            err("Registry login failed. Provide --registry-user and --registry-token.")
-            sys.exit(1)
-        config_candidates = [
-            Path.home() / ".docker" / "config.json",
-            Path.home() / ".config" / "containers" / "auth.json",
-            Path(os.environ.get("XDG_RUNTIME_DIR", "/tmp")) / "containers" / "auth.json",
-        ]
-        config_path = next((p for p in config_candidates if p.exists()), None)
-        if not config_path:
-            err("Could not locate docker config after login. "
-                "Provide --registry-user and --registry-token.")
-            sys.exit(1)
-        yaml_out = run(
-            ["kubectl", "create", "secret", "docker-registry", "registry-secret",
-             f"--namespace={cfg.namespace}",
-             f"--from-file=.dockerconfigjson={config_path}",
-             "--dry-run=client", "-o", "yaml"],
-            capture=True,
-        ).stdout
-        run(["kubectl", "apply", "-f", "-"], input=yaml_out)
-        ok("registry-secret created/updated from container login")
-
-# ── Step 5: Registry Credential Test ─────────────────────────────────
+# ── Step 2: Registry credential test ─────────────────────────────────
 
 def _do_test_push(container_rt: str, full_image: str, docker_server: str,
                   reg_user: str, reg_token: str) -> bool:
@@ -573,10 +261,8 @@ def _do_test_push(container_rt: str, full_image: str, docker_server: str,
 
 def step_test_push(cfg: SetupConfig, container_rt: str, test_push_tag: str,
                    auto_push: bool) -> None:
-    """Step 5: Optional registry credential test with retry on failure."""
-    step(5, 8, "Registry Credential Test")
-    if cfg.no_cluster:
-        ok("Registry test (skipped — --no-cluster)"); return
+    """Step 2: Optional registry credential test with retry on failure."""
+    step(2, 3, "Registry Credential Test")
     if not cfg.registry:
         ok("Registry test (skipped — no registry configured)"); return
     if not container_rt:
@@ -616,93 +302,17 @@ def step_test_push(cfg: SetupConfig, container_rt: str, test_push_tag: str,
         else:
             sys.exit(1)
 
-# ── Step 6: PVCs ─────────────────────────────────────────────────────
+# ── Step 3: Config Output ────────────────────────────────────────────
 
-def step_pvcs(cfg: SetupConfig) -> None:
-    """Step 6: Create PVCs for data and source."""
-    step(6, 8, "PVCs")
-    pvcs = [("data-pvc", "50Gi"), ("source-pvc", "50Gi")]
-    sc_line = f"  storageClassName: {cfg.storage_class}" if cfg.storage_class else ""
+def step_config_output(cfg: SetupConfig, run_dir: Path) -> None:
+    """Step 3: Write setup_config.json and run_metadata.json.
 
-    for name, size in pvcs:
-        if cfg.no_cluster:
-            ok(f"PVC {name} (skipped — --no-cluster)"); continue
-        if run(["kubectl", "get", "pvc", name, f"-n={cfg.namespace}"],
-               check=False, capture=True).returncode == 0:
-            ok(f"PVC {name} already exists"); continue
-        manifest = (
-            f"apiVersion: v1\nkind: PersistentVolumeClaim\n"
-            f"metadata:\n  name: {name}\n  namespace: {cfg.namespace}\n"
-            f"spec:\n{sc_line}\n  accessModes:\n    - ReadWriteMany\n"
-            f"  resources:\n    requests:\n      storage: {size}\n"
-        )
-        run(["kubectl", "apply", "-f", "-"], input=manifest)
-        ok(f"Created PVC {name} ({size})")
-
-    if not cfg.no_cluster:
-        info("Waiting for PVCs to bind (timeout 120s)...")
-        for name, _ in pvcs:
-            result = run(
-                ["kubectl", "wait", "--for=jsonpath={.status.phase}=Bound",
-                 f"pvc/{name}", f"-n={cfg.namespace}", "--timeout=120s"],
-                check=False, capture=True,
-            )
-            if result.returncode == 0:
-                ok(f"PVC {name} is Bound")
-            else:
-                warn(f"PVC {name} not yet Bound after 120s — check storageClass: "
-                     f"{cfg.storage_class or '(cluster default)'}. "
-                     f"If the cluster has no default StorageClass, or the default "
-                     f"is unsuitable, re-run setup.py with --storage-class <name>. "
-                     f"Available classes: kubectl get storageclass")
-
-# ── Step 7: Tekton ───────────────────────────────────────────────────
-
-def step_tekton(cfg: SetupConfig) -> None:
-    """Step 7: Verify Tekton operator and deploy steps/tasks + Pipeline."""
-    step(7, 8, "Tekton")
-    if cfg.no_cluster:
-        ok("Tekton (skipped — --no-cluster)"); return
-
-    # Soft verification — warn only
-    result = run(["kubectl", "get", "pods", "-n", "tekton-pipelines", "--no-headers"],
-                 check=False, capture=True)
-    if result.returncode == 0 and "Running" in result.stdout:
-        ok("Tekton operator is running")
-    else:
-        warn("Tekton operator not detected — install: "
-             "https://tekton.dev/docs/installation/pipelines/")
-
-    # Deploy steps and tasks
-    for subdir in ["steps", "tasks"]:
-        tekton_dir = TEKTONC_DIR / "tekton" / subdir
-        if not tekton_dir.exists():
-            warn(f"{tekton_dir} not found — skipping"); continue
-        for yaml_file in sorted(tekton_dir.glob("*.yaml")):
-            run(["kubectl", "apply", "-f", str(yaml_file), f"-n={cfg.namespace}"])
-    ok("Tekton steps and tasks deployed")
-
-    # Deploy Pipeline YAML
-    pipeline_path = Path(cfg.pipeline_yaml) if cfg.pipeline_yaml else REPO_ROOT / "pipeline" / "pipeline.yaml"
-    if not pipeline_path.exists():
-        if cfg.pipeline_yaml:
-            warn(f"Custom pipeline YAML not found at {pipeline_path} — skipping")
-        else:
-            err(f"Pipeline YAML not found at {pipeline_path}")
-            sys.exit(1)
-    else:
-        r = run(["kubectl", "apply", "-f", str(pipeline_path), f"-n={cfg.namespace}"],
-                check=False, capture=True)
-        if r.returncode == 0:
-            ok(f"Pipeline applied from {pipeline_path}")
-        else:
-            warn(f"Failed to apply Pipeline to {cfg.namespace}: {r.stderr.strip()}")
-
-# ── Step 8: Config Output ────────────────────────────────────────────
-
-def step_config_output(cfg: SetupConfig, run_dir: Path, container_rt: str) -> None:
-    """Step 8: Write setup_config.json and run_metadata.json."""
-    step(8, 8, "Config")
+    Both files are read-modify-write. setup_config.json now preserves keys
+    this script doesn't own (e.g. future cluster_id pointer or any other
+    writer's field). run_metadata.json preserves deploy-owned keys
+    (source_hashes, epp_image, stages.deploy.last_completed_step). See #365.
+    """
+    step(3, 3, "Config")
 
     workspace = EXPERIMENT_ROOT / "workspace"
     workspace.mkdir(parents=True, exist_ok=True)
@@ -713,30 +323,27 @@ def step_config_output(cfg: SetupConfig, run_dir: Path, container_rt: str) -> No
         capture_output=True, text=True, check=False,
     ).stdout.strip() or "unknown"
 
-    # setup_config.json
-    setup_config = {
-        "namespace": cfg.namespace,
-        "namespaces": cfg.namespaces,
+    # setup_config.json — operator-side fields only. Cluster-side fields
+    # (namespace[s], is_openshift, storage_class, hf_secret_name, workspaces)
+    # live in workspace/clusters/<id>/cluster_config.json, written by
+    # `cluster.py provision`.
+    setup_config_path = workspace / "setup_config.json"
+    existing_setup = {}
+    if setup_config_path.exists():
+        try:
+            existing_setup = json.loads(setup_config_path.read_text())
+        except json.JSONDecodeError:
+            existing_setup = {}
+    existing_setup.update({
         "registry": cfg.registry,
         "repo_name": cfg.repo_name,
-        "storage_class": cfg.storage_class,
-        "is_openshift": cfg.is_openshift,
-        "tektonc_dir": str(TEKTONC_DIR),
         "sim2real_root": str(REPO_ROOT),
         "pipeline_yaml": cfg.pipeline_yaml,
         "orchestrator_image": cfg.orchestrator_image,
-        "container_runtime": container_rt,
         "current_run": cfg.run_name,
-        "setup_timestamp": now_iso,
-        "hf_secret_name": _DEFAULT_HF_SECRET_NAME,
-        "workspaces": {
-            "data-storage":   {"persistentVolumeClaim": {"claimName": "data-pvc"}},
-            "source":         {"persistentVolumeClaim": {"claimName": "source-pvc"}},
-        },
-    }
-    setup_path = workspace / "setup_config.json"
-    setup_path.write_text(json.dumps(setup_config, indent=2))
-    ok(f"Setup config → {setup_path}")
+    })
+    setup_config_path.write_text(json.dumps(existing_setup, indent=2))
+    ok(f"Setup config → {setup_config_path}")
 
     # run_metadata.json — read-modify-write so deploy-owned keys
     # (source_hashes, epp_image, stages.deploy.last_completed_step) survive
@@ -752,12 +359,8 @@ def step_config_output(cfg: SetupConfig, run_dir: Path, container_rt: str) -> No
 
     existing.update({
         "version": 1,
-        "namespace": cfg.namespace,
         "registry": cfg.registry,
         "repo_name": cfg.repo_name,
-        "storage_class": cfg.storage_class,
-        "is_openshift": cfg.is_openshift,
-        "container_runtime": container_rt,
         "created_at": now_iso,
         "pipeline_commit": commit,
     })
@@ -768,8 +371,7 @@ def step_config_output(cfg: SetupConfig, run_dir: Path, container_rt: str) -> No
     stages["setup"] = {
         "status": "completed",
         "completed_at": now_iso,
-        "summary": f"Namespace {cfg.namespace} configured, "
-                   f"PVCs created, Tekton tasks deployed",
+        "summary": "Workspace config written",
     }
     stages.setdefault("prepare", {"status": "pending"})
     stages.setdefault("deploy",  {"status": "pending"})
@@ -787,66 +389,9 @@ def main() -> int:
     global EXPERIMENT_ROOT
     EXPERIMENT_ROOT = Path(args.experiment_root).resolve() if getattr(args, "experiment_root", None) else Path.cwd()
 
-    # --redeploy-tasks shortcut
-    if args.redeploy_tasks:
-        if not args.namespace:
-            err("--namespace is required with --redeploy-tasks"); return 1
-        # Minimal step 7 only
-        step(7, 8, "Tekton (redeploy)")
-        for subdir in ["steps", "tasks"]:
-            tekton_dir = TEKTONC_DIR / "tekton" / subdir
-            if not tekton_dir.exists():
-                warn(f"{tekton_dir} not found — skipping"); continue
-            for yaml_file in sorted(tekton_dir.glob("*.yaml")):
-                run(["kubectl", "apply", "-f", str(yaml_file), f"-n={args.namespace}"])
-        ok("Tekton steps and tasks redeployed")
-        # Also redeploy Pipeline YAML
-        pipeline_path = Path(args.pipeline_yaml) if args.pipeline_yaml else REPO_ROOT / "pipeline" / "pipeline.yaml"
-        if not pipeline_path.exists():
-            if args.pipeline_yaml:
-                warn(f"Custom pipeline YAML not found at {pipeline_path} — skipping")
-            else:
-                err(f"Pipeline YAML not found at {pipeline_path}")
-                return 1
-        else:
-            r = run(["kubectl", "apply", "-f", str(pipeline_path), f"-n={args.namespace}"],
-                    check=False, capture=True)
-            if r.returncode == 0:
-                ok(f"Pipeline redeployed from {pipeline_path}")
-            else:
-                err(f"Failed to apply Pipeline: {r.stderr.strip()}")
-                return 1
-        return 0
-
-    # 8-step flow
     cfg, run_dir, container_rt = collect_config(args)
-
     step_test_push(cfg, container_rt, args.test_push_tag, args.test_push)
-    for ns in cfg.namespaces:
-        ns_cfg = SetupConfig(
-            namespace=ns,
-            namespaces=cfg.namespaces,
-            registry=cfg.registry,
-            repo_name=cfg.repo_name,
-            run_name=cfg.run_name,
-            hf_token=cfg.hf_token,
-            github_token=cfg.github_token,
-            registry_user=cfg.registry_user,
-            registry_token=cfg.registry_token,
-            storage_class=cfg.storage_class,
-            is_openshift=cfg.is_openshift,
-            no_cluster=cfg.no_cluster,
-            pipeline_yaml=cfg.pipeline_yaml,
-            orchestrator_image=cfg.orchestrator_image,
-        )
-        if len(cfg.namespaces) > 1:
-            print(_c("36", f"\n  ── Provisioning namespace: {ns} ──"))
-        step_namespace(ns_cfg)
-        step_rbac(ns_cfg)
-        step_secrets(ns_cfg, container_rt)
-        step_pvcs(ns_cfg)
-        step_tekton(ns_cfg)
-    step_config_output(cfg, run_dir, container_rt)
+    step_config_output(cfg, run_dir)
 
     # Completion
     print()
@@ -858,8 +403,9 @@ def main() -> int:
     print(f"Run directory: {run_dir}")
     print()
     print("Next steps:")
-    print("  1. Edit <experiment-root>/transfer.yaml (algorithm source, workloads, context)")
-    print("  2. Run: python <repo-root>/pipeline/prepare.py")
+    print("  1. Provision cluster: python pipeline/cluster.py provision <cluster_id> --namespaces NS1[,NS2,...]")
+    print("  2. Edit <experiment-root>/transfer.yaml (algorithm source, workloads, context)")
+    print("  3. Run: python pipeline/prepare.py")
     return 0
 
 if __name__ == "__main__":

--- a/pipeline/tests/test_setup_pipeline.py
+++ b/pipeline/tests/test_setup_pipeline.py
@@ -1,265 +1,77 @@
-"""Tests for setup.py Pipeline YAML application in step_tekton."""
+"""Tests for the trimmed setup.py (workspace config writer).
+
+Cluster-side responsibilities (namespace, RBAC, secrets, PVCs, Tekton) moved
+to pipeline/cluster.py + pipeline/lib/cluster_ops.py — see issue #424 and
+the epic #416 design. Tests for those primitives live in
+pipeline/tests/test_cluster_ops.py and pipeline/tests/test_cluster_py.py.
+"""
 import json
-from unittest.mock import patch
+import pytest
 
 
 def _make_config(**overrides):
     """Build a minimal SetupConfig with defaults for testing."""
     from pipeline.setup import SetupConfig
     defaults = dict(
-        namespace="test-ns",
-        namespaces=["test-ns"],
         registry="quay.io/test",
         repo_name="llm-d-inference-scheduler",
         run_name="test-run",
-        hf_token="hf_xxx",
-        github_token="gh_xxx",
         registry_user="user",
         registry_token="token",
-        storage_class="standard",
-        is_openshift=False,
-        no_cluster=False,
         pipeline_yaml=None,
     )
     defaults.update(overrides)
     return SetupConfig(**defaults)
 
 
-class TestStepTektonPipelineApply:
-    """step_tekton applies Pipeline YAML to namespace."""
-
-    @patch("pipeline.setup.run")
-    def test_applies_default_pipeline_yaml(self, mock_run, tmp_path):
-        """step_tekton applies pipeline/pipeline.yaml (default) after steps/tasks."""
-        from pipeline.setup import step_tekton, REPO_ROOT
-
-        cfg = _make_config()
-        mock_run.return_value.returncode = 0
-        mock_run.return_value.stdout = "pod Running"
-        mock_run.return_value.stderr = ""
-
-        step_tekton(cfg)
-
-        # Find the call that applies the pipeline YAML (with check=False, capture=True)
-        default_pipeline_path = REPO_ROOT / "pipeline" / "pipeline.yaml"
-        pipeline_calls = [c for c in mock_run.call_args_list
-                          if str(default_pipeline_path) in str(c) and "apply" in str(c)]
-        assert len(pipeline_calls) == 1
-
-    @patch("pipeline.setup.run")
-    def test_applies_custom_pipeline_yaml(self, mock_run, tmp_path):
-        """step_tekton uses custom pipeline_yaml path when set on config."""
-        from pipeline.setup import step_tekton
-
-        custom_path = str(tmp_path / "custom-pipeline.yaml")
-        (tmp_path / "custom-pipeline.yaml").write_text("apiVersion: tekton.dev/v1\n")
-        cfg = _make_config(pipeline_yaml=custom_path)
-
-        mock_run.return_value.returncode = 0
-        mock_run.return_value.stdout = "pod Running"
-        mock_run.return_value.stderr = ""
-
-        step_tekton(cfg)
-
-        pipeline_calls = [c for c in mock_run.call_args_list
-                          if custom_path in str(c) and "apply" in str(c)]
-        assert len(pipeline_calls) == 1
-
-    @patch("pipeline.setup.run")
-    def test_skipped_when_no_cluster(self, mock_run):
-        """step_tekton is skipped entirely when no_cluster=True."""
-        from pipeline.setup import step_tekton
-
-        cfg = _make_config(no_cluster=True)
-        step_tekton(cfg)
-
-        # run() should not be called at all
-        mock_run.assert_not_called()
-
-    @patch("pipeline.setup.run")
-    def test_warns_if_custom_pipeline_yaml_missing(self, mock_run, tmp_path, capsys):
-        """step_tekton warns (not errors) if custom pipeline YAML doesn't exist."""
-        from pipeline.setup import step_tekton
-
-        nonexistent = str(tmp_path / "does-not-exist.yaml")
-        cfg = _make_config(pipeline_yaml=nonexistent)
-
-        mock_run.return_value.returncode = 0
-        mock_run.return_value.stdout = "pod Running"
-
-        # Should not raise — custom path warns
-        step_tekton(cfg)
-
-        captured = capsys.readouterr()
-        assert "not found" in captured.out.lower() or "WARN" in captured.out
-
-    @patch("pipeline.setup.run")
-    @patch("pipeline.setup.REPO_ROOT")
-    def test_fatal_if_default_pipeline_yaml_missing(self, mock_root, mock_run, tmp_path):
-        """step_tekton exits fatally if default pipeline/pipeline.yaml is missing."""
-        from pipeline.setup import step_tekton
-
-        # Point REPO_ROOT to a dir without pipeline/pipeline.yaml
-        mock_root.__truediv__ = lambda self, other: tmp_path / other
-        cfg = _make_config(pipeline_yaml=None)
-
-        mock_run.return_value.returncode = 0
-        mock_run.return_value.stdout = "pod Running"
-
-        import pytest
-        with patch("pipeline.setup.REPO_ROOT", tmp_path):
-            with pytest.raises(SystemExit):
-                step_tekton(cfg)
-
-    @patch("pipeline.setup.run")
-    def test_kubectl_apply_failure_warns_and_continues(self, mock_run, tmp_path, capsys):
-        """step_tekton warns (not exits) if kubectl apply for Pipeline fails."""
-        from pipeline.setup import step_tekton, REPO_ROOT
-
-        cfg = _make_config()
-
-        def side_effect(cmd, *, check=True, capture=False, input=None):
-            class R:
-                returncode = 0
-                stdout = "pod Running"
-                stderr = ""
-            r = R()
-            if "pipeline.yaml" in str(cmd):
-                r.returncode = 1
-                r.stderr = "error: RBAC denied"
-            return r
-
-        mock_run.side_effect = side_effect
-
-        pipeline_path = REPO_ROOT / "pipeline" / "pipeline.yaml"
-        if pipeline_path.exists():
-            step_tekton(cfg)
-            captured = capsys.readouterr()
-            assert "Failed to apply Pipeline" in captured.out
-
-
 class TestSetupConfigJson:
-    """setup_config.json includes pipeline_yaml key."""
+    """step_config_output writes the operator-side keys."""
 
-    def test_config_output_includes_pipeline_yaml(self, tmp_path):
-        """step_config_output writes pipeline_yaml to setup_config.json."""
+    def test_writes_kept_keys(self, tmp_path):
         from pipeline.setup import step_config_output
         import pipeline.setup as setup_module
 
-        # Point EXPERIMENT_ROOT to tmp_path
-        original_experiment_root = setup_module.EXPERIMENT_ROOT
+        original = setup_module.EXPERIMENT_ROOT
         setup_module.EXPERIMENT_ROOT = tmp_path
-
         try:
             run_dir = tmp_path / "workspace" / "runs" / "test-run"
             run_dir.mkdir(parents=True)
 
-            cfg = _make_config(pipeline_yaml="/path/to/pipeline.yaml")
-            step_config_output(cfg, run_dir, "podman")
+            cfg = _make_config(pipeline_yaml="/path/to/pipeline.yaml",
+                               orchestrator_image="ghcr.io/x/orch:abc")
+            step_config_output(cfg, run_dir)
 
-            config_path = tmp_path / "workspace" / "setup_config.json"
-            assert config_path.exists()
-            data = json.loads(config_path.read_text())
-            assert "pipeline_yaml" in data
+            data = json.loads((tmp_path / "workspace" / "setup_config.json").read_text())
+            assert data["registry"] == "quay.io/test"
+            assert data["repo_name"] == "llm-d-inference-scheduler"
             assert data["pipeline_yaml"] == "/path/to/pipeline.yaml"
+            assert data["orchestrator_image"] == "ghcr.io/x/orch:abc"
+            assert data["current_run"] == "test-run"
+            assert "sim2real_root" in data
         finally:
-            setup_module.EXPERIMENT_ROOT = original_experiment_root
+            setup_module.EXPERIMENT_ROOT = original
 
-    def test_config_output_pipeline_yaml_none(self, tmp_path):
+    def test_pipeline_yaml_none_persisted(self, tmp_path):
         """When pipeline_yaml is None, key still present with null value."""
         from pipeline.setup import step_config_output
         import pipeline.setup as setup_module
 
-        original_experiment_root = setup_module.EXPERIMENT_ROOT
+        original = setup_module.EXPERIMENT_ROOT
         setup_module.EXPERIMENT_ROOT = tmp_path
-
         try:
             run_dir = tmp_path / "workspace" / "runs" / "test-run"
             run_dir.mkdir(parents=True)
 
-            cfg = _make_config(pipeline_yaml=None)
-            step_config_output(cfg, run_dir, "podman")
+            step_config_output(_make_config(pipeline_yaml=None), run_dir)
 
-            config_path = tmp_path / "workspace" / "setup_config.json"
-            data = json.loads(config_path.read_text())
+            data = json.loads((tmp_path / "workspace" / "setup_config.json").read_text())
             assert "pipeline_yaml" in data
             assert data["pipeline_yaml"] is None
         finally:
-            setup_module.EXPERIMENT_ROOT = original_experiment_root
-
-
-    def test_config_output_includes_hf_secret_name(self, tmp_path):
-        """setup_config.json includes hf_secret_name field."""
-        from pipeline.setup import step_config_output
-        import pipeline.setup as setup_module
-
-        original_experiment_root = setup_module.EXPERIMENT_ROOT
-        setup_module.EXPERIMENT_ROOT = tmp_path
-
-        try:
-            run_dir = tmp_path / "workspace" / "runs" / "test-run"
-            run_dir.mkdir(parents=True)
-
-            cfg = _make_config()
-            step_config_output(cfg, run_dir, "podman")
-
-            config_path = tmp_path / "workspace" / "setup_config.json"
-            data = json.loads(config_path.read_text())
-            assert data["hf_secret_name"] == "hf-secret"
-        finally:
-            setup_module.EXPERIMENT_ROOT = original_experiment_root
-
-
-class TestBuildParser:
-    """build_parser includes --pipeline-yaml flag."""
-
-    def test_pipeline_yaml_flag_exists(self):
-        from pipeline.setup import build_parser
-        parser = build_parser()
-        args = parser.parse_args(["--pipeline-yaml", "/path/to/pipeline.yaml"])
-        assert args.pipeline_yaml == "/path/to/pipeline.yaml"
-
-    def test_pipeline_yaml_defaults_to_none(self):
-        from pipeline.setup import build_parser
-        parser = build_parser()
-        args = parser.parse_args([])
-        assert args.pipeline_yaml is None
-
-    def test_orchestrator_image_flag_exists(self):
-        from pipeline.setup import build_parser
-        parser = build_parser()
-        args = parser.parse_args(["--orchestrator-image", "ghcr.io/inference-sim/sim2real/orchestrator:latest"])
-        assert args.orchestrator_image == "ghcr.io/inference-sim/sim2real/orchestrator:latest"
-
-    def test_orchestrator_image_defaults_to_none(self):
-        from pipeline.setup import build_parser
-        parser = build_parser()
-        args = parser.parse_args([])
-        assert args.orchestrator_image is None
-
-
-class TestOrchestratorImageConfig:
-    """setup_config.json includes orchestrator_image key."""
-
-    def test_config_output_includes_orchestrator_image(self, tmp_path):
-        """step_config_output writes orchestrator_image to setup_config.json."""
-        from pipeline.setup import step_config_output
-        import pipeline.setup as setup_module
-
-        original = setup_module.EXPERIMENT_ROOT
-        setup_module.EXPERIMENT_ROOT = tmp_path
-        try:
-            run_dir = tmp_path / "workspace" / "runs" / "test-run"
-            run_dir.mkdir(parents=True)
-            cfg = _make_config(orchestrator_image="ghcr.io/inference-sim/sim2real/orchestrator:abc123")
-            step_config_output(cfg, run_dir, "podman")
-            data = json.loads((tmp_path / "workspace" / "setup_config.json").read_text())
-            assert data["orchestrator_image"] == "ghcr.io/inference-sim/sim2real/orchestrator:abc123"
-        finally:
             setup_module.EXPERIMENT_ROOT = original
 
-    def test_config_output_orchestrator_image_empty(self, tmp_path):
-        """orchestrator_image written as empty string when not set."""
+    def test_orchestrator_image_empty_default(self, tmp_path):
+        """orchestrator_image written as empty string when not set on cfg."""
         from pipeline.setup import step_config_output
         import pipeline.setup as setup_module
 
@@ -268,72 +80,96 @@ class TestOrchestratorImageConfig:
         try:
             run_dir = tmp_path / "workspace" / "runs" / "test-run"
             run_dir.mkdir(parents=True)
-            cfg = _make_config()
-            step_config_output(cfg, run_dir, "podman")
+            step_config_output(_make_config(), run_dir)
             data = json.loads((tmp_path / "workspace" / "setup_config.json").read_text())
             assert "orchestrator_image" in data
             assert data["orchestrator_image"] == ""
         finally:
             setup_module.EXPERIMENT_ROOT = original
 
+    @pytest.mark.parametrize("removed_key", [
+        "namespace", "namespaces", "is_openshift", "storage_class",
+        "hf_secret_name", "workspaces", "tektonc_dir", "setup_timestamp",
+        "container_runtime",
+    ])
+    def test_removed_keys_absent(self, tmp_path, removed_key):
+        """Cluster-scoped and cruft keys are not written to setup_config.json."""
+        from pipeline.setup import step_config_output
+        import pipeline.setup as setup_module
 
-class TestRedeployTasksPipeline:
-    """--redeploy-tasks also applies Pipeline YAML."""
+        original = setup_module.EXPERIMENT_ROOT
+        setup_module.EXPERIMENT_ROOT = tmp_path
+        try:
+            run_dir = tmp_path / "workspace" / "runs" / "test-run"
+            run_dir.mkdir(parents=True)
+            step_config_output(_make_config(), run_dir)
+            data = json.loads((tmp_path / "workspace" / "setup_config.json").read_text())
+            assert removed_key not in data
+        finally:
+            setup_module.EXPERIMENT_ROOT = original
 
-    @patch("pipeline.setup.run")
-    def test_redeploy_applies_pipeline(self, mock_run, tmp_path):
-        """--redeploy-tasks applies Pipeline alongside steps/tasks."""
-        from pipeline.setup import main, REPO_ROOT
+    def test_preserves_keys_owned_by_other_writers(self, tmp_path):
+        """A pre-existing setup_config.json with foreign keys is preserved
+        on re-run — setup.py only owns the keys it writes."""
+        from pipeline.setup import step_config_output
+        import pipeline.setup as setup_module
 
-        mock_run.return_value.returncode = 0
-        mock_run.return_value.stdout = ""
-        mock_run.return_value.stderr = ""
+        original = setup_module.EXPERIMENT_ROOT
+        setup_module.EXPERIMENT_ROOT = tmp_path
+        try:
+            workspace = tmp_path / "workspace"
+            workspace.mkdir(parents=True)
+            # Simulate a foreign key (e.g. a future cluster_id pointer, or
+            # any other writer's field) already in the file.
+            (workspace / "setup_config.json").write_text(json.dumps({
+                "registry": "old.example/x",
+                "foreign_key": "must-survive",
+            }))
+            run_dir = workspace / "runs" / "test-run"
+            run_dir.mkdir(parents=True)
+            step_config_output(_make_config(), run_dir)
 
-        pipeline_path = REPO_ROOT / "pipeline" / "pipeline.yaml"
-        if not pipeline_path.exists():
-            return  # skip if repo structure doesn't have the file
+            data = json.loads((workspace / "setup_config.json").read_text())
+            assert data["registry"] == "quay.io/test"  # refreshed
+            assert data["foreign_key"] == "must-survive"  # preserved
+        finally:
+            setup_module.EXPERIMENT_ROOT = original
 
-        with patch("sys.argv", ["setup.py", "--redeploy-tasks", "--namespace", "test-ns"]):
-            result = main()
 
-        assert result == 0
-        pipeline_calls = [c for c in mock_run.call_args_list
-                          if "pipeline.yaml" in str(c)]
-        assert len(pipeline_calls) >= 1
+class TestBuildParser:
+    """build_parser surface: kept flags accepted; removed flags raise."""
 
-    @patch("pipeline.setup.run")
-    def test_redeploy_custom_pipeline_missing_warns(self, mock_run, tmp_path, capsys):
-        """--redeploy-tasks with missing custom --pipeline-yaml warns."""
-        from pipeline.setup import main
+    KEPT_FLAGS = [
+        ("--registry", "REG"),
+        ("--repo-name", "NAME"),
+        ("--pipeline-yaml", "/p"),
+        ("--orchestrator-image", "img"),
+        ("--run", "n"),
+        ("--experiment-root", "/x"),
+        ("--test-push", None),       # store_true
+        ("--test-push-tag", "t"),
+        ("--registry-user", "u"),
+        ("--registry-token", "t"),
+    ]
 
-        mock_run.return_value.returncode = 0
-        mock_run.return_value.stdout = ""
-        mock_run.return_value.stderr = ""
+    REMOVED_FLAGS = [
+        "--namespace", "--namespaces", "--storage-class",
+        "--hf-token", "--github-token",
+        "--no-cluster", "--redeploy-tasks",
+    ]
 
-        nonexistent = str(tmp_path / "nope.yaml")
-        with patch("sys.argv", ["setup.py", "--redeploy-tasks", "--namespace", "ns",
-                                "--pipeline-yaml", nonexistent]):
-            result = main()
+    @pytest.mark.parametrize("flag,value", KEPT_FLAGS)
+    def test_kept_flag_parses(self, flag, value):
+        from pipeline.setup import build_parser
+        argv = [flag] if value is None else [flag, value]
+        # Confirm no SystemExit / argparse error.
+        build_parser().parse_args(argv)
 
-        assert result == 0
-        captured = capsys.readouterr()
-        assert "not found" in captured.out.lower() or "WARN" in captured.out
-
-    @patch("pipeline.setup.run")
-    def test_redeploy_default_pipeline_missing_errors(self, mock_run, tmp_path):
-        """--redeploy-tasks fails if default pipeline.yaml is missing."""
-        from pipeline.setup import main
-
-        mock_run.return_value.returncode = 0
-        mock_run.return_value.stdout = ""
-        mock_run.return_value.stderr = ""
-
-        with patch("pipeline.setup.REPO_ROOT", tmp_path), \
-             patch("pipeline.setup.TEKTONC_DIR", tmp_path), \
-             patch("sys.argv", ["setup.py", "--redeploy-tasks", "--namespace", "ns"]):
-            result = main()
-
-        assert result == 1
+    @pytest.mark.parametrize("flag", REMOVED_FLAGS)
+    def test_removed_flag_raises(self, flag):
+        from pipeline.setup import build_parser
+        with pytest.raises(SystemExit):
+            build_parser().parse_args([flag, "x"])
 
 
 class TestRunMetadataIdempotent:
@@ -349,7 +185,7 @@ class TestRunMetadataIdempotent:
             run_dir = tmp_path / "workspace" / "runs" / "test-run"
             run_dir.mkdir(parents=True, exist_ok=True)
             cfg = _make_config(**cfg_overrides)
-            step_config_output(cfg, run_dir, "podman")
+            step_config_output(cfg, run_dir)
             return run_dir
         finally:
             setup_module.EXPERIMENT_ROOT = original
@@ -399,7 +235,7 @@ class TestRunMetadataIdempotent:
         assert meta2["stages"]["deploy"].get("last_completed_step") == "build"
 
     def test_refreshes_setup_owned_fields_on_rerun(self, tmp_path):
-        """Setup-owned fields (registry, namespace, container_runtime) reflect the latest cfg on re-run."""
+        """Setup-owned fields (registry, repo_name) reflect the latest cfg on re-run."""
         from pipeline.setup import step_config_output
         import pipeline.setup as setup_module
 
@@ -409,257 +245,28 @@ class TestRunMetadataIdempotent:
         original = setup_module.EXPERIMENT_ROOT
         setup_module.EXPERIMENT_ROOT = tmp_path
         try:
-            cfg2 = _make_config(registry="quay.io/new-registry", namespace="new-ns")
-            step_config_output(cfg2, run_dir, "docker")
+            cfg2 = _make_config(registry="quay.io/new-registry", repo_name="new-repo")
+            step_config_output(cfg2, run_dir)
         finally:
             setup_module.EXPERIMENT_ROOT = original
 
         meta2 = json.loads(meta_path.read_text())
         assert meta2["registry"] == "quay.io/new-registry"
-        assert meta2["namespace"] == "new-ns"
-        assert meta2["container_runtime"] == "docker"
+        assert meta2["repo_name"] == "new-repo"
 
-    def test_first_run_creates_full_metadata(self, tmp_path):
-        """First-run path (no existing file) still produces all setup-owned fields."""
+    def test_first_run_creates_metadata(self, tmp_path):
+        """First-run path produces setup-owned fields. Cluster-scoped fields
+        are NOT written by setup.py anymore (cluster_config.json owns them)."""
         run_dir = self._run_setup(tmp_path)
         meta = json.loads((run_dir / "run_metadata.json").read_text())
         assert meta["version"] == 1
-        assert meta["namespace"] == "test-ns"
         assert meta["registry"] == "quay.io/test"
+        assert meta["repo_name"] == "llm-d-inference-scheduler"
         assert meta["component_image"] == "quay.io/test/llm-d-inference-scheduler:test-run"
         assert meta["stages"]["setup"]["status"] == "completed"
         assert meta["stages"]["prepare"] == {"status": "pending"}
         assert meta["stages"]["deploy"] == {"status": "pending"}
         assert meta["stages"]["results"] == {"status": "pending"}
-
-
-class TestResolveStorageClass:
-    """_resolve_storage_class: flag overrides; otherwise empty (cluster default)."""
-
-    def _args(self, storage_class):
-        from argparse import Namespace
-        return Namespace(storage_class=storage_class)
-
-    def test_default_returns_empty_so_cluster_default_applies(self):
-        """No flag → empty string → PVC writer omits storageClassName entirely."""
-        from pipeline.setup import _resolve_storage_class
-        assert _resolve_storage_class(self._args(None)) == ""
-
-    def test_flag_overrides(self):
-        """Flag value is returned verbatim."""
-        from pipeline.setup import _resolve_storage_class
-        assert _resolve_storage_class(self._args("ibm-spectrum-scale-fileset")) == "ibm-spectrum-scale-fileset"
-
-    def test_empty_flag_treated_as_unset(self):
-        """`--storage-class ""` falls through to empty (cluster default)."""
-        from pipeline.setup import _resolve_storage_class
-        assert _resolve_storage_class(self._args("")) == ""
-
-
-class TestStepRbacApply:
-    """step_rbac applies five YAMLs with required/best-effort semantics.
-
-    Tests stub out the five YAML paths under tmp_path so they don't depend
-    on the tektonc-data-collection submodule being checked out — CI runs
-    with `submodules: false`.
-    """
-
-    APPLY_PREFIX = ["kubectl", "apply", "-f", "-"]
-    _STUB_YAML = (
-        "apiVersion: v1\n"
-        "kind: ServiceAccount\n"
-        "metadata:\n"
-        "  name: stub\n"
-        "  namespace: $NAMESPACE\n"
-    )
-    _STUB_RELPATHS = [
-        "tekton/roles-ns.yaml",
-        "tekton/roles-cluster.yaml",
-        "tekton/rbac/sim2real-runner.yaml",
-        "pipeline/rbac/sim2real-runner-ns.yaml",
-        "pipeline/rbac/sim2real-runner-cluster.yaml",
-    ]
-
-    def _stage(self, tmp_path, monkeypatch, *, omit=()):
-        """Create stub YAMLs (omitting any in `omit`) and patch path constants."""
-        import pipeline.setup as setup_mod
-        for relpath in self._STUB_RELPATHS:
-            if relpath in omit:
-                continue
-            target = tmp_path / relpath
-            target.parent.mkdir(parents=True, exist_ok=True)
-            target.write_text(self._STUB_YAML)
-        monkeypatch.setattr(setup_mod, "TEKTONC_DIR", tmp_path)
-        monkeypatch.setattr(setup_mod, "REPO_ROOT", tmp_path)
-
-    def _apply_calls(self, mock_run):
-        return [c for c in mock_run.call_args_list
-                if c.args and list(c.args[0][:4]) == self.APPLY_PREFIX]
-
-    def _index_aware_side_effect(self, mock_run, fail_indices, fail_stderr):
-        """Build a side_effect that returns Forbidden on the given apply indices."""
-        def side_effect(cmd, *args, **kwargs):
-            r = type("R", (), {})()
-            if list(cmd[:4]) == self.APPLY_PREFIX:
-                idx = len([c for c in mock_run.call_args_list
-                           if c.args and list(c.args[0][:4]) == self.APPLY_PREFIX]) - 1
-                if idx in fail_indices:
-                    r.returncode = 1; r.stdout = ""; r.stderr = fail_stderr
-                else:
-                    r.returncode = 0; r.stdout = "ok\n"; r.stderr = ""
-            else:
-                r.returncode = 0; r.stdout = ""; r.stderr = ""
-            return r
-        return side_effect
-
-    @patch("pipeline.setup.run")
-    def test_all_succeed(self, mock_run, tmp_path, monkeypatch):
-        """Five YAMLs apply cleanly — five kubectl apply calls, no exit."""
-        from pipeline.setup import step_rbac
-        self._stage(tmp_path, monkeypatch)
-        mock_run.return_value.returncode = 0
-        mock_run.return_value.stdout = "role.rbac.../helm-access configured\n"
-        mock_run.return_value.stderr = ""
-        step_rbac(_make_config())
-        assert len(self._apply_calls(mock_run)) == 5
-
-    @patch("pipeline.setup.run")
-    def test_required_failure_aborts(self, mock_run, tmp_path, monkeypatch, capsys):
-        """Required file with non-zero apply causes sys.exit, with file name in stderr."""
-        import pytest
-        from pipeline.setup import step_rbac
-        self._stage(tmp_path, monkeypatch)
-        mock_run.return_value.returncode = 1
-        mock_run.return_value.stdout = ""
-        mock_run.return_value.stderr = "Error from server: something broke\n"
-        with pytest.raises(SystemExit) as exc:
-            step_rbac(_make_config())
-        assert exc.value.code == 1
-        # Aborts on the FIRST required file (roles-ns.yaml) — only one apply call.
-        assert len(self._apply_calls(mock_run)) == 1
-        # The labeled err() should name the file so the operator knows what failed.
-        captured = capsys.readouterr()
-        assert "roles-ns.yaml" in captured.err
-
-    @patch("pipeline.setup.run")
-    def test_cluster_rbac_forbidden_skips_with_warn(self, mock_run, tmp_path, monkeypatch, capsys):
-        """Best-effort file with Forbidden on clusterrole resource skips and continues."""
-        from pipeline.setup import step_rbac
-        self._stage(tmp_path, monkeypatch)
-        cluster_forbidden = (
-            'Error from server (Forbidden): error when creating "STDIN": '
-            'clusterroles.rbac.authorization.k8s.io is forbidden: User "x" '
-            'cannot create resource "clusterroles" at the cluster scope'
-        )
-        # Indices in the apply order: 0=ns, 1=cluster (best-effort), 2=runner, 3=runner-ns, 4=runner-cluster (best-effort)
-        mock_run.side_effect = self._index_aware_side_effect(
-            mock_run, fail_indices={1, 4}, fail_stderr=cluster_forbidden,
-        )
-        step_rbac(_make_config())
-        # Both best-effort skips should have produced a warn line.
-        captured = capsys.readouterr()
-        assert captured.out.count("Skipped") + captured.err.count("Skipped") >= 2
-        assert len(self._apply_calls(mock_run)) == 5
-
-    @patch("pipeline.setup.run")
-    def test_cluster_augment_non_rbac_forbidden_aborts(self, mock_run, tmp_path, monkeypatch):
-        """Best-effort file with Forbidden NOT on a clusterrole resource still aborts."""
-        import pytest
-        from pipeline.setup import step_rbac
-        self._stage(tmp_path, monkeypatch)
-        # Forbidden from an SCC admission webhook — no clusterrole text in error.
-        scc_forbidden = (
-            'Error from server (Forbidden): admission webhook "scc.openshift.io" '
-            'denied the request: pod "x" requires anyuid SCC'
-        )
-        mock_run.side_effect = self._index_aware_side_effect(
-            mock_run, fail_indices={1}, fail_stderr=scc_forbidden,
-        )
-        with pytest.raises(SystemExit) as exc:
-            step_rbac(_make_config())
-        assert exc.value.code == 1
-        # Aborts on the second file (cluster augment) — exactly two apply calls.
-        assert len(self._apply_calls(mock_run)) == 2
-
-    @patch("pipeline.setup.run")
-    def test_skip_branch_emits_stderr(self, mock_run, tmp_path, monkeypatch, capsys):
-        """Forbidden-skip branch prints kubectl's stderr before the warn."""
-        from pipeline.setup import step_rbac
-        self._stage(tmp_path, monkeypatch)
-        cluster_forbidden = "Error from server (Forbidden): clusterroles cannot create"
-        mock_run.side_effect = self._index_aware_side_effect(
-            mock_run, fail_indices={1, 4}, fail_stderr=cluster_forbidden,
-        )
-        step_rbac(_make_config())
-        captured = capsys.readouterr()
-        # The actual kubectl Forbidden text should reach stderr — not be silently swallowed.
-        assert "clusterroles cannot create" in captured.err
-
-    @patch("pipeline.setup.run")
-    def test_required_file_not_found_aborts(self, mock_run, tmp_path, monkeypatch):
-        """Missing required YAML (e.g. submodule init failed) exits before apply."""
-        import pytest
-        import pipeline.setup as setup_mod
-        # Stage everything EXCEPT the first required file.
-        self._stage(tmp_path, monkeypatch, omit=("tekton/roles-ns.yaml",))
-        with pytest.raises(SystemExit) as exc:
-            setup_mod.step_rbac(_make_config())
-        assert exc.value.code == 1
-        # No kubectl apply should have been issued.
-        assert len(self._apply_calls(mock_run)) == 0
-
-
-class TestSimRealRunnerNsRoleContent:
-    """Content assertions on pipeline/rbac/sim2real-runner-ns.yaml.
-
-    The orchestrator SA needs every rule in this Role to be present in every
-    slot namespace. step_rbac applies the file unmodified (just envsubst), so
-    the rules here ARE the orchestrator's namespaced permission set. If a rule
-    silently disappears, the orchestrator's pod-health polling 403s in slot
-    namespaces — see issue #410 for the failure shape.
-    """
-
-    def _load_role_rules(self):
-        import yaml
-        from pipeline.setup import REPO_ROOT
-        path = REPO_ROOT / "pipeline" / "rbac" / "sim2real-runner-ns.yaml"
-        docs = list(yaml.safe_load_all(path.read_text()))
-        role = next(d for d in docs if d.get("kind") == "Role")
-        return role["rules"]
-
-    def _rule_for(self, rules, api_group, resource):
-        """Return the first rule covering (api_group, resource), or None."""
-        for r in rules:
-            if api_group in r.get("apiGroups", []) and resource in r.get("resources", []):
-                return r
-        return None
-
-    def test_pipelineruns_rule_present(self):
-        """Tekton PipelineRun CRUD — the orchestrator's primary verb set."""
-        rule = self._rule_for(self._load_role_rules(), "tekton.dev", "pipelineruns")
-        assert rule is not None
-        assert set(rule["verbs"]) >= {"create", "get", "watch", "list", "delete", "patch"}
-
-    def test_pvc_secret_get_rule_present(self):
-        """Slot-readiness checks read PVC bind state and HF secret presence."""
-        rules = self._load_role_rules()
-        for resource in ("persistentvolumeclaims", "secrets"):
-            rule = self._rule_for(rules, "", resource)
-            assert rule is not None, f"missing rule for core/{resource}"
-            assert "get" in rule["verbs"]
-
-    def test_pods_rule_present(self):
-        """Issue #410: pods get/list/watch is what _check_pod_health and
-        _check_pending_pods exercise on every poll tick; without it, the
-        orchestrator's health triage silently degrades to no-ops."""
-        rule = self._rule_for(self._load_role_rules(), "", "pods")
-        assert rule is not None, "pods rule missing — orchestrator pod health checks will 403"
-        assert set(rule["verbs"]) >= {"get", "list", "watch"}
-
-    def test_events_rule_present(self):
-        """Issue #410: events get/list feeds get_events(), which provides the
-        warning-event context for pod_pending classification (FailedScheduling,
-        ImagePullBackOff, etc.)."""
-        rule = self._rule_for(self._load_role_rules(), "", "events")
-        assert rule is not None, "events rule missing — pending-pod triage loses event context"
-        assert set(rule["verbs"]) >= {"get", "list"}
+        # Cluster-scoped fields are NOT written by setup anymore.
+        for absent in ("namespace", "storage_class", "is_openshift", "container_runtime"):
+            assert absent not in meta


### PR DESCRIPTION
Closes #424. Parent epic: #416. Base: `refactor/v2-step-0`.

## What changed

`pipeline/setup.py` is now a workspace-config writer. Cluster-side
provisioning (namespaces, RBAC, secrets, PVCs, Tekton, Pipeline definition)
moved to `pipeline/cluster.py provision` + `pipeline/lib/cluster_ops.py` in
prior children #420 / #421. Consumers (`deploy.py`, `prepare.py`, `run.py`,
`lib/remote.py`, `lib/run_manager.py`) read cluster fields from
`cluster_config.json` after children #422 / #423. This PR finishes the
carve-out.

## Acceptance (issue #424)

- [x] setup.py writes no cluster-scoped field to `setup_config.json`
      (verified by grep).
- [x] Cruft fields (`tektonc_dir`, `setup_timestamp`, `container_runtime`)
      no longer written.
- [x] `sim2real_root` still written (retires in Step 2).
- [x] CLI flag list matches the kept list; removed flags raise argparse
      errors when passed (parametrized test in `TestBuildParser`).
- [x] `step_test_push` and `_detect_container_runtime` retained as-is.
- [x] Obsolete tests deleted; remaining tests pass (35/35 in
      `test_setup_pipeline.py`; 1276 total pass, 2 xfailed pre-existing).
- [x] `ruff check pipeline/ .claude/skills/ --select F` clean.
- [x] No leftover dead code in the diff.

## Judgment calls worth a reviewer's eye

**1. `--registry-user` / `--registry-token` kept on setup.py.** The issue
lists these under "CLI flags removed → moved to `cluster.py provision`",
but `step_test_push` (which stays) uses `cfg.registry_user` /
`cfg.registry_token` in `_do_test_push` for the `podman/docker login`.
Removing the flags would force `--test-push` through env vars or
interactive prompts only. They're workspace-scoped (registry, not
cluster), so I kept them. **This duplicates the same flags on
`cluster.py provision`** — that dedup is tracked in #435.

**2. `TestSimRealRunnerNsRoleContent` removed.** These were content
assertions against `pipeline/rbac/sim2real-runner-ns.yaml` — that the
Role contains the verb set the orchestrator needs (pipelineruns CRUD,
pods/events get/list/watch, PVCs/secrets get). The RBAC file is applied
by `cluster_ops.provision_namespace` now, not setup.py. The class is
not on the issue's literal "delete" list, but leaving it in
`test_setup_pipeline.py` would be stale (asserts against behavior
setup.py no longer owns). Flagging here so the epic-cleanup PR (#426)
can decide whether to port the file-content checks into
`test_cluster_ops.py` or leave them — `cluster_ops.provision_namespace`
already exercises the apply end-to-end via `test_cluster_ops.py`.

**3. `setup_config.json` is now read-modify-write.** Previously
overwrite-only. Foreign keys (e.g. a future `cluster_id` pointer, or
any other writer's field) survive a setup re-run. Test:
`test_preserves_keys_owned_by_other_writers`.

## Sweep for stale references

Within scope of this PR:
- `pipeline/README.md` — `setup.py` section rewritten; two
  `setup.py --namespaces` references in other sections redirected to
  `cluster.py provision`.
- No remaining `setup_config.get("namespace|namespaces|is_openshift|...|container_runtime")` reads in `pipeline/` (verified by `grep -nrE`).

Broader README / CLAUDE.md / CI rewrite remains scoped to #425.

## Verification

```
ruff check pipeline/ .claude/skills/ --select F       # clean
python -m pytest pipeline/ .claude/skills/sim2real-analyze/tests/ \
  .claude/skills/sim2real-bootstrap/tests/ \
  .claude/skills/sim2real-translate/tests/ -v          # 1276 passed
```