### PR TITLE
step-2 PR 1: slicer.translation_hash_with_sources

### DIFF
--- a/pipeline/lib/slicer.py
+++ b/pipeline/lib/slicer.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from pathlib import Path
 from typing import Any
 
 TRANSLATION_FIELDS: list[str] = [
@@ -99,6 +100,65 @@ def translation_hash(manifest: dict) -> str:
     """
     canonical = json.dumps(
         translation_slice(manifest),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def translation_hash_with_sources(manifest: dict, experiment_root: Path) -> str:
+    """SHA-256 over the translation slice folded with each algorithm's source bytes.
+
+    Reads every ``algorithms[i].source`` file from ``experiment_root``,
+    computes its SHA-256, and folds the per-algorithm digests (sorted by
+    algorithm name) into a canonical envelope alongside
+    ``translation_slice(manifest)``. Callers use this when the translation
+    result depends on algorithm source contents — the skill-driven step-2
+    ``translate`` path.
+
+    Envelope shape (canonical JSON, sorted keys, no whitespace):
+
+        {"slice": <translation_slice>,
+         "sources": [{"name": <str>, "sha256": <hex>}, ...  # sorted by name
+                    ]}
+
+    Algorithm-order normalization: ``sources`` is sorted by ``name`` so
+    ``[a, b]`` and ``[b, a]`` produce the same hash. Algorithms without a
+    ``source`` field are skipped (they contribute nothing to the sources
+    list — matches the projection semantics of ``translation_slice``).
+
+    Raises:
+        AssembleError: if any ``algorithms[i].source`` file does not exist
+        under ``experiment_root``. Message format: ``source file not
+        found: <path>``.
+    """
+    # Deferred import to avoid the ``assemble_run -> slicer`` import cycle.
+    from pipeline.lib.assemble_run import AssembleError
+
+    sources: list[dict[str, str]] = []
+    algos = manifest.get("algorithms") or []
+    for algo in _sorted_by_name(algos):
+        if not isinstance(algo, dict):
+            continue
+        source_rel = algo.get("source")
+        if source_rel is None:
+            continue
+        source_path = experiment_root / source_rel
+        try:
+            data = source_path.read_bytes()
+        except FileNotFoundError as exc:
+            raise AssembleError(f"source file not found: {source_path}") from exc
+        sources.append(
+            {
+                "name": algo.get("name", ""),
+                "sha256": hashlib.sha256(data).hexdigest(),
+            }
+        )
+
+    envelope = {"slice": translation_slice(manifest), "sources": sources}
+    canonical = json.dumps(
+        envelope,
         sort_keys=True,
         separators=(",", ":"),
         ensure_ascii=False,

--- a/pipeline/tests/test_slicer.py
+++ b/pipeline/tests/test_slicer.py
@@ -3,9 +3,11 @@
 import copy
 import re
 
+import pytest
 import yaml
 
 from pipeline.lib import slicer
+from pipeline.lib.assemble_run import AssembleError
 
 
 # ── Test fixtures ──────────────────────────────────────────────────────
@@ -237,6 +239,278 @@ class TestTranslationHash:
     def test_baseline_only_manifest_hashes(self):
         h = slicer.translation_hash(_baseline_only_manifest())
         assert _HEX64_RE.match(h)
+
+
+# ── translation_hash_with_sources ──────────────────────────────────────
+
+
+def _write_algorithm_sources(
+    root, entries: list[tuple[str, bytes]]
+) -> None:
+    """Materialize ``[(relpath, bytes), ...]`` under ``root`` (parents made)."""
+    for rel, data in entries:
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(data)
+
+
+class TestTranslationHashWithSources:
+    def test_format_is_sha256_hex(self, tmp_path):
+        m = _full_manifest()
+        _write_algorithm_sources(
+            tmp_path,
+            [("algorithm/ac1.go", b"package a\n"), ("algorithm/ac2.go", b"package b\n")],
+        )
+        h = slicer.translation_hash_with_sources(m, tmp_path)
+        assert _HEX64_RE.match(h), f"expected 64-char lowercase hex, got: {h!r}"
+
+    def test_deterministic(self, tmp_path):
+        m = _full_manifest()
+        _write_algorithm_sources(
+            tmp_path,
+            [("algorithm/ac1.go", b"aaa"), ("algorithm/ac2.go", b"bbb")],
+        )
+        assert (
+            slicer.translation_hash_with_sources(m, tmp_path)
+            == slicer.translation_hash_with_sources(m, tmp_path)
+        )
+
+    def test_missing_source_file_raises_assemble_error(self, tmp_path):
+        m = _full_manifest()
+        # Write only ac1; ac2 is missing.
+        _write_algorithm_sources(tmp_path, [("algorithm/ac1.go", b"aaa")])
+        with pytest.raises(AssembleError, match="source file not found") as exc_info:
+            slicer.translation_hash_with_sources(m, tmp_path)
+        # Message should include the offending path.
+        assert "ac2.go" in str(exc_info.value)
+
+    def test_missing_source_error_includes_full_path(self, tmp_path):
+        m = _full_manifest()
+        with pytest.raises(AssembleError) as exc_info:
+            slicer.translation_hash_with_sources(m, tmp_path)
+        assert str(tmp_path) in str(exc_info.value)
+
+    def test_stable_across_algorithms_list_reordering(self, tmp_path):
+        """Algorithm order in the manifest must not affect the hash."""
+        m1 = _full_manifest()
+        m2 = copy.deepcopy(m1)
+        m2["algorithms"] = list(reversed(m2["algorithms"]))
+        _write_algorithm_sources(
+            tmp_path,
+            [("algorithm/ac1.go", b"first"), ("algorithm/ac2.go", b"second")],
+        )
+        assert (
+            slicer.translation_hash_with_sources(m1, tmp_path)
+            == slicer.translation_hash_with_sources(m2, tmp_path)
+        )
+
+    def test_changes_when_source_bytes_change(self, tmp_path):
+        m = _full_manifest()
+        _write_algorithm_sources(
+            tmp_path,
+            [("algorithm/ac1.go", b"aaa"), ("algorithm/ac2.go", b"bbb")],
+        )
+        h1 = slicer.translation_hash_with_sources(m, tmp_path)
+        (tmp_path / "algorithm/ac1.go").write_bytes(b"aaa-CHANGED")
+        h2 = slicer.translation_hash_with_sources(m, tmp_path)
+        assert h1 != h2
+
+    def test_changes_when_slice_changes(self, tmp_path):
+        m1 = _full_manifest()
+        m2 = copy.deepcopy(m1)
+        m2["scenario"] = "different_scenario"
+        _write_algorithm_sources(
+            tmp_path,
+            [("algorithm/ac1.go", b"aaa"), ("algorithm/ac2.go", b"bbb")],
+        )
+        assert (
+            slicer.translation_hash_with_sources(m1, tmp_path)
+            != slicer.translation_hash_with_sources(m2, tmp_path)
+        )
+
+    def test_differs_from_bare_translation_hash(self, tmp_path):
+        """Folding source bytes must change the hash relative to the slice-only hash."""
+        m = _full_manifest()
+        _write_algorithm_sources(
+            tmp_path,
+            [("algorithm/ac1.go", b"aaa"), ("algorithm/ac2.go", b"bbb")],
+        )
+        assert (
+            slicer.translation_hash(m)
+            != slicer.translation_hash_with_sources(m, tmp_path)
+        )
+
+    def test_empty_source_file(self, tmp_path):
+        """Zero-byte source is a valid content — hash still stable."""
+        m = _full_manifest()
+        _write_algorithm_sources(
+            tmp_path,
+            [("algorithm/ac1.go", b""), ("algorithm/ac2.go", b"content\n")],
+        )
+        h = slicer.translation_hash_with_sources(m, tmp_path)
+        assert _HEX64_RE.match(h)
+        # Determinism check on empty content specifically.
+        assert h == slicer.translation_hash_with_sources(m, tmp_path)
+
+    def test_binary_source_content(self, tmp_path):
+        """Non-UTF-8 bytes must not break hashing."""
+        m = _full_manifest()
+        binary = bytes(range(256))
+        _write_algorithm_sources(
+            tmp_path,
+            [("algorithm/ac1.go", binary), ("algorithm/ac2.go", b"\x00\x01\x02")],
+        )
+        h = slicer.translation_hash_with_sources(m, tmp_path)
+        assert _HEX64_RE.match(h)
+
+    def test_unicode_source_content(self, tmp_path):
+        """Unicode content encoded as UTF-8 hashes deterministically."""
+        m = _full_manifest()
+        _write_algorithm_sources(
+            tmp_path,
+            [
+                ("algorithm/ac1.go", "// αβγ δε\n".encode("utf-8")),
+                ("algorithm/ac2.go", "// 日本語 テスト\n".encode("utf-8")),
+            ],
+        )
+        h = slicer.translation_hash_with_sources(m, tmp_path)
+        assert _HEX64_RE.match(h)
+        assert h == slicer.translation_hash_with_sources(m, tmp_path)
+
+    def test_single_algorithm(self, tmp_path):
+        """Single-algorithm manifest hashes without error and differs from empty."""
+        m = _full_manifest()
+        m["algorithms"] = [{"name": "solo", "source": "algorithm/solo.go", "defaults": "b1"}]
+        _write_algorithm_sources(tmp_path, [("algorithm/solo.go", b"only-one")])
+        h = slicer.translation_hash_with_sources(m, tmp_path)
+        assert _HEX64_RE.match(h)
+
+    def test_multi_algorithm_extends_over_two(self, tmp_path):
+        """Adding a third algorithm changes the hash from the two-algorithm case."""
+        m2 = _full_manifest()
+        m3 = copy.deepcopy(m2)
+        m3["algorithms"].append(
+            {"name": "ac3", "source": "algorithm/ac3.go", "defaults": "b1"}
+        )
+        _write_algorithm_sources(
+            tmp_path,
+            [
+                ("algorithm/ac1.go", b"aaa"),
+                ("algorithm/ac2.go", b"bbb"),
+                ("algorithm/ac3.go", b"ccc"),
+            ],
+        )
+        assert (
+            slicer.translation_hash_with_sources(m2, tmp_path)
+            != slicer.translation_hash_with_sources(m3, tmp_path)
+        )
+
+    def test_baseline_only_manifest_hashes(self, tmp_path):
+        """No algorithms → hash is defined and equals slice-only hash of an equivalent envelope."""
+        m = _baseline_only_manifest()
+        h = slicer.translation_hash_with_sources(m, tmp_path)
+        assert _HEX64_RE.match(h)
+
+    def test_does_not_mutate_input(self, tmp_path):
+        m = _full_manifest()
+        _write_algorithm_sources(
+            tmp_path,
+            [("algorithm/ac1.go", b"aaa"), ("algorithm/ac2.go", b"bbb")],
+        )
+        snapshot = copy.deepcopy(m)
+        slicer.translation_hash_with_sources(m, tmp_path)
+        assert m == snapshot
+
+
+# ── Golden-file stability ──────────────────────────────────────────────
+
+
+# Pinned SHA-256 values guard against accidental canonicalization changes
+# (envelope shape, sort keys, separators). Any drift here means a manifest
+# that used to hash to X now hashes to Y — every existing translation
+# would be treated as stale. If you have a deliberate reason to change
+# the canonicalization, bump these values and note the reason.
+
+
+def _golden_manifest() -> dict:
+    """Fixed manifest for pinned-hash tests. Do not modify — pinned hashes
+    depend on this exact shape."""
+    return {
+        "scenario": "golden",
+        "component": {
+            "repo": "https://github.com/example/repo",
+            "kind": "scheduler",
+        },
+        "context": {"text": "ctx", "files": ["a.md"]},
+        "algorithms": [
+            {"name": "one", "source": "algorithm/one.go", "defaults": "b1"},
+            {"name": "two", "source": "algorithm/two.go", "defaults": "b1"},
+        ],
+    }
+
+
+class TestGoldenFileStability:
+    def test_single_algorithm_golden(self, tmp_path):
+        m = {
+            "scenario": "golden",
+            "component": {"repo": "https://github.com/example/repo", "kind": "scheduler"},
+            "context": {"text": "ctx", "files": ["a.md"]},
+            "algorithms": [
+                {"name": "one", "source": "algorithm/one.go", "defaults": "b1"},
+            ],
+        }
+        _write_algorithm_sources(tmp_path, [("algorithm/one.go", b"package one\n")])
+        assert (
+            slicer.translation_hash_with_sources(m, tmp_path)
+            == "7d43c058adbbe0affc086473d5e803d98878d65943c01755ac95fcf1e9ccb3f8"
+        )
+
+    def test_multi_algorithm_golden(self, tmp_path):
+        m = _golden_manifest()
+        _write_algorithm_sources(
+            tmp_path,
+            [
+                ("algorithm/one.go", b"package one\n"),
+                ("algorithm/two.go", b"package two\n"),
+            ],
+        )
+        assert (
+            slicer.translation_hash_with_sources(m, tmp_path)
+            == "db1f1085597ed2b6ef5b09eb1e3282f09ac318901f479de0ee57870141b88b54"
+        )
+
+    def test_empty_source_golden(self, tmp_path):
+        m = {
+            "scenario": "golden",
+            "component": {"repo": "https://github.com/example/repo", "kind": "scheduler"},
+            "context": {"text": "ctx", "files": ["a.md"]},
+            "algorithms": [
+                {"name": "one", "source": "algorithm/one.go", "defaults": "b1"},
+            ],
+        }
+        _write_algorithm_sources(tmp_path, [("algorithm/one.go", b"")])
+        assert (
+            slicer.translation_hash_with_sources(m, tmp_path)
+            == "faac79661cf136f495ddd04d637e7c6373bcdca0b31e7b7d7c67d79ec6f0c57e"
+        )
+
+    def test_unicode_source_golden(self, tmp_path):
+        m = {
+            "scenario": "golden",
+            "component": {"repo": "https://github.com/example/repo", "kind": "scheduler"},
+            "context": {"text": "ctx", "files": ["a.md"]},
+            "algorithms": [
+                {"name": "one", "source": "algorithm/one.go", "defaults": "b1"},
+            ],
+        }
+        _write_algorithm_sources(
+            tmp_path,
+            [("algorithm/one.go", "// αβγ 日本語\n".encode("utf-8"))],
+        )
+        assert (
+            slicer.translation_hash_with_sources(m, tmp_path)
+            == "ae316a469cfd947049bc89222fac239b65684ffa34f5b56f6b6f40b0e1ee312c"
+        )
 
 
 # ── TRANSLATION_FIELDS constant ────────────────────────────────────────


### PR DESCRIPTION
Closes #465
Refs #463 (Epic: step-2 — Skill-driven translation)

## Summary

Adds `pipeline/lib/slicer.py:translation_hash_with_sources(manifest, experiment_root) -> str` — the source-content-aware hash that step-2's skill-driven `translate` will use to decide when to invalidate a translation. Extends the existing `translation_slice`/`translation_hash` substrate; leaves BYO's `_compute_translation_hash` in `sim2real.py` untouched (different producer, different inputs — as scoped in the design doc §14).

## Design

Envelope hashed:

```json
{"slice": <translation_slice(manifest)>,
 "sources": [{"name": "...", "sha256": "..."}, ... sorted by name]}
```

- Iterates `manifest["algorithms"]` sorted by name so `[a, b]` and `[b, a]` hash to the same value.
- Reads each `algorithms[i].source` file's bytes from `experiment_root` and folds its SHA-256 into `sources`.
- Missing source file → `AssembleError("source file not found: <path>")`. Imported from `pipeline.lib.assemble_run` inside the function to avoid the `assemble_run → slicer` import cycle.
- Algorithms without a `source` field (or non-dict entries) are skipped — matches the projection semantics of `translation_slice`, which also omits missing fields.
- Empty algorithms list / baseline-only manifest returns a valid hash — `sources` is `[]`.

## Acceptance criteria (from #465)

- [x] `translation_hash_with_sources(manifest, experiment_root)` exists and returns a stable 64-char SHA-256 hex.
- [x] Hash covers both `translation_slice(manifest)` and the byte contents of each `algorithms[i].source` file.
- [x] Algorithm order normalized — `[a, b]` and `[b, a]` produce the same hash (tested via `test_stable_across_algorithms_list_reordering`).
- [x] Missing source file → `AssembleError` with a clear `source file not found: <path>` message (tested via `test_missing_source_file_raises_assemble_error` and `test_missing_source_error_includes_full_path`).
- [x] Tests: both algorithms present, one missing (error), source file empty, source file binary content, multi-algorithm, hash stability across process invocations (four pinned golden hashes: single, multi, empty, unicode).

## Test matrix

Added 20 tests across two classes (`TestTranslationHashWithSources`, `TestGoldenFileStability`). Full suite: `1178 passed, 2 xfailed in 22.60s`. Lint (`ruff check pipeline/ --select F`) clean.

## Non-obvious choices worth reviewer attention

- **Deferred `AssembleError` import** inside `translation_hash_with_sources` — `pipeline/lib/assemble_run.py` already imports `slicer`, so a top-level import here would cycle. The alternative (define a `SlicerError` in slicer.py) contradicts the issue's acceptance criteria which explicitly names `AssembleError`.
- **Skipping algorithms without a `source` key** rather than raising — matches `translation_slice`'s "omit-when-absent" posture. Callers that require every algorithm to have a source can enforce that at the manifest-load layer; this hash function is intentionally tolerant.
- **`sources` element uses `{name, sha256}` (not just a bare hex list)** — carries the algorithm identity so future debug/inspect tooling can print the envelope and read it. Cost is 16 chars of JSON overhead per algorithm.
- **Sweep**: grepped `docs/`, `.claude/`, and `pipeline/` for `translation_hash_with_sources`; all matches are either the new code or forward-looking spec references in `docs/epics/step-2/design.md` that this PR fulfills. No stale references.