### PR TITLE
step-2: -gaie override + baselines[] plural schema + registry-creds Secret plumbing + setup.py runs/ ownership (#477, #479, #480, #481)

### DIFF
--- a/.claude/skills/sim2real-translate/SKILL.md
+++ b/.claude/skills/sim2real-translate/SKILL.md
@@ -153,7 +153,7 @@ test -f "$TRANSLATIONS_DIR/skill_input.json" || {
 Load per-algorithm inputs from `skill_input.json`. Every path in the file is
 interpreted relative to `experiment_root` (for `source_path`) or
 `translations_dir` (for `output_dir`, `config_output_path`,
-`baseline.generated_overlay_path`):
+`algorithms[i].baseline_overlay_path`):
 
 Path-safe emission: each `ALGO` row is TAB-delimited; each context file path is
 written to a separate line in a dedicated file (`/tmp/sim2real_translate_ctx_paths.txt`)
@@ -172,11 +172,6 @@ required = ("version", "translation_hash", "experiment_root", "translations_dir"
 missing = [k for k in required if k not in si]
 if missing:
     raise SystemExit(f"HALT: skill_input.json missing keys: {missing}")
-baseline = si.get("baseline")
-if baseline is not None:
-    print("BASELINE_OVERLAY_REL=" + baseline["generated_overlay_path"])
-else:
-    print("BASELINE_OVERLAY_REL=")
 ctx = si.get("context") or {}
 print("CONTEXT_TEXT_B64=" + base64.b64encode(
     (ctx.get("text") or "").encode()).decode())
@@ -185,22 +180,21 @@ ctx_paths_out = Path("/tmp/sim2real_translate_ctx_paths.txt")
 paths = [str(exp / p) for p in (ctx.get("file_paths") or [])]
 ctx_paths_out.write_text("".join(p + "\n" for p in paths))
 for algo in si["algorithms"]:
+    # baseline_overlay_path is None when this algorithm's ``defaults``
+    # baseline isn't in ``skill_input.baselines`` (or the manifest has
+    # no baselines at all) — emit an empty string so the writer's
+    # Phase 2 skip-check triggers.
     print("ALGO\t" + "\t".join([
         algo["name"],
         algo["source_path"],
         algo["output_dir"],
         algo["config_output_path"],
+        algo.get("baseline_overlay_path") or "",
         algo.get("notes") or "",
     ]))
 PY
 [ $? -eq 0 ] || exit 1
 
-BASELINE_OVERLAY_REL=$(grep '^BASELINE_OVERLAY_REL=' /tmp/sim2real_translate_algos.txt | cut -d= -f2-)
-if [ -n "$BASELINE_OVERLAY_REL" ]; then
-    BASELINE_OVERLAY_PATH="$TRANSLATIONS_DIR/$BASELINE_OVERLAY_REL"
-else
-    BASELINE_OVERLAY_PATH=""
-fi
 CONTEXT_TEXT_B64_VAL=$(grep '^CONTEXT_TEXT_B64=' /tmp/sim2real_translate_algos.txt | cut -d= -f2-)
 if [ -n "$CONTEXT_TEXT_B64_VAL" ]; then
     CONTEXT_TEXT=$(printf '%s' "$CONTEXT_TEXT_B64_VAL" | base64 -d) || {
@@ -220,7 +214,7 @@ script, and read context paths line-by-line so paths containing spaces are
 preserved):
 
 ```bash
-while IFS=$'\t' read -r _ name source_rel _ _ _; do
+while IFS=$'\t' read -r _ name source_rel _ _ _ _; do
     test -f "$EXPERIMENT_ROOT/$source_rel" || {
         echo "HALT: algorithm source not found: $EXPERIMENT_ROOT/$source_rel"
         exit 1
@@ -240,7 +234,7 @@ every algorithm is complete, exit with an "already complete" message:
 
 ```bash
 INCOMPLETE_ALGOS=""
-while IFS=$'\t' read -r _ name _ output_dir _ _; do
+while IFS=$'\t' read -r _ name _ output_dir _ _ _; do
     algo_out="$TRANSLATIONS_DIR/$output_dir/${name}_output.json"
     if [ ! -f "$algo_out" ]; then
         INCOMPLETE_ALGOS="$INCOMPLETE_ALGOS $name"
@@ -267,12 +261,17 @@ For each `ALGO_NAME` in `$INCOMPLETE_ALGOS`:
 
 ```bash
 # Extract this algorithm's row from /tmp/sim2real_translate_algos.txt.
-IFS=$'\t' read -r _ _ ALGO_SOURCE_REL OUTPUT_DIR_REL CONFIG_OUTPUT_REL ALGO_NOTES < <(
+IFS=$'\t' read -r _ _ ALGO_SOURCE_REL OUTPUT_DIR_REL CONFIG_OUTPUT_REL BASELINE_OVERLAY_REL ALGO_NOTES < <(
     awk -F$'\t' -v n="$ALGO_NAME" '$1=="ALGO" && $2==n {print}' /tmp/sim2real_translate_algos.txt
 )
 ALGO_SOURCE="$EXPERIMENT_ROOT/$ALGO_SOURCE_REL"
 OUTPUT_DIR="$TRANSLATIONS_DIR/$OUTPUT_DIR_REL"
 CONFIG_OUTPUT_PATH="$TRANSLATIONS_DIR/$CONFIG_OUTPUT_REL"
+if [ -n "$BASELINE_OVERLAY_REL" ]; then
+    BASELINE_OVERLAY_PATH="$TRANSLATIONS_DIR/$BASELINE_OVERLAY_REL"
+else
+    BASELINE_OVERLAY_PATH=""
+fi
 # The new skill_input schema has no algorithm_config field — parameters (if
 # any) live inside the source file. Pass "" so the prompts take their
 # "parameter-free" branches when reasoning about configurable weights.
@@ -295,8 +294,10 @@ variable:
 - `{EXPERIMENT_ROOT}` → `$EXPERIMENT_ROOT`
 - `{TRANSLATIONS_DIR}` → `$TRANSLATIONS_DIR`
 - `{OUTPUT_DIR}` → `$OUTPUT_DIR`
-- `{BASELINE_OVERLAY_PATH}` → `$BASELINE_OVERLAY_PATH` (empty string when the
-  manifest declares no baseline overlay — writer's Phase 2 handles this)
+- `{BASELINE_OVERLAY_PATH}` → `$BASELINE_OVERLAY_PATH` (per-algorithm — points
+  at the overlay for THIS algorithm's baseline via `algorithms[i].baseline_overlay_path`;
+  empty when the algorithm's `defaults` isn't in `skill_input.baselines` or the
+  manifest has no baselines — writer's Phase 2 handles this)
 - `{ALGO_SOURCE}` → `$ALGO_SOURCE`
 - `{ALGO_CONFIG}` → `$ALGO_CONFIG` (always empty string; see Step 1 comment)
 - `{ALGO_NAME}` → `$ALGO_NAME`

--- a/.claude/skills/sim2real-translate/prompts/agent-writer.md
+++ b/.claude/skills/sim2real-translate/prompts/agent-writer.md
@@ -100,18 +100,17 @@ assembly time.
 - Top-level `scenario:` list with one dict
 - The `name` field MUST match the scenario name in the experiment's baseline file exactly
   (mismatched names cause llmdbenchmark to deploy multiple scenarios instead of merging)
-- InferenceObjectives go in `extraObjects`. The format pins one rule:
-  - `spec.poolRef.name` MUST equal `${model.idLabel}-gaie` so llm-d-benchmark
-    substitutes `${model.idLabel}` at render time (requires llm-d-benchmark
-    >= PR #1103).
-
-  Everything else MUST be copied verbatim from the project's context files
-  (typically including `config.md`) at the field level. In particular: copy the entire
-  `spec.poolRef` block (including `group`, `name`, and any other keys), not
-  just `name`. Same applies to `apiVersion`, `metadata`, `spec.priority`, and
-  any other nested fields the project's `config.md` declares — if it's in
-  config.md's InferenceObjective, it MUST appear in the generated output.
-  Do not paraphrase or selectively include fields.
+- InferenceObjectives go in `extraObjects`. Copy the InferenceObjective
+  verbatim from the project's context files (typically `config.md`) at the
+  field level. In particular: copy the entire `spec.poolRef` block
+  (including `group`, `name`, and any other keys). Same applies to
+  `apiVersion`, `metadata`, `spec.priority`, and any other nested fields
+  the project's `config.md` declares — if it's in config.md's
+  InferenceObjective, it MUST appear in the generated output. Do not
+  paraphrase or selectively include fields, and do not substitute or
+  rewrite `${model.idLabel}` — llm-d-benchmark expands it at render time
+  (requires llm-d-benchmark >= PR #1103), so pass any such placeholders
+  through verbatim.
 - Plugin config in `inferenceExtension.pluginsCustomConfig` as a YAML-in-YAML string
 - Only include fields you are adding or overriding
 

--- a/.claude/skills/sim2real-translate/prompts/agent-writer.md
+++ b/.claude/skills/sim2real-translate/prompts/agent-writer.md
@@ -81,14 +81,16 @@ Example queries:
 
 Use TaskCreate: `"Phase 2: Baseline Config Derivation"` → TaskUpdate in_progress
 
-**Skip check:** If `{BASELINE_OVERLAY_PATH}` is empty (the manifest declared no baseline
-overlay for this translation), skip Phase 2 entirely and proceed to Phase 3. If
-`{BASELINE_OVERLAY_PATH}` is set and the file already exists (written by a prior algorithm's
-skill invocation in the same translation), skip Phase 2 — send:
+**Skip check:** If `{BASELINE_OVERLAY_PATH}` is empty (this algorithm's baseline is not
+in the manifest's `baselines[]` — should not happen for valid manifests), skip Phase 2
+entirely and proceed to Phase 3. If `{BASELINE_OVERLAY_PATH}` is set and the file already
+exists (written by a prior algorithm's skill invocation in the same translation whose
+`defaults` cross-references the same baseline), skip Phase 2 — send:
 ```
 SendMessage({MAIN_SESSION_NAME}, "baseline-ready: {BASELINE_OVERLAY_PATH}")
 ```
-and wait for "continue". Baseline config is shared across algorithms in the same translation.
+and wait for "continue". Algorithms that share a baseline (via `defaults`) share this
+overlay file; algorithms with distinct baselines produce distinct overlay files.
 
 Use the inputs listed in the upfront "Inputs — Read These Now" table.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ python pipeline/sim2real.py --experiment-root ../admission-control use --run <ru
 
 **Backward compat:** Omitting `--experiment-root` defaults to the current working directory. Run all pipeline commands from the experiment repo root and the default will resolve correctly without the flag.
 
-**`pipeline/setup.py`** — One-time workspace config writer. Writes `setup_config.json` and `run_metadata.json` with operator-side fields (registry, repo name, current run, orchestrator image, sim2real_root). Idempotent — safe to re-run. Cluster-side bootstrap (namespaces, RBAC, secrets, PVCs, Tekton tasks, Pipeline definition, and the optional `--pipeline-yaml` manifest override) lives in `cluster.py provision`.
+**`pipeline/setup.py`** — One-time workspace config writer. Writes `setup_config.json` with operator-side fields (registry, repo name, orchestrator image, sim2real_root). Idempotent — safe to re-run. Does not touch `workspace/runs/` — run directory materialization is owned by `sim2real assemble`. `current_run` in `setup_config.json` is owned by `sim2real use`. Cluster-side bootstrap (namespaces, RBAC, secrets, PVCs, Tekton tasks, Pipeline definition, and the optional `--pipeline-yaml` manifest override) lives in `cluster.py provision`.
 
 **`pipeline/sim2real.py translation register`** — Records a BYO translation on disk. Writes `workspace/translations/<hash>/translation_output.json` (algorithm index + provenance), `registered.json` (image ref + digest), and `generated/<algo>/<algo>_config.yaml` (verbatim copy of the treatment overlay). `translation_hash` is deterministic — same inputs produce the same hash. See [`pipeline/README.md`](pipeline/README.md#register-a-translation) for the flag reference and idempotency rules.
 
@@ -96,7 +96,8 @@ All artifacts live under `<experiment-root>/workspace/` (gitignored). When no `-
 
 | File | Written by | Read by |
 |------|-----------|---------|
-| `setup_config.json` (workspace fields: registry, repo_name, current_run, orchestrator_image, sim2real_root) | `setup.py`, `sim2real.py use` | `deploy.py`, `sim2real.py list runs` |
+| `setup_config.json` (workspace fields: registry, repo_name, orchestrator_image, sim2real_root) | `setup.py` | `deploy.py`, `sim2real.py list runs` |
+| `setup_config.json:current_run` (active run pointer) | `sim2real.py use` | `deploy.py` (default `--run`), `sim2real.py list runs` (active-mark `*`) |
 | `clusters/<id>/cluster_config.json` (cluster fields: cluster_id, namespaces, is_openshift, storage_class, secret_names, workspaces, pipeline_yaml (optional), created_at) | `cluster.py provision` | `sim2real assemble`, `deploy.py`, `lib/remote.py` |
 | `translations/<hash>/translation_output.json` (step-2 shape: top-level `alias`; per-algo `image_ref`/`image_digest`/`config_path`/`source_path`/`source_sha256` inside `algorithms[i]`. Step-1 legacy files with top-level `image_ref` remain readable via `translation_ref.read_translation_output`) | `sim2real translation register` (BYO); `sim2real translate` (skill; writes null image fields); `sim2real build` (fills `image_ref`/`image_digest` per algo) | `sim2real assemble`, `sim2real list translations`, `deploy.py` |
 | `translations/<hash>/skill_input.json` (skill-driven only) | `sim2real translate` | `/sim2real-translate` skill |

--- a/docs/epics/step-2/design.md
+++ b/docs/epics/step-2/design.md
@@ -213,6 +213,7 @@ The contract between `sim2real translate` (Python) and `/sim2real-translate` (sk
       "source_sha256": "e3b0c44…",
       "output_dir": "generated/softreflective",
       "config_output_path": "generated/softreflective/softreflective_config.yaml",
+      "baseline_overlay_path": "generated/baseline_base/baseline_config.yaml",
       "notes": "…free-form guidance from transfer.yaml.context…"
     }
   ],
@@ -225,10 +226,11 @@ The contract between `sim2real translate` (Python) and `/sim2real-translate` (sk
 
 Field semantics:
 
-- **Paths are relative to `experiment_root` or `translations_dir`** as appropriate — `algorithms[i].source_path` is relative to `experiment_root`; `algorithms[i].output_dir`, `config_output_path`, and `baselines[i].generated_overlay_path` are relative to `translations_dir`. Absolute-path variants of `experiment_root` and `translations_dir` are provided at the top level so the skill doesn't have to compose them itself.
+- **Paths are relative to `experiment_root` or `translations_dir`** as appropriate — `algorithms[i].source_path` is relative to `experiment_root`; `algorithms[i].output_dir`, `config_output_path`, `algorithms[i].baseline_overlay_path`, and `baselines[i].generated_overlay_path` are relative to `translations_dir`. Absolute-path variants of `experiment_root` and `translations_dir` are provided at the top level so the skill doesn't have to compose them itself.
 - **`baselines`** is a list — one entry per baseline that any `algorithms[*].defaults` cross-references (`manifest.py` requires `defaults` and validates it names a real `baselines[].name`). Unreferenced baselines are dropped by `sim2real translate`. When the manifest declares baselines but no algorithms, the list defensively includes `baselines[0]` so assemble can still resolve a baseline for standby workloads. `baselines` may be empty; the writer's Phase 2 loop collapses to a no-op. Each entry's `generated_overlay_path` lives under `generated/baseline_<name>/baseline_config.yaml`.
 - **Source content is not embedded.** The skill reads algorithm source files directly from `experiment_root/algorithms[i].source_path`. That keeps `skill_input.json` small and lets the skill inspect the full source file (imports, comments) rather than a truncated JSON blob.
 - **`algorithms[i].output_dir`** is the directory the skill must populate with `{cmd,pkg,<name>_output.json,<name>_config.yaml}` — matches the layout under `translations/<hash>/generated/<name>/`.
+- **`algorithms[i].baseline_overlay_path`** resolves this algorithm's `defaults` cross-reference into the concrete per-baseline overlay path (points into one of the `baselines[]` entries' `generated_overlay_path`). Null when the algorithm's `defaults` names a baseline that isn't in `baselines[]` (rare — the manifest layer prevents this for valid v3 shapes). Algorithms with the same `defaults` receive the same path; the writer's Phase 2 skip-if-exists check keeps them from clobbering each other.
 - **`context`** carries the `transfer.yaml:context` block (text + file paths) so the skill has the same free-form input the pre-refactor `prepare.py` fed it.
 
 `skill_input.json` is written by `sim2real translate` at initial-run time and is not mutated afterward. The skill reads it at its Step 0 and writes into the paths it names.

--- a/docs/epics/step-2/design.md
+++ b/docs/epics/step-2/design.md
@@ -202,7 +202,6 @@ The contract between `sim2real translate` (Python) and `/sim2real-translate` (sk
   "baselines": [
     {
       "name": "base",
-      "config_path": "baselines/base.yaml",
       "generated_overlay_path": "generated/baseline_base/baseline_config.yaml"
     }
   ],

--- a/docs/epics/step-2/design.md
+++ b/docs/epics/step-2/design.md
@@ -199,10 +199,13 @@ The contract between `sim2real translate` (Python) and `/sim2real-translate` (sk
   "experiment_root": "/absolute/path/to/experiment-repo",
   "translations_dir": "/absolute/path/to/workspace/translations/abc123def456…",
   "scenario": "softreflective-v1",
-  "baseline": {
-    "config_path": "baselines/base.yaml",
-    "generated_overlay_path": "generated/baseline_config.yaml"
-  },
+  "baselines": [
+    {
+      "name": "base",
+      "config_path": "baselines/base.yaml",
+      "generated_overlay_path": "generated/baseline_base/baseline_config.yaml"
+    }
+  ],
   "algorithms": [
     {
       "name": "softreflective",
@@ -222,7 +225,8 @@ The contract between `sim2real translate` (Python) and `/sim2real-translate` (sk
 
 Field semantics:
 
-- **Paths are relative to `experiment_root` or `translations_dir`** as appropriate — `algorithms[i].source_path` is relative to `experiment_root`; `algorithms[i].output_dir`, `config_output_path`, and `baseline.generated_overlay_path` are relative to `translations_dir`. Absolute-path variants of `experiment_root` and `translations_dir` are provided at the top level so the skill doesn't have to compose them itself.
+- **Paths are relative to `experiment_root` or `translations_dir`** as appropriate — `algorithms[i].source_path` is relative to `experiment_root`; `algorithms[i].output_dir`, `config_output_path`, and `baselines[i].generated_overlay_path` are relative to `translations_dir`. Absolute-path variants of `experiment_root` and `translations_dir` are provided at the top level so the skill doesn't have to compose them itself.
+- **`baselines`** is a list — one entry per baseline that any `algorithms[*].defaults` cross-references (`manifest.py` requires `defaults` and validates it names a real `baselines[].name`). Unreferenced baselines are dropped by `sim2real translate`. When the manifest declares baselines but no algorithms, the list defensively includes `baselines[0]` so assemble can still resolve a baseline for standby workloads. `baselines` may be empty; the writer's Phase 2 loop collapses to a no-op. Each entry's `generated_overlay_path` lives under `generated/baseline_<name>/baseline_config.yaml`.
 - **Source content is not embedded.** The skill reads algorithm source files directly from `experiment_root/algorithms[i].source_path`. That keeps `skill_input.json` small and lets the skill inspect the full source file (imports, comments) rather than a truncated JSON blob.
 - **`algorithms[i].output_dir`** is the directory the skill must populate with `{cmd,pkg,<name>_output.json,<name>_config.yaml}` — matches the layout under `translations/<hash>/generated/<name>/`.
 - **`context`** carries the `transfer.yaml:context` block (text + file paths) so the skill has the same free-form input the pre-refactor `prepare.py` fed it.
@@ -236,10 +240,11 @@ workspace/translations/<hash>/
 ├── skill_input.json                       # translate step-1 output; the skill's read
 ├── translation_output.json                 # written by translate step-1 (as above)
 └── generated/
-    ├── baseline_config.yaml               # optional shared baseline overlay
-    ├── <algo>/<algo>_config.yaml          # per-algorithm treatment overlay
-    ├── <algo>/<algo>_output.json          # per-algorithm skill output (existence probed by --resume)
-    └── <algo>/{cmd,pkg}/                   # translated Go plugin source
+    ├── baseline_config.yaml                # BYO ``translation register`` — legacy shared baseline overlay (applies to every baseline in the manifest)
+    ├── baseline_<name>/baseline_config.yaml # skill-driven — per-baseline overlay for each entry in ``skill_input.baselines``
+    ├── <algo>/<algo>_config.yaml           # per-algorithm treatment overlay
+    ├── <algo>/<algo>_output.json           # per-algorithm skill output (existence probed by --resume)
+    └── <algo>/{cmd,pkg}/                    # translated Go plugin source
 ```
 
 The `generated/` subtree replaces the pre-refactor `workspace/runs/<run>/generated/` shape — one of the pain points 3D identified. Under step-2 it lives under `translations/<hash>/`, so multiple runs reuse the same translation without re-translating.

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -183,9 +183,10 @@ The translation hash is derived from `transfer.yaml`'s translation slice (scenar
 
 **Outputs** — under `workspace/translations/<translation_hash>/` (initial run only; the skill populates the rest):
 
-- `skill_input.json` — the material `/sim2real-translate` reads (translation hash, experiment root, per-algorithm output paths, context text and files).
+- `skill_input.json` — the material `/sim2real-translate` reads. Pinned schema (see `docs/epics/step-2/design.md`) — includes `translation_hash`, absolute `experiment_root` and `translations_dir`, `scenario`, a `baselines[]` list (one entry per baseline that any algorithm's `defaults` cross-references, each carrying `name`, `config_path`, and a `generated_overlay_path` under `generated/baseline_<name>/`), `algorithms[]` (each with `source_path`, `source_sha256`, `output_dir`, `config_output_path`, and a `baseline_overlay_path` resolved via `defaults`), and `context` (text + file paths).
 - `translation_output.json` — algorithm index with `image_ref: null` on every entry. `sim2real build` fills these in later.
 - `generated/<algo>/` (empty) — the skill writes `cmd/`, `pkg/`, `<algo>_output.json`, and `<algo>_config.yaml` under this directory.
+- `generated/baseline_<name>/` (empty) — one directory per referenced baseline. The skill writes `baseline_config.yaml` under each. Shared by all algorithms whose `defaults` names that baseline.
 
 Once `translate --resume` succeeds, run `sim2real build --translation <alias>` to compile and push images, then `sim2real assemble` as usual.
 
@@ -257,7 +258,8 @@ python pipeline/sim2real.py assemble \
 **Inputs read:**
 
 - `workspace/translations/<hash>/translation_output.json` — algorithms with per-algo `image_ref`. Legacy step-1 files (top-level `image_ref`) are read transparently via `pipeline/lib/translation_ref.py`'s on-read shim.
-- `workspace/translations/<hash>/generated/baseline_config.yaml` — optional baseline overlay (written when `translation register --baseline-config` was passed).
+- `workspace/translations/<hash>/generated/baseline_<name>/baseline_config.yaml` — per-baseline overlay (skill-driven; written by `/sim2real-translate` for each baseline that any algorithm's `defaults` names). Assemble applies each entry to its matching `manifest.baselines[]` entry.
+- `workspace/translations/<hash>/generated/baseline_config.yaml` — legacy BYO overlay (written by `translation register --baseline-config`). Applied to every baseline in the manifest when the per-baseline directory above is absent — falls back automatically so BYO translations remain resolvable.
 - `workspace/translations/<hash>/generated/<algo>/<algo>_config.yaml` — per-algorithm treatment overlay.
 - `workspace/clusters/<cluster_id>/cluster_config.json` — namespaces, workspace bindings, hf secret name.
 - `<experiment-root>/transfer.yaml` (or `config/transfer.yaml`) — v3 manifest.
@@ -709,10 +711,16 @@ All subcommands (`status`, `collect`, `run`, `reset`, `wipe`) use a run-scoped `
 
 ## Scenario Overlay Format
 
-Overlay files live under `workspace/translations/<hash>/generated/`. Both translation producers write the same layout: `sim2real translation register` (BYO) copies the operator-supplied config in, and the `/sim2real-translate` skill (skill-driven) writes it from the translated Go source.
+Overlay files live under `workspace/translations/<hash>/generated/`. The baseline overlay layout differs between the two translation producers:
 
-- `baseline_config.yaml` — optional shared baseline overlay (present when `--baseline-config` was passed to `translation register`)
-- `{algo_name}/{algo_name}_config.yaml` — per-algorithm treatment overlay (verbatim copy of the `--config` file for BYO; produced by the skill for skill-driven)
+- **Skill-driven** (`/sim2real-translate`) — writes one overlay per referenced baseline at `baseline_<name>/baseline_config.yaml`. Assemble reads each baseline's overlay from its own directory.
+- **BYO** (`sim2real translation register`) — writes a single shared overlay at `baseline_config.yaml` (the operator-supplied `--baseline-config` file). Applied to every baseline in the manifest; used as the fallback when a per-baseline directory is absent.
+
+Overlays present in each translation:
+
+- `baseline_<name>/baseline_config.yaml` — per-baseline overlay (skill-driven). One directory per baseline that any algorithm's `defaults` cross-references.
+- `baseline_config.yaml` — legacy shared overlay (BYO). Present when `--baseline-config` was passed to `translation register`.
+- `{algo_name}/{algo_name}_config.yaml` — per-algorithm treatment overlay (verbatim copy of the `--config` file for BYO; produced by the skill for skill-driven).
 
 ### Assembly formula
 

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -80,7 +80,7 @@ python pipeline/cluster.py provision <cluster_id> --namespaces NS1,NS2,... [flag
 
 **What it provisions per namespace:** namespace, RBAC bindings, Secrets (HF, registry, GitHub, Docker Hub), PVCs (data, source), Tekton tasks, and the cluster-wide Pipeline definition. Re-runs reconcile via `kubectl apply` — drift is overwritten.
 
-**Boundary with `setup.py`:** anything operator-side (registry choice, repo name, current run, orchestrator image, sim2real_root) belongs in `setup.py` and lands in `setup_config.json`. Anything cluster-side (namespaces, RBAC, secrets, PVCs, Tekton tasks, Pipeline definition, Pipeline manifest override) belongs in `cluster.py provision` and lands in `cluster_config.json`. The two never write the same file.
+**Boundary with `setup.py`:** anything operator-side (registry choice, repo name, orchestrator image, sim2real_root) belongs in `setup.py` and lands in `setup_config.json`. The `current_run` pointer in that same file is written by `sim2real use` (setup.py leaves it alone). Anything cluster-side (namespaces, RBAC, secrets, PVCs, Tekton tasks, Pipeline definition, Pipeline manifest override) belongs in `cluster.py provision` and lands in `cluster_config.json`. The three writers never overlap on the same key.
 
 ---
 
@@ -184,7 +184,7 @@ The translation hash is derived from `transfer.yaml`'s translation slice (scenar
 
 **Outputs** — under `workspace/translations/<translation_hash>/` (initial run only; the skill populates the rest):
 
-- `skill_input.json` — the material `/sim2real-translate` reads. Pinned schema (see `docs/epics/step-2/design.md`) — includes `translation_hash`, absolute `experiment_root` and `translations_dir`, `scenario`, a `baselines[]` list (one entry per baseline that any algorithm's `defaults` cross-references, each carrying `name`, `config_path`, and a `generated_overlay_path` under `generated/baseline_<name>/`), `algorithms[]` (each with `source_path`, `source_sha256`, `output_dir`, `config_output_path`, and a `baseline_overlay_path` resolved via `defaults`), and `context` (text + file paths).
+- `skill_input.json` — the material `/sim2real-translate` reads. Pinned schema (see `docs/epics/step-2/design.md`) — includes `translation_hash`, absolute `experiment_root` and `translations_dir`, `scenario`, a `baselines[]` list (one entry per baseline that any algorithm's `defaults` cross-references, each carrying `name` and a `generated_overlay_path` under `generated/baseline_<name>/`), `algorithms[]` (each with `source_path`, `source_sha256`, `output_dir`, `config_output_path`, and a `baseline_overlay_path` resolved via `defaults`), and `context` (text + file paths).
 - `translation_output.json` — algorithm index with `image_ref: null` on every entry. `sim2real build` fills these in later.
 - `generated/<algo>/` (empty) — the skill writes `cmd/`, `pkg/`, `<algo>_output.json`, and `<algo>_config.yaml` under this directory.
 - `generated/baseline_<name>/` (empty) — one directory per referenced baseline. The skill writes `baseline_config.yaml` under each. Shared by all algorithms whose `defaults` names that baseline.

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -106,7 +106,7 @@ python pipeline/setup.py [flags]
 | `--test-push` | — | false |
 | `--test-push-tag TAG` | — | `_test-image-push` |
 
-**`--test-push`** — optional workspace-scoped registry credential check (pull busybox, tag, push to `<registry>/<repo_name>:<test-push-tag>`, pull back). Skipped when no registry is configured or no container runtime (`podman`/`docker`) is found. `--registry-user` / `--registry-token` (or `REGISTRY_USER` / `REGISTRY_TOKEN`) gate the registry login. The cluster-side `registry-secret` is created independently by `cluster.py provision`; see #435 for the dedup plan.
+**`--test-push`** — optional workspace-scoped registry credential check (pull busybox, tag, push to `<registry>/<repo_name>:<test-push-tag>`, pull back). Skipped when no registry is configured or no container runtime (`podman`/`docker`) is found. `--registry-user` / `--registry-token` (or `REGISTRY_USER` / `REGISTRY_TOKEN`) gate the registry login. The cluster-side registry credentials Secret (name recorded in `cluster_config.json:secret_names.registry_creds` — default `registry-creds`) is created independently by `cluster.py provision`; see #435 for the dedup plan.
 
 Cluster-scoped fields (`namespaces`, `is_openshift`, `storage_class`, `secret_names`, `workspaces`, `pipeline_yaml`) live in `workspace/clusters/<cluster_id>/cluster_config.json`, written by `cluster.py provision`. PVC bind state (`data-pvc`, `source-pvc`) is gated by `deploy.py`'s slot-readiness check before `deploy.py run` accepts a namespace slot.
 
@@ -223,7 +223,7 @@ python pipeline/sim2real.py build \
 1. Compose `image_ref = <registry>/<repo_name>:<translation_hash[:12]>-<algo>`.
 2. **Idempotency short-circuit**: if the algorithm's recorded `image_ref` already equals the composed value AND `image_digest` is non-null AND `--force-rebuild` is not set, skip. Prints `already built: <ref> (<digest>)`.
 3. **Pre-build registry probe**: `skopeo inspect docker://<ref>`. Success returns the digest; the digest is written back to `translation_output.json` and the build is skipped. Any failure (network, auth, missing tag, timeout) is treated as "absent → build" (fail-safe).
-4. **Buildkit dispatch**: submits an in-cluster `moby/buildkit:latest` pod that reads component source from a PVC and pushes to the target registry via `registry-secret` (provisioned by `cluster.py provision`). Same `pipeline/scripts/build-epp.sh` code path `deploy.py:_cmd_build` has always used.
+4. **Buildkit dispatch**: submits an in-cluster `moby/buildkit:latest` pod that reads component source from a PVC and pushes to the target registry via the credentials Secret whose name is recorded in `cluster_config.json:secret_names.registry_creds` (default `registry-creds`, provisioned by `cluster.py provision`). Same `pipeline/scripts/build-epp.sh` code path `deploy.py:_cmd_build` has always used; the Secret name is threaded in via `--registry-secret-name`.
 5. **Post-build digest inspect**: `skopeo inspect` runs a second time to record the pushed digest. On success, `image_digest` is set. On failure, the build is still considered successful (the image was pushed); `image_digest` is recorded as `null` with a warning. Digest can be back-filled by a later `sim2real build --force-rebuild`.
 6. **Atomic writeback**: `translations/<hash>/translation_output.json:algorithms[i].image_ref` and `image_digest` are written after every algorithm via tempfile-and-rename. A mid-run failure preserves prior algorithms' recorded state.
 
@@ -236,7 +236,7 @@ Return code: `0` on all-success (including all-idempotent). `2` on any prereq fa
 | `skopeo not found on PATH` | Local prereq missing | Install skopeo per the hint in the error message. |
 | `translation <hash> incomplete — missing outputs for: X` | `/sim2real-translate` has not been run for algorithm X | Run `/sim2real-translate`, then `sim2real translate --resume` to verify, then `sim2real build`. |
 | `workspace/setup_config.json is missing 'registry' or 'repo_name'` | `setup.py` was not run, or was run without `--registry` | `python pipeline/setup.py --registry quay.io/username --repo-name <repo>` |
-| `build failed for <algo> (image_ref=...)` | Buildkit pod exited non-zero — usually a compile error, missing PVC, or bad `registry-secret` | Inspect `kubectl logs epp-build-sim2real-build-<hash8>-<algo> -n <namespace>` for the compiler output. |
+| `build failed for <algo> (image_ref=...)` | Buildkit pod exited non-zero — usually a compile error, missing PVC, or bad registry credentials Secret (see `cluster_config.json:secret_names.registry_creds`) | Inspect `kubectl logs epp-build-sim2real-build-<hash8>-<algo> -n <namespace>` for the compiler output. |
 | `translation <ref> not built for algorithms: X` when running `sim2real assemble` | You ran `assemble` before `build` | Run `sim2real build --translation <ref>` first. |
 
 ---

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -86,7 +86,9 @@ python pipeline/cluster.py provision <cluster_id> --namespaces NS1,NS2,... [flag
 
 ## setup.py
 
-Workspace config writer. Writes `workspace/setup_config.json` and `workspace/runs/<run>/run_metadata.json` with operator-side fields (registry, repo_name, current_run, orchestrator_image, sim2real_root). Idempotent.
+Workspace config writer. Writes `workspace/setup_config.json` with operator-side fields (registry, repo_name, orchestrator_image, sim2real_root). Idempotent.
+
+Run-directory materialization is owned by `sim2real assemble`; setup.py does not touch `workspace/runs/`. The `current_run` field in `setup_config.json` is written by `sim2real use` — setup.py leaves any pre-existing value in place.
 
 Cluster-side provisioning (namespaces, RBAC, secrets, PVCs, Tekton tasks, Pipeline definition) lives in `cluster.py provision` and writes a separate `workspace/clusters/<cluster_id>/cluster_config.json`. Run `cluster.py provision` before `sim2real assemble` / `deploy.py`. The Pipeline manifest override (`--pipeline-yaml`) lives on `cluster.py provision`, not here.
 
@@ -100,7 +102,6 @@ python pipeline/setup.py [flags]
 | `--repo-name NAME` | — | `llm-d-inference-scheduler` |
 | `--registry-user USER` | `REGISTRY_USER` | interactive (with `--test-push`) |
 | `--registry-token TOKEN` | `REGISTRY_TOKEN` | interactive (with `--test-push`) |
-| `--run NAME` | — | `sim2real-YYYY-MM-DD` |
 | `--experiment-root PATH` | — | current working directory |
 | `--orchestrator-image IMAGE` | `ORCHESTRATOR_IMAGE` | `ghcr.io/inference-sim/sim2real/orchestrator:latest` |
 | `--test-push` | — | false |
@@ -483,7 +484,7 @@ Writes `workspace/clusters/<cluster_id>/cluster_config.json`. Idempotent — re-
 python pipeline/setup.py --experiment-root <experiment-root>
 ```
 
-Writes `workspace/setup_config.json` with registry, orchestrator image, and `current_run` defaults.
+Writes `workspace/setup_config.json` with registry, repo name, and orchestrator image. Does not touch `workspace/runs/` — that's `sim2real assemble`'s job.
 
 ### 3. Register a translation (BYO)
 
@@ -612,7 +613,8 @@ All artifacts live under `<experiment-root>/workspace/` (gitignored). Key files:
 
 | File | Written by | Read by |
 |------|-----------|---------|
-| `setup_config.json` (workspace fields: registry, repo_name, current_run, orchestrator_image, sim2real_root) | `setup.py`, `sim2real.py use` | `deploy.py`, `sim2real.py list runs` |
+| `setup_config.json` (workspace fields: registry, repo_name, orchestrator_image, sim2real_root) | `setup.py` | `deploy.py`, `sim2real.py list runs` |
+| `setup_config.json:current_run` (active run pointer) | `sim2real.py use` | `deploy.py` (default `--run`), `sim2real.py list runs` (active-mark `*`) |
 | `clusters/<id>/cluster_config.json` (cluster fields: cluster_id, namespaces, is_openshift, storage_class, secret_names, workspaces, created_at) | `cluster.py provision` | `sim2real assemble`, `deploy.py`, `lib/remote.py` |
 | `translations/<hash>/translation_output.json` | `sim2real translation register` | `sim2real assemble`, `deploy.py` |
 | `translations/<hash>/registered.json` | `sim2real translation register` | audit trail |

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -254,11 +254,21 @@ def _write_build_metadata(run_dir: Path, epp_image: str) -> None:
     build.atomic_write_json(meta_path, meta)
 
 
-def _cmd_build(run_dir: Path, namespace: str, skip_build: bool) -> str:
+def _cmd_build(
+    run_dir: Path,
+    namespace: str,
+    skip_build: bool,
+    registry_secret_name: str,
+) -> str:
     """Ensure all required scenario images exist. Returns 'built', 'skip', or 'current'.
 
     Iterates over resolved scenarios in cluster/, extracts image refs,
     and builds any that are stale (source hash mismatch).
+
+    ``registry_secret_name`` is the k8s Secret name holding the
+    dockerconfigjson push credentials — resolved from
+    ``cluster_config.json:secret_names.registry_creds`` by callers.
+    Empty string aborts before dispatch.
     """
     from pipeline.lib.ensure_image import (
         collect_scenario_images, compute_source_hash,
@@ -286,6 +296,13 @@ def _cmd_build(run_dir: Path, namespace: str, skip_build: bool) -> str:
     if skip_build:
         info("--skip-build: skipping image build")
         return "skip"
+
+    if not registry_secret_name:
+        err(
+            "cluster_config.json has no secret_names.registry_creds — "
+            "re-run 'cluster.py provision --registry-user U --registry-token T'"
+        )
+        sys.exit(1)
 
     step(1, "Ensure Images")
 
@@ -408,6 +425,7 @@ def _cmd_build(run_dir: Path, namespace: str, skip_build: bool) -> str:
             source_dir=source_dir,
             run_dir=run_dir,
             repo_root=REPO_ROOT,
+            registry_secret_name=registry_secret_name,
         )
 
         # Restore baseline after algorithm build (clean state for next iteration)
@@ -2429,7 +2447,15 @@ def _cmd_run(args, run_dir: Path, cluster_config: dict) -> None:
     if not namespaces or not namespaces[0]:
         err("No namespaces configured. Run cluster.py provision with --namespaces."); sys.exit(1)
 
-    _cmd_build(run_dir, namespace=namespaces[0], skip_build=args.skip_build)
+    registry_secret_name = (
+        (cluster_config.get("secret_names") or {}).get("registry_creds") or ""
+    )
+    _cmd_build(
+        run_dir,
+        namespace=namespaces[0],
+        skip_build=args.skip_build,
+        registry_secret_name=registry_secret_name,
+    )
 
     max_retries = getattr(args, "max_retries", 2)
     poll_interval = getattr(args, "poll_interval", 30)
@@ -3266,7 +3292,15 @@ def _cmd_run_remote(args, run_dir: "Path", setup_config: dict,
                     }
             _resolve_scope(progress, args)
 
-    _cmd_build(run_dir, namespace=namespace, skip_build=args.skip_build)
+    registry_secret_name = (
+        (cluster_config.get("secret_names") or {}).get("registry_creds") or ""
+    )
+    _cmd_build(
+        run_dir,
+        namespace=namespace,
+        skip_build=args.skip_build,
+        registry_secret_name=registry_secret_name,
+    )
 
     workspace_dir = EXPERIMENT_ROOT / "workspace"
     run_name = run_dir.name
@@ -3476,8 +3510,15 @@ def main():
         namespaces = cluster_config.get("namespaces") or []
         if not namespaces or not namespaces[0]:
             err("No namespaces configured. Run cluster.py provision with --namespaces."); sys.exit(1)
-        _cmd_build(run_dir, namespace=namespaces[0],
-                   skip_build=getattr(args, "skip_build", False))
+        registry_secret_name = (
+            (cluster_config.get("secret_names") or {}).get("registry_creds") or ""
+        )
+        _cmd_build(
+            run_dir,
+            namespace=namespaces[0],
+            skip_build=getattr(args, "skip_build", False),
+            registry_secret_name=registry_secret_name,
+        )
         return
 
     if cmd == "run":

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -277,12 +277,12 @@ def _cmd_build(
 
     run_meta_path = run_dir / "run_metadata.json"
     if not run_meta_path.exists():
-        err("run_metadata.json not found — run setup.py first.")
+        err(f"run_metadata.json not found at {run_meta_path} — run 'sim2real assemble --run <name>' first.")
         sys.exit(1)
     try:
         run_meta = json.loads(run_meta_path.read_text())
     except json.JSONDecodeError as e:
-        err(f"run_metadata.json is not valid JSON: {e}. Re-run setup.py.")
+        err(f"run_metadata.json is not valid JSON: {e}. Re-run 'sim2real assemble --run <name>'.")
         sys.exit(1)
 
     component_image = run_meta.get("component_image")
@@ -290,7 +290,7 @@ def _cmd_build(
         info("No component_image in run metadata — skipping image build")
         return "skip"
     if not component_image:
-        err("component_image is empty in run_metadata.json — re-run setup.py with a valid --registry.")
+        err("component_image is empty in run_metadata.json — re-run 'sim2real assemble --run <name>'.")
         sys.exit(1)
 
     if skip_build:
@@ -308,7 +308,7 @@ def _cmd_build(
 
     registry = run_meta.get("registry", "")
     if not registry:
-        err("registry is empty in run_metadata.json — re-run setup.py with a valid --registry.")
+        err("registry is empty in run_metadata.json — re-run 'sim2real assemble --run <name>'.")
         sys.exit(1)
     repo_name = run_meta.get("repo_name", "llm-d-inference-scheduler")
     run_name = run_dir.name

--- a/pipeline/lib/assemble_run.py
+++ b/pipeline/lib/assemble_run.py
@@ -539,7 +539,6 @@ def assemble_run(
         disable=(manifest.get("defaults") or {}).get("disable") or [],
     )
     generated_root = tdir / "generated"
-    baseline_overlay_path = generated_root / "baseline_config.yaml"
 
     packages: list[tuple[str, dict]] = []
     resolved_baselines: dict[str, dict] = {}
@@ -550,9 +549,17 @@ def assemble_run(
         )
         if bundle_path is None:
             raise AssembleError(f"baseline '{bl_name}' has no scenario file")
+        overlay_path = generated_root / f"baseline_{bl_name}" / "baseline_config.yaml"
+        if not overlay_path.exists():
+            # BYO ``translation register`` writes the shared step-1
+            # ``generated/baseline_config.yaml`` at the generated root.
+            # Fall back to that layout when the per-baseline dir is
+            # absent so BYO translations remain resolvable.
+            legacy_overlay = generated_root / "baseline_config.yaml"
+            overlay_path = legacy_overlay if legacy_overlay.exists() else None
         resolved = resolve_baseline(
             bundle_path=bundle_path,
-            overlay_path=baseline_overlay_path,
+            overlay_path=overlay_path,
             framework_defaults=framework_defaults,
         )
         resolved_baselines[bl_name] = resolved

--- a/pipeline/lib/build.py
+++ b/pipeline/lib/build.py
@@ -89,16 +89,33 @@ def dispatch_buildkit_build(
     source_dir: Path,
     run_dir: Path,
     repo_root: Path,
+    registry_secret_name: str,
 ) -> int:
     """Invoke ``pipeline/scripts/build-epp.sh`` and return its exit code.
 
     Passes every arg the script requires. The script does the actual
-    buildkit-pod submit, source-copy PVC upload, and registry-secret
-    check. Never raises on non-zero exit — the caller inspects the
-    return code (and may retry, log, or record a null-digest result).
+    buildkit-pod submit, source-copy PVC upload, and registry
+    credentials Secret check. Never raises on non-zero exit — the
+    caller inspects the return code (and may retry, log, or record a
+    null-digest result).
 
-    Raises ``BuildError`` only when ``build-epp.sh`` itself is missing.
+    ``registry_secret_name`` is the k8s Secret name that holds the
+    dockerconfigjson push credentials. Callers read it from
+    ``cluster_config.json:secret_names.registry_creds`` — the same
+    single-source-of-truth that ``cluster.py provision`` writes to.
+    Empty string is rejected (BuildError) rather than sent to the shell
+    script, because build-epp.sh would then read the wrong (or no)
+    Secret and buildkit would fail to authenticate.
+
+    Raises ``BuildError`` when ``build-epp.sh`` is missing or
+    ``registry_secret_name`` is empty.
     """
+    if not registry_secret_name:
+        raise BuildError(
+            "registry_secret_name must not be empty — populate "
+            "cluster_config.json:secret_names.registry_creds via "
+            "'cluster.py provision'"
+        )
     build_script = repo_root / "pipeline" / "scripts" / "build-epp.sh"
     if not build_script.exists():
         raise BuildError(f"build-epp.sh not found at {build_script}")
@@ -110,6 +127,7 @@ def dispatch_buildkit_build(
             "--namespace", namespace,
             "--image-ref", image_ref,
             "--source-dir", str(source_dir),
+            "--registry-secret-name", registry_secret_name,
         ],
         check=False,
         cwd=repo_root,

--- a/pipeline/scripts/build-epp.sh
+++ b/pipeline/scripts/build-epp.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 #          [--image-ref <ref>] [--source-dir <path>] [--experiment-root <path>]
 #
 # When --image-ref and --source-dir are provided, uses them directly.
-# Otherwise reads registry/repo from run_metadata.json (created by /sim2real-setup).
+# Otherwise reads registry/repo from run_metadata.json (created by `sim2real assemble`).
 # Requires a dockerconfigjson Secret in the namespace for push credentials;
 # the caller passes its name via --registry-secret-name (populated from
 # cluster_config.json:secret_names.registry_creds).

--- a/pipeline/scripts/build-epp.sh
+++ b/pipeline/scripts/build-epp.sh
@@ -3,11 +3,14 @@ set -euo pipefail
 
 # ── Build EPP image on Kubernetes cluster ──────────────────────────
 # Usage: build-epp.sh --run-dir <path> --run-name <name> --namespace <ns>
+#          --registry-secret-name <name>
 #          [--image-ref <ref>] [--source-dir <path>] [--experiment-root <path>]
 #
 # When --image-ref and --source-dir are provided, uses them directly.
 # Otherwise reads registry/repo from run_metadata.json (created by /sim2real-setup).
-# Requires registry-secret in the namespace for push credentials.
+# Requires a dockerconfigjson Secret in the namespace for push credentials;
+# the caller passes its name via --registry-secret-name (populated from
+# cluster_config.json:secret_names.registry_creds).
 
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
 info()  { echo -e "${BLUE}[INFO]${NC}  $*"; }
@@ -24,24 +27,26 @@ trap cleanup EXIT
 RUN_DIR=""
 RUN_NAME=""
 NAMESPACE=""
+REGISTRY_SECRET_NAME=""
 EXPERIMENT_ROOT=""
 IMAGE_REF=""
 SOURCE_DIR=""
 
 while [[ $# -gt 0 ]]; do
   case $1 in
-    --run-dir)          RUN_DIR="$2"; shift 2 ;;
-    --run-name)         RUN_NAME="$2"; shift 2 ;;
-    --namespace)        NAMESPACE="$2"; shift 2 ;;
-    --experiment-root)  EXPERIMENT_ROOT="$2"; shift 2 ;;
-    --image-ref)        IMAGE_REF="$2"; shift 2 ;;
-    --source-dir)       SOURCE_DIR="$2"; shift 2 ;;
+    --run-dir)              RUN_DIR="$2"; shift 2 ;;
+    --run-name)             RUN_NAME="$2"; shift 2 ;;
+    --namespace)            NAMESPACE="$2"; shift 2 ;;
+    --registry-secret-name) REGISTRY_SECRET_NAME="$2"; shift 2 ;;
+    --experiment-root)      EXPERIMENT_ROOT="$2"; shift 2 ;;
+    --image-ref)            IMAGE_REF="$2"; shift 2 ;;
+    --source-dir)           SOURCE_DIR="$2"; shift 2 ;;
     *) err "Unknown arg: $1"; exit 1 ;;
   esac
 done
 
-if [ -z "${RUN_DIR}" ] || [ -z "${RUN_NAME}" ] || [ -z "${NAMESPACE}" ]; then
-  err "Usage: build-epp.sh --run-dir <path> --run-name <name> --namespace <ns> [--experiment-root <path>]"
+if [ -z "${RUN_DIR}" ] || [ -z "${RUN_NAME}" ] || [ -z "${NAMESPACE}" ] || [ -z "${REGISTRY_SECRET_NAME}" ]; then
+  err "Usage: build-epp.sh --run-dir <path> --run-name <name> --namespace <ns> --registry-secret-name <name> [--experiment-root <path>]"
   exit 1
 fi
 
@@ -74,23 +79,22 @@ info "Target image: ${FULL_IMAGE}"
 info "Source dir: ${SCHEDULER_DIR}"
 
 # ── Step 2: Check registry secret ─────────────────────────────────
-info "Checking registry-secret..."
-if ! kubectl get secret registry-secret -n "${NAMESPACE}" >/dev/null 2>&1; then
-  err "registry-secret not found in namespace ${NAMESPACE}"
+info "Checking registry secret '${REGISTRY_SECRET_NAME}'..."
+if ! kubectl get secret "${REGISTRY_SECRET_NAME}" -n "${NAMESPACE}" >/dev/null 2>&1; then
+  err "registry secret '${REGISTRY_SECRET_NAME}' not found in namespace ${NAMESPACE}"
   echo
-  echo "If using Quay.io, ensure you have:"
-  echo "  1. A robot account with 'Write' permission on your repository"
-  echo "  2. The robot account's Docker config JSON"
+  echo "This Secret is provisioned by 'cluster.py provision --registry-user <u> --registry-token <t>';"
+  echo "its name is recorded in cluster_config.json:secret_names.registry_creds."
   echo
-  echo "Create the secret:"
-  echo "  kubectl create secret docker-registry registry-secret \\"
+  echo "If provisioning by hand instead, create with:"
+  echo "  kubectl create secret docker-registry ${REGISTRY_SECRET_NAME} \\"
   echo "    --namespace ${NAMESPACE} \\"
   echo "    --docker-server=quay.io \\"
   echo "    --docker-username=<robot-account-name> \\"
   echo "    --docker-password=<robot-account-token>"
   exit 1
 fi
-ok "registry-secret found"
+ok "registry secret '${REGISTRY_SECRET_NAME}' found"
 
 # ── Step 3: Copy source to cluster ─────────────────────────────────
 info "Copying ${DIR_BASENAME} source to cluster..."
@@ -168,7 +172,7 @@ spec:
         claimName: source-pvc
     - name: registry-creds
       secret:
-        secretName: registry-secret
+        secretName: ${REGISTRY_SECRET_NAME}
         items:
           - key: .dockerconfigjson
             path: config.json

--- a/pipeline/setup.py
+++ b/pipeline/setup.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python3
 """sim2real workspace config writer.
 
-Writes `workspace/setup_config.json` and `workspace/runs/<run>/run_metadata.json`
-with operator-side fields. Optionally runs a registry credential test push.
+Writes `workspace/setup_config.json` with operator-side fields (registry,
+repo name, orchestrator image, sim2real_root). Optionally runs a registry
+credential test push.
+
+Run-directory materialization is owned by `sim2real assemble`; this script
+does not touch `workspace/runs/`. `current_run` in `setup_config.json` is
+owned by `sim2real use`.
 
 Cluster-side provisioning (namespaces, RBAC, secrets, PVCs, Tekton) lives in
 `pipeline/cluster.py provision`; this script no longer touches the cluster.
@@ -15,14 +20,12 @@ import os
 import subprocess
 import sys
 from dataclasses import dataclass
-from datetime import datetime, timezone
 from pathlib import Path
 
 @dataclass
 class SetupConfig:
     registry: str
     repo_name: str
-    run_name: str
     registry_user: str
     registry_token: str
     orchestrator_image: str = ""
@@ -49,7 +52,8 @@ def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="pipeline/setup.py",
         description="Workspace config writer for the sim2real pipeline.\n"
-                    "Writes setup_config.json + run_metadata.json. Idempotent.\n"
+                    "Writes setup_config.json (operator-side fields only). Idempotent.\n"
+                    "Run directories are created by `sim2real assemble`.\n"
                     "Cluster-side provisioning lives in `cluster.py provision`.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
@@ -67,7 +71,6 @@ Examples:
                                                         help="Registry repository name [llm-d-inference-scheduler]")
     p.add_argument("--registry-user",  metavar="USER",  help="Registry username (used by --test-push)")
     p.add_argument("--registry-token", metavar="TOKEN", help="Registry token (used by --test-push)")
-    p.add_argument("--run",            metavar="NAME",  help="Run name [sim2real-YYYY-MM-DD]")
     p.add_argument("--experiment-root", metavar="PATH", dest="experiment_root",
                    help="Root of the experiment repo (default: current working directory)")
     p.add_argument("--test-push",      action="store_true",
@@ -127,31 +130,10 @@ def _detect_container_runtime() -> str:
     return next((rt for rt in ["podman", "docker"] if which(rt)), "")
 
 
-def _resolve_run_name(args: argparse.Namespace) -> tuple[str, Path]:
-    """Resolve run name, handle directory collision."""
-    default = f"sim2real-{datetime.now().strftime('%Y-%m-%d')}"
-    run_name = args.run or prompt("run_name", "Enter a name for this run", default=default)
-
-    while True:
-        run_dir = EXPERIMENT_ROOT / "workspace" / "runs" / run_name
-        if run_dir.exists():
-            warn(f"Run '{run_name}' already exists at {run_dir}")
-            answer = prompt("overwrite", "Overwrite it, or enter a new name? [overwrite/NAME]",
-                            default="overwrite")
-            if answer.strip().lower() in ("overwrite", "o", "y", "yes", ""):
-                break
-            run_name = answer.strip()
-        else:
-            break
-
-    run_dir.mkdir(parents=True, exist_ok=True)
-    return run_name, run_dir
-
-
 # ── Step 1: Configuration ────────────────────────────────────────────
 
-def collect_config(args: argparse.Namespace) -> tuple[SetupConfig, Path, str]:
-    """Step 1: Collect operator-side config. Returns (config, run_dir, container_runtime)."""
+def collect_config(args: argparse.Namespace) -> tuple[SetupConfig, str]:
+    """Step 1: Collect operator-side config. Returns (config, container_runtime)."""
     step(1, 3, "Configuration")
 
     config_path = EXPERIMENT_ROOT / "workspace" / "setup_config.json"
@@ -168,8 +150,6 @@ def collect_config(args: argparse.Namespace) -> tuple[SetupConfig, Path, str]:
         repo_name = args.repo_name
     else:
         repo_name = prompt("repo_name", "Registry repo name", default=repo_default)
-
-    run_name, run_dir = _resolve_run_name(args)
 
     # Registry credentials are workspace-scoped (used by step_test_push). The
     # in-cluster registry credentials Secret (name recorded in
@@ -206,12 +186,11 @@ def collect_config(args: argparse.Namespace) -> tuple[SetupConfig, Path, str]:
 
     cfg = SetupConfig(
         registry=registry, repo_name=repo_name,
-        run_name=run_name,
         registry_user=reg_user, registry_token=reg_token,
         orchestrator_image=orchestrator_image,
     )
     ok(f"Configuration complete (registry={registry or '(none)'})")
-    return cfg, run_dir, container_rt
+    return cfg, container_rt
 
 # ── Step 2: Registry credential test ─────────────────────────────────
 
@@ -301,29 +280,24 @@ def step_test_push(cfg: SetupConfig, container_rt: str, test_push_tag: str,
 
 # ── Step 3: Config Output ────────────────────────────────────────────
 
-def step_config_output(cfg: SetupConfig, run_dir: Path) -> None:
-    """Step 3: Write setup_config.json and run_metadata.json.
+def step_config_output(cfg: SetupConfig) -> None:
+    """Step 3: Write setup_config.json.
 
-    Both files are read-modify-write. setup_config.json now preserves keys
-    this script doesn't own (e.g. future cluster_id pointer or any other
-    writer's field). run_metadata.json preserves deploy-owned keys
-    (source_hashes, epp_image, stages.deploy.last_completed_step). See #365.
+    Read-modify-write — preserves keys this script doesn't own. Values
+    written: registry, repo_name, sim2real_root, orchestrator_image.
+    ``current_run`` is owned by ``sim2real use``; run directories and
+    ``run_metadata.json`` are owned by ``sim2real assemble``. This
+    script only touches workspace-scoped operator fields.
     """
     step(3, 3, "Config")
 
     workspace = EXPERIMENT_ROOT / "workspace"
     workspace.mkdir(parents=True, exist_ok=True)
 
-    now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    commit = subprocess.run(
-        ["git", "-C", str(REPO_ROOT), "rev-parse", "--short", "HEAD"],
-        capture_output=True, text=True, check=False,
-    ).stdout.strip() or "unknown"
-
     # setup_config.json — operator-side fields only. Cluster-side fields
     # (namespaces, is_openshift, storage_class, secret_names, workspaces)
     # live in workspace/clusters/<id>/cluster_config.json, written by
-    # `cluster.py provision`.
+    # `cluster.py provision`. `current_run` is written by `sim2real use`.
     setup_config_path = workspace / "setup_config.json"
     existing_setup = {}
     if setup_config_path.exists():
@@ -336,45 +310,9 @@ def step_config_output(cfg: SetupConfig, run_dir: Path) -> None:
         "repo_name": cfg.repo_name,
         "sim2real_root": str(REPO_ROOT),
         "orchestrator_image": cfg.orchestrator_image,
-        "current_run": cfg.run_name,
     })
     setup_config_path.write_text(json.dumps(existing_setup, indent=2))
     ok(f"Setup config → {setup_config_path}")
-
-    # run_metadata.json — read-modify-write so deploy-owned keys
-    # (source_hashes, epp_image, stages.deploy.last_completed_step) survive
-    # setup re-runs. See issue #365.
-    meta_path = run_dir / "run_metadata.json"
-    if meta_path.exists():
-        try:
-            existing = json.loads(meta_path.read_text())
-        except json.JSONDecodeError:
-            existing = {}
-    else:
-        existing = {}
-
-    existing.update({
-        "version": 1,
-        "registry": cfg.registry,
-        "repo_name": cfg.repo_name,
-        "created_at": now_iso,
-        "pipeline_commit": commit,
-    })
-    if cfg.registry:
-        existing["component_image"] = f"{cfg.registry}/{cfg.repo_name}:{cfg.run_name}"
-
-    stages = existing.setdefault("stages", {})
-    stages["setup"] = {
-        "status": "completed",
-        "completed_at": now_iso,
-        "summary": "Workspace config written",
-    }
-    stages.setdefault("prepare", {"status": "pending"})
-    stages.setdefault("deploy",  {"status": "pending"})
-    stages.setdefault("results", {"status": "pending"})
-
-    meta_path.write_text(json.dumps(existing, indent=2))
-    ok(f"Run metadata → {meta_path}")
 
 
 # ── main ─────────────────────────────────────────────────────────────
@@ -385,9 +323,9 @@ def main() -> int:
     global EXPERIMENT_ROOT
     EXPERIMENT_ROOT = Path(args.experiment_root).resolve() if getattr(args, "experiment_root", None) else Path.cwd()
 
-    cfg, run_dir, container_rt = collect_config(args)
+    cfg, container_rt = collect_config(args)
     step_test_push(cfg, container_rt, args.test_push_tag, args.test_push)
-    step_config_output(cfg, run_dir)
+    step_config_output(cfg)
 
     # Completion
     print()
@@ -395,15 +333,16 @@ def main() -> int:
     print()
     cfg_path = EXPERIMENT_ROOT / "workspace" / "setup_config.json"
     print(f"Setup config:  {cfg_path}")
-    print(f"Run name:      {cfg.run_name}")
-    print(f"Run directory: {run_dir}")
     print()
     print("Next steps:")
-    print("  1. Provision cluster: python pipeline/cluster.py provision <cluster_id> --namespaces NS1[,NS2,...]")
+    print("  1. Provision cluster:      python pipeline/cluster.py provision <cluster_id> --namespaces NS1[,NS2,...]")
     print("  2. Edit <experiment-root>/transfer.yaml (algorithm source, workloads, context)")
-    print("  3. Register a translation: python pipeline/sim2real.py translation register \\")
+    print("  3a. Skill-driven translate: python pipeline/sim2real.py translate")
+    print("      (then run /sim2real-translate in Claude, then 'sim2real translate --resume')")
+    print("      Followed by:            python pipeline/sim2real.py build --translation REF")
+    print("  3b. Or BYO register:        python pipeline/sim2real.py translation register \\")
     print("                                 --algorithm NAME --image REF --config PATH")
-    print("  4. Assemble a run:         python pipeline/sim2real.py assemble \\")
+    print("  4. Assemble a run:          python pipeline/sim2real.py assemble \\")
     print("                                 --translation HASH --cluster CLUSTER_ID --run RUN_NAME")
     return 0
 

--- a/pipeline/setup.py
+++ b/pipeline/setup.py
@@ -172,8 +172,10 @@ def collect_config(args: argparse.Namespace) -> tuple[SetupConfig, Path, str]:
     run_name, run_dir = _resolve_run_name(args)
 
     # Registry credentials are workspace-scoped (used by step_test_push). The
-    # in-cluster registry-secret is created by cluster.py provision, which
-    # collects credentials independently — see #435 for the dedup plan.
+    # in-cluster registry credentials Secret (name recorded in
+    # cluster_config.json:secret_names.registry_creds — default
+    # ``registry-creds``) is created by cluster.py provision, which collects
+    # credentials independently — see #435 for the dedup plan.
     reg_user = args.registry_user or os.environ.get("REGISTRY_USER", "")
     reg_token = args.registry_token or os.environ.get("REGISTRY_TOKEN", "")
     docker_server = registry.split("/")[0] if registry else ""

--- a/pipeline/sim2real.py
+++ b/pipeline/sim2real.py
@@ -182,7 +182,7 @@ def _build_skill_input(
     experiment_root: Path,
     translations_dir: Path,
     scenario: str,
-    baseline: dict | None,
+    baselines: list[dict],
     algorithms: list[dict],
     context: dict,
 ) -> dict:
@@ -191,16 +191,22 @@ def _build_skill_input(
     Absolute paths at the top level so the skill doesn't have to compose
     them; per-algorithm ``output_dir`` and ``config_output_path`` are
     relative to ``translations_dir``. ``source_path`` is relative to
-    ``experiment_root``. ``baseline`` is ``None`` when the manifest has no
-    baseline overlay.
+    ``experiment_root``. ``baselines`` is a list — one entry per baseline
+    that any algorithm's ``defaults`` cross-references (see
+    ``manifest.py``'s baselines↔algorithms xref). Empty list is valid
+    (no referenced baseline overlay) — the writer's Phase 2 loop
+    collapses to a no-op.
     """
+    baseline_overlay_by_name = {
+        bl["name"]: bl["generated_overlay_path"] for bl in baselines
+    }
     return {
         "version": 1,
         "translation_hash": translation_hash,
         "experiment_root": str(experiment_root),
         "translations_dir": str(translations_dir),
         "scenario": scenario,
-        "baseline": baseline,
+        "baselines": baselines,
         "algorithms": [
             {
                 "name": a["name"],
@@ -208,6 +214,7 @@ def _build_skill_input(
                 "source_sha256": a["source_sha256"],
                 "output_dir": f"generated/{a['name']}",
                 "config_output_path": f"generated/{a['name']}/{a['name']}_config.yaml",
+                "baseline_overlay_path": baseline_overlay_by_name.get(a.get("defaults")),
                 "notes": a.get("notes", ""),
             }
             for a in algorithms
@@ -753,6 +760,7 @@ def _translate_write_checkpoint(
             "name": name,
             "source_path": source_rel,
             "source_sha256": source_sha,
+            "defaults": algo.get("defaults"),
             "notes": algo.get("notes", ""),
         })
 
@@ -765,14 +773,31 @@ def _translate_write_checkpoint(
     )
     _atomic_write_json(layout.translation_output_path(thash), tout)
 
-    baseline_manifest = manifest.get("baseline") or None
-    if baseline_manifest:
-        skin_baseline: dict | None = {
-            "config_path": baseline_manifest.get("config"),
-            "generated_overlay_path": "generated/baseline_config.yaml",
+    # skill_input.baselines is the list of baseline entries whose overlays
+    # the skill's Phase 2 must produce. Only baselines that are actually
+    # cross-referenced by ``algorithms[*].defaults`` need overlays;
+    # unreferenced baselines are dropped. Manifest validation
+    # (``manifest.py``) makes ``defaults`` required on every algorithm and
+    # ensures it names a real baseline, so the referenced set matches the
+    # set of baselines any downstream treatment scenario merges onto. The
+    # defensive ``baselines[0]`` fallback covers manifests with baselines
+    # but zero algorithms (assemble can still run for baseline-only
+    # standby workloads).
+    manifest_baselines = manifest.get("baselines") or []
+    referenced: set[str] = {
+        a["defaults"] for a in manifest.get("algorithms", []) if a.get("defaults")
+    }
+    if not referenced and manifest_baselines:
+        referenced = {manifest_baselines[0]["name"]}
+    skin_baselines: list[dict] = [
+        {
+            "name": bl["name"],
+            "config_path": bl.get("config"),
+            "generated_overlay_path": f"generated/baseline_{bl['name']}/baseline_config.yaml",
         }
-    else:
-        skin_baseline = None
+        for bl in manifest_baselines
+        if bl["name"] in referenced
+    ]
 
     # Bridge manifest ``context.files`` → skill_input ``context.file_paths``
     # (design §Schemas §skill_input.json). Manifest keys are pinned by
@@ -787,7 +812,7 @@ def _translate_write_checkpoint(
         experiment_root=exp_root,
         translations_dir=layout.translation_dir(thash),
         scenario=scenario,
-        baseline=skin_baseline,
+        baselines=skin_baselines,
         algorithms=algo_records,
         context=context,
     )

--- a/pipeline/sim2real.py
+++ b/pipeline/sim2real.py
@@ -792,7 +792,6 @@ def _translate_write_checkpoint(
     skin_baselines: list[dict] = [
         {
             "name": bl["name"],
-            "config_path": bl.get("config"),
             "generated_overlay_path": f"generated/baseline_{bl['name']}/baseline_config.yaml",
         }
         for bl in manifest_baselines

--- a/pipeline/sim2real.py
+++ b/pipeline/sim2real.py
@@ -951,8 +951,19 @@ def _cmd_build(args) -> int:
             )
             return 2
         build_namespace = namespaces[0]
+        registry_secret_name = (
+            (cluster_config.get("secret_names") or {}).get("registry_creds") or ""
+        )
+        if not registry_secret_name:
+            print(
+                "error: cluster_config.json has no secret_names.registry_creds; "
+                "re-run 'cluster.py provision --registry-user U --registry-token T'",
+                file=sys.stderr,
+            )
+            return 2
     else:
         build_namespace = ""
+        registry_secret_name = ""
 
     source_dir = exp_root / repo_name
     tag_prefix = translation_hash[:12]
@@ -1008,6 +1019,7 @@ def _cmd_build(args) -> int:
                 source_dir=source_dir,
                 run_dir=tdir,
                 repo_root=_REPO_ROOT,
+                registry_secret_name=registry_secret_name,
             )
         except build.BuildError as exc:
             print(f"error: {exc}", file=sys.stderr)

--- a/pipeline/tests/test_assemble_run.py
+++ b/pipeline/tests/test_assemble_run.py
@@ -577,6 +577,50 @@ class TestAssembleRun:
         assert params["benchmarkGitRepoUrl"] == "https://example.com/llm-d-benchmark.git"
         assert assemble_run.assemble_run.missing_submodules == ["llm-d-benchmark"]  # type: ignore[attr-defined]
 
+    def test_byo_legacy_baseline_overlay_at_generated_root_is_applied(self, tmp_path):
+        """BYO ``translation register`` writes a single shared overlay at
+        ``translations/<hash>/generated/baseline_config.yaml`` (no
+        per-baseline subdirectory). Assemble must fall back to that path
+        when the per-baseline dir is absent, or every BYO translation
+        loses its baseline overlay content silently.
+        """
+        fx = _make_experiment(
+            tmp_path,
+            algo_names_registered=["sr"],
+            algo_names_manifest=["sr"],
+        )
+        # Simulate BYO translation register: write ONLY the legacy shared
+        # overlay path — no ``generated/baseline_<name>/`` subdirectory.
+        tdir = fx["exp_root"] / "workspace" / "translations" / fx["translation_hash"]
+        legacy_overlay = tdir / "generated" / "baseline_config.yaml"
+        marker_extra_object = {"kind": "InferenceObjective", "metadata": {"name": "byo-marker"}}
+        _write_yaml(
+            legacy_overlay,
+            {"scenario": [{"name": "test-scenario", "extraObjects": [marker_extra_object]}]},
+        )
+        # Guard the precondition: per-baseline dir must NOT exist so the
+        # code path under test is the legacy-fallback branch.
+        assert not (tdir / "generated" / "baseline_baseline" / "baseline_config.yaml").exists()
+
+        assemble_run.assemble_run(
+            translation_hash=fx["translation_hash"],
+            translation_ref=fx["translation_hash"],
+            cluster_id=fx["cluster_id"],
+            run_name="trial-1",
+            experiment_root=fx["exp_root"],
+            manifest_path=fx["manifest_path"],
+            force=False,
+            now_iso="2026-07-01T14:05:00Z",
+        )
+        run_dir = fx["exp_root"] / "workspace" / "runs" / "trial-1"
+        baseline_yaml = yaml.safe_load((run_dir / "cluster" / "baseline.yaml").read_text())
+        # The legacy overlay's extraObjects should have deep-merged onto
+        # the baseline scenario. If the fallback regressed to overlay_path=None,
+        # this field would be absent.
+        scenarios = baseline_yaml["scenario"]
+        scenario = next(s for s in scenarios if s["name"] == "test-scenario")
+        assert scenario["extraObjects"] == [marker_extra_object]
+
     def test_filters_unregistered_algorithms(self, tmp_path):
         fx = _make_experiment(
             tmp_path,

--- a/pipeline/tests/test_assemble_run.py
+++ b/pipeline/tests/test_assemble_run.py
@@ -577,6 +577,56 @@ class TestAssembleRun:
         assert params["benchmarkGitRepoUrl"] == "https://example.com/llm-d-benchmark.git"
         assert assemble_run.assemble_run.missing_submodules == ["llm-d-benchmark"]  # type: ignore[attr-defined]
 
+    def test_skill_driven_per_baseline_overlay_is_applied(self, tmp_path):
+        """The PR's headline contract: assemble reads the per-baseline
+        overlay at ``generated/baseline_<name>/baseline_config.yaml``
+        (skill-driven layout) and applies it to that baseline. If the
+        primary path in ``assemble_run.py`` regressed to the wrong
+        subpath — or reverted to the shared root — this test would
+        fail.
+        """
+        fx = _make_experiment(
+            tmp_path,
+            algo_names_registered=["sr"],
+            algo_names_manifest=["sr"],
+        )
+        # Simulate a skill-driven translation: write ONLY the
+        # per-baseline overlay under generated/baseline_<name>/. No
+        # legacy top-level file — ensures the primary branch is under
+        # test, not the fallback.
+        tdir = fx["exp_root"] / "workspace" / "translations" / fx["translation_hash"]
+        per_baseline_overlay = (
+            tdir / "generated" / "baseline_baseline" / "baseline_config.yaml"
+        )
+        marker_extra_object = {
+            "kind": "InferenceObjective",
+            "metadata": {"name": "skill-marker"},
+        }
+        _write_yaml(
+            per_baseline_overlay,
+            {"scenario": [{"name": "test-scenario", "extraObjects": [marker_extra_object]}]},
+        )
+        # Precondition: the legacy top-level file must NOT exist so that
+        # a passing assertion proves the primary branch (not the
+        # fallback) resolved the overlay.
+        assert not (tdir / "generated" / "baseline_config.yaml").exists()
+
+        assemble_run.assemble_run(
+            translation_hash=fx["translation_hash"],
+            translation_ref=fx["translation_hash"],
+            cluster_id=fx["cluster_id"],
+            run_name="trial-1",
+            experiment_root=fx["exp_root"],
+            manifest_path=fx["manifest_path"],
+            force=False,
+            now_iso="2026-07-01T14:05:00Z",
+        )
+        run_dir = fx["exp_root"] / "workspace" / "runs" / "trial-1"
+        baseline_yaml = yaml.safe_load((run_dir / "cluster" / "baseline.yaml").read_text())
+        scenarios = baseline_yaml["scenario"]
+        scenario = next(s for s in scenarios if s["name"] == "test-scenario")
+        assert scenario["extraObjects"] == [marker_extra_object]
+
     def test_byo_legacy_baseline_overlay_at_generated_root_is_applied(self, tmp_path):
         """BYO ``translation register`` writes a single shared overlay at
         ``translations/<hash>/generated/baseline_config.yaml`` (no

--- a/pipeline/tests/test_build.py
+++ b/pipeline/tests/test_build.py
@@ -184,6 +184,7 @@ class TestDispatchBuildkitBuild:
                 source_dir=source_dir,
                 run_dir=run_dir,
                 repo_root=repo_root,
+                registry_secret_name="my-registry-creds",
             )
         assert rc == 0
         assert mock_run.called
@@ -200,6 +201,13 @@ class TestDispatchBuildkitBuild:
         assert str(run_dir) in cmd
         assert "--run-name" in cmd
         assert "build-xyz" in cmd
+        assert "--registry-secret-name" in cmd
+        assert "my-registry-creds" in cmd
+        # Enforce adjacency between the flag and its value — otherwise a
+        # future refactor could split them and the shell script would
+        # parse the next flag as the secret name.
+        flag_idx = cmd.index("--registry-secret-name")
+        assert cmd[flag_idx + 1] == "my-registry-creds"
 
     def test_returns_nonzero_on_script_failure(self, tmp_path):
         (tmp_path / "src").mkdir()
@@ -211,6 +219,7 @@ class TestDispatchBuildkitBuild:
                 image_ref="r/r:t", build_id="b", namespace="ns",
                 source_dir=tmp_path / "src", run_dir=tmp_path / "run",
                 repo_root=tmp_path / "repo",
+                registry_secret_name="rc",
             )
         assert rc == 42
 
@@ -220,6 +229,23 @@ class TestDispatchBuildkitBuild:
                 image_ref="r/r:t", build_id="b", namespace="ns",
                 source_dir=tmp_path, run_dir=tmp_path,
                 repo_root=tmp_path,
+                registry_secret_name="rc",
+            )
+
+    def test_raises_when_registry_secret_name_empty(self, tmp_path):
+        """Fail-early: an empty secret name would make build-epp.sh
+        parse the next argv token as the secret name, then either fail
+        the existence check with a useless message or (worse) point at
+        an unrelated Secret. Refuse before we ever exec bash.
+        """
+        (tmp_path / "pipeline" / "scripts").mkdir(parents=True)
+        (tmp_path / "pipeline" / "scripts" / "build-epp.sh").touch()
+        with pytest.raises(build.BuildError, match="registry_secret_name"):
+            build.dispatch_buildkit_build(
+                image_ref="r/r:t", build_id="b", namespace="ns",
+                source_dir=tmp_path, run_dir=tmp_path,
+                repo_root=tmp_path,
+                registry_secret_name="",
             )
 
     def test_cwd_is_repo_root(self, tmp_path):
@@ -232,6 +258,7 @@ class TestDispatchBuildkitBuild:
                 image_ref="r/r:t", build_id="b", namespace="ns",
                 source_dir=tmp_path / "src", run_dir=tmp_path / "run",
                 repo_root=tmp_path,
+                registry_secret_name="rc",
             )
         assert mock_run.call_args.kwargs.get("cwd") == tmp_path
 
@@ -388,15 +415,19 @@ class TestSim2realBuildLoop:
     """
 
     def _make_cluster_config(self, tmp_path, cluster_id="test-cluster",
-                             namespaces=("sim2real-slot1",)):
+                             namespaces=("sim2real-slot1",),
+                             registry_creds="registry-creds"):
         cdir = tmp_path / "workspace" / "clusters" / cluster_id
         cdir.mkdir(parents=True)
+        secret_names = {"hf_token": "hf-token"}
+        if registry_creds is not None:
+            secret_names["registry_creds"] = registry_creds
         (cdir / "cluster_config.json").write_text(json.dumps({
             "cluster_id": cluster_id,
             "namespaces": list(namespaces),
             "is_openshift": False,
             "storage_class": "",
-            "secret_names": {"hf_token": "hf-token"},
+            "secret_names": secret_names,
             "workspaces": [],
         }))
 
@@ -448,11 +479,73 @@ class TestSim2realBuildLoop:
         assert rc == 0
         assert mock_probe.call_count == 2  # pre + post
         mock_build.assert_called_once()
+        # sim2real build must forward the secret name from
+        # cluster_config.secret_names.registry_creds to
+        # dispatch_buildkit_build, otherwise the buildkit pod mounts the
+        # wrong Secret (issue #480).
+        assert (
+            mock_build.call_args.kwargs["registry_secret_name"]
+            == "registry-creds"
+        )
 
         data = self._read_translation_output(tmp_path, thash)
         algo = data["algorithms"][0]
         assert algo["image_ref"] == f"quay.io/user/sched:{thash[:12]}-softref"
         assert algo["image_digest"] == "sha256:" + "b" * 64
+
+    def test_forwards_custom_registry_secret_name_from_cluster_config(
+        self, tmp_path
+    ):
+        """Non-default secret_names.registry_creds must propagate all the
+        way to dispatch — the fix for #480 is undone if a caller ever
+        substitutes a hardcoded string.
+        """
+        _make_workspace(tmp_path)
+        self._make_cluster_config(tmp_path, registry_creds="my-org-creds")
+        _make_translation(tmp_path, alias="softref")
+
+        with patch("pipeline.lib.build.shutil.which",
+                   return_value="/usr/bin/skopeo"), \
+             patch("pipeline.lib.build.probe_image_digest",
+                   side_effect=[None, "sha256:" + "b" * 64]), \
+             patch("pipeline.lib.build.dispatch_buildkit_build",
+                   return_value=0) as mock_build:
+            rc = sim2real.main([
+                "--experiment-root", str(tmp_path),
+                "build", "--translation", "softref",
+            ])
+        assert rc == 0
+        assert (
+            mock_build.call_args.kwargs["registry_secret_name"]
+            == "my-org-creds"
+        )
+
+    def test_missing_registry_creds_in_cluster_config_exits_2(
+        self, tmp_path, capsys
+    ):
+        """cluster_config.json without secret_names.registry_creds → the
+        command must fail-early with an actionable message pointing at
+        cluster.py provision, before touching skopeo or spawning any
+        buildkit pod.
+        """
+        _make_workspace(tmp_path)
+        # registry_creds=None omits the key from secret_names entirely.
+        self._make_cluster_config(tmp_path, registry_creds=None)
+        _make_translation(tmp_path, alias="softref")
+
+        with patch("pipeline.lib.build.probe_image_digest") as mock_probe, \
+             patch("pipeline.lib.build.dispatch_buildkit_build") as mock_build, \
+             patch("pipeline.lib.build.check_skopeo"):
+            rc = sim2real.main([
+                "--experiment-root", str(tmp_path),
+                "build", "--translation", "softref",
+            ])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "registry_creds" in err
+        assert "cluster.py provision" in err
+        mock_probe.assert_not_called()
+        mock_build.assert_not_called()
 
     def test_force_rebuild_ignores_probe_hit(self, tmp_path):
         _make_workspace(tmp_path)

--- a/pipeline/tests/test_deploy_build.py
+++ b/pipeline/tests/test_deploy_build.py
@@ -1,10 +1,13 @@
 """Tests for deploy build subcommand."""
 import json
 import subprocess
+from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 import yaml
 
+from pipeline import deploy
 from pipeline.deploy import build_parser
 
 
@@ -203,3 +206,82 @@ class TestWriteBuildMetadata:
         _write_build_metadata(run_dir, "img:tag")
 
         assert (run_dir / "run_metadata.json").read_text() == "not json {{{"
+
+
+class TestCmdBuildForwardsRegistrySecretName:
+    """Regression tests for issue #480 — deploy.py:_cmd_build must
+    thread cluster_config.secret_names.registry_creds through to
+    dispatch_buildkit_build. Without this, buildkit mounts the wrong
+    (or a nonexistent) k8s Secret and pushes fail after rotation.
+    """
+
+    def _make_run_dir(self, tmp_path: Path, *, component_image: str = "img:tag") -> Path:
+        run_dir = tmp_path / "run"
+        (run_dir / "cluster").mkdir(parents=True)
+        (run_dir / "run_metadata.json").write_text(json.dumps({
+            "version": 1,
+            "component_image": component_image,
+            "registry": "ghcr.io/org",
+            "repo_name": "sched",
+            "stages": {},
+        }))
+        # Source dir on the experiment root — _cmd_build reads it via
+        # EXPERIMENT_ROOT / repo_name.
+        (tmp_path / "sched").mkdir()
+        deploy.EXPERIMENT_ROOT = tmp_path
+        return run_dir
+
+    def test_forwards_registry_secret_name_to_dispatch(self, tmp_path):
+        run_dir = self._make_run_dir(tmp_path)
+        with patch("pipeline.lib.ensure_image.collect_scenario_images",
+                   return_value=[{"image_ref": "ghcr.io/org/sched:r", "package": "treatment"}]), \
+             patch("pipeline.lib.ensure_image.image_needs_build",
+                   return_value=True), \
+             patch("pipeline.lib.ensure_image.compute_source_hash",
+                   return_value="hash-x"), \
+             patch("pipeline.lib.ensure_image.save_source_hash"), \
+             patch("pipeline.lib.build.dispatch_buildkit_build",
+                   return_value=0) as mock_dispatch:
+            deploy._cmd_build(
+                run_dir,
+                namespace="sim2real-slot-0",
+                skip_build=False,
+                registry_secret_name="my-org-creds",
+            )
+        assert mock_dispatch.called
+        assert (
+            mock_dispatch.call_args.kwargs["registry_secret_name"]
+            == "my-org-creds"
+        )
+
+    def test_missing_registry_secret_name_exits_1(self, tmp_path, capsys):
+        run_dir = self._make_run_dir(tmp_path)
+        # Should abort before any build primitive is called.
+        with patch("pipeline.lib.ensure_image.collect_scenario_images") as m_col, \
+             patch("pipeline.lib.build.dispatch_buildkit_build") as m_dispatch, \
+             pytest.raises(SystemExit) as excinfo:
+            deploy._cmd_build(
+                run_dir,
+                namespace="sim2real-slot-0",
+                skip_build=False,
+                registry_secret_name="",
+            )
+        assert excinfo.value.code == 1
+        err = capsys.readouterr().err
+        assert "registry_creds" in err
+        assert "cluster.py provision" in err
+        m_col.assert_not_called()
+        m_dispatch.assert_not_called()
+
+    def test_skip_build_does_not_require_registry_secret_name(self, tmp_path):
+        """--skip-build returns 'skip' before touching credentials, so
+        an empty secret name must NOT cause an error in that path.
+        """
+        run_dir = self._make_run_dir(tmp_path)
+        result = deploy._cmd_build(
+            run_dir,
+            namespace="sim2real-slot-0",
+            skip_build=True,
+            registry_secret_name="",
+        )
+        assert result == "skip"

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -2152,14 +2152,14 @@ def test_cmd_build_missing_metadata(tmp_path):
     """Missing run_metadata.json → sys.exit."""
     from pipeline.deploy import _cmd_build
     with pytest.raises(SystemExit):
-        _cmd_build(tmp_path, namespace="ns", skip_build=False)
+        _cmd_build(tmp_path, namespace="ns", skip_build=False, registry_secret_name="registry-creds")
 
 
 def test_cmd_build_no_component_image(tmp_path, capsys):
     """component_image absent → skip."""
     from pipeline.deploy import _cmd_build
     (tmp_path / "run_metadata.json").write_text(json.dumps({"registry": "quay.io/me"}))
-    result = _cmd_build(tmp_path, namespace="ns", skip_build=False)
+    result = _cmd_build(tmp_path, namespace="ns", skip_build=False, registry_secret_name="registry-creds")
     assert result == "skip"
 
 
@@ -2168,7 +2168,7 @@ def test_cmd_build_empty_component_image(tmp_path):
     from pipeline.deploy import _cmd_build
     (tmp_path / "run_metadata.json").write_text(json.dumps({"component_image": ""}))
     with pytest.raises(SystemExit):
-        _cmd_build(tmp_path, namespace="ns", skip_build=False)
+        _cmd_build(tmp_path, namespace="ns", skip_build=False, registry_secret_name="registry-creds")
 
 
 def test_cmd_build_skip_flag(tmp_path, capsys):
@@ -2177,7 +2177,7 @@ def test_cmd_build_skip_flag(tmp_path, capsys):
     (tmp_path / "run_metadata.json").write_text(
         json.dumps({"component_image": "quay.io/me/sched:r1", "registry": "quay.io/me", "repo_name": "sched"})
     )
-    result = _cmd_build(tmp_path, namespace="ns", skip_build=True)
+    result = _cmd_build(tmp_path, namespace="ns", skip_build=True, registry_secret_name="")
     assert result == "skip"
 
 

--- a/pipeline/tests/test_setup_pipeline.py
+++ b/pipeline/tests/test_setup_pipeline.py
@@ -4,6 +4,11 @@ Cluster-side responsibilities (namespace, RBAC, secrets, PVCs, Tekton) moved
 to pipeline/cluster.py + pipeline/lib/cluster_ops.py — see issue #424 and
 the epic #416 design. Tests for those primitives live in
 pipeline/tests/test_cluster_ops.py and pipeline/tests/test_cluster_py.py.
+
+Run-directory materialization (workspace/runs/<run>/) moved to
+`sim2real assemble` in step-2 — see issue #481. setup.py no longer touches
+workspace/runs/ or writes run_metadata.json or current_run. Tests here
+enforce that invariant.
 """
 import json
 import pytest
@@ -15,7 +20,6 @@ def _make_config(**overrides):
     defaults = dict(
         registry="quay.io/test",
         repo_name="llm-d-inference-scheduler",
-        run_name="test-run",
         registry_user="user",
         registry_token="token",
     )
@@ -33,17 +37,13 @@ class TestSetupConfigJson:
         original = setup_module.EXPERIMENT_ROOT
         setup_module.EXPERIMENT_ROOT = tmp_path
         try:
-            run_dir = tmp_path / "workspace" / "runs" / "test-run"
-            run_dir.mkdir(parents=True)
-
             cfg = _make_config(orchestrator_image="ghcr.io/x/orch:abc")
-            step_config_output(cfg, run_dir)
+            step_config_output(cfg)
 
             data = json.loads((tmp_path / "workspace" / "setup_config.json").read_text())
             assert data["registry"] == "quay.io/test"
             assert data["repo_name"] == "llm-d-inference-scheduler"
             assert data["orchestrator_image"] == "ghcr.io/x/orch:abc"
-            assert data["current_run"] == "test-run"
             assert "sim2real_root" in data
         finally:
             setup_module.EXPERIMENT_ROOT = original
@@ -56,9 +56,7 @@ class TestSetupConfigJson:
         original = setup_module.EXPERIMENT_ROOT
         setup_module.EXPERIMENT_ROOT = tmp_path
         try:
-            run_dir = tmp_path / "workspace" / "runs" / "test-run"
-            run_dir.mkdir(parents=True)
-            step_config_output(_make_config(), run_dir)
+            step_config_output(_make_config())
             data = json.loads((tmp_path / "workspace" / "setup_config.json").read_text())
             assert "orchestrator_image" in data
             assert data["orchestrator_image"] == ""
@@ -66,23 +64,24 @@ class TestSetupConfigJson:
             setup_module.EXPERIMENT_ROOT = original
 
     @pytest.mark.parametrize("removed_key", [
+        # Cluster-side (moved to cluster.py provision + cluster_config.json)
         "namespace", "namespaces", "is_openshift", "storage_class",
         "hf_secret_name", "workspaces", "tektonc_dir", "setup_timestamp",
         "container_runtime",
         # #442: pipeline_yaml moved to cluster.py provision + cluster_config.json.
         "pipeline_yaml",
+        # #481: current_run is owned by sim2real use.
+        "current_run",
     ])
     def test_removed_keys_absent(self, tmp_path, removed_key):
-        """Cluster-scoped and cruft keys are not written to setup_config.json."""
+        """Cluster-scoped, run-scoped, and cruft keys are not written to setup_config.json."""
         from pipeline.setup import step_config_output
         import pipeline.setup as setup_module
 
         original = setup_module.EXPERIMENT_ROOT
         setup_module.EXPERIMENT_ROOT = tmp_path
         try:
-            run_dir = tmp_path / "workspace" / "runs" / "test-run"
-            run_dir.mkdir(parents=True)
-            step_config_output(_make_config(), run_dir)
+            step_config_output(_make_config())
             data = json.loads((tmp_path / "workspace" / "setup_config.json").read_text())
             assert removed_key not in data
         finally:
@@ -90,7 +89,10 @@ class TestSetupConfigJson:
 
     def test_preserves_keys_owned_by_other_writers(self, tmp_path):
         """A pre-existing setup_config.json with foreign keys is preserved
-        on re-run — setup.py only owns the keys it writes."""
+        on re-run — setup.py only owns the keys it writes. In particular,
+        ``current_run`` (owned by ``sim2real use``) must survive a setup
+        re-run.
+        """
         from pipeline.setup import step_config_output
         import pipeline.setup as setup_module
 
@@ -99,21 +101,70 @@ class TestSetupConfigJson:
         try:
             workspace = tmp_path / "workspace"
             workspace.mkdir(parents=True)
-            # Simulate a foreign key (e.g. a future cluster_id pointer, or
-            # any other writer's field) already in the file.
+            # Simulate current_run set by `sim2real use` plus an unrelated
+            # foreign key.
             (workspace / "setup_config.json").write_text(json.dumps({
                 "registry": "old.example/x",
+                "current_run": "trial-1",
                 "foreign_key": "must-survive",
             }))
-            run_dir = workspace / "runs" / "test-run"
-            run_dir.mkdir(parents=True)
-            step_config_output(_make_config(), run_dir)
+            step_config_output(_make_config())
 
             data = json.loads((workspace / "setup_config.json").read_text())
             assert data["registry"] == "quay.io/test"  # refreshed
+            assert data["current_run"] == "trial-1"    # preserved (owned by `sim2real use`)
             assert data["foreign_key"] == "must-survive"  # preserved
         finally:
             setup_module.EXPERIMENT_ROOT = original
+
+
+class TestSetupDoesNotTouchRuns:
+    """Regression tests for issue #481 — setup.py must not create or
+    modify anything under ``workspace/runs/``. Any write there would
+    collide with ``sim2real assemble``'s existence guard on a fresh
+    workspace.
+    """
+
+    def test_step_config_output_does_not_create_runs_dir(self, tmp_path):
+        from pipeline.setup import step_config_output
+        import pipeline.setup as setup_module
+
+        original = setup_module.EXPERIMENT_ROOT
+        setup_module.EXPERIMENT_ROOT = tmp_path
+        try:
+            step_config_output(_make_config())
+        finally:
+            setup_module.EXPERIMENT_ROOT = original
+
+        assert not (tmp_path / "workspace" / "runs").exists()
+
+    def test_step_config_output_leaves_existing_runs_dir_untouched(
+        self, tmp_path
+    ):
+        """A pre-existing runs/<run>/ from a prior ``sim2real assemble``
+        must survive a setup re-run byte-for-byte. If setup.py touched
+        the directory, it would collide with the assemble guard on the
+        NEXT ``sim2real assemble --run <other>`` invocation.
+        """
+        from pipeline.setup import step_config_output
+        import pipeline.setup as setup_module
+
+        run_dir = tmp_path / "workspace" / "runs" / "trial-1"
+        run_dir.mkdir(parents=True)
+        marker = run_dir / "marker.txt"
+        marker.write_text("assembled-by-sim2real")
+
+        original = setup_module.EXPERIMENT_ROOT
+        setup_module.EXPERIMENT_ROOT = tmp_path
+        try:
+            step_config_output(_make_config())
+        finally:
+            setup_module.EXPERIMENT_ROOT = original
+
+        assert marker.read_text() == "assembled-by-sim2real"
+        # No sibling runs/<other> directory was created.
+        siblings = [p.name for p in (tmp_path / "workspace" / "runs").iterdir()]
+        assert siblings == ["trial-1"]
 
 
 class TestBuildParser:
@@ -123,7 +174,6 @@ class TestBuildParser:
         ("--registry", "REG"),
         ("--repo-name", "NAME"),
         ("--orchestrator-image", "img"),
-        ("--run", "n"),
         ("--experiment-root", "/x"),
         ("--test-push", None),       # store_true
         ("--test-push-tag", "t"),
@@ -137,6 +187,8 @@ class TestBuildParser:
         "--no-cluster", "--redeploy-tasks",
         # #442: --pipeline-yaml moved to cluster.py provision.
         "--pipeline-yaml",
+        # #481: --run moved to `sim2real assemble --run` / `sim2real use --run`.
+        "--run",
     ]
 
     @pytest.mark.parametrize("flag,value", KEPT_FLAGS)
@@ -151,103 +203,3 @@ class TestBuildParser:
         from pipeline.setup import build_parser
         with pytest.raises(SystemExit):
             build_parser().parse_args([flag, "x"])
-
-
-class TestRunMetadataIdempotent:
-    """Re-running setup must preserve deploy-owned fields in run_metadata.json (issue #365)."""
-
-    def _run_setup(self, tmp_path, **cfg_overrides):
-        from pipeline.setup import step_config_output
-        import pipeline.setup as setup_module
-
-        original = setup_module.EXPERIMENT_ROOT
-        setup_module.EXPERIMENT_ROOT = tmp_path
-        try:
-            run_dir = tmp_path / "workspace" / "runs" / "test-run"
-            run_dir.mkdir(parents=True, exist_ok=True)
-            cfg = _make_config(**cfg_overrides)
-            step_config_output(cfg, run_dir)
-            return run_dir
-        finally:
-            setup_module.EXPERIMENT_ROOT = original
-
-    def test_preserves_source_hashes_on_rerun(self, tmp_path):
-        """Deploy-written source_hashes must survive a setup re-run."""
-        run_dir = self._run_setup(tmp_path)
-        meta_path = run_dir / "run_metadata.json"
-
-        meta = json.loads(meta_path.read_text())
-        meta["source_hashes"] = {"quay.io/test/llm-d-inference-scheduler:test-run": "abc123def456"}
-        meta_path.write_text(json.dumps(meta))
-
-        self._run_setup(tmp_path)
-
-        meta2 = json.loads(meta_path.read_text())
-        assert meta2.get("source_hashes") == {
-            "quay.io/test/llm-d-inference-scheduler:test-run": "abc123def456"
-        }
-
-    def test_preserves_epp_image_on_rerun(self, tmp_path):
-        """Deploy-written epp_image must survive a setup re-run."""
-        run_dir = self._run_setup(tmp_path)
-        meta_path = run_dir / "run_metadata.json"
-
-        meta = json.loads(meta_path.read_text())
-        meta["epp_image"] = "quay.io/test/llm-d-inference-scheduler:test-run"
-        meta_path.write_text(json.dumps(meta))
-
-        self._run_setup(tmp_path)
-
-        meta2 = json.loads(meta_path.read_text())
-        assert meta2.get("epp_image") == "quay.io/test/llm-d-inference-scheduler:test-run"
-
-    def test_preserves_stages_deploy_last_completed_step(self, tmp_path):
-        """stages.deploy.last_completed_step (deploy-owned) must survive a setup re-run."""
-        run_dir = self._run_setup(tmp_path)
-        meta_path = run_dir / "run_metadata.json"
-
-        meta = json.loads(meta_path.read_text())
-        meta.setdefault("stages", {}).setdefault("deploy", {})["last_completed_step"] = "build"
-        meta_path.write_text(json.dumps(meta))
-
-        self._run_setup(tmp_path)
-
-        meta2 = json.loads(meta_path.read_text())
-        assert meta2["stages"]["deploy"].get("last_completed_step") == "build"
-
-    def test_refreshes_setup_owned_fields_on_rerun(self, tmp_path):
-        """Setup-owned fields (registry, repo_name) reflect the latest cfg on re-run."""
-        from pipeline.setup import step_config_output
-        import pipeline.setup as setup_module
-
-        run_dir = self._run_setup(tmp_path)
-        meta_path = run_dir / "run_metadata.json"
-
-        original = setup_module.EXPERIMENT_ROOT
-        setup_module.EXPERIMENT_ROOT = tmp_path
-        try:
-            cfg2 = _make_config(registry="quay.io/new-registry", repo_name="new-repo")
-            step_config_output(cfg2, run_dir)
-        finally:
-            setup_module.EXPERIMENT_ROOT = original
-
-        meta2 = json.loads(meta_path.read_text())
-        assert meta2["registry"] == "quay.io/new-registry"
-        assert meta2["repo_name"] == "new-repo"
-
-    def test_first_run_creates_metadata(self, tmp_path):
-        """First-run path produces setup-owned fields. Cluster-scoped fields
-        are NOT written by setup.py anymore (cluster_config.json owns them)."""
-        run_dir = self._run_setup(tmp_path)
-        meta = json.loads((run_dir / "run_metadata.json").read_text())
-        assert meta["version"] == 1
-        assert meta["registry"] == "quay.io/test"
-        assert meta["repo_name"] == "llm-d-inference-scheduler"
-        assert meta["component_image"] == "quay.io/test/llm-d-inference-scheduler:test-run"
-        assert meta["stages"]["setup"]["status"] == "completed"
-        assert meta["stages"]["prepare"] == {"status": "pending"}
-        assert meta["stages"]["deploy"] == {"status": "pending"}
-        assert meta["stages"]["results"] == {"status": "pending"}
-        # Cluster-scoped fields are NOT written by setup anymore.
-        for absent in ("namespace", "storage_class", "is_openshift", "container_runtime"):
-            assert absent not in meta

--- a/pipeline/tests/test_translate.py
+++ b/pipeline/tests/test_translate.py
@@ -188,17 +188,21 @@ class TestBuildSkillInput:
             scenario="s",
             baselines=[{
                 "name": "base",
-                "config_path": "baselines/base.yaml",
                 "generated_overlay_path": "generated/baseline_base/baseline_config.yaml",
             }],
             algorithms=[],
             context={"text": "hint text", "file_paths": ["docs/a.md"]},
         )
         assert skin["baselines"][0]["name"] == "base"
-        assert skin["baselines"][0]["config_path"] == "baselines/base.yaml"
         assert skin["baselines"][0]["generated_overlay_path"] == (
             "generated/baseline_base/baseline_config.yaml"
         )
+        # ``config_path`` was dropped in the #480/#481 review cycle — the
+        # v3 manifest schema nests baseline config paths under
+        # sim.config / real.config, and no downstream consumer read the
+        # top-level field. Assert its absence to catch accidental
+        # re-introduction.
+        assert "config_path" not in skin["baselines"][0]
         assert skin["context"]["text"] == "hint text"
         assert skin["context"]["file_paths"] == ["docs/a.md"]
 
@@ -211,12 +215,10 @@ class TestBuildSkillInput:
             baselines=[
                 {
                     "name": "base",
-                    "config_path": None,
                     "generated_overlay_path": "generated/baseline_base/baseline_config.yaml",
                 },
                 {
                     "name": "alt",
-                    "config_path": None,
                     "generated_overlay_path": "generated/baseline_alt/baseline_config.yaml",
                 },
             ],
@@ -365,7 +367,6 @@ class TestTranslateEmpty:
         # per-algorithm baseline_overlay_path resolves via defaults="base".
         assert skin["baselines"] == [{
             "name": "base",
-            "config_path": None,
             "generated_overlay_path": "generated/baseline_base/baseline_config.yaml",
         }]
         assert (

--- a/pipeline/tests/test_translate.py
+++ b/pipeline/tests/test_translate.py
@@ -137,7 +137,7 @@ class TestBuildSkillInput:
             experiment_root=exp,
             translations_dir=tdir,
             scenario="softreflective-v1",
-            baseline=None,
+            baselines=[],
             algorithms=[{
                 "name": "softreflective",
                 "source_path": "algorithms/softreflective.py",
@@ -155,7 +155,7 @@ class TestBuildSkillInput:
             experiment_root=Path("/e"),
             translations_dir=Path("/t"),
             scenario="s",
-            baseline=None,
+            baselines=[],
             algorithms=[{
                 "name": "softreflective",
                 "source_path": "algorithms/softreflective.py",
@@ -168,34 +168,97 @@ class TestBuildSkillInput:
         assert a["output_dir"] == "generated/softreflective"
         assert a["config_output_path"] == "generated/softreflective/softreflective_config.yaml"
 
-    def test_baseline_null_when_absent(self):
+    def test_baselines_empty_when_absent(self):
         skin = sim2real._build_skill_input(
             translation_hash="a" * 64,
             experiment_root=Path("/e"),
             translations_dir=Path("/t"),
             scenario="s",
-            baseline=None,
+            baselines=[],
             algorithms=[],
             context={"text": "", "file_paths": []},
         )
-        assert skin["baseline"] is None
+        assert skin["baselines"] == []
 
-    def test_baseline_populated_when_present(self):
+    def test_baselines_populated_when_present(self):
         skin = sim2real._build_skill_input(
             translation_hash="a" * 64,
             experiment_root=Path("/e"),
             translations_dir=Path("/t"),
             scenario="s",
-            baseline={
+            baselines=[{
+                "name": "base",
                 "config_path": "baselines/base.yaml",
-                "generated_overlay_path": "generated/baseline_config.yaml",
-            },
+                "generated_overlay_path": "generated/baseline_base/baseline_config.yaml",
+            }],
             algorithms=[],
             context={"text": "hint text", "file_paths": ["docs/a.md"]},
         )
-        assert skin["baseline"]["config_path"] == "baselines/base.yaml"
+        assert skin["baselines"][0]["name"] == "base"
+        assert skin["baselines"][0]["config_path"] == "baselines/base.yaml"
+        assert skin["baselines"][0]["generated_overlay_path"] == (
+            "generated/baseline_base/baseline_config.yaml"
+        )
         assert skin["context"]["text"] == "hint text"
         assert skin["context"]["file_paths"] == ["docs/a.md"]
+
+    def test_algorithm_baseline_overlay_path_resolves_via_defaults(self):
+        skin = sim2real._build_skill_input(
+            translation_hash="a" * 64,
+            experiment_root=Path("/e"),
+            translations_dir=Path("/t"),
+            scenario="s",
+            baselines=[
+                {
+                    "name": "base",
+                    "config_path": None,
+                    "generated_overlay_path": "generated/baseline_base/baseline_config.yaml",
+                },
+                {
+                    "name": "alt",
+                    "config_path": None,
+                    "generated_overlay_path": "generated/baseline_alt/baseline_config.yaml",
+                },
+            ],
+            algorithms=[
+                {
+                    "name": "algo1",
+                    "source_path": "algorithms/a1.py",
+                    "source_sha256": "a" * 64,
+                    "defaults": "base",
+                    "notes": "",
+                },
+                {
+                    "name": "algo2",
+                    "source_path": "algorithms/a2.py",
+                    "source_sha256": "b" * 64,
+                    "defaults": "alt",
+                    "notes": "",
+                },
+            ],
+            context={"text": "", "file_paths": []},
+        )
+        overlay_by_algo = {a["name"]: a["baseline_overlay_path"] for a in skin["algorithms"]}
+        assert overlay_by_algo["algo1"] == "generated/baseline_base/baseline_config.yaml"
+        assert overlay_by_algo["algo2"] == "generated/baseline_alt/baseline_config.yaml"
+
+    def test_algorithm_baseline_overlay_path_null_when_defaults_unreferenced(self):
+        skin = sim2real._build_skill_input(
+            translation_hash="a" * 64,
+            experiment_root=Path("/e"),
+            translations_dir=Path("/t"),
+            scenario="s",
+            baselines=[],
+            algorithms=[{
+                "name": "algo1",
+                "source_path": "algorithms/a1.py",
+                "source_sha256": "a" * 64,
+                "defaults": "not-in-baselines",
+                "notes": "",
+            }],
+            context={"text": "", "file_paths": []},
+        )
+        assert skin["algorithms"][0]["baseline_overlay_path"] is None
 
     def test_notes_default_to_empty(self):
         skin = sim2real._build_skill_input(
@@ -203,7 +266,7 @@ class TestBuildSkillInput:
             experiment_root=Path("/e"),
             translations_dir=Path("/t"),
             scenario="s",
-            baseline=None,
+            baselines=[],
             algorithms=[{
                 "name": "algo1",
                 "source_path": "algorithms/a.py",
@@ -298,6 +361,17 @@ class TestTranslateEmpty:
         # output paths (relative to translations_dir) land in the right
         # subtree.
         assert skin["translations_dir"] == str(tdir)
+        # baselines list carries the one baseline `softreflective` builds on;
+        # per-algorithm baseline_overlay_path resolves via defaults="base".
+        assert skin["baselines"] == [{
+            "name": "base",
+            "config_path": None,
+            "generated_overlay_path": "generated/baseline_base/baseline_config.yaml",
+        }]
+        assert (
+            skin["algorithms"][0]["baseline_overlay_path"]
+            == "generated/baseline_base/baseline_config.yaml"
+        )
 
     def test_plain_prints_checkpoint_message(self, tmp_path, capsys):
         _write_manifest(tmp_path)


### PR DESCRIPTION
Closes #477, #479, #480, and #481. Bundling four step-2 fixes on the same branch — see the individual commits for each fix's diff. All four are conceptually independent but share the step-2 lifecycle, so landing them together simplifies the review of the interlocking test surface.

## Commit 1 — remove hardcoded -gaie override (#477)

The `sim2real-translate` writer prompt had two contradictory rules for the InferenceObjective section: (a) `spec.poolRef.name` MUST equal `${model.idLabel}-gaie` and (b) everything else in `poolRef` MUST be copied verbatim from `config.md`. The writer followed (a), so projects like `sr` (whose `config.md` declared `-router`) got an overlay pointing at a pool that would not bind. Fix: unify under "copy verbatim from `config.md`", preserving the `${model.idLabel}` templating dependency as a documentary note.

## Commit 2 — derive baseline overlay(s) from baselines[] via defaults (#479)

`sim2real translate` read a singular `baseline:` key from `transfer.yaml`, but the pinned v3 schema uses `baselines:` (plural list) with `algorithms[*].defaults` cross-references. Consequence: `skill_input.baseline` was always null, Phase 2 was always skipped, and no baseline overlay ever landed on disk. Fix: `_cmd_translate` walks `manifest[\"baselines\"]` filtered by algorithm `defaults` and emits `skill_input.baselines[]` with per-entry `generated_overlay_path` = `generated/baseline_<name>/baseline_config.yaml`. Each algorithm entry gets a resolved `baseline_overlay_path`. Assemble reads the per-baseline path, with a legacy fallback to `generated/baseline_config.yaml` so BYO translations remain resolvable. The pinned `skill_input.json` schema in `docs/epics/step-2/design.md` is updated. Tests cover unit-level and end-to-end shapes.

## Commit 3 — thread registry-creds Secret name from cluster_config to build-epp.sh (#480)

`cluster.py provision` writes the registry-credentials k8s Secret with name `registry-creds`, but `pipeline/scripts/build-epp.sh` hardcoded `registry-secret`. On clusters where both Secrets coexisted from the pre-refactor era, credential rotation via `cluster.py provision --registry-token <new>` looked successful while buildkit kept pushing with the stale token. Fix: `dispatch_buildkit_build` gains a required `registry_secret_name` kwarg; `build-epp.sh` gains a required `--registry-secret-name NAME` flag. Both `_cmd_build` implementations (`pipeline/sim2real.py` step-2, `pipeline/deploy.py` step-1) read `secret_names['registry_creds']` from `cluster_config` and forward it, failing fast when absent.

## Commit 4 — setup.py stops creating workspace/runs/ (#481)

`setup.py` created the run directory and wrote `run_metadata.json`, but `sim2real assemble` (introduced in step-1) also materializes that directory and refuses when it already exists. The documented `setup.py → sim2real assemble --run <name>` flow failed on a fresh workspace with `run directory already exists — pass --force to overwrite`. Fix: setup.py stops touching `workspace/runs/` and stops writing `current_run` / `component_image`. `sim2real assemble` becomes the sole writer of the run directory and `run_metadata.json`; `sim2real use` becomes the sole writer of `current_run`. setup.py's read-modify-write preserves any pre-existing `current_run`, so the setup → use → setup re-run cycle is stable. `pipeline/README.md` and `CLAUDE.md` are updated (split the setup_config.json writer table row into workspace fields vs. current_run pointer). `test_setup_pipeline.py` is rewritten — the `TestRunMetadataIdempotent` class is removed (vacuous now that setup.py doesn't write run_metadata) and a new `TestSetupDoesNotTouchRuns` regression class is added.

## Base correction (#477)

Issue #477 was filed with `Base: refactor/v2-step-1` but the bug is live on `refactor/v2-step-2` (the skill was DISABLED on step-1 by PR #474; step-1 epic #443 is closed). Retargeted to `refactor/v2-step-2` per user confirmation before implementation.

## Verification

- `python -m pytest pipeline/ .claude/skills/ -v` → 1415 passed, 2 xfailed
- `ruff check pipeline/ .claude/skills/ --select F` clean
- Sweep: no hardcoded `registry-secret` string, no singular-baseline references, no `-gaie` references, no setup.py writes to `workspace/runs/`, all in runtime code and user-facing docs. Archival plan/design docs under `docs/superpowers/plans/` and `docs/epics/step-0/design.md` retain the pre-refactor descriptions as history.

## Test plan

- [x] Full pytest and ruff pass locally
- [x] No leaks into the parent repo (all changes contained to the worktree)
- [x] BYO translation compat preserved via the legacy `generated/baseline_config.yaml` fallback in `assemble_run.py` (covered by dedicated tests)
- [ ] Real-cluster smoke for #480: rotate the PAT via `cluster.py provision --registry-token <new>`, then `sim2real build --translation <alias>` pushes on the new token — needs a live cluster and rotatable PAT; not automatable from the harness.
- [ ] Real-cluster smoke for #481: on a fresh workspace, `setup.py` → `sim2real assemble --run trial-1` completes without any `--force` flag — not automatable from the harness, but the two regression tests in `TestSetupDoesNotTouchRuns` capture the equivalent local-filesystem contract.