### PR TITLE
step-2 PR 4: /sim2real-translate skill re-enable + prompt update

### DIFF
--- a/.claude/skills/sim2real-translate/SKILL.md
+++ b/.claude/skills/sim2real-translate/SKILL.md
@@ -1,42 +1,491 @@
 ---
 name: sim2real-translate
 description: |
-  DISABLED for step-1. The skill-driven translation flow is scheduled to
-  be restored in step-2 of the refactor/v2-step-1 epic (issue #443).
-  Step-1 supports BYO translations only — use
-  `pipeline/sim2real.py translation register` instead.
-user-invocable: false
+  Translates simulation-discovered algorithms into production Go plugins for the
+  target component (e.g. llm-d-inference-scheduler). Reads
+  workspace/translations/<hash>/skill_input.json (written by `sim2real translate`),
+  spawns a three-agent team (expert + writer + reviewer) per algorithm, and
+  writes plugin source + treatment overlay to
+  workspace/translations/<hash>/generated/<algo>/{cmd,pkg,<algo>_config.yaml,<algo>_output.json}.
+  Use after `sim2real translate` reaches the translation checkpoint; follow up
+  with `sim2real translate --resume` to validate outputs.
+argument-hint: "[--experiment-root PATH] [--rounds N]"
+user-invocable: true
+allowed-tools:
+  - Agent
+  - TeamCreate
+  - TeamDelete
+  - SendMessage
+  - TaskCreate
+  - TaskUpdate
+  - TaskList
+  - Bash(python3 *)
+  - Bash(.venv/bin/python *)
+  - Bash(cd * && *)
+  - Bash(test *)
+  - Bash(git *)
+  - Glob
+  - Read
+  - Edit
+  - Write
+  - Grep
 ---
 
-# sim2real-translate — DISABLED for step-1
+# sim2real-translate
 
-This skill has been removed as part of the **BYO MVP** (step-1 of the
-`refactor/v2-step-1` epic — issue
-[#443](https://github.com/inference-sim/sim2real/issues/443)).
+Translate simulation algorithms into production plugins using a two-agent team
+per algorithm: a writer that owns the build/test gate and round loop, and a
+reviewer that is exceptionally critical and includes assembly-simulation
+checks. Runs one algorithm at a time; iterates over every algorithm that
+`skill_input.json:algorithms[]` declares but has no `<algo>_output.json` yet.
 
-Step-1 supports **bring-your-own translations only**. Register a
-pre-built translation with:
+## CRITICAL: Working Directory
 
-```
-python pipeline/sim2real.py translation register \
-    --algorithm NAME \
-    --image REF \
-    --config PATH_TO_TREATMENT_OVERLAY
-```
+Run from the **experiment repo root** (where `transfer.yaml`, `algorithms/`,
+and the target component checkout live) OR pass `--experiment-root PATH`. The
+`sim2real/` pipeline root is discovered automatically from
+`workspace/setup_config.json` (falls back to the `SIM2REAL_ROOT` env var).
 
-Then assemble a run:
+Target repo commands run via subshell: `(cd $TARGET_REPO && ...)`
 
-```
-python pipeline/sim2real.py assemble \
-    --translation HASH \
-    --cluster CLUSTER_ID \
-    --run RUN_NAME
+Before proceeding, verify the experiment root has the expected layout:
+```bash
+test -f "$EXPERIMENT_ROOT/transfer.yaml" || { echo "ERROR: no transfer.yaml in $EXPERIMENT_ROOT"; exit 1; }
 ```
 
-The skill-driven flow (evolved algorithm → translated EPP plugin) is
-scheduled to be restored in step-2 of the epic. Invoking the skill in
-the current state exits with this message.
+## Arguments
 
-**If you got here from a slash command:** stop and use
-`sim2real translation register` instead. If you don't yet have a
-prebuilt image + config, wait for step-2 to land.
+- `--experiment-root PATH` — Path to experiment repo (default: current working directory).
+- `--rounds N` — Max review rounds per algorithm (default: 3).
+
+Initialize shell variables from skill invocation arguments:
+
+```bash
+EXPERIMENT_ROOT=$(pwd)    # overridden by --experiment-root PATH
+REVIEW_ROUNDS=3           # overridden by --rounds N
+```
+
+If `--experiment-root PATH` was passed, set `EXPERIMENT_ROOT=$(realpath PATH)`.
+If `--rounds N` was passed, set `REVIEW_ROUNDS=N`.
+
+## Prerequisites
+
+Create an overall progress task:
+```
+TaskCreate subject="sim2real-translate" description="Running translation skill against workspace/translations/<hash>/"
+```
+
+Locate `REPO_ROOT` (the sim2real repo root — this file's ancestor). Prefer
+`workspace/setup_config.json:sim2real_root` if present; fall back to
+`SIM2REAL_ROOT`:
+
+```bash
+REPO_ROOT=$(python3 - <<'PY'
+import json, os
+from pathlib import Path
+exp = Path(os.environ.get("EXPERIMENT_ROOT", os.getcwd()))
+cfg = exp / "workspace" / "setup_config.json"
+root = ""
+if cfg.exists():
+    try:
+        root = json.loads(cfg.read_text()).get("sim2real_root", "")
+    except Exception:
+        root = ""
+if not root:
+    root = os.environ.get("SIM2REAL_ROOT", "")
+if not root or not Path(root).exists():
+    raise SystemExit(
+        "HALT: cannot determine sim2real repo root. "
+        "Run `pipeline/setup.py` first, or export SIM2REAL_ROOT=/path/to/sim2real."
+    )
+print(root)
+PY
+) || exit 1
+test -n "$REPO_ROOT" || exit 1
+```
+
+Load and validate `transfer.yaml`, then compute the translation hash exactly
+the way `sim2real translate` does (same call site — the skill is not allowed
+to drift from the pinned hash):
+
+```bash
+python3 - "$EXPERIMENT_ROOT" "$REPO_ROOT" <<'PY' > /tmp/sim2real_translate_prereq.txt
+import sys
+from pathlib import Path
+exp = Path(sys.argv[1])
+repo = Path(sys.argv[2])
+sys.path.insert(0, str(repo))
+from pipeline.lib import manifest as mf
+from pipeline.lib import slicer as sl
+manifest_path = exp / "transfer.yaml"
+data = mf.load_manifest(manifest_path)
+thash = sl.translation_hash_with_sources(data, exp)
+print(f"TRANSLATION_HASH={thash}")
+print(f"SCENARIO={data['scenario']}")
+component = data.get("component", {}) or {}
+print(f"TARGET_REPO_REL={component.get('path', '')}")
+print(f"CONFIG_KIND={component.get('kind', '')}")
+build = component.get("build") or {}
+import json as _json
+print("BUILD_COMMANDS_JSON=" + _json.dumps(build.get("commands", [])))
+PY
+[ $? -eq 0 ] || exit 1
+
+TRANSLATION_HASH=$(grep '^TRANSLATION_HASH=' /tmp/sim2real_translate_prereq.txt | cut -d= -f2-)
+SCENARIO=$(grep '^SCENARIO=' /tmp/sim2real_translate_prereq.txt | cut -d= -f2-)
+TARGET_REPO_REL=$(grep '^TARGET_REPO_REL=' /tmp/sim2real_translate_prereq.txt | cut -d= -f2-)
+CONFIG_KIND=$(grep '^CONFIG_KIND=' /tmp/sim2real_translate_prereq.txt | cut -d= -f2-)
+BUILD_COMMANDS=$(grep '^BUILD_COMMANDS_JSON=' /tmp/sim2real_translate_prereq.txt | cut -d= -f2-)
+TARGET_REPO="$EXPERIMENT_ROOT/$TARGET_REPO_REL"
+TRANSLATIONS_DIR="$EXPERIMENT_ROOT/workspace/translations/$TRANSLATION_HASH"
+
+test -n "$TRANSLATION_HASH" || { echo "HALT: empty TRANSLATION_HASH"; exit 1; }
+test -n "$TARGET_REPO_REL" || { echo "HALT: transfer.yaml component.repo/path missing"; exit 1; }
+test -d "$TARGET_REPO" || { echo "HALT: target repo not found at $TARGET_REPO"; exit 1; }
+test -f "$TRANSLATIONS_DIR/skill_input.json" || {
+    echo "HALT: $TRANSLATIONS_DIR/skill_input.json not found — run 'sim2real translate' first"
+    exit 1
+}
+```
+
+Load per-algorithm inputs from `skill_input.json`. Every path in the file is
+interpreted relative to `experiment_root` (for `source_path`) or
+`translations_dir` (for `output_dir`, `config_output_path`,
+`baseline.generated_overlay_path`):
+
+```bash
+python3 - "$TRANSLATIONS_DIR" "$EXPERIMENT_ROOT" <<'PY' > /tmp/sim2real_translate_algos.txt
+import json, sys
+from pathlib import Path
+tdir = Path(sys.argv[1])
+exp = Path(sys.argv[2])
+si = json.loads((tdir / "skill_input.json").read_text())
+required = ("version", "translation_hash", "experiment_root", "translations_dir",
+            "scenario", "algorithms", "context")
+missing = [k for k in required if k not in si]
+if missing:
+    raise SystemExit(f"HALT: skill_input.json missing keys: {missing}")
+baseline = si.get("baseline")
+if baseline is not None:
+    print("BASELINE_OVERLAY_REL=" + baseline["generated_overlay_path"])
+else:
+    print("BASELINE_OVERLAY_REL=")
+ctx = si.get("context") or {}
+print("CONTEXT_TEXT_B64=" + __import__("base64").b64encode(
+    (ctx.get("text") or "").encode()).decode())
+paths = [str(exp / p) for p in (ctx.get("file_paths") or [])]
+print("CONTEXT_FILE_PATHS=" + " ".join(paths))
+for algo in si["algorithms"]:
+    print("ALGO\t" + "\t".join([
+        algo["name"],
+        algo["source_path"],
+        algo["output_dir"],
+        algo["config_output_path"],
+        algo.get("notes") or "",
+    ]))
+PY
+[ $? -eq 0 ] || exit 1
+
+BASELINE_OVERLAY_REL=$(grep '^BASELINE_OVERLAY_REL=' /tmp/sim2real_translate_algos.txt | cut -d= -f2-)
+if [ -n "$BASELINE_OVERLAY_REL" ]; then
+    BASELINE_OVERLAY_PATH="$TRANSLATIONS_DIR/$BASELINE_OVERLAY_REL"
+else
+    BASELINE_OVERLAY_PATH=""
+fi
+CONTEXT_TEXT=$(grep '^CONTEXT_TEXT_B64=' /tmp/sim2real_translate_algos.txt | cut -d= -f2- | base64 -d 2>/dev/null || true)
+CONTEXT_FILE_PATHS=$(grep '^CONTEXT_FILE_PATHS=' /tmp/sim2real_translate_algos.txt | cut -d= -f2-)
+```
+
+Verify that every algorithm source and every context file exists (absolute
+paths):
+
+```bash
+grep -E '^ALGO\b' /tmp/sim2real_translate_algos.txt | while IFS=$'\t' read -r _ name source_rel _ _ _; do
+    test -f "$EXPERIMENT_ROOT/$source_rel" || {
+        echo "HALT: algorithm source not found: $EXPERIMENT_ROOT/$source_rel"
+        exit 1
+    }
+done || exit 1
+
+for p in $CONTEXT_FILE_PATHS; do
+    test -f "$p" || { echo "HALT: context file not found: $p"; exit 1; }
+done
+```
+
+## Idempotency Check
+
+Skip algorithms whose `<algo>_output.json` already exists — those are done. If
+every algorithm is complete, exit with an "already complete" message:
+
+```bash
+INCOMPLETE_ALGOS=""
+while IFS=$'\t' read -r _ name _ output_dir _ _; do
+    algo_out="$TRANSLATIONS_DIR/$output_dir/${name}_output.json"
+    if [ ! -f "$algo_out" ]; then
+        INCOMPLETE_ALGOS="$INCOMPLETE_ALGOS $name"
+    fi
+done < <(grep -E '^ALGO\b' /tmp/sim2real_translate_algos.txt)
+INCOMPLETE_ALGOS=$(echo "$INCOMPLETE_ALGOS" | xargs)
+
+if [ -z "$INCOMPLETE_ALGOS" ]; then
+    echo "translation $TRANSLATION_HASH already complete — run 'sim2real translate --resume' next"
+    exit 0
+fi
+```
+
+## Per-Algorithm Loop
+
+For each name in `$INCOMPLETE_ALGOS`, run one full team session. Every session
+is independent — a failure on one algorithm leaves the others available to
+retry on the next skill invocation (the on-disk `<algo>_output.json`
+completeness check ensures idempotency).
+
+For each `ALGO_NAME` in `$INCOMPLETE_ALGOS`:
+
+### Step 1: Load per-algorithm variables
+
+```bash
+# Extract this algorithm's row from /tmp/sim2real_translate_algos.txt.
+IFS=$'\t' read -r _ _ ALGO_SOURCE_REL OUTPUT_DIR_REL CONFIG_OUTPUT_REL ALGO_NOTES < <(
+    awk -F$'\t' -v n="$ALGO_NAME" '$1=="ALGO" && $2==n {print}' /tmp/sim2real_translate_algos.txt
+)
+ALGO_SOURCE="$EXPERIMENT_ROOT/$ALGO_SOURCE_REL"
+OUTPUT_DIR="$TRANSLATIONS_DIR/$OUTPUT_DIR_REL"
+CONFIG_OUTPUT_PATH="$TRANSLATIONS_DIR/$CONFIG_OUTPUT_REL"
+# The new skill_input schema has no algorithm_config field — parameters (if
+# any) live inside the source file. Pass "" so the prompts take their
+# "parameter-free" branches when reasoning about configurable weights.
+ALGO_CONFIG=""
+
+mkdir -p "$OUTPUT_DIR"
+```
+
+### Step 2: Spawn the team
+
+Read the three prompt templates:
+- `$REPO_ROOT/.claude/skills/sim2real-translate/prompts/agent-expert.md`
+- `$REPO_ROOT/.claude/skills/sim2real-translate/prompts/agent-writer.md`
+- `$REPO_ROOT/.claude/skills/sim2real-translate/prompts/agent-reviewer.md`
+
+Substitute every `{PLACEHOLDER}` occurrence with the corresponding shell
+variable:
+
+- `{REPO_ROOT}` → `$REPO_ROOT`
+- `{EXPERIMENT_ROOT}` → `$EXPERIMENT_ROOT`
+- `{TRANSLATIONS_DIR}` → `$TRANSLATIONS_DIR`
+- `{OUTPUT_DIR}` → `$OUTPUT_DIR`
+- `{BASELINE_OVERLAY_PATH}` → `$BASELINE_OVERLAY_PATH` (empty string when the
+  manifest declares no baseline overlay — writer's Phase 2 handles this)
+- `{ALGO_SOURCE}` → `$ALGO_SOURCE`
+- `{ALGO_CONFIG}` → `$ALGO_CONFIG` (always empty string; see Step 1 comment)
+- `{ALGO_NAME}` → `$ALGO_NAME`
+- `{ALGO_NOTES}` → `$ALGO_NOTES`
+- `{TARGET_REPO}` → `$TARGET_REPO`
+- `{CONFIG_KIND}` → `$CONFIG_KIND`
+- `{SCENARIO}` → `$SCENARIO`
+- `{BUILD_COMMANDS}` → `$BUILD_COMMANDS` (JSON list of shell commands)
+- `{REVIEW_ROUNDS}` → `$REVIEW_ROUNDS`
+- `{CONTEXT_TEXT}` → `$CONTEXT_TEXT`
+- `{CONTEXT_FILE_PATHS}` → `$CONTEXT_FILE_PATHS` (space-separated absolute paths)
+- `{EXPERT_AGENT_NAME}` → `"expert"`
+- `{MAIN_SESSION_NAME}` → `"main-session"`
+
+Create the team:
+```
+TeamCreate(team_name="translate-${TRANSLATION_HASH:0:12}-$ALGO_NAME",
+           description="sim2real expert+writer+reviewer for $ALGO_NAME")
+```
+
+**Spawn all three agents in a single tool-call message** so they start in
+parallel. Issue three Agent tool calls at once — do not wait between them:
+
+1. Agent(name="expert", team_name="translate-<prefix>-<algo>",
+         run_in_background=true, subagent_type=general-purpose, model="opus",
+         prompt=<substituted agent-expert.md>)
+2. Agent(name="reviewer", team_name="translate-<prefix>-<algo>",
+         run_in_background=true, subagent_type=general-purpose, model="opus",
+         prompt=<substituted agent-reviewer.md>)
+3. Agent(name="writer", team_name="translate-<prefix>-<algo>",
+         subagent_type=general-purpose, model="opus",
+         prompt=<substituted agent-writer.md>)
+
+All three start simultaneously. Expert and Reviewer initialize in the
+background while Writer begins Phase 2. By the time Writer reaches Phase 4
+(translation), Expert will have completed its repo exploration and be ready
+to answer queries.
+
+### Step 3: Handle writer messages
+
+Wait for the Writer to send a message to the main session. Handle each case:
+
+**On `baseline-ready: ...`:**
+
+If `$BASELINE_OVERLAY_PATH` is empty (manifest declares no baseline overlay),
+this branch should not fire; if it does, send back
+`SendMessage("writer", "no-baseline")` and skip. Otherwise read the file the
+writer produced (at `$BASELINE_OVERLAY_PATH`) and print to the user:
+```
+━━━ Baseline Config (derived from sim → real EPP) ━━━
+<file contents>
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Provide feedback to revise, or type 'done' to proceed.
+```
+Read user input. If it starts with `feedback:`, forward verbatim to the
+writer. If it is exactly `done`, send `SendMessage("writer", "continue")`.
+
+**On `treatment-ready: ...`:**
+
+Read `$CONFIG_OUTPUT_PATH` and print to the user:
+```
+━━━ Treatment Config (derived from baseline + algorithm) ━━━
+<file contents>
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Provide feedback to revise, or type 'done' to proceed.
+```
+Handle feedback / continue as above.
+
+**On `review-passed: round=N plugin_type=<type>`:**
+
+Read `$OUTPUT_DIR/${ALGO_NAME}_output.json` for the plugin file list and
+print `$CONFIG_OUTPUT_PATH` for the operator. Then prompt:
+```
+━━━ Review Passed — ACTION REQUIRED ━━━
+Treatment Config: <contents above>
+Plugin files: <files_created from ${ALGO_NAME}_output.json>
+
+⚠ This algorithm's translation is INCOMPLETE until you reply. Source files
+  have NOT yet been copied to $OUTPUT_DIR/. Choose one:
+
+  • Reply `done`             → finalize: copy source overlay to $OUTPUT_DIR/,
+                               shut down the team, and move to the next algorithm
+  • Reply `feedback: <text>` → iterate one more review round with the feedback
+
+Without a reply, the writer agent will wait indefinitely.
+```
+If reply is exactly `done`: `SendMessage("writer", "done")`.
+If reply starts with `feedback:`: `SendMessage("writer", "feedback: <text>")`.
+Otherwise: re-print the prompt and wait — do NOT silently treat ambiguous
+input as either branch.
+
+**On `done: ...`:**
+
+The writer completed successfully. Proceed to Step 4.
+
+**On `escalate: ...`:**
+
+Prompt the operator:
+```
+Translation exhausted $REVIEW_ROUNDS rounds without reviewer approval for
+$ALGO_NAME. Remaining issues:
+<paste issues from the escalate message>
+
+Options:
+  [c] Continue for N more rounds — reply with: continue N
+  [a] Accept translation as-is — reply with: accept
+  [q] Quit and investigate — reply with: quit
+```
+
+- If `continue N`: bump `REVIEW_ROUNDS=$((REVIEW_ROUNDS + N))`, then spawn a
+  NEW writer agent with the updated value substituted. The reviewer is still
+  idle — it does not need to be restarted.
+- If `accept`: proceed to Step 4 with `consensus='accepted_without_consensus'`.
+- If `quit`:
+  ```
+  SendMessage("writer", "shutdown")
+  SendMessage("reviewer", "shutdown")
+  SendMessage("expert", "shutdown")
+  TeamDelete()
+  ```
+  Skip to the next algorithm in the loop (or exit if none remain).
+
+**On `build-failed: ...`:**
+
+Surface the build error to the operator:
+```
+Translation build failed after 6 retries for $ALGO_NAME.
+Error: <paste error from message>
+
+Fix the algorithm source or target repo state, then re-run /sim2real-translate.
+```
+Shut down the team as under `quit` and skip to the next algorithm.
+
+### Step 4: Copy source and shut down
+
+Derive the file list from git state in `$TARGET_REPO`, update
+`${ALGO_NAME}_output.json`, and copy plugin sources into `$OUTPUT_DIR`:
+
+```bash
+python3 -c "
+import sys
+sys.path.insert(0, '$REPO_ROOT/.claude/skills/sim2real-translate/scripts')
+from copy_generated import copy_generated
+copy_generated('$TARGET_REPO', '$TRANSLATIONS_DIR', algo_name='$ALGO_NAME')
+" || exit 1
+```
+
+Verify the per-algorithm output:
+
+```bash
+python3 - "$OUTPUT_DIR" "$ALGO_NAME" <<'PY' || exit 1
+import json, sys
+from pathlib import Path
+out_dir = Path(sys.argv[1])
+algo = sys.argv[2]
+algo_out = out_dir / f"{algo}_output.json"
+if not algo_out.exists():
+    raise SystemExit(f"ERROR: {algo_out} not found")
+o = json.loads(algo_out.read_text())
+required = ("plugin_type", "files_created", "files_modified", "package",
+            "register_file", "test_commands", "config_kind",
+            "treatment_config_generated", "description")
+missing = [f for f in required if f not in o]
+if missing:
+    raise SystemExit(f"ERROR: {algo_out} missing keys: {missing}")
+for rel in o["files_created"] + o.get("files_modified", []):
+    if not (out_dir / rel).exists():
+        raise SystemExit(f"ERROR: expected copy at {out_dir}/{rel} not found")
+print(f"Verified {algo}: plugin_type={o['plugin_type']}, "
+      f"{len(o['files_created'])} created, "
+      f"{len(o.get('files_modified', []))} modified")
+PY
+```
+
+Shut down the team:
+```
+SendMessage("writer", "shutdown")
+SendMessage("reviewer", "shutdown")
+SendMessage("expert", "shutdown")
+TeamDelete()
+```
+
+Loop to the next algorithm in `$INCOMPLETE_ALGOS`.
+
+## Completion
+
+After all algorithms are done, print:
+
+```
+━━━ /sim2real-translate complete ━━━
+
+Translation: $TRANSLATION_HASH
+Algorithms translated: <count>
+
+Per-algorithm artifacts:
+  $TRANSLATIONS_DIR/generated/<algo>/{cmd,pkg}/
+  $TRANSLATIONS_DIR/generated/<algo>/<algo>_config.yaml
+  $TRANSLATIONS_DIR/generated/<algo>/<algo>_output.json
+
+Next: run `sim2real translate --resume` to validate outputs, then
+`sim2real build --translation <alias-or-hash>` to build the EPP images.
+```
+
+TaskUpdate all open tasks → completed.
+
+## What This Skill Does NOT Do
+
+- Does not compute or verify `translation_hash` — that comes from `skill_input.json`, written by `sim2real translate`.
+- Does not build container images (`sim2real build`'s job).
+- Does not touch cluster config, bundle inputs, or run summaries.
+- Job: produce working, reviewed Go plugin source + treatment overlay + per-algo metadata under `translations/<hash>/generated/<algo>/`.

--- a/.claude/skills/sim2real-translate/SKILL.md
+++ b/.claude/skills/sim2real-translate/SKILL.md
@@ -155,9 +155,14 @@ interpreted relative to `experiment_root` (for `source_path`) or
 `translations_dir` (for `output_dir`, `config_output_path`,
 `baseline.generated_overlay_path`):
 
+Path-safe emission: each `ALGO` row is TAB-delimited; each context file path is
+written to a separate line in a dedicated file (`/tmp/sim2real_translate_ctx_paths.txt`)
+so paths containing spaces are preserved unchanged. `CONTEXT_TEXT` is base64-encoded
+to survive newlines and non-printable characters in operator-supplied notes.
+
 ```bash
 python3 - "$TRANSLATIONS_DIR" "$EXPERIMENT_ROOT" <<'PY' > /tmp/sim2real_translate_algos.txt
-import json, sys
+import json, sys, base64
 from pathlib import Path
 tdir = Path(sys.argv[1])
 exp = Path(sys.argv[2])
@@ -173,10 +178,12 @@ if baseline is not None:
 else:
     print("BASELINE_OVERLAY_REL=")
 ctx = si.get("context") or {}
-print("CONTEXT_TEXT_B64=" + __import__("base64").b64encode(
+print("CONTEXT_TEXT_B64=" + base64.b64encode(
     (ctx.get("text") or "").encode()).decode())
+# Write context paths (one per line) to a dedicated file — paths may contain spaces.
+ctx_paths_out = Path("/tmp/sim2real_translate_ctx_paths.txt")
 paths = [str(exp / p) for p in (ctx.get("file_paths") or [])]
-print("CONTEXT_FILE_PATHS=" + " ".join(paths))
+ctx_paths_out.write_text("".join(p + "\n" for p in paths))
 for algo in si["algorithms"]:
     print("ALGO\t" + "\t".join([
         algo["name"],
@@ -194,24 +201,36 @@ if [ -n "$BASELINE_OVERLAY_REL" ]; then
 else
     BASELINE_OVERLAY_PATH=""
 fi
-CONTEXT_TEXT=$(grep '^CONTEXT_TEXT_B64=' /tmp/sim2real_translate_algos.txt | cut -d= -f2- | base64 -d 2>/dev/null || true)
-CONTEXT_FILE_PATHS=$(grep '^CONTEXT_FILE_PATHS=' /tmp/sim2real_translate_algos.txt | cut -d= -f2-)
+CONTEXT_TEXT_B64_VAL=$(grep '^CONTEXT_TEXT_B64=' /tmp/sim2real_translate_algos.txt | cut -d= -f2-)
+if [ -n "$CONTEXT_TEXT_B64_VAL" ]; then
+    CONTEXT_TEXT=$(printf '%s' "$CONTEXT_TEXT_B64_VAL" | base64 -d) || {
+        echo "HALT: failed to decode CONTEXT_TEXT_B64"; exit 1;
+    }
+else
+    CONTEXT_TEXT=""
+fi
+# When the writer/reviewer/expert prompts substitute {CONTEXT_FILE_PATHS},
+# they receive the newline-delimited file contents (spaces preserved).
+CONTEXT_FILE_PATHS=$(cat /tmp/sim2real_translate_ctx_paths.txt)
 ```
 
 Verify that every algorithm source and every context file exists (absolute
-paths):
+paths; iterate via `< <(...)` so `exit 1` inside the loop halts the outer
+script, and read context paths line-by-line so paths containing spaces are
+preserved):
 
 ```bash
-grep -E '^ALGO\b' /tmp/sim2real_translate_algos.txt | while IFS=$'\t' read -r _ name source_rel _ _ _; do
+while IFS=$'\t' read -r _ name source_rel _ _ _; do
     test -f "$EXPERIMENT_ROOT/$source_rel" || {
         echo "HALT: algorithm source not found: $EXPERIMENT_ROOT/$source_rel"
         exit 1
     }
-done || exit 1
+done < <(grep -E '^ALGO\b' /tmp/sim2real_translate_algos.txt) || exit 1
 
-for p in $CONTEXT_FILE_PATHS; do
+while IFS= read -r p; do
+    [ -n "$p" ] || continue
     test -f "$p" || { echo "HALT: context file not found: $p"; exit 1; }
-done
+done < /tmp/sim2real_translate_ctx_paths.txt || exit 1
 ```
 
 ## Idempotency Check
@@ -320,6 +339,12 @@ to answer queries.
 
 Wait for the Writer to send a message to the main session. Handle each case:
 
+**On `expert-ready: ...`:**
+
+The Expert has finished initialization and is ready for queries. Log
+`"Expert initialized"` and continue waiting for the next message (no reply
+to the Expert needed — its readiness state is implicit from here on).
+
 **On `baseline-ready: ...`:**
 
 If `$BASELINE_OVERLAY_PATH` is empty (manifest declares no baseline overlay),
@@ -360,7 +385,7 @@ Plugin files: <files_created from ${ALGO_NAME}_output.json>
 ⚠ This algorithm's translation is INCOMPLETE until you reply. Source files
   have NOT yet been copied to $OUTPUT_DIR/. Choose one:
 
-  • Reply `done`             → finalize: copy source overlay to $OUTPUT_DIR/,
+  • Reply `done`             → finalize: copy plugin source files from the target repo into $OUTPUT_DIR/,
                                shut down the team, and move to the next algorithm
   • Reply `feedback: <text>` → iterate one more review round with the feedback
 
@@ -487,7 +512,7 @@ TaskUpdate all open tasks → completed.
 
 ## What This Skill Does NOT Do
 
-- Does not compute or verify `translation_hash` — that comes from `skill_input.json`, written by `sim2real translate`.
+- Does not drift from the pinned `translation_hash`: it calls `slicer.translation_hash_with_sources` at the same call site `sim2real translate` uses (so hashes stay identical) and then looks up `translations/<hash>/skill_input.json`. It does not cross-check the hash inside `skill_input.json` against the recomputed value — divergence there is treated as a caller bug in `sim2real translate`, not a skill invariant.
 - Does not build container images (`sim2real build`'s job).
 - Does not touch cluster config, bundle inputs, or run summaries.
 - Job: produce working, reviewed Go plugin source + treatment overlay + per-algo metadata under `translations/<hash>/generated/<algo>/`.

--- a/.claude/skills/sim2real-translate/SKILL.md
+++ b/.claude/skills/sim2real-translate/SKILL.md
@@ -307,7 +307,7 @@ variable:
 - `{BUILD_COMMANDS}` → `$BUILD_COMMANDS` (JSON list of shell commands)
 - `{REVIEW_ROUNDS}` → `$REVIEW_ROUNDS`
 - `{CONTEXT_TEXT}` → `$CONTEXT_TEXT`
-- `{CONTEXT_FILE_PATHS}` → `$CONTEXT_FILE_PATHS` (space-separated absolute paths)
+- `{CONTEXT_FILE_PATHS}` → `$CONTEXT_FILE_PATHS` (newline-separated absolute paths — one path per line)
 - `{EXPERT_AGENT_NAME}` → `"expert"`
 - `{MAIN_SESSION_NAME}` → `"main-session"`
 
@@ -335,9 +335,10 @@ background while Writer begins Phase 2. By the time Writer reaches Phase 4
 (translation), Expert will have completed its repo exploration and be ready
 to answer queries.
 
-### Step 3: Handle writer messages
+### Step 3: Handle team messages
 
-Wait for the Writer to send a message to the main session. Handle each case:
+Wait for messages from the team (Expert and Writer both send to
+`{MAIN_SESSION_NAME}`). Handle each case:
 
 **On `expert-ready: ...`:**
 

--- a/.claude/skills/sim2real-translate/SKILL.md
+++ b/.claude/skills/sim2real-translate/SKILL.md
@@ -33,11 +33,13 @@ allowed-tools:
 
 # sim2real-translate
 
-Translate simulation algorithms into production plugins using a two-agent team
-per algorithm: a writer that owns the build/test gate and round loop, and a
-reviewer that is exceptionally critical and includes assembly-simulation
-checks. Runs one algorithm at a time; iterates over every algorithm that
-`skill_input.json:algorithms[]` declares but has no `<algo>_output.json` yet.
+Translate simulation algorithms into production plugins using a three-agent
+team per algorithm: an expert that explores the target repo up front and
+answers technical queries, a writer that owns the build/test gate and round
+loop, and a reviewer that is exceptionally critical and includes
+assembly-simulation checks. Runs one algorithm at a time; iterates over every
+algorithm that `skill_input.json:algorithms[]` declares but has no
+`<algo>_output.json` yet.
 
 ## CRITICAL: Working Directory
 

--- a/.claude/skills/sim2real-translate/prompts/agent-expert.md
+++ b/.claude/skills/sim2real-translate/prompts/agent-expert.md
@@ -30,8 +30,8 @@ Read the following to build your foundation:
 
 1. Read `{EXPERIMENT_ROOT}/transfer.yaml` — understand scenario, algorithm, baseline, context
 2. Read `{ALGO_SOURCE}` — the simulation algorithm being translated
-3. If `{ALGO_CONFIG}` is non-empty: read it — algorithm weights and thresholds (ground truth)
-4. Read all files in context.files (listed in transfer.yaml)
+3. If `{ALGO_CONFIG}` is non-empty: read it — algorithm weights and thresholds (ground truth). Under the current schema this is always empty; inspect `{ALGO_SOURCE}` directly for any inline parameters.
+4. Read every path in `{CONTEXT_FILE_PATHS}` (space-separated absolute paths) — these are the operator-declared context files (mirror of `transfer.yaml:context.files`) that the writer and reviewer also load
 
 Then do targeted exploration of the target repo:
 

--- a/.claude/skills/sim2real-translate/prompts/agent-expert.md
+++ b/.claude/skills/sim2real-translate/prompts/agent-expert.md
@@ -31,7 +31,7 @@ Read the following to build your foundation:
 1. Read `{EXPERIMENT_ROOT}/transfer.yaml` — understand scenario, algorithm, baseline, context
 2. Read `{ALGO_SOURCE}` — the simulation algorithm being translated
 3. If `{ALGO_CONFIG}` is non-empty: read it — algorithm weights and thresholds (ground truth). Under the current schema this is always empty; inspect `{ALGO_SOURCE}` directly for any inline parameters.
-4. Read every path in `{CONTEXT_FILE_PATHS}` (space-separated absolute paths) — these are the operator-declared context files (mirror of `transfer.yaml:context.files`) that the writer and reviewer also load
+4. Read every path in `{CONTEXT_FILE_PATHS}` (newline-separated absolute paths, one per line) — these are the operator-declared context files (mirror of `transfer.yaml:context.files`) that the writer and reviewer also load
 
 Then do targeted exploration of the target repo:
 

--- a/.claude/skills/sim2real-translate/prompts/agent-reviewer.md
+++ b/.claude/skills/sim2real-translate/prompts/agent-reviewer.md
@@ -25,8 +25,8 @@ Config kind: {CONFIG_KIND}
 
 Read and hold in context:
 
-1. **Context files** `{CONTEXT_FILE_PATHS}` — space-separated absolute paths from
-   `transfer.yaml:context.files`. These provide the architecture overview, signal mapping,
+1. **Context files** `{CONTEXT_FILE_PATHS}` — newline-separated absolute paths
+   (one path per line) from `transfer.yaml:context.files`. These provide the architecture overview, signal mapping,
    available plugin types and their type strings.
 2. **Algorithm source** `{ALGO_SOURCE}` — the simulation source file being translated
 3. If `{ALGO_CONFIG}` is non-empty: read it — weights and thresholds (ground truth). Under

--- a/.claude/skills/sim2real-translate/prompts/agent-reviewer.md
+++ b/.claude/skills/sim2real-translate/prompts/agent-reviewer.md
@@ -16,7 +16,8 @@ to block a bad plugin than to let one reach production.
 
 Experiment root: {EXPERIMENT_ROOT}
 Target repo: {TARGET_REPO}
-Run directory: {RUN_DIR}
+Translations dir: {TRANSLATIONS_DIR}
+Per-algorithm output dir: {OUTPUT_DIR}
 Scenario: {SCENARIO}
 Config kind: {CONFIG_KIND}
 
@@ -24,10 +25,12 @@ Config kind: {CONFIG_KIND}
 
 Read and hold in context:
 
-1. **Context document** `{CONTEXT_PATH}` — architecture overview, signal mapping,
-   available plugin types and their type strings
-2. **Algorithm source** `{ALGO_SOURCE}` — the simulation Go file being translated
-3. If `{ALGO_CONFIG}` is non-empty: read it — weights and thresholds (ground truth)
+1. **Context files** `{CONTEXT_FILE_PATHS}` — space-separated absolute paths from
+   `transfer.yaml:context.files`. These provide the architecture overview, signal mapping,
+   available plugin types and their type strings.
+2. **Algorithm source** `{ALGO_SOURCE}` — the simulation source file being translated
+3. If `{ALGO_CONFIG}` is non-empty: read it — weights and thresholds (ground truth). Under
+   the current schema this is always empty; any inline weights/thresholds live in `{ALGO_SOURCE}`.
 4. **Pipeline overlay format** `{REPO_ROOT}/pipeline/README.md` — "Scenario Overlay Format"
    section defines valid overlay structure
 
@@ -42,7 +45,8 @@ Context from the operator (held in mind, not written to disk):
 ## Tool Discipline
 
 **Do not explore `{TARGET_REPO}` yourself** beyond the specific files you must read per
-review request (plugin files, registration file, {ALGO_NAME}_config.yaml, {ALGO_NAME}_output.json).
+review request (plugin files, registration file, `{OUTPUT_DIR}/{ALGO_NAME}_config.yaml`,
+`{OUTPUT_DIR}/{ALGO_NAME}_output.json`).
 
 For anything that requires verifying code-level details — Go interface signatures,
 config struct field names, whether a built-in plugin already exists, exact type string
@@ -68,8 +72,8 @@ Example queries:
 You stay idle after initialization. When the writer sends you a review request:
 
 1. Read ALL plugin files listed in the writer's message (paths provided in the request) — fresh
-2. Read `{RUN_DIR}/generated/{ALGO_NAME}/{ALGO_NAME}_config.yaml` fresh
-3. Read `{RUN_DIR}/generated/{ALGO_NAME}/{ALGO_NAME}_output.json` for metadata cross-reference
+2. Read `{OUTPUT_DIR}/{ALGO_NAME}_config.yaml` fresh
+3. Read `{OUTPUT_DIR}/{ALGO_NAME}_output.json` for metadata cross-reference
 4. Read the registration file mentioned in `{ALGO_NAME}_output.json` — just the relevant section
 5. Apply ALL review criteria below (never skip one)
 6. Send your verdict to the writer using SendMessage
@@ -92,11 +96,11 @@ Flag any divergence from the source algorithm as `[fidelity]` NEEDS_CHANGES.
 
 ### Criterion 2: Code Quality
 
-- Interface correctly implemented — verify method signatures against the context document or Expert
+- Interface correctly implemented — verify method signatures against the context files or Expert
 - Slice/array indexing guarded: if inputs are accessed by index, check bounds
 - No implicit assumptions: all assumptions documented in comments
 - Production patterns followed (struct layout, error propagation, naming) — verify
-  against the context document or ask the Expert for examples from the live repo
+  against the context files or ask the Expert for examples from the live repo
 - Logging and observability follow the pattern of existing plugins in the same subsystem
   (ask Expert for a reference if uncertain)
 - No unused imports, dead code, or unexported types that should be exported
@@ -129,8 +133,8 @@ This is the most common failure mode — check it carefully.
 
 ### Criterion 5: Assembly Simulation (CRITICAL)
 
-This verifies that `prepare.py` Phase 4 Assembly will succeed when it deep-merges the
-treatment overlay into the baseline-resolved scenario.
+This verifies that `sim2real assemble` will succeed when it deep-merges the
+treatment overlay into the baseline-resolved scenario at run assembly time.
 
 **Step A — Validate overlay structure:**
 Confirm `{ALGO_NAME}_config.yaml` follows the scenario overlay format from
@@ -141,7 +145,7 @@ Confirm `{ALGO_NAME}_config.yaml` follows the scenario overlay format from
 - Valid YAML: no unescaped colons, correct indentation, properly quoted special characters
 
 **Step B — Simulate the merge:**
-`prepare.py` Phase 4 calls:
+Assembly deep-merges as:
 ```python
 baseline_resolved = deep_merge(baseline_bundle, baseline_overlay)
 treatment_resolved = deep_merge(deep_merge(baseline_resolved, treatment_diffs), treatment_overlay)

--- a/.claude/skills/sim2real-translate/prompts/agent-writer.md
+++ b/.claude/skills/sim2real-translate/prompts/agent-writer.md
@@ -30,7 +30,7 @@ Run Go commands via: `(cd {TARGET_REPO} && <cmd>)`
 | `{ALGO_CONFIG}` | Algorithm policy config (weights, thresholds) — empty for the current schema (parameters, if any, live inline in `{ALGO_SOURCE}`) |
 | `{REPO_ROOT}/pipeline/README.md` | "Scenario Overlay Format" section — defines output structure |
 
-Also inspect the operator-supplied context files (space-separated absolute paths):
+Also inspect the operator-supplied context files (newline-separated absolute paths, one per line):
 
 {CONTEXT_FILE_PATHS}
 
@@ -41,6 +41,10 @@ guidance for the translation.
 Context from the operator (held in mind, not written to disk):
 
 {CONTEXT_TEXT}
+
+Per-algorithm notes from the operator ({ALGO_NAME}, may be empty):
+
+{ALGO_NOTES}
 
 Expert agent name (for queries): {EXPERT_AGENT_NAME}
 
@@ -123,7 +127,7 @@ SendMessage({MAIN_SESSION_NAME}, "baseline-ready: {BASELINE_OVERLAY_PATH}")
 ```
 
 Wait for the reply. The main session will either forward user feedback ("feedback: ...") or
-send "continue". If feedback: revise `baseline_config.yaml` and re-send `baseline-ready:`.
+send "continue". If feedback: revise `{BASELINE_OVERLAY_PATH}` and re-send `baseline-ready:`.
 Repeat until you receive "continue".
 
 TaskUpdate Phase 2 → completed

--- a/.claude/skills/sim2real-translate/prompts/agent-writer.md
+++ b/.claude/skills/sim2real-translate/prompts/agent-writer.md
@@ -14,7 +14,8 @@ and iterate with the reviewer until you receive APPROVE.
 
 Experiment root: {EXPERIMENT_ROOT}
 Target repo (submodule): {TARGET_REPO}
-Run directory: {RUN_DIR}
+Translations dir: {TRANSLATIONS_DIR}
+Per-algorithm output dir: {OUTPUT_DIR}
 Main session name: {MAIN_SESSION_NAME}
 Algorithm being translated: {ALGO_NAME}
 
@@ -25,10 +26,17 @@ Run Go commands via: `(cd {TARGET_REPO} && <cmd>)`
 
 | File | Purpose |
 |------|---------|
-| `{CONTEXT_PATH}` | Architecture overview, signal mapping, plugin types, overlay format |
-| `{ALGO_SOURCE}` | Source algorithm Go file from simulation |
-| `{ALGO_CONFIG}` | Algorithm policy config (weights, thresholds) — empty when parameter-free |
+| `{ALGO_SOURCE}` | Source algorithm file from simulation |
+| `{ALGO_CONFIG}` | Algorithm policy config (weights, thresholds) — empty for the current schema (parameters, if any, live inline in `{ALGO_SOURCE}`) |
 | `{REPO_ROOT}/pipeline/README.md` | "Scenario Overlay Format" section — defines output structure |
+
+Also inspect the operator-supplied context files (space-separated absolute paths):
+
+{CONTEXT_FILE_PATHS}
+
+These files were declared in `transfer.yaml:context.files` and typically hold
+architecture overview, signal mapping, plugin types, and any project-specific
+guidance for the translation.
 
 Context from the operator (held in mind, not written to disk):
 
@@ -41,7 +49,7 @@ Expert agent name (for queries): {EXPERT_AGENT_NAME}
 **Do not explore `{TARGET_REPO}` yourself** beyond reading specific files you already
 know the path to (from the context document or Expert answers).
 
-The context document gives you the architecture overview and signal mapping. For anything
+The context files ({CONTEXT_FILE_PATHS}) give you the architecture overview and signal mapping. For anything
 code-level — Go interface signatures, struct definitions, factory function patterns,
 registration examples, exact type strings — ask the Expert. The Expert has already
 read the full repo and will give you file:line answers.
@@ -69,17 +77,20 @@ Example queries:
 
 Use TaskCreate: `"Phase 2: Baseline Config Derivation"` → TaskUpdate in_progress
 
-**Skip check:** If `{RUN_DIR}/generated/baseline_config.yaml` already exists (written by a
-prior algorithm's skill invocation), skip Phase 2 — send:
+**Skip check:** If `{BASELINE_OVERLAY_PATH}` is empty (the manifest declared no baseline
+overlay for this translation), skip Phase 2 entirely and proceed to Phase 3. If
+`{BASELINE_OVERLAY_PATH}` is set and the file already exists (written by a prior algorithm's
+skill invocation in the same translation), skip Phase 2 — send:
 ```
-SendMessage({MAIN_SESSION_NAME}, "baseline-ready: {RUN_DIR}/generated/baseline_config.yaml")
+SendMessage({MAIN_SESSION_NAME}, "baseline-ready: {BASELINE_OVERLAY_PATH}")
 ```
-and wait for "continue". Baseline config is shared across algorithms.
+and wait for "continue". Baseline config is shared across algorithms in the same translation.
 
 Use the inputs listed in the upfront "Inputs — Read These Now" table.
 
-Your goal: produce `{RUN_DIR}/generated/baseline_config.yaml` — a **llmdbenchmark scenario overlay**
-that will be deep-merged onto the experiment's `baseline.yaml` by `prepare.py`.
+Your goal: produce `{BASELINE_OVERLAY_PATH}` — a **llmdbenchmark scenario overlay** that
+will be deep-merged onto the experiment's baseline scenario by `sim2real assemble` at run
+assembly time.
 
 **Output format** (from pipeline/README.md "Scenario Overlay Format"):
 - Top-level `scenario:` list with one dict
@@ -101,14 +112,14 @@ that will be deep-merged onto the experiment's `baseline.yaml` by `prepare.py`.
 - Only include fields you are adding or overriding
 
 **Content rules:**
-- Use `{CONTEXT_PATH}` to determine what plugin config and priorities to include
-- Map sim concepts to real plugin type strings via the signal mapping in `{CONTEXT_PATH}`
+- Use the context files listed above (`{CONTEXT_FILE_PATHS}`) to determine what plugin config and priorities to include
+- Map sim concepts to real plugin type strings via the signal mapping in the context files
 - Ask the Expert if you are unsure about any plugin type string or config field name
 
-Create the `generated/` directory if needed, then write `{RUN_DIR}/generated/baseline_config.yaml`.
+Create the parent directory if needed, then write `{BASELINE_OVERLAY_PATH}`.
 Then send to main session:
 ```
-SendMessage({MAIN_SESSION_NAME}, "baseline-ready: {RUN_DIR}/generated/baseline_config.yaml")
+SendMessage({MAIN_SESSION_NAME}, "baseline-ready: {BASELINE_OVERLAY_PATH}")
 ```
 
 Wait for the reply. The main session will either forward user feedback ("feedback: ...") or
@@ -122,11 +133,11 @@ TaskUpdate Phase 2 → completed
 Use TaskCreate: `"Phase 3: Treatment Config Derivation"` → TaskUpdate in_progress
 
 Read:
-1. `{RUN_DIR}/generated/baseline_config.yaml` — the approved baseline overlay
-2. If `{ALGO_CONFIG}` is non-empty: read it — the algorithm policy config (what changes from baseline)
+1. `{BASELINE_OVERLAY_PATH}` — the approved baseline overlay (skip when empty; treat the framework baseline as the reference)
+2. If `{ALGO_CONFIG}` is non-empty: read it — the algorithm policy config (what changes from baseline). Under the current schema this is always empty; inspect `{ALGO_SOURCE}` directly for any inline weights or thresholds.
 3. `{ALGO_SOURCE}` — the algorithm source
 
-Your goal: produce `{RUN_DIR}/generated/{ALGO_NAME}/{ALGO_NAME}_config.yaml` — a **llmdbenchmark scenario overlay**
+Your goal: produce `{OUTPUT_DIR}/{ALGO_NAME}_config.yaml` — a **llmdbenchmark scenario overlay**
 containing ONLY what differs from the baseline. Since assembly computes
 `treatment_resolved = deep_merge(baseline_resolved, treatment_overlay)`, anything already in
 baseline propagates automatically.
@@ -147,9 +158,9 @@ baseline propagates automatically.
   no `parameters:` block is needed — just declare the plugin type and name
 - Ask the Expert about config struct field names if needed
 
-Create the directory `{RUN_DIR}/generated/{ALGO_NAME}/` if needed, then write `{RUN_DIR}/generated/{ALGO_NAME}/{ALGO_NAME}_config.yaml`. Then send to main session:
+Create the directory `{OUTPUT_DIR}/` if needed, then write `{OUTPUT_DIR}/{ALGO_NAME}_config.yaml`. Then send to main session:
 ```
-SendMessage({MAIN_SESSION_NAME}, "treatment-ready: {RUN_DIR}/generated/{ALGO_NAME}/{ALGO_NAME}_config.yaml")
+SendMessage({MAIN_SESSION_NAME}, "treatment-ready: {OUTPUT_DIR}/{ALGO_NAME}_config.yaml")
 ```
 
 Wait for the reply. Handle feedback / continue as in Phase 2.
@@ -162,13 +173,13 @@ TaskUpdate Phase 3 → completed
 2. **Ask the Expert** for exact Go interface signatures, the Factory function pattern, an
    example plugin to model your code after, and the registration file location
 3. **Write** the production plugin code into `{TARGET_REPO}` at the package path identified
-   in the context document or by the Expert
+   in the context files or by the Expert
 4. Define a `Type` constant (kebab-case string) and a `Factory` function matching the
    pattern used by existing plugins in this subsystem
 5. **Register** the plugin in the registration file identified by the Expert
-6. Update `{RUN_DIR}/generated/{ALGO_NAME}/{ALGO_NAME}_config.yaml` if the plugin type or parameters changed
+6. Update `{OUTPUT_DIR}/{ALGO_NAME}_config.yaml` if the plugin type or parameters changed
 7. **Follow logging and code patterns** used by existing plugins in the same subsystem —
-   ask the Expert for a representative example if the context document doesn't show one
+   ask the Expert for a representative example if the context files don't show one
 8. **Write tests** — for every new plugin Go file (e.g., `foo.go`), write a corresponding
    `foo_test.go` in the same package directory. Tests must cover: Factory construction,
    algorithm logic (at least main branches), and (if configurable) at least one
@@ -176,7 +187,7 @@ TaskUpdate Phase 3 → completed
 
 ## Phase 4.5: Write Preliminary {ALGO_NAME}_output.json
 
-After writing all plugin code (but before running the build), write `{RUN_DIR}/generated/{ALGO_NAME}/{ALGO_NAME}_output.json`
+After writing all plugin code (but before running the build), write `{OUTPUT_DIR}/{ALGO_NAME}_output.json`
 with all 9 required fields. If the file list changes in a later round, update it.
 
 ```json
@@ -193,7 +204,7 @@ with all 9 required fields. If the file list changes in a later round, update it
 }
 ```
 
-Note: `review_rounds` and `consensus` are NOT fields in this file — they go in `.state.json`.
+Note: `review_rounds` and `consensus` are NOT fields in this file — the main session records them in `{TRANSLATIONS_DIR}/review/round_<N>.json` (see Step 4).
 
 ## Step 2: Build/Test Gate (You Own This)
 
@@ -218,30 +229,30 @@ After EVERY successful build/test pass (including the first):
 ```bash
 SNAP_NUM=$(python3 -c "
 from pathlib import Path
-snaps = [d for d in (Path('{RUN_DIR}/snapshots')).glob('v*') if d.is_dir()]
+snaps = [d for d in (Path('{TRANSLATIONS_DIR}/snapshots/{ALGO_NAME}')).glob('v*') if d.is_dir()]
 print(len(snaps) + 1)
 " 2>/dev/null || echo 1)
-SNAP_DIR="{RUN_DIR}/snapshots/v${SNAP_NUM}"
+SNAP_DIR="{TRANSLATIONS_DIR}/snapshots/{ALGO_NAME}/v${SNAP_NUM}"
 mkdir -p "$SNAP_DIR"
 ```
 
 Copy all `files_created` + `files_modified` entries (relative to `{TARGET_REPO}`) plus
-`{RUN_DIR}/generated/{ALGO_NAME}/{ALGO_NAME}_config.yaml` into `$SNAP_DIR`:
+`{OUTPUT_DIR}/{ALGO_NAME}_config.yaml` into `$SNAP_DIR`:
 
 ```bash
 python3 -c "
 import json, shutil
 from pathlib import Path
-o = json.load(open('{RUN_DIR}/generated/{ALGO_NAME}/{ALGO_NAME}_output.json'))
+o = json.load(open('{OUTPUT_DIR}/{ALGO_NAME}_output.json'))
 snap = Path('$SNAP_DIR')
 target = Path('{TARGET_REPO}')
 for f in o['files_created'] + o.get('files_modified', []):
     src = target / f
     dst = snap / Path(f).name
     shutil.copy2(src, dst)
-    print(f'  {Path(f).name} -> snapshots/v$SNAP_NUM/')
-shutil.copy2('{RUN_DIR}/generated/{ALGO_NAME}/{ALGO_NAME}_config.yaml', snap / '{ALGO_NAME}_config.yaml')
-print(f'Snapshot v$SNAP_NUM saved')
+    print(f'  {Path(f).name} -> snapshots/{ALGO_NAME}/v$SNAP_NUM/')
+shutil.copy2('{OUTPUT_DIR}/{ALGO_NAME}_config.yaml', snap / '{ALGO_NAME}_config.yaml')
+print(f'Snapshot {ALGO_NAME}/v$SNAP_NUM saved')
 "
 ```
 
@@ -263,7 +274,7 @@ After each green build, send a review request to the reviewer agent:
 REVIEW REQUEST — Round <N>
 Plugin files: <absolute paths of all files_created (excluding test files), one per line>
 Test files: <absolute paths of all _test.go files created or modified, one per line>
-Treatment config: {RUN_DIR}/generated/{ALGO_NAME}/{ALGO_NAME}_config.yaml
+Treatment config: {OUTPUT_DIR}/{ALGO_NAME}_config.yaml
 Build: PASSED
 Changed since last round: <brief description, or "initial" for round 1>
 ```
@@ -272,8 +283,8 @@ Wait for the reviewer's reply.
 
 ### On APPROVE
 
-1. Write `{RUN_DIR}/generated/{ALGO_NAME}/{ALGO_NAME}_output.json` (update if needed)
-2. Create `{RUN_DIR}/review/` directory if needed, write `round_<N>.json` (see schema below)
+1. Write `{OUTPUT_DIR}/{ALGO_NAME}_output.json` (update if needed)
+2. Create `{TRANSLATIONS_DIR}/review/{ALGO_NAME}/` directory if needed, write `round_<N>.json` (see schema below)
 3. Send to main session:
    ```
    SendMessage({MAIN_SESSION_NAME}, "review-passed: round=<N> plugin_type=<plugin_type>")
@@ -294,7 +305,7 @@ Then exit.
 
 ### On NEEDS_CHANGES (round < {REVIEW_ROUNDS})
 
-Before fixing issues, write `{RUN_DIR}/review/round_<N>.json` with `"consensus": false, "approve_count": 0` and the reviewer's issues list.
+Before fixing issues, write `{TRANSLATIONS_DIR}/review/{ALGO_NAME}/round_<N>.json` with `"consensus": false, "approve_count": 0` and the reviewer's issues list.
 
 Fix ALL issues listed in the reviewer's reply. Then repeat Step 2 (build/test) → Step 3 (snapshot)
 → Step 4 (next review round, incrementing N).
@@ -303,7 +314,7 @@ Do NOT send the reviewer broken code. Only send after a green build.
 
 ### On NEEDS_CHANGES (round == {REVIEW_ROUNDS})
 
-Write `{RUN_DIR}/review/round_<N>.json` with `"consensus": false, "approve_count": 0` and the reviewer's issues list.
+Write `{TRANSLATIONS_DIR}/review/{ALGO_NAME}/round_<N>.json` with `"consensus": false, "approve_count": 0` and the reviewer's issues list.
 
 Collect all remaining issues. Send to main:
 ```
@@ -314,7 +325,7 @@ Then exit.
 
 ## Review Round File Schema
 
-### `{RUN_DIR}/review/round_<N>.json`
+### `{TRANSLATIONS_DIR}/review/{ALGO_NAME}/round_<N>.json`
 
 ```json
 {

--- a/.claude/skills/sim2real-translate/prompts/agent-writer.md
+++ b/.claude/skills/sim2real-translate/prompts/agent-writer.md
@@ -47,7 +47,7 @@ Expert agent name (for queries): {EXPERT_AGENT_NAME}
 ## Tool Discipline
 
 **Do not explore `{TARGET_REPO}` yourself** beyond reading specific files you already
-know the path to (from the context document or Expert answers).
+know the path to (from the context files or Expert answers).
 
 The context files ({CONTEXT_FILE_PATHS}) give you the architecture overview and signal mapping. For anything
 code-level — Go interface signatures, struct definitions, factory function patterns,
@@ -101,8 +101,8 @@ assembly time.
     substitutes `${model.idLabel}` at render time (requires llm-d-benchmark
     >= PR #1103).
 
-  Everything else MUST be copied verbatim from the project's context document
-  (typically `config.md`) at the field level. In particular: copy the entire
+  Everything else MUST be copied verbatim from the project's context files
+  (typically including `config.md`) at the field level. In particular: copy the entire
   `spec.poolRef` block (including `group`, `name`, and any other keys), not
   just `name`. Same applies to `apiVersion`, `metadata`, `spec.priority`, and
   any other nested fields the project's `config.md` declares — if it's in
@@ -138,9 +138,12 @@ Read:
 3. `{ALGO_SOURCE}` — the algorithm source
 
 Your goal: produce `{OUTPUT_DIR}/{ALGO_NAME}_config.yaml` — a **llmdbenchmark scenario overlay**
-containing ONLY what differs from the baseline. Since assembly computes
-`treatment_resolved = deep_merge(baseline_resolved, treatment_overlay)`, anything already in
-baseline propagates automatically.
+containing ONLY plugin-specific additions not already covered by the algorithm's diffs.
+Since assembly computes
+`treatment_resolved = deep_merge(deep_merge(baseline_resolved, treatment_diffs), treatment_overlay)`
+— where `treatment_diffs` comes from the algorithm's `scenario/treatment.yaml` in the
+experiment repo — anything already in either the baseline or the diffs propagates
+automatically; only add things neither layer supplies.
 
 **Output format** (same structure as baseline overlay):
 - Top-level `scenario:` list with one dict

--- a/.claude/skills/sim2real-translate/prompts/agent-writer.md
+++ b/.claude/skills/sim2real-translate/prompts/agent-writer.md
@@ -204,7 +204,7 @@ with all 9 required fields. If the file list changes in a later round, update it
 }
 ```
 
-Note: `review_rounds` and `consensus` are NOT fields in this file — the main session records them in `{TRANSLATIONS_DIR}/review/round_<N>.json` (see Step 4).
+Note: `review_rounds` and `consensus` are NOT fields in this file — you (the writer) record them in `{TRANSLATIONS_DIR}/review/{ALGO_NAME}/round_<N>.json` on each APPROVE / NEEDS_CHANGES round (see Step 4 below).
 
 ## Step 2: Build/Test Gate (You Own This)
 
@@ -248,9 +248,10 @@ snap = Path('$SNAP_DIR')
 target = Path('{TARGET_REPO}')
 for f in o['files_created'] + o.get('files_modified', []):
     src = target / f
-    dst = snap / Path(f).name
+    dst = snap / f
+    dst.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(src, dst)
-    print(f'  {Path(f).name} -> snapshots/{ALGO_NAME}/v$SNAP_NUM/')
+    print(f'  {f} -> snapshots/{ALGO_NAME}/v$SNAP_NUM/{f}')
 shutil.copy2('{OUTPUT_DIR}/{ALGO_NAME}_config.yaml', snap / '{ALGO_NAME}_config.yaml')
 print(f'Snapshot {ALGO_NAME}/v$SNAP_NUM saved')
 "

--- a/.claude/skills/sim2real-translate/scripts/copy_generated.py
+++ b/.claude/skills/sim2real-translate/scripts/copy_generated.py
@@ -4,6 +4,11 @@ Replaces blind trust of translation_output.json lists with git-based
 discovery. Uses uncommitted working-tree state (git diff HEAD + untracked)
 as the source of truth.
 
+The output directory is a sim2real translation directory
+(workspace/translations/<hash>/). When ``algo_name`` is set the script writes
+into ``translation_dir/generated/<algo_name>/`` and updates
+``<algo_name>_output.json``.
+
 Precondition: the target repo working tree must contain only changes from
 this translation run (no pre-existing uncommitted edits from other sources).
 """
@@ -14,13 +19,14 @@ from pathlib import Path
 
 
 def copy_generated(
-    target_repo: str, run_dir: str, algo_name: str | None = None
+    target_repo: str, translation_dir: str, algo_name: str | None = None
 ) -> tuple[list[str], list[str]]:
     """Discover changed/new files via git, update translation_output.json, copy to generated/.
 
     Args:
         target_repo: Path to the target repo (e.g., llm-d-inference-scheduler directory).
-        run_dir: Path to the run directory containing translation_output.json.
+        translation_dir: Path to the translation directory (workspace/translations/<hash>/)
+            containing translation_output.json.
         algo_name: When set, files are written to generated/{algo_name}/ preserving
             full relative paths; an {algo_name}_output.json is also written there.
             When None, existing flat-copy behavior with basename collision check.
@@ -29,7 +35,7 @@ def copy_generated(
         Tuple of (files_created, files_modified) as written to translation_output.json.
     """
     target = Path(target_repo)
-    rd = Path(run_dir)
+    rd = Path(translation_dir)
 
     if algo_name is not None:
         gen = rd / "generated" / algo_name

--- a/.claude/skills/sim2real-translate/scripts/copy_generated.py
+++ b/.claude/skills/sim2real-translate/scripts/copy_generated.py
@@ -25,14 +25,21 @@ def copy_generated(
 
     Args:
         target_repo: Path to the target repo (e.g., llm-d-inference-scheduler directory).
-        translation_dir: Path to the translation directory (workspace/translations/<hash>/)
-            containing translation_output.json.
-        algo_name: When set, files are written to generated/{algo_name}/ preserving
-            full relative paths; an {algo_name}_output.json is also written there.
-            When None, existing flat-copy behavior with basename collision check.
+        translation_dir: Path to the translation directory
+            (``workspace/translations/<hash>/``). In flat mode (``algo_name`` is
+            None) must contain ``translation_output.json``; in per-algorithm mode
+            (``algo_name`` set) must contain
+            ``generated/{algo_name}/{algo_name}_output.json``, written by the
+            writer agent before this call.
+        algo_name: When set, files are written to ``generated/{algo_name}/``
+            preserving full relative paths; ``{algo_name}_output.json`` is
+            updated in place there. When None, existing flat-copy behavior
+            with basename collision check.
 
     Returns:
-        Tuple of (files_created, files_modified) as written to translation_output.json.
+        Tuple of (files_created, files_modified) as written to
+        ``translation_output.json`` (flat mode) or
+        ``{algo_name}_output.json`` (per-algorithm mode).
     """
     target = Path(target_repo)
     rd = Path(translation_dir)

--- a/.claude/skills/sim2real-translate/scripts/copy_generated.py
+++ b/.claude/skills/sim2real-translate/scripts/copy_generated.py
@@ -21,7 +21,7 @@ from pathlib import Path
 def copy_generated(
     target_repo: str, translation_dir: str, algo_name: str | None = None
 ) -> tuple[list[str], list[str]]:
-    """Discover changed/new files via git, update translation_output.json, copy to generated/.
+    """Discover changed/new files via git, update output JSON, copy to generated/ (flat mode) or generated/{algo_name}/ (per-algorithm mode).
 
     Args:
         target_repo: Path to the target repo (e.g., llm-d-inference-scheduler directory).

--- a/.claude/skills/sim2real-translate/tests/test_copy_generated.py
+++ b/.claude/skills/sim2real-translate/tests/test_copy_generated.py
@@ -34,8 +34,8 @@ def git_repo(tmp_path):
 
 
 @pytest.fixture
-def run_dir(tmp_path):
-    """Create a run directory with a minimal translation_output.json."""
+def translation_dir(tmp_path):
+    """Create a translation directory with a minimal translation_output.json."""
     rd = tmp_path / "run"
     rd.mkdir()
     (rd / "translation_output.json").write_text(json.dumps({
@@ -52,122 +52,122 @@ def run_dir(tmp_path):
     return rd
 
 
-def test_modified_tracked_file(git_repo, run_dir):
+def test_modified_tracked_file(git_repo, translation_dir):
     """Modified tracked files appear in files_modified."""
     (git_repo / "existing.go").write_text("package main\n// changed")
-    created, modified = cg.copy_generated(str(git_repo), str(run_dir))
+    created, modified = cg.copy_generated(str(git_repo), str(translation_dir))
     assert modified == ["existing.go"]
     assert created == []
 
 
-def test_new_untracked_file(git_repo, run_dir):
+def test_new_untracked_file(git_repo, translation_dir):
     """New untracked files appear in files_created."""
     (git_repo / "pkg" / "plugins").mkdir(parents=True)
     (git_repo / "pkg" / "plugins" / "new_plugin.go").write_text("package plugins")
-    created, modified = cg.copy_generated(str(git_repo), str(run_dir))
+    created, modified = cg.copy_generated(str(git_repo), str(translation_dir))
     assert "pkg/plugins/new_plugin.go" in created
     assert modified == []
 
 
-def test_files_copied_to_generated(git_repo, run_dir):
+def test_files_copied_to_generated(git_repo, translation_dir):
     """All listed files exist in generated/ after copy."""
     (git_repo / "existing.go").write_text("package main\n// changed")
     (git_repo / "new_file.go").write_text("package main\n// new")
-    cg.copy_generated(str(git_repo), str(run_dir))
-    gen = run_dir / "generated"
+    cg.copy_generated(str(git_repo), str(translation_dir))
+    gen = translation_dir / "generated"
     assert (gen / "existing.go").exists()
     assert (gen / "new_file.go").exists()
 
 
-def test_translation_output_updated(git_repo, run_dir):
+def test_translation_output_updated(git_repo, translation_dir):
     """translation_output.json lists are overwritten with git state."""
-    o = json.loads((run_dir / "translation_output.json").read_text())
+    o = json.loads((translation_dir / "translation_output.json").read_text())
     o["files_created"] = ["stale.go"]
     o["files_modified"] = ["also_stale.go"]
-    (run_dir / "translation_output.json").write_text(json.dumps(o))
+    (translation_dir / "translation_output.json").write_text(json.dumps(o))
 
     (git_repo / "existing.go").write_text("package main\n// changed")
-    cg.copy_generated(str(git_repo), str(run_dir))
+    cg.copy_generated(str(git_repo), str(translation_dir))
 
-    result = json.loads((run_dir / "translation_output.json").read_text())
+    result = json.loads((translation_dir / "translation_output.json").read_text())
     assert result["files_modified"] == ["existing.go"]
     assert result["files_created"] == []
     assert "stale.go" not in result["files_created"]
 
 
-def test_empty_diff_empty_lists(git_repo, run_dir):
+def test_empty_diff_empty_lists(git_repo, translation_dir):
     """No changes -> empty lists, no files in generated/."""
-    created, modified = cg.copy_generated(str(git_repo), str(run_dir))
+    created, modified = cg.copy_generated(str(git_repo), str(translation_dir))
     assert created == []
     assert modified == []
-    gen = run_dir / "generated"
+    gen = translation_dir / "generated"
     if gen.exists():
         assert list(gen.iterdir()) == []
 
 
-def test_nested_path_uses_basename(git_repo, run_dir):
+def test_nested_path_uses_basename(git_repo, translation_dir):
     """Files in subdirectories use basename in generated/."""
     (git_repo / "pkg" / "deep").mkdir(parents=True)
     (git_repo / "pkg" / "deep" / "nested.go").write_text("package deep")
-    cg.copy_generated(str(git_repo), str(run_dir))
-    gen = run_dir / "generated"
+    cg.copy_generated(str(git_repo), str(translation_dir))
+    gen = translation_dir / "generated"
     assert (gen / "nested.go").exists()
 
 
-def test_mixed_created_and_modified(git_repo, run_dir):
+def test_mixed_created_and_modified(git_repo, translation_dir):
     """Both created and modified files are correctly classified in one call."""
     (git_repo / "existing.go").write_text("package main\n// changed")
     (git_repo / "pkg").mkdir()
     (git_repo / "pkg" / "new_plugin.go").write_text("package pkg")
-    created, modified = cg.copy_generated(str(git_repo), str(run_dir))
+    created, modified = cg.copy_generated(str(git_repo), str(translation_dir))
     assert modified == ["existing.go"]
     assert "pkg/new_plugin.go" in created
-    result = json.loads((run_dir / "translation_output.json").read_text())
+    result = json.loads((translation_dir / "translation_output.json").read_text())
     assert result["files_modified"] == ["existing.go"]
     assert "pkg/new_plugin.go" in result["files_created"]
-    gen = run_dir / "generated"
+    gen = translation_dir / "generated"
     assert (gen / "existing.go").exists()
     assert (gen / "new_plugin.go").exists()
 
 
-def test_config_yamls_preserved(git_repo, run_dir):
+def test_config_yamls_preserved(git_repo, translation_dir):
     """Config yamls placed by writer agent survive the copy step."""
-    gen = run_dir / "generated"
+    gen = translation_dir / "generated"
     gen.mkdir()
     (gen / "baseline_config.yaml").write_text("baseline: true")
     (gen / "treatment_config.yaml").write_text("treatment: true")
 
     (git_repo / "existing.go").write_text("package main\n// changed")
-    cg.copy_generated(str(git_repo), str(run_dir))
+    cg.copy_generated(str(git_repo), str(translation_dir))
 
     assert (gen / "baseline_config.yaml").read_text() == "baseline: true"
     assert (gen / "treatment_config.yaml").read_text() == "treatment: true"
     assert (gen / "existing.go").exists()
 
 
-def test_basename_collision_raises(git_repo, run_dir):
+def test_basename_collision_raises(git_repo, translation_dir):
     """Basename collision between different paths raises ValueError."""
     (git_repo / "pkg" / "scorer").mkdir(parents=True)
     (git_repo / "pkg" / "admission").mkdir(parents=True)
     (git_repo / "pkg" / "scorer" / "config.go").write_text("package scorer")
     (git_repo / "pkg" / "admission" / "config.go").write_text("package admission")
     with pytest.raises(ValueError, match="Basename collision.*config.go"):
-        cg.copy_generated(str(git_repo), str(run_dir))
+        cg.copy_generated(str(git_repo), str(translation_dir))
 
 
-def test_deleted_file_excluded(git_repo, run_dir):
+def test_deleted_file_excluded(git_repo, translation_dir):
     """Deleted tracked files do not appear in files_modified."""
     (git_repo / "existing.go").unlink()
-    created, modified = cg.copy_generated(str(git_repo), str(run_dir))
+    created, modified = cg.copy_generated(str(git_repo), str(translation_dir))
     assert "existing.go" not in modified
     assert created == []
 
 
-def test_preserves_other_json_fields(git_repo, run_dir):
+def test_preserves_other_json_fields(git_repo, translation_dir):
     """Other fields in translation_output.json are not disturbed."""
     (git_repo / "existing.go").write_text("package main\n// changed")
-    cg.copy_generated(str(git_repo), str(run_dir))
-    result = json.loads((run_dir / "translation_output.json").read_text())
+    cg.copy_generated(str(git_repo), str(translation_dir))
+    result = json.loads((translation_dir / "translation_output.json").read_text())
     assert result["plugin_type"] == "scorer"
     assert result["description"] == "test plugin"
 
@@ -175,9 +175,9 @@ def test_preserves_other_json_fields(git_repo, run_dir):
 # --- Per-algorithm subdirectory tests ---
 
 
-def _setup_algo_output(run_dir, algo_name="myalgo"):
+def _setup_algo_output(translation_dir, algo_name="myalgo"):
     """Pre-create per-algo output JSON as the writer would before copy_generated runs."""
-    algo_dir = run_dir / "generated" / algo_name
+    algo_dir = translation_dir / "generated" / algo_name
     algo_dir.mkdir(parents=True, exist_ok=True)
     (algo_dir / f"{algo_name}_output.json").write_text(json.dumps({
         "plugin_type": "scorer",
@@ -192,14 +192,14 @@ def _setup_algo_output(run_dir, algo_name="myalgo"):
     }))
 
 
-def test_per_algorithm_subdirectory(git_repo, run_dir):
+def test_per_algorithm_subdirectory(git_repo, translation_dir):
     """With algo_name, files go to generated/{algo_name}/ preserving full paths."""
-    _setup_algo_output(run_dir)
+    _setup_algo_output(translation_dir)
     (git_repo / "pkg" / "scorer").mkdir(parents=True)
     (git_repo / "pkg" / "scorer" / "plugin.go").write_text("package scorer")
     (git_repo / "existing.go").write_text("package main\n// changed")
-    created, modified = cg.copy_generated(str(git_repo), str(run_dir), algo_name="myalgo")
-    gen = run_dir / "generated" / "myalgo"
+    created, modified = cg.copy_generated(str(git_repo), str(translation_dir), algo_name="myalgo")
+    gen = translation_dir / "generated" / "myalgo"
     assert gen.exists()
     # Full relative paths preserved
     assert (gen / "pkg" / "scorer" / "plugin.go").exists()
@@ -208,26 +208,26 @@ def test_per_algorithm_subdirectory(git_repo, run_dir):
     assert "existing.go" in modified
 
 
-def test_per_algorithm_no_basename_collision(git_repo, run_dir):
+def test_per_algorithm_no_basename_collision(git_repo, translation_dir):
     """With algo_name, same basename in different dirs does NOT raise."""
-    _setup_algo_output(run_dir)
+    _setup_algo_output(translation_dir)
     (git_repo / "pkg" / "scorer").mkdir(parents=True)
     (git_repo / "pkg" / "admission").mkdir(parents=True)
     (git_repo / "pkg" / "scorer" / "config.go").write_text("package scorer")
     (git_repo / "pkg" / "admission" / "config.go").write_text("package admission")
     # Should not raise — full paths can't collide
-    created, modified = cg.copy_generated(str(git_repo), str(run_dir), algo_name="myalgo")
-    gen = run_dir / "generated" / "myalgo"
+    created, modified = cg.copy_generated(str(git_repo), str(translation_dir), algo_name="myalgo")
+    gen = translation_dir / "generated" / "myalgo"
     assert (gen / "pkg" / "scorer" / "config.go").exists()
     assert (gen / "pkg" / "admission" / "config.go").exists()
 
 
-def test_per_algorithm_output_json(git_repo, run_dir):
+def test_per_algorithm_output_json(git_repo, translation_dir):
     """With algo_name, {algo_name}_output.json is updated in the subdirectory."""
-    _setup_algo_output(run_dir)
+    _setup_algo_output(translation_dir)
     (git_repo / "existing.go").write_text("package main\n// changed")
-    cg.copy_generated(str(git_repo), str(run_dir), algo_name="myalgo")
-    gen = run_dir / "generated" / "myalgo"
+    cg.copy_generated(str(git_repo), str(translation_dir), algo_name="myalgo")
+    gen = translation_dir / "generated" / "myalgo"
     algo_out = gen / "myalgo_output.json"
     assert algo_out.exists()
     data = json.loads(algo_out.read_text())

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ python pipeline/sim2real.py --experiment-root ../admission-control use --run <ru
 
 **`pipeline/sim2real.py assemble`** — Materializes `workspace/runs/<run>/` from a registered translation and the experiment repo's `transfer.yaml`. Slices the manifest via `pipeline/lib/slicer.py`, snapshots the assembly slice into `manifest.assembly.yaml`, deep-merges framework defaults + baseline bundle + per-algorithm overlays into resolved scenarios, injects the BYO image ref into treatment scenarios, generates one PipelineRun per (workload, package), and writes `run_metadata.json` (with `params_hash` = SHA-256 of `manifest.assembly.yaml`). Algorithms in `transfer.yaml` but not in the registered translation are warned and skipped.
 
-**`/sim2real-translate`** — DISABLED for step-1. The skill-driven flow is scheduled to be restored in step-2 of the epic (issue [#443](https://github.com/inference-sim/sim2real/issues/443)). See `.claude/skills/sim2real-translate/SKILL.md` for the current stub.
+**`/sim2real-translate`** — Skill-driven translation. Reads `workspace/translations/<hash>/skill_input.json` (written by `sim2real translate`) and spawns a three-agent team (expert + writer + reviewer) per algorithm to produce the Go plugin source + treatment overlay under `workspace/translations/<hash>/generated/<algo>/`. Follow up with `sim2real translate --resume` to validate outputs. See `.claude/skills/sim2real-translate/SKILL.md`.
 
 **`pipeline/deploy.py`** — Builds EPP image and orchestrates PipelineRun execution across namespace slots (`deploy.py run`). Use `deploy.py collect` to pull results from the cluster PVC after runs complete. Operates independently of `transfer.yaml` — driven by workspace files, `setup_config.json`, and `clusters/<id>/cluster_config.json`.
 


### PR DESCRIPTION
Closes #468. Part of epic #463.

## Summary

Restores the `/sim2real-translate` skill (DISABLED since step-1's BYO cutover) against the step-2 workspace layout defined in `docs/epics/step-2/design.md`. The skill now reads `workspace/translations/<hash>/skill_input.json` (written by `sim2real translate` in #473 / PR 3) and writes per-algorithm outputs to `workspace/translations/<hash>/generated/<algo>/{cmd,pkg,<algo>_config.yaml,<algo>_output.json}`, exactly as `sim2real translate --resume` probes for.

## What changed

- **`SKILL.md`**: full rewrite. Drops DISABLED preamble; `user-invocable: true`; computes translation hash via `pipeline.lib.slicer.translation_hash_with_sources` (same call site `sim2real translate` uses — no drift risk); loads `skill_input.json`; loops over `algorithms[]`, skipping any whose `<algo>_output.json` already exists (idempotent per-algo). Directs the operator to `sim2real translate --resume` next.
- **`prompts/agent-writer.md`, `prompts/agent-reviewer.md`**: path placeholders repointed from `{RUN_DIR}/generated/{ALGO_NAME}/...` to `{OUTPUT_DIR}/...` and `{BASELINE_OVERLAY_PATH}`. Snapshot directory moves to `{TRANSLATIONS_DIR}/snapshots/{ALGO_NAME}/vN` so multi-algo runs don't collide. All three `prepare.py` references (writer:82, reviewer:132, reviewer:144 — the PR #455 sweep followup) are rewritten to describe `sim2real assemble` semantics.
- **`prompts/agent-expert.md`**: the "read files in context.files" instruction now points at the inline `{CONTEXT_FILE_PATHS}` placeholder (the new `skill_input.json` inlines the operator's context set from `transfer.yaml:context.files`, rather than having the skill re-parse the manifest).
- **`scripts/copy_generated.py` + `tests/test_copy_generated.py`**: rename the `run_dir` parameter to `translation_dir`. Behavior unchanged — the parameter refers to `workspace/translations/<hash>/`, so the pre-refactor `run_dir` name was stale.
- **`CLAUDE.md`**: update the `/sim2real-translate` blurb from "DISABLED for step-1" to the new re-enabled description.

`.github/workflows/test.yml` already lists `.claude/skills/sim2real-translate/tests/` (line 41) — no CI wiring update needed.

## Notes for reviewers

- **`{ALGO_CONFIG}` placeholder**: kept in the prompts but always substituted with `""`. The v3 manifest (`pipeline/lib/manifest.py`) has no `algorithm_config` field — inline parameters live in the algorithm source. The existing "if `{ALGO_CONFIG}` is non-empty" branches in the prompts already handle empty gracefully (parameter-free path).
- **Semantics inside writer/reviewer**: unchanged. The design explicitly scopes this PR to paths + `user-invocable`. Phase 2 (baseline overlay), Phase 3 (treatment overlay), Phase 4 (translate + build + review) still run the same way — only file locations change.
- **`scripts/review.py` + `tests/test_review.py`**: not touched. That's the DEPRECATED external-LLM multi-model review flow (retired 2026-04-10 per `review.py:1`); the current review path spawns `agent-reviewer` as a Claude subagent. This PR's stated scope in `design.md:472-478` is the `prepare.py` sweep + prompt rewrite; the broader dead-code sweep is PR-6 (`design.md:498`).
- **`README.md` step 4-6 workflow section** (top-level, not `pipeline/README.md`) still describes the pre-refactor `prepare.py` flow. Leaving it — that section needs a coordinated rewrite alongside `sim2real build`, which lands in PR-5, and the final docs pass is PR-6 (`design.md:497`). Flagging so reviewers aren't surprised by the stale bit.

## Test plan

- [x] `.venv/bin/python -m pytest .claude/skills/sim2real-translate/tests/ -v` — 37 passed
- [x] `.venv/bin/python -m pytest pipeline/tests/test_translate.py -v` — 29 passed (regression check on PR-3)
- [x] `.venv/bin/python -m pytest pipeline/ -x --ignore=pipeline/tests/test_translate.py` — 1245 passed, 2 xfailed
- [x] `.venv/bin/ruff check pipeline/ .claude/skills/ --select F` — clean
- [x] `grep -rn "prepare\.py" .claude/skills/sim2real-translate/prompts/ .claude/skills/sim2real-translate/SKILL.md` — no hits
- [x] `grep -rn "DISABLED" .claude/skills/sim2real-translate/SKILL.md CLAUDE.md` — no hits
- [ ] Manual integration gate (issue acceptance criterion, not automatable): run `sim2real translate` in a scratch experiment repo, then `/sim2real-translate` — confirm the skill reaches the team-spawn step against a real PR-3-produced `skill_input.json`.