### PR TITLE
step-4 PR 2: sim2real translation register batched-algorithm mode

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -27,7 +27,7 @@ python pipeline/cluster.py provision <cluster_id> --namespaces NS1,NS2,...
 # Per-workspace + per-run cycle:
 python pipeline/setup.py       --experiment-root ../admission-control
 python pipeline/sim2real.py translation register \
-    --algorithm <name> --image <ref> --config <treatment-overlay-path>
+    --algorithm <name>=<image-ref>@<config-path>
 python pipeline/sim2real.py assemble \
     --translation <hash> --cluster <cluster_id> --run <run_name>
 python pipeline/deploy.py      --experiment-root ../admission-control
@@ -168,7 +168,7 @@ python pipeline/sim2real.py translation register \
 **`translation_hash` derivation (BYO, batched):** SHA-256 hex over canonical JSON of a list of `{name, image, config}` dicts sorted by `name`, where `config` is the SHA-256 of the overlay file content and `image` is the digest ref if present (otherwise the raw ref string). Order-invariant — registering the same algorithms in a different order produces the same hash.
 
 ```
-sha256(canonical-json(sorted-by-name list of {name, image_digest_or_ref, config_sha256}))
+sha256(canonical-json(sorted-by-name list of {name, image, config}))
 ```
 
 **Idempotency:** re-registering the same set of (algorithm, image, config-content) tuples — in any order — is a no-op. The existing translation directory is detected, a warning is printed, and exit is 0.

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -178,7 +178,7 @@ sha256(canonical-json(sorted-by-name list of {name, image, config}))
 - `--config` file missing or malformed YAML → exit 2, no writes.
 - Existing translation directory records different algorithm names (hash collision) → exit 2, no writes.
 - `--registered-hash` given and does not match computed → exit 2, no writes.
-- Another translation already owns an `--algorithm` alias with a different hash → exit 2, no writes; re-run with `--force` to reassign (N=1 only).
+- Another translation already owns an `--algorithm` alias (an algorithm name from the batch collides with an existing translation's alias, on any N) → exit 2, no writes; re-run with `--force` to clear the previous owners' aliases before proceeding.
 - Duplicate algorithm names within a single invocation → exit 2, no writes.
 
 ---

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -129,7 +129,7 @@ Pass `--algorithm` once per algorithm. Each value is a single `NAME=IMAGE@CONFIG
 # N=2 example
 python pipeline/sim2real.py translation register \
     --algorithm softreflective=ghcr.io/org/sr-router:v1@overlays/sr.yaml \
-    --algorithm eager=ghcr.io/org/eager-router:v1@sha256:abc123@overlays/eager.yaml \
+    --algorithm eager=ghcr.io/org/eager-router@sha256:<64-hex-digest>@overlays/eager.yaml \
     [--baseline-config path/to/baseline-overlay.yaml] \
     [--registered-hash <expected-sha256-hex>] \
     [--experiment-root PATH]
@@ -140,7 +140,7 @@ python pipeline/sim2real.py translation register \
 | `--algorithm NAME=IMAGE@CONFIG` | yes (repeatable) | `NAME` follows `[A-Za-z0-9][A-Za-z0-9._-]*`, max 128 chars, no `.` / `..`. `IMAGE` is the registry ref. `CONFIG` is the treatment overlay YAML path. Rightmost `@` is the split point, so digest refs (e.g. `image@sha256:abc`) work. **Overlay paths containing `@` cannot be represented** (structural constraint — the `@` would be misread as part of the image ref). Overlay paths containing `=` are supported. |
 | `--baseline-config PATH` | no | Baseline overlay YAML, if the translation needs one. |
 | `--registered-hash HASH` | no | Assert the computed `translation_hash` equals this value; error if not. |
-| `--force` | no | Reassign an alias if another translation already owns it. Only meaningful for N=1 (N>1 translations have `alias=null`). |
+| `--force` | no | Reassign an alias if another translation already owns it. Applies per-algorithm for any N — use `--force` whenever any algorithm name in the batch was previously used as an alias by a different translation. For N>1 the newly-registered translation itself has `alias=null` (batched translations are referenced by hash); `--force` only clears the colliding aliases on the previous owners. |
 | `--experiment-root PATH` | no | Defaults to cwd. |
 
 #### Deprecated form: `--algorithm NAME --image REF --config PATH`

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -119,9 +119,36 @@ Top-level CLI introduced in step-1 of the v2 refactor. Subcommands: `translation
 
 ### Register a translation (BYO)
 
-`sim2real.py translation register` imports a pre-built EPP image and its treatment overlay YAML as a registered translation. Downstream commands (`assemble`, `deploy.py run`) treat a BYO-registered translation identically to a skill-produced one.
+`sim2real.py translation register` imports one or more pre-built EPP images and their treatment overlay YAMLs as a single registered translation. Downstream commands (`assemble`, `deploy.py run`) treat a BYO-registered translation identically to a skill-produced one.
+
+#### Preferred form: repeatable `--algorithm NAME=IMAGE@CONFIG`
+
+Pass `--algorithm` once per algorithm. Each value is a single `NAME=IMAGE@CONFIG` triple: first `=` splits the name from the rest; rightmost `@` splits the image ref from the config path. This allows digest refs (`image@sha256:…`) without ambiguity.
 
 ```bash
+# N=2 example
+python pipeline/sim2real.py translation register \
+    --algorithm softreflective=ghcr.io/org/sr-router:v1@overlays/sr.yaml \
+    --algorithm eager=ghcr.io/org/eager-router:v1@sha256:abc123@overlays/eager.yaml \
+    [--baseline-config path/to/baseline-overlay.yaml] \
+    [--registered-hash <expected-sha256-hex>] \
+    [--experiment-root PATH]
+```
+
+| Flag | Required | Notes |
+|------|----------|-------|
+| `--algorithm NAME=IMAGE@CONFIG` | yes (repeatable) | `NAME` follows `[A-Za-z0-9][A-Za-z0-9._-]*`, max 128 chars, no `.` / `..`. `IMAGE` is the registry ref. `CONFIG` is the treatment overlay YAML path. Rightmost `@` is the split point, so digest refs (e.g. `image@sha256:abc`) work. **Overlay paths containing `@` cannot be represented** (structural constraint — the `@` would be misread as part of the image ref). Overlay paths containing `=` are supported. |
+| `--baseline-config PATH` | no | Baseline overlay YAML, if the translation needs one. |
+| `--registered-hash HASH` | no | Assert the computed `translation_hash` equals this value; error if not. |
+| `--force` | no | Reassign an alias if another translation already owns it. Only meaningful for N=1 (N>1 translations have `alias=null`). |
+| `--experiment-root PATH` | no | Defaults to cwd. |
+
+#### Deprecated form: `--algorithm NAME --image REF --config PATH`
+
+The step-1 single-algorithm form still works as the N=1 case but **is deprecated**. A deprecation warning is emitted to stderr. Removal is targeted for step-5+.
+
+```bash
+# Deprecated — prefer the NAME=IMAGE@CONFIG form above
 python pipeline/sim2real.py translation register \
     --algorithm softreflective \
     --image ghcr.io/kalantar-msb/sr-router:some-tag \
@@ -131,33 +158,28 @@ python pipeline/sim2real.py translation register \
     [--experiment-root PATH]
 ```
 
-| Flag | Required | Notes |
-|------|----------|-------|
-| `--algorithm NAME` | yes | `[A-Za-z0-9][A-Za-z0-9._-]*`, max 128 chars, reject `.` / `..`. Also written as the translation's `alias`. Single algorithm per call. |
-| `--image REF` | yes | Registry ref. If it contains `@sha256:HEX`, that digest is recorded; otherwise `image_digest` is `null` with a warning. |
-| `--config PATH` | yes | Treatment overlay YAML. Validated as YAML before any writes. |
-| `--baseline-config PATH` | no | Baseline overlay YAML, if the translation needs one. |
-| `--registered-hash HASH` | no | Assert the computed `translation_hash` equals this value; error if not. |
-| `--force` | no | Reassign the alias (`--algorithm` value) if another translation already owns it. Clears the alias on the previous translation atomically. |
-| `--experiment-root PATH` | no | Defaults to cwd. |
-
 **Outputs** — under `workspace/translations/<translation_hash>/`:
 
-- `translation_output.json` — algorithm index + provenance (v1 schema). Includes `alias` (top-level, same value as `--algorithm`) and per-algorithm `image_ref` / `image_digest` inside `algorithms[i]`. Step-1 legacy files (top-level `image_ref`) remain readable via a compatibility shim in `pipeline/lib/translation_ref.py`.
-- `registered.json` — image ref + digest (BYO-only audit trail; v1 schema).
-- `generated/<algorithm>/<algorithm>_config.yaml` — the treatment overlay content.
+- `translation_output.json` — algorithm index + provenance. Top-level `alias` (set to the algorithm name for N=1; `null` for N>1). Per-algorithm `image_ref` / `image_digest` inside `algorithms[i]`. Step-1 legacy files (top-level `image_ref`) remain readable via a compatibility shim in `pipeline/lib/translation_ref.py`.
+- `registered.json` — per-algorithm image refs and digests (BYO-only audit trail; batched shape with an `algorithms` list).
+- `generated/<algorithm>/<algorithm>_config.yaml` — the treatment overlay content, one file per algorithm.
 - `generated/baseline_config.yaml` — present only when `--baseline-config` is given.
 
-**`translation_hash` derivation (BYO):** SHA-256 hex over canonical JSON of `{algorithm_name, config_sha256, image_digest_or_ref}`. Deterministic — same inputs produce the same hash. When the image ref lacks a digest, the raw ref string is substituted for `image_digest_or_ref`, so the hash is stable within the offline session but changes if the same image is later re-registered with a digest ref.
+**`translation_hash` derivation (BYO, batched):** SHA-256 hex over canonical JSON of a list of `{name, image, config}` dicts sorted by `name`, where `config` is the SHA-256 of the overlay file content and `image` is the digest ref if present (otherwise the raw ref string). Order-invariant — registering the same algorithms in a different order produces the same hash.
 
-**Idempotency:** re-registering the same triple (algorithm, image, config content) is a no-op — the existing translation directory is detected, a warning is printed, and exit is 0.
+```
+sha256(canonical-json(sorted-by-name list of {name, image_digest_or_ref, config_sha256}))
+```
+
+**Idempotency:** re-registering the same set of (algorithm, image, config-content) tuples — in any order — is a no-op. The existing translation directory is detected, a warning is printed, and exit is 0.
 
 **Failure modes:**
 
 - `--config` file missing or malformed YAML → exit 2, no writes.
-- Existing translation directory records a different algorithm name (hash collision) → exit 2, no writes.
+- Existing translation directory records different algorithm names (hash collision) → exit 2, no writes.
 - `--registered-hash` given and does not match computed → exit 2, no writes.
-- Another translation already owns the `--algorithm` alias with a different hash → exit 2, no writes; re-run with `--force` to reassign.
+- Another translation already owns an `--algorithm` alias with a different hash → exit 2, no writes; re-run with `--force` to reassign (N=1 only).
+- Duplicate algorithm names within a single invocation → exit 2, no writes.
 
 ---
 
@@ -491,14 +513,14 @@ Writes `workspace/setup_config.json` with registry, repo name, and orchestrator 
 ### 3. Register a translation (BYO)
 
 ```bash
+# Preferred: repeatable --algorithm NAME=IMAGE@CONFIG (N algorithms in one call)
 python pipeline/sim2real.py translation register \
-    --algorithm <algorithm> \
-    --image <image-ref> \
-    --config <treatment-overlay-path> \
+    --algorithm <name>=<image-ref>@<config-path> \
+    [--algorithm <name>=<image-ref>@<config-path> ...] \
     --experiment-root <experiment-root>
 ```
 
-Writes `workspace/translations/<hash>/` with `translation_output.json`, `registered.json`, and `generated/<algorithm>/<algorithm>_config.yaml`. Prints the `<hash>` on success.
+Writes `workspace/translations/<hash>/` with `translation_output.json`, `registered.json`, and `generated/<algorithm>/<algorithm>_config.yaml` for each algorithm. Prints the `<hash>` on success. See the [Register a translation](#register-a-translation-byo) section for the full flag reference, the hash formula, and the deprecated single-algorithm form.
 
 ### 4. Assemble the run
 
@@ -618,8 +640,8 @@ All artifacts live under `<experiment-root>/workspace/` (gitignored). Key files:
 | `setup_config.json` (workspace fields: registry, repo_name, orchestrator_image, sim2real_root) | `setup.py` | `deploy.py`, `sim2real.py list runs` |
 | `setup_config.json:current_run` (active run pointer) | `sim2real.py use` | `deploy.py` (default `--run`), `sim2real.py list runs` (active-mark `*`) |
 | `clusters/<id>/cluster_config.json` (cluster fields: cluster_id, namespaces, is_openshift, storage_class, secret_names, workspaces, created_at) | `cluster.py provision` | `sim2real assemble`, `deploy.py`, `lib/remote.py` |
-| `translations/<hash>/translation_output.json` | `sim2real translation register` | `sim2real assemble`, `deploy.py` |
-| `translations/<hash>/registered.json` | `sim2real translation register` | audit trail |
+| `translations/<hash>/translation_output.json` | `sim2real translation register` (batched; N per-algo entries in `algorithms`) | `sim2real assemble`, `deploy.py` |
+| `translations/<hash>/registered.json` | `sim2real translation register` (batched; N per-algo entries in `algorithms`) | audit trail |
 | `translations/<hash>/generated/…` | `sim2real translation register` | `sim2real assemble` |
 | `runs/<run>/run_metadata.json` | `sim2real assemble` | `deploy.py`, `sim2real.py list runs` |
 | `runs/<run>/manifest.assembly.yaml` | `sim2real assemble` | reproducibility / drift detection (step-5) |

--- a/pipeline/sim2real.py
+++ b/pipeline/sim2real.py
@@ -62,6 +62,60 @@ def _extract_digest_from_ref(image_ref: str) -> str | None:
     return digest
 
 
+def _parse_algorithm_triple(value: str) -> tuple[str, str, str]:
+    """Parse ``<name>=<image-ref>@<config-path>`` into ``(name, image_ref, config_path)``.
+
+    Splits on the first ``=`` (names cannot contain ``=`` by regex) and
+    then on the rightmost ``@`` in the RHS (digest refs contain ``@``;
+    overlay paths must not contain ``@`` — enforced by rejecting image
+    refs with more than one ``@`` after the split). Config paths
+    containing ``=`` are supported.
+
+    Raises ``argparse.ArgumentTypeError`` on any parse failure.
+    """
+    from pipeline.lib import translation_ref
+    eq_idx = value.find("=")
+    if eq_idx < 0:
+        raise argparse.ArgumentTypeError(
+            f"--algorithm value {value!r} missing '=' "
+            "(expected '<name>=<image-ref>@<config-path>')"
+        )
+    name = value[:eq_idx]
+    rhs = value[eq_idx + 1:]
+    at_idx = rhs.rfind("@")
+    if at_idx < 0:
+        raise argparse.ArgumentTypeError(
+            f"--algorithm value {value!r} missing '@' after '=' "
+            "(expected '<name>=<image-ref>@<config-path>')"
+        )
+    image_ref = rhs[:at_idx]
+    config_path = rhs[at_idx + 1:]
+    if not image_ref:
+        raise argparse.ArgumentTypeError(
+            f"--algorithm value {value!r} has empty image-ref"
+        )
+    if not config_path:
+        raise argparse.ArgumentTypeError(
+            f"--algorithm value {value!r} has empty config-path"
+        )
+    # Valid image refs have at most one '@' (the digest suffix). More than
+    # one '@' in the parsed image ref means the config path likely had a
+    # '@' that rightmost-@ split cannot disambiguate — reject.
+    if image_ref.count("@") > 1:
+        raise argparse.ArgumentTypeError(
+            f"--algorithm value {value!r}: overlay path cannot contain '@' "
+            "(parsed image ref has multiple '@'; the rightmost-@ split rule "
+            "cannot distinguish a digest '@' from a path '@')"
+        )
+    try:
+        translation_ref.validate_name(name)
+    except translation_ref.ValidationError as exc:
+        raise argparse.ArgumentTypeError(
+            f"--algorithm value {value!r} has invalid name: {exc}"
+        ) from exc
+    return name, image_ref, config_path
+
+
 def _clear_alias_on(other_hash: str) -> None:
     """Rewrite ``translations/<other_hash>/translation_output.json`` with ``alias=null``.
 

--- a/pipeline/sim2real.py
+++ b/pipeline/sim2real.py
@@ -163,20 +163,19 @@ def _compute_translation_hash(entries: list[dict]) -> str:
 
 def _build_translation_output(
     *,
-    algorithm_name: str,
-    image_ref: str,
-    image_digest: str | None,
-    config_path: str,
+    algorithms: list[dict],
     translation_hash: str,
     source: str,
     alias: str | None,
     created_at: str,
 ) -> dict:
-    """Build the ``translation_output.json`` body for step-2 schema.
+    """Build the ``translation_output.json`` body — step-2 batched shape.
 
-    Single-algorithm shape (BYO register in this PR). ``image_ref`` and
-    ``image_digest`` live per-algo. ``source_path``/``source_sha256`` are
-    ``None`` for BYO (populated by the skill-driven ``translate`` in PR 3).
+    Each entry in ``algorithms`` is ``{"name", "image_ref", "image_digest",
+    "config_path"}`` (``config_path`` is the relative path
+    ``generated/<name>/<name>_config.yaml``). ``source_path``/``source_sha256``
+    are ``None`` for BYO. ``alias`` is the shared translation-level alias
+    (algorithm name when N==1, ``None`` when N>1).
     """
     return {
         "version": 1,
@@ -185,13 +184,14 @@ def _build_translation_output(
         "alias": alias,
         "algorithms": [
             {
-                "name": algorithm_name,
+                "name": a["name"],
                 "source_path": None,
                 "source_sha256": None,
-                "config_path": config_path,
-                "image_ref": image_ref,
-                "image_digest": image_digest,
+                "config_path": a["config_path"],
+                "image_ref": a["image_ref"],
+                "image_digest": a["image_digest"],
             }
+            for a in algorithms
         ],
         "created_at": created_at,
     }
@@ -316,47 +316,80 @@ def _translate_delete_dir(translation_hash: str) -> None:
 
 
 def _build_registered(
-    image_ref: str,
-    image_digest: str | None,
+    prepared: list[dict],
     registered_at: str,
 ) -> dict:
+    """Build the ``registered.json`` body for a BYO translation.
+
+    Batched shape: N per-algorithm entries under ``algorithms``. For N==1
+    the shape is the same (a list of one). ``prepared`` is the internal
+    per-algorithm record produced by ``_register_translation`` and carries
+    ``name``, ``image_ref``, ``image_digest``.
+    """
     return {
         "version": 1,
-        "image_ref": image_ref,
-        "image_digest": image_digest,
         "source": "byo",
         "registered_at": registered_at,
+        "algorithms": [
+            {
+                "name": p["name"],
+                "image_ref": p["image_ref"],
+                "image_digest": p["image_digest"],
+            }
+            for p in prepared
+        ],
     }
 
 
 def _register_translation(
     *,
-    algorithm_name: str,
-    image_ref: str,
-    config_path: Path,
+    algorithms: list[dict],
     baseline_config_path: Path | None,
     registered_hash: str | None,
     now_iso: str,
     force: bool = False,
 ) -> tuple[str, str]:
-    """Register a BYO translation on disk.
+    """Register a BYO translation on disk (single or batched).
 
-    Returns ``(translation_hash, status)`` where status is either
+    ``algorithms`` is a list of ``AlgorithmSpec`` dicts:
+    ``{"name": str, "image_ref": str, "config_path": Path}``. Caller has
+    already validated names and confirmed each config file exists and
+    parses as YAML — this function does not re-validate.
+
+    Alias policy: when ``len(algorithms) == 1``, the translation's
+    top-level ``alias`` is the sole algorithm's name (matches step-1
+    behavior for N=1). When ``len(algorithms) > 1``, top-level ``alias``
+    is ``None`` — batched translations are referenced by hash. Alias
+    collision is still checked per-algorithm name against
+    ``find_by_alias`` regardless of N (each algo name must not shadow an
+    existing translation's alias unless ``force`` is set, in which case
+    the previous alias is cleared).
+
+    Returns ``(translation_hash, status)`` where ``status`` is
     ``"created"`` (fresh registration) or ``"idempotent"`` (matching
-    translation already existed; no writes performed).
-
-    Raises:
-        RuntimeError: ``--registered-hash`` given and does not match
-            computed; OR alias collision on a different hash without
-            ``force``.
-        ValueError: existing translation dir has the same hash but records
-            a different algorithm name (corrupted state or collision).
+    translation already existed; no writes).
     """
     from pipeline.lib import translation_ref
-    config_bytes = config_path.read_bytes()
-    image_digest = _extract_digest_from_ref(image_ref)
-    digest_or_ref = image_digest if image_digest is not None else image_ref
-    thash = _compute_translation_hash(digest_or_ref, config_bytes, algorithm_name)
+
+    # Prepare per-algorithm derived fields: config bytes, digest, digest_or_ref.
+    prepared: list[dict] = []
+    for a in algorithms:
+        cfg_bytes = a["config_path"].read_bytes()
+        digest = _extract_digest_from_ref(a["image_ref"])
+        prepared.append({
+            "name": a["name"],
+            "image_ref": a["image_ref"],
+            "image_digest": digest,
+            "digest_or_ref": digest if digest is not None else a["image_ref"],
+            "config_bytes": cfg_bytes,
+            "config_sha": hashlib.sha256(cfg_bytes).hexdigest(),
+        })
+
+    # Compute the batched translation hash.
+    thash = _compute_translation_hash([
+        {"name": p["name"], "image": p["digest_or_ref"], "config_sha": p["config_sha"]}
+        for p in prepared
+    ])
 
     if registered_hash is not None and registered_hash != thash:
         raise RuntimeError(
@@ -366,17 +399,21 @@ def _register_translation(
     out_path = layout.translation_output_path(thash)
     if out_path.exists():
         existing = translation_ref.read_translation_output(out_path)
-        existing_algos = [a.get("name") for a in existing.get("algorithms", [])]
-        if algorithm_name not in existing_algos:
+        existing_names = sorted(a.get("name") for a in existing.get("algorithms", []))
+        wanted_names = sorted(p["name"] for p in prepared)
+        if existing_names != wanted_names:
             raise ValueError(
-                f"algorithm name mismatch: translation {thash} records "
-                f"{existing_algos}, refusing to register {algorithm_name!r}"
+                f"algorithm-set mismatch: translation {thash} records "
+                f"{existing_names}, refusing to re-register with {wanted_names} "
+                "(hash collision — investigate)"
             )
-        missing = []
+        # Verify all on-disk artifacts are present; incomplete state → surface.
+        missing: list[str] = []
         if not layout.registered_path(thash).exists():
             missing.append("registered.json")
-        if not layout.generated_config_path(thash, algorithm_name).exists():
-            missing.append(f"generated/{algorithm_name}/{algorithm_name}_config.yaml")
+        for p in prepared:
+            if not layout.generated_config_path(thash, p["name"]).exists():
+                missing.append(f"generated/{p['name']}/{p['name']}_config.yaml")
         if missing:
             raise RuntimeError(
                 f"translation {thash} directory is incomplete (missing: "
@@ -385,39 +422,45 @@ def _register_translation(
             )
         return thash, "idempotent"
 
-    # Alias collision — detect BEFORE creating any new files. Only a
-    # different-hash collision matters; same-hash "collision" fell out
-    # into the idempotent path above.
-    other_hash = translation_ref.find_by_alias(
-        algorithm_name, layout.translations_dir()
-    )
-    if other_hash is not None and other_hash != thash:
-        if not force:
-            raise RuntimeError(
-                f"alias {algorithm_name!r} already assigned to translation "
-                f"{other_hash}; pass --force to reassign"
-            )
-        _clear_alias_on(other_hash)
+    # Alias-collision check per algorithm — must precede any writes.
+    for p in prepared:
+        other = translation_ref.find_by_alias(p["name"], layout.translations_dir())
+        if other is not None and other != thash:
+            if not force:
+                raise RuntimeError(
+                    f"alias {p['name']!r} already assigned to translation "
+                    f"{other}; pass --force to reassign"
+                )
+            _clear_alias_on(other)
 
+    # All checks passed — materialize the translation dir.
     tdir = layout.translation_dir(thash)
-    (tdir / "generated" / algorithm_name).mkdir(parents=True, exist_ok=True)
+    for p in prepared:
+        (tdir / "generated" / p["name"]).mkdir(parents=True, exist_ok=True)
 
-    out = _build_translation_output(
-        algorithm_name=algorithm_name,
-        image_ref=image_ref,
-        image_digest=image_digest,
-        config_path=f"generated/{algorithm_name}/{algorithm_name}_config.yaml",
+    alias = prepared[0]["name"] if len(prepared) == 1 else None
+    tout = _build_translation_output(
+        algorithms=[
+            {
+                "name": p["name"],
+                "image_ref": p["image_ref"],
+                "image_digest": p["image_digest"],
+                "config_path": f"generated/{p['name']}/{p['name']}_config.yaml",
+            }
+            for p in prepared
+        ],
         translation_hash=thash,
         source="byo",
-        alias=algorithm_name,
+        alias=alias,
         created_at=now_iso,
     )
-    _atomic_write_json(out_path, out)
+    _atomic_write_json(out_path, tout)
 
-    reg = _build_registered(image_ref, image_digest, now_iso)
+    reg = _build_registered(prepared, now_iso)
     layout.registered_path(thash).write_text(json.dumps(reg, indent=2) + "\n")
 
-    layout.generated_config_path(thash, algorithm_name).write_bytes(config_bytes)
+    for p in prepared:
+        layout.generated_config_path(thash, p["name"]).write_bytes(p["config_bytes"])
 
     if baseline_config_path is not None:
         (tdir / "generated" / "baseline_config.yaml").write_bytes(

--- a/pipeline/sim2real.py
+++ b/pipeline/sim2real.py
@@ -446,28 +446,40 @@ def build_parser() -> argparse.ArgumentParser:
     translation = sub.add_parser("translation", help="Manage translations")
     tsub = translation.add_subparsers(dest="subcommand", required=True)
 
-    reg = tsub.add_parser("register", help="Register a BYO (pre-built) translation")
+    reg = tsub.add_parser(
+        "register",
+        help="Register one or more BYO (pre-built) translations into a single translation dir",
+    )
     reg.add_argument(
         "--algorithm",
         required=True,
-        type=_validate_algorithm_name,
+        action="append",
+        metavar="ALG",
         help=(
-            "Algorithm name; also written as the translation's alias. "
-            "Must match [A-Za-z0-9][A-Za-z0-9._-]*, max 128 chars; "
-            "'.' and '..' are rejected."
+            "Algorithm spec — repeatable. Preferred form: "
+            "'<name>=<image-ref>@<config-path>' (all fields inline). "
+            "Deprecated form: '<name>' alone, with --image and --config "
+            "supplied separately (N=1 only; emits deprecation warning). "
+            "Names match [A-Za-z0-9][A-Za-z0-9._-]*, max 128 chars."
         ),
     )
     reg.add_argument(
         "--image",
-        required=True,
+        default=None,
         metavar="REF",
-        help="EPP image reference (e.g. ghcr.io/foo/bar:v1 or ...@sha256:...)",
+        help=(
+            "DEPRECATED: EPP image reference. Use the '<name>=<image>@<config>' "
+            "form of --algorithm instead."
+        ),
     )
     reg.add_argument(
         "--config",
-        required=True,
+        default=None,
         metavar="PATH",
-        help="Path to the treatment overlay YAML",
+        help=(
+            "DEPRECATED: Treatment overlay YAML path. Use the "
+            "'<name>=<image>@<config>' form of --algorithm instead."
+        ),
     )
     reg.add_argument(
         "--baseline-config",
@@ -484,7 +496,7 @@ def build_parser() -> argparse.ArgumentParser:
     reg.add_argument(
         "--force",
         action="store_true",
-        help="Reassign the alias (--algorithm) from a previous translation.",
+        help="Reassign an alias from a previous translation.",
     )
 
     asm = sub.add_parser(
@@ -588,20 +600,88 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def _cmd_translation_register(args) -> int:
-    config_path = Path(args.config)
+    # Normalize CLI forms into a list of AlgorithmSpec dicts.
+    algo_values: list[str] = args.algorithm  # action='append' guarantees list
+    algorithms: list[dict] = []
+    if args.image is not None or args.config is not None:
+        # Deprecated form: single --algorithm plus separate --image/--config.
+        if len(algo_values) != 1:
+            print(
+                "error: --image/--config are only valid with a single --algorithm "
+                "in the deprecated form; use --algorithm '<name>=<image>@<config>' "
+                "for multiple algorithms",
+                file=sys.stderr,
+            )
+            return 2
+        if args.image is None or args.config is None:
+            print(
+                "error: deprecated form requires BOTH --image and --config",
+                file=sys.stderr,
+            )
+            return 2
+        if "=" in algo_values[0]:
+            print(
+                f"error: --algorithm value {algo_values[0]!r} appears to be an "
+                "inline triple; do not combine with --image/--config",
+                file=sys.stderr,
+            )
+            return 2
+        from pipeline.lib import translation_ref
+        try:
+            name = translation_ref.validate_name(algo_values[0])
+        except translation_ref.ValidationError as exc:
+            print(f"error: --algorithm: {exc}", file=sys.stderr)
+            return 2
+        algorithms.append({
+            "name": name,
+            "image_ref": args.image,
+            "config_path": Path(args.config),
+        })
+        print(
+            "warning: --image/--config are deprecated; use "
+            "--algorithm '<name>=<image-ref>@<config-path>' instead",
+            file=sys.stderr,
+        )
+    else:
+        # New form: each --algorithm value is an inline triple.
+        for val in algo_values:
+            try:
+                name, image_ref, config_path_str = _parse_algorithm_triple(val)
+            except argparse.ArgumentTypeError as exc:
+                print(f"error: {exc}", file=sys.stderr)
+                return 2
+            algorithms.append({
+                "name": name,
+                "image_ref": image_ref,
+                "config_path": Path(config_path_str),
+            })
+
+    # Duplicate-name check (either form).
+    seen: dict[str, int] = {}
+    for a in algorithms:
+        seen[a["name"]] = seen.get(a["name"], 0) + 1
+    dupes = sorted(n for n, c in seen.items() if c > 1)
+    if dupes:
+        print(
+            f"error: duplicate algorithm name(s) in one register call: "
+            f"{', '.join(dupes)}",
+            file=sys.stderr,
+        )
+        return 2
+
+    # Existence + YAML validation for every config file (fail-fast, no writes).
+    for a in algorithms:
+        cp: Path = a["config_path"]
+        if not cp.exists():
+            print(f"error: config file not found: {cp}", file=sys.stderr)
+            return 2
+        try:
+            yaml.safe_load(cp.read_text())
+        except yaml.YAMLError as exc:
+            print(f"error: {cp} is not valid YAML: {exc}", file=sys.stderr)
+            return 2
+
     baseline_config_path = Path(args.baseline_config) if args.baseline_config else None
-
-    if not config_path.exists():
-        print(f"error: --config file not found: {config_path}", file=sys.stderr)
-        return 2
-
-    # Fail-fast YAML validation. Malformed overlay → error before any writes.
-    try:
-        yaml.safe_load(config_path.read_text())
-    except yaml.YAMLError as e:
-        print(f"error: --config is not valid YAML: {e}", file=sys.stderr)
-        return 2
-
     if baseline_config_path is not None:
         if not baseline_config_path.exists():
             print(
@@ -611,28 +691,21 @@ def _cmd_translation_register(args) -> int:
             return 2
         try:
             yaml.safe_load(baseline_config_path.read_text())
-        except yaml.YAMLError as e:
-            print(f"error: --baseline-config is not valid YAML: {e}", file=sys.stderr)
+        except yaml.YAMLError as exc:
+            print(f"error: --baseline-config is not valid YAML: {exc}", file=sys.stderr)
             return 2
 
     now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     try:
         thash, status = _register_translation(
-            algorithm_name=args.algorithm,
-            image_ref=args.image,
-            config_path=config_path,
+            algorithms=algorithms,
             baseline_config_path=baseline_config_path,
             registered_hash=args.registered_hash,
             now_iso=now_iso,
             force=args.force,
         )
     except (RuntimeError, ValueError, OSError) as e:
-        # OSError covers filesystem faults from mkdir/write_text/write_bytes/
-        # read_bytes inside _register_translation (disk full, permission
-        # denied, missing parent unwritable). Surfacing as the same
-        # `error: ...; return 2` shape used elsewhere keeps failures
-        # consistent with the rest of the command.
         print(f"error: {e}", file=sys.stderr)
         return 2
 
@@ -642,13 +715,13 @@ def _cmd_translation_register(args) -> int:
             file=sys.stderr,
         )
     else:
-        digest = _extract_digest_from_ref(args.image)
-        if digest is None:
-            print(
-                "warning: image_digest recorded as null "
-                "(no @sha256: in --image); hash falls back to using image_ref",
-                file=sys.stderr,
-            )
+        for a in algorithms:
+            if _extract_digest_from_ref(a["image_ref"]) is None:
+                print(
+                    f"warning: image_digest for {a['name']!r} recorded as null "
+                    f"(no @sha256: in image); hash falls back to using image_ref",
+                    file=sys.stderr,
+                )
     print(f"registered translation {thash}")
     return 0
 

--- a/pipeline/sim2real.py
+++ b/pipeline/sim2real.py
@@ -78,26 +78,28 @@ def _clear_alias_on(other_hash: str) -> None:
     _atomic_write_json(other_path, data)
 
 
-def _compute_translation_hash(
-    image_digest_or_ref: str,
-    config_bytes: bytes,
-    algorithm_name: str,
-) -> str:
-    """SHA-256 hex over canonical JSON of the three BYO inputs.
+def _compute_translation_hash(entries: list[dict]) -> str:
+    """SHA-256 hex over canonical-JSON of the sorted-by-name algorithm list.
 
-    Design: ``translation_hash = sha256(image_digest_or_ref || config || name)``.
-    Implementation embeds ``sha256(config)`` in a canonical JSON envelope
-    (sorted keys, no whitespace) to prevent boundary-shift collisions
-    from raw concatenation while preserving determinism. Mirrors
-    ``pipeline/lib/slicer.translation_hash``'s canonical-JSON approach.
+    Each entry is ``{"name": str, "image": str, "config_sha": str}`` where
+    ``image`` is the ``sha256:...`` digest when the image ref carried one,
+    else the raw ref. ``config_sha`` is ``sha256(config_bytes).hexdigest()``.
+
+    Order-invariant: entries are sorted by ``name`` before serialization.
+    Deterministic in the algorithm-set membership — same triples in a
+    different order produce the same hash. N=1 uses the same shape as
+    N>1 (list of one entry), superseding the step-1 formula.
     """
-    config_sha = hashlib.sha256(config_bytes).hexdigest()
+    sorted_entries = sorted(entries, key=lambda e: e["name"])
     canonical = json.dumps(
-        {
-            "algorithm_name": algorithm_name,
-            "config_sha256": config_sha,
-            "image_digest_or_ref": image_digest_or_ref,
-        },
+        [
+            {
+                "config": e["config_sha"],
+                "image": e["image"],
+                "name": e["name"],
+            }
+            for e in sorted_entries
+        ],
         sort_keys=True,
         separators=(",", ":"),
         ensure_ascii=False,

--- a/pipeline/tests/test_sim2real.py
+++ b/pipeline/tests/test_sim2real.py
@@ -77,6 +77,68 @@ class TestExtractDigest:
         assert sim2real._extract_digest_from_ref("ghcr.io/foo@sha256:" + "z" * 64) is None
 
 
+class TestParseAlgorithmTriple:
+    def test_simple_triple(self):
+        name, image, cfg = sim2real._parse_algorithm_triple("foo=img:v1@algo.yaml")
+        assert name == "foo"
+        assert image == "img:v1"
+        assert cfg == "algo.yaml"
+
+    def test_digest_ref_uses_rightmost_at(self):
+        name, image, cfg = sim2real._parse_algorithm_triple(
+            "foo=registry.io/img@sha256:" + "d" * 64 + "@algorithms/foo/foo_config.yaml"
+        )
+        assert name == "foo"
+        assert image == "registry.io/img@sha256:" + "d" * 64
+        assert cfg == "algorithms/foo/foo_config.yaml"
+
+    def test_config_path_with_equals_supported(self):
+        name, image, cfg = sim2real._parse_algorithm_triple("foo=img:v1@path=weird.yaml")
+        assert name == "foo"
+        assert image == "img:v1"
+        assert cfg == "path=weird.yaml"
+
+    def test_missing_equals_rejected(self):
+        with pytest.raises(argparse.ArgumentTypeError) as ei:
+            sim2real._parse_algorithm_triple("fooimg@algo.yaml")
+        assert "=" in str(ei.value)
+
+    def test_missing_at_rejected(self):
+        with pytest.raises(argparse.ArgumentTypeError) as ei:
+            sim2real._parse_algorithm_triple("foo=img:v1")
+        assert "@" in str(ei.value)
+
+    def test_empty_image_rejected(self):
+        with pytest.raises(argparse.ArgumentTypeError):
+            sim2real._parse_algorithm_triple("foo=@algo.yaml")
+
+    def test_empty_config_rejected(self):
+        with pytest.raises(argparse.ArgumentTypeError):
+            sim2real._parse_algorithm_triple("foo=img:v1@")
+
+    def test_invalid_name_rejected(self):
+        with pytest.raises(argparse.ArgumentTypeError) as ei:
+            sim2real._parse_algorithm_triple("bad name=img@cfg.yaml")
+        # Message should mention the name-regex constraint.
+        assert "name" in str(ei.value).lower()
+
+    def test_at_in_middle_goes_to_image(self):
+        """Rightmost-@ split rule: any earlier '@' stays in the image ref."""
+        name, image, cfg = sim2real._parse_algorithm_triple("foo=a@b@c.yaml")
+        assert name == "foo"
+        assert image == "a@b"
+        assert cfg == "c.yaml"
+
+    def test_multiple_at_in_image_rejected(self):
+        """Reject values whose parsed image ref has more than one '@'.
+
+        Common cause: user tried to put a '@' in the config path.
+        """
+        with pytest.raises(argparse.ArgumentTypeError) as ei:
+            sim2real._parse_algorithm_triple("foo=img:tag@path@with@ats/overlay.yaml")
+        assert "overlay path cannot contain" in str(ei.value)
+
+
 class TestComputeTranslationHash:
     """Batched hash formula (replaces step-1 single-algo formula for all N)."""
 

--- a/pipeline/tests/test_sim2real.py
+++ b/pipeline/tests/test_sim2real.py
@@ -514,46 +514,51 @@ class TestRegisterTranslation:
 
 
 class TestBuildParser:
-    def test_parses_translation_register(self):
-        parser = sim2real.build_parser()
-        args = parser.parse_args([
+    def test_parses_new_form_single_algo(self):
+        p = sim2real.build_parser()
+        args = p.parse_args([
             "translation", "register",
-            "--algorithm", "softreflective",
-            "--image", "ghcr.io/foo:v1",
-            "--config", "/tmp/treatment.yaml",
+            "--algorithm", "foo=img:v1@overlay.yaml",
         ])
         assert args.command == "translation"
         assert args.subcommand == "register"
-        assert args.algorithm == "softreflective"
-        assert args.image == "ghcr.io/foo:v1"
-        assert args.config == "/tmp/treatment.yaml"
-        assert args.baseline_config is None
-        assert args.registered_hash is None
+        assert args.algorithm == ["foo=img:v1@overlay.yaml"]
+        assert args.image is None
+        assert args.config is None
+
+    def test_parses_new_form_multi_algo(self):
+        p = sim2real.build_parser()
+        args = p.parse_args([
+            "translation", "register",
+            "--algorithm", "foo=img1@o1.yaml",
+            "--algorithm", "bar=img2@o2.yaml",
+        ])
+        assert args.algorithm == ["foo=img1@o1.yaml", "bar=img2@o2.yaml"]
+
+    def test_parses_deprecated_form(self):
+        p = sim2real.build_parser()
+        args = p.parse_args([
+            "translation", "register",
+            "--algorithm", "foo",
+            "--image", "img:v1",
+            "--config", "overlay.yaml",
+        ])
+        assert args.algorithm == ["foo"]
+        assert args.image == "img:v1"
+        assert args.config == "overlay.yaml"
 
     def test_accepts_baseline_and_registered_hash(self):
-        parser = sim2real.build_parser()
-        args = parser.parse_args([
+        p = sim2real.build_parser()
+        args = p.parse_args([
             "translation", "register",
-            "--algorithm", "softreflective",
-            "--image", "ghcr.io/foo:v1",
-            "--config", "/tmp/treatment.yaml",
-            "--baseline-config", "/tmp/baseline.yaml",
-            "--registered-hash", "abcd" * 16,
+            "--algorithm", "foo=img:v1@overlay.yaml",
+            "--baseline-config", "b.yaml",
+            "--registered-hash", "abc",
+            "--force",
         ])
-        assert args.baseline_config == "/tmp/baseline.yaml"
-        assert args.registered_hash == "abcd" * 16
-
-    def test_rejects_bad_algorithm_name(self):
-        # Leading hyphen fails the shared regex; use it instead of Bad_Name
-        # (uppercase+underscore are now accepted per step-2 widening).
-        parser = sim2real.build_parser()
-        with pytest.raises(SystemExit):
-            parser.parse_args([
-                "translation", "register",
-                "--algorithm", "-bad-name",
-                "--image", "ghcr.io/foo:v1",
-                "--config", "/tmp/treatment.yaml",
-            ])
+        assert args.baseline_config == "b.yaml"
+        assert args.registered_hash == "abc"
+        assert args.force is True
 
 
 class TestMainEndToEnd:

--- a/pipeline/tests/test_sim2real.py
+++ b/pipeline/tests/test_sim2real.py
@@ -78,31 +78,79 @@ class TestExtractDigest:
 
 
 class TestComputeTranslationHash:
-    def test_is_deterministic(self):
-        h1 = sim2real._compute_translation_hash("sha256:aa", b"config: 1\n", "algo")
-        h2 = sim2real._compute_translation_hash("sha256:aa", b"config: 1\n", "algo")
+    """Batched hash formula (replaces step-1 single-algo formula for all N)."""
+
+    def _e(self, name: str, image: str = "sha256:aa", config: bytes = b"c") -> dict:
+        import hashlib
+        return {
+            "name": name,
+            "image": image,
+            "config_sha": hashlib.sha256(config).hexdigest(),
+        }
+
+    def test_is_deterministic_n1(self):
+        h1 = sim2real._compute_translation_hash([self._e("algo")])
+        h2 = sim2real._compute_translation_hash([self._e("algo")])
         assert h1 == h2
-        assert len(h1) == 64  # sha256 hex length
+        assert len(h1) == 64
+
+    def test_is_deterministic_n2(self):
+        h1 = sim2real._compute_translation_hash([self._e("a"), self._e("b")])
+        h2 = sim2real._compute_translation_hash([self._e("a"), self._e("b")])
+        assert h1 == h2
+        assert len(h1) == 64
+
+    def test_order_invariant(self):
+        h_ab = sim2real._compute_translation_hash([self._e("a"), self._e("b")])
+        h_ba = sim2real._compute_translation_hash([self._e("b"), self._e("a")])
+        assert h_ab == h_ba
 
     def test_changes_with_algorithm_name(self):
-        h1 = sim2real._compute_translation_hash("sha256:aa", b"c", "a")
-        h2 = sim2real._compute_translation_hash("sha256:aa", b"c", "b")
+        h1 = sim2real._compute_translation_hash([self._e("a")])
+        h2 = sim2real._compute_translation_hash([self._e("b")])
         assert h1 != h2
 
-    def test_changes_with_config_content(self):
-        h1 = sim2real._compute_translation_hash("sha256:aa", b"a", "algo")
-        h2 = sim2real._compute_translation_hash("sha256:aa", b"b", "algo")
+    def test_changes_with_config(self):
+        h1 = sim2real._compute_translation_hash([self._e("a", config=b"x")])
+        h2 = sim2real._compute_translation_hash([self._e("a", config=b"y")])
         assert h1 != h2
 
     def test_changes_with_image_ref(self):
-        h1 = sim2real._compute_translation_hash("sha256:aa", b"c", "algo")
-        h2 = sim2real._compute_translation_hash("sha256:bb", b"c", "algo")
+        h1 = sim2real._compute_translation_hash([self._e("a", image="sha256:aa")])
+        h2 = sim2real._compute_translation_hash([self._e("a", image="sha256:bb")])
         assert h1 != h2
 
     def test_offline_ref_produces_stable_hash(self):
-        h1 = sim2real._compute_translation_hash("ghcr.io/foo:v1", b"c", "algo")
-        h2 = sim2real._compute_translation_hash("ghcr.io/foo:v1", b"c", "algo")
+        e = self._e("a", image="ghcr.io/foo:v1")
+        h1 = sim2real._compute_translation_hash([e])
+        h2 = sim2real._compute_translation_hash([e])
         assert h1 == h2
+
+    def test_adding_algo_changes_hash(self):
+        h1 = sim2real._compute_translation_hash([self._e("a")])
+        h2 = sim2real._compute_translation_hash([self._e("a"), self._e("b")])
+        assert h1 != h2
+
+    def test_n1_new_differs_from_n1_old_shape(self):
+        """The new formula wraps entries in a list, so N=1 hashes differ
+        from the step-1 formula (which framed a single dict). Documented
+        break in the design (no long-lived step-1 registrations exist)."""
+        import hashlib
+        import json as _json
+        new_hash = sim2real._compute_translation_hash([self._e("a")])
+        # Old formula: sha256(canonical-json({algorithm_name, config_sha256, image_digest_or_ref}))
+        old_canonical = _json.dumps(
+            {
+                "algorithm_name": "a",
+                "config_sha256": hashlib.sha256(b"c").hexdigest(),
+                "image_digest_or_ref": "sha256:aa",
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
+        old_hash = hashlib.sha256(old_canonical.encode("utf-8")).hexdigest()
+        assert new_hash != old_hash
 
 
 class TestBuildSchemas:

--- a/pipeline/tests/test_sim2real.py
+++ b/pipeline/tests/test_sim2real.py
@@ -595,117 +595,229 @@ class TestBuildParser:
 
 
 class TestMainEndToEnd:
-    def test_happy_path(self, tmp_path, capsys):
-        cfg = tmp_path / "treatment.yaml"
-        cfg.write_text("scorer: mine\n")
+    def _cfg(self, tmp_path, name: str) -> Path:
+        p = tmp_path / f"{name}.yaml"
+        p.write_text(f"scorers:\n  - name: {name}\n")
+        return p
+
+    def test_happy_path_n1_new_form(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = self._cfg(tmp_path, "foo")
         rc = sim2real.main([
-            "--experiment-root", str(tmp_path),
             "translation", "register",
-            "--algorithm", "softreflective",
-            "--image", "ghcr.io/foo:v1",
+            "--algorithm", f"foo=ghcr.io/img:v1@{cfg}",
+        ])
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "registered translation" in captured.out
+        # No deprecation warning under the new form.
+        assert "deprecated" not in captured.err.lower()
+
+    def test_happy_path_n1_deprecated_form(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = self._cfg(tmp_path, "foo")
+        rc = sim2real.main([
+            "translation", "register",
+            "--algorithm", "foo",
+            "--image", "ghcr.io/img:v1",
             "--config", str(cfg),
         ])
         assert rc == 0
         captured = capsys.readouterr()
         assert "registered translation" in captured.out
-        # Warn about null digest since image ref is tag-only.
-        assert "image_digest recorded as null" in captured.err
+        assert "deprecated" in captured.err.lower()
 
-    def test_idempotent_second_run(self, tmp_path):
-        cfg = tmp_path / "treatment.yaml"
-        cfg.write_text("scorer: mine\n")
-        argv = [
-            "--experiment-root", str(tmp_path),
-            "translation", "register",
-            "--algorithm", "softreflective",
-            "--image", "ghcr.io/foo:v1",
-            "--config", str(cfg),
-        ]
-        assert sim2real.main(argv) == 0
-        assert sim2real.main(argv) == 0  # idempotent, still exit 0
-
-    def test_malformed_config_errors_no_writes(self, tmp_path):
-        cfg = tmp_path / "bad.yaml"
-        cfg.write_text("scorer: [unclosed\n")  # invalid YAML
+    def test_happy_path_n2(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        c1 = self._cfg(tmp_path, "foo")
+        c2 = self._cfg(tmp_path, "bar")
         rc = sim2real.main([
-            "--experiment-root", str(tmp_path),
             "translation", "register",
-            "--algorithm", "softreflective",
-            "--image", "ghcr.io/foo:v1",
-            "--config", str(cfg),
-        ])
-        assert rc == 2
-        # No translation dir should have been created.
-        assert not layout.translations_dir().exists() or not any(
-            layout.translations_dir().iterdir()
-        )
-
-    def test_missing_config_errors(self, tmp_path):
-        rc = sim2real.main([
-            "--experiment-root", str(tmp_path),
-            "translation", "register",
-            "--algorithm", "softreflective",
-            "--image", "ghcr.io/foo:v1",
-            "--config", str(tmp_path / "does-not-exist.yaml"),
-        ])
-        assert rc == 2
-
-    def test_registered_hash_mismatch_exits_2(self, tmp_path):
-        cfg = tmp_path / "treatment.yaml"
-        cfg.write_text("scorer: mine\n")
-        rc = sim2real.main([
-            "--experiment-root", str(tmp_path),
-            "translation", "register",
-            "--algorithm", "softreflective",
-            "--image", "ghcr.io/foo:v1",
-            "--config", str(cfg),
-            "--registered-hash", "deadbeef" * 8,
-        ])
-        assert rc == 2
-
-    def test_digest_ref_no_null_warning(self, tmp_path, capsys):
-        cfg = tmp_path / "treatment.yaml"
-        cfg.write_text("scorer: mine\n")
-        rc = sim2real.main([
-            "--experiment-root", str(tmp_path),
-            "translation", "register",
-            "--algorithm", "softreflective",
-            "--image", "ghcr.io/foo@sha256:" + "a" * 64,
-            "--config", str(cfg),
+            "--algorithm", f"foo=ghcr.io/img1:v1@{c1}",
+            "--algorithm", f"bar=ghcr.io/img2:v1@{c2}",
         ])
         assert rc == 0
-        captured = capsys.readouterr()
-        assert "image_digest recorded as null" not in captured.err
+        # Extract the hash from stdout to inspect on-disk shape.
+        out = capsys.readouterr().out.strip()
+        thash = out.rsplit(" ", 1)[-1]
+        tdir = Path("workspace") / "translations" / thash
+        assert (tdir / "generated" / "foo" / "foo_config.yaml").exists()
+        assert (tdir / "generated" / "bar" / "bar_config.yaml").exists()
+        tout = json.loads((tdir / "translation_output.json").read_text())
+        assert sorted(a["name"] for a in tout["algorithms"]) == ["bar", "foo"]
+        assert tout["alias"] is None
+
+    def test_order_invariant_hash(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        c1 = self._cfg(tmp_path, "foo")
+        c2 = self._cfg(tmp_path, "bar")
+        rc1 = sim2real.main([
+            "translation", "register",
+            "--algorithm", f"foo=img1:v1@{c1}",
+            "--algorithm", f"bar=img2:v1@{c2}",
+        ])
+        assert rc1 == 0
+        # Second run — reversed order. Should hit idempotent path.
+        rc2 = sim2real.main([
+            "translation", "register",
+            "--algorithm", f"bar=img2:v1@{c2}",
+            "--algorithm", f"foo=img1:v1@{c1}",
+        ])
+        assert rc2 == 0
+        # Only one translation dir exists.
+        dirs = list((Path("workspace") / "translations").iterdir())
+        assert len(dirs) == 1
+
+    def test_rightmost_at_in_image_ref(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = tmp_path / "algorithms" / "foo" / "foo_config.yaml"
+        cfg.parent.mkdir(parents=True)
+        cfg.write_text("scorers: []\n")
+        image = "registry.io/img@sha256:" + "d" * 64
+        rc = sim2real.main([
+            "translation", "register",
+            "--algorithm", f"foo={image}@{cfg}",
+        ])
+        assert rc == 0
+        out = capsys.readouterr().out.strip()
+        thash = out.rsplit(" ", 1)[-1]
+        reg = json.loads((Path("workspace") / "translations" / thash / "registered.json").read_text())
+        entry = reg["algorithms"][0]
+        assert entry["image_ref"] == image
+        assert entry["image_digest"] == "sha256:" + "d" * 64
+
+    def test_at_in_config_path_rejected(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        rc = sim2real.main([
+            "translation", "register",
+            "--algorithm", "foo=img:tag@path@with@ats/overlay.yaml",
+        ])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "overlay path cannot contain" in err
+
+    def test_config_path_with_equals_supported(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+        cfg = tmp_path / "weird=name.yaml"
+        cfg.write_text("scorers: []\n")
+        rc = sim2real.main([
+            "translation", "register",
+            "--algorithm", f"foo=img:v1@{cfg}",
+        ])
+        assert rc == 0
+
+    def test_duplicate_algorithm_names_rejected(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        c1 = self._cfg(tmp_path, "foo")
+        c2 = self._cfg(tmp_path, "foo2")
+        rc = sim2real.main([
+            "translation", "register",
+            "--algorithm", f"foo=img1@{c1}",
+            "--algorithm", f"foo=img2@{c2}",
+        ])
+        assert rc == 2
+        assert "duplicate algorithm name" in capsys.readouterr().err
+
+    def test_missing_config_errors(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        rc = sim2real.main([
+            "translation", "register",
+            "--algorithm", "foo=img:v1@does-not-exist.yaml",
+        ])
+        assert rc == 2
+        assert "not found" in capsys.readouterr().err
+
+    def test_malformed_config_errors_no_writes(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = tmp_path / "bad.yaml"
+        cfg.write_text("::not: yaml: [\n")
+        rc = sim2real.main([
+            "translation", "register",
+            "--algorithm", f"foo=img:v1@{cfg}",
+        ])
+        assert rc == 2
+        assert "not valid YAML" in capsys.readouterr().err
+        assert not (tmp_path / "workspace" / "translations").exists()
+
+    def test_registered_hash_mismatch_exits_2(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = self._cfg(tmp_path, "foo")
+        rc = sim2real.main([
+            "translation", "register",
+            "--algorithm", f"foo=img:v1@{cfg}",
+            "--registered-hash", "deadbeef",
+        ])
+        assert rc == 2
+        assert "--registered-hash mismatch" in capsys.readouterr().err
+
+    def test_idempotent_second_run_prints_warning(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = self._cfg(tmp_path, "foo")
+        sim2real.main([
+            "translation", "register",
+            "--algorithm", f"foo=img:v1@{cfg}",
+        ])
+        capsys.readouterr()  # reset
+        rc = sim2real.main([
+            "translation", "register",
+            "--algorithm", f"foo=img:v1@{cfg}",
+        ])
+        assert rc == 0
+        err = capsys.readouterr().err
+        assert "already registered" in err
+
+    def test_digest_ref_no_null_warning(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = self._cfg(tmp_path, "foo")
+        rc = sim2real.main([
+            "translation", "register",
+            "--algorithm", f"foo=reg/img@sha256:{'a'*64}@{cfg}",
+        ])
+        assert rc == 0
+        err = capsys.readouterr().err
+        assert "null" not in err
+
+    def test_deprecated_form_with_multiple_algorithms_rejected(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = self._cfg(tmp_path, "foo")
+        rc = sim2real.main([
+            "translation", "register",
+            "--algorithm", "foo",
+            "--algorithm", "bar",
+            "--image", "img:v1",
+            "--config", str(cfg),
+        ])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "deprecated form" in err or "single --algorithm" in err
+
+    def test_mixed_form_new_algo_plus_image_rejected(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = self._cfg(tmp_path, "foo")
+        rc = sim2real.main([
+            "translation", "register",
+            "--algorithm", f"foo=img:v1@{cfg}",
+            "--image", "other:v1",
+        ])
+        assert rc == 2
 
     def test_oserror_from_register_returns_2_not_traceback(
         self, tmp_path, capsys, monkeypatch
     ):
-        # translation_output.json is now written via _atomic_write_json
-        # (tempfile + os.replace), not write_text. Patch the helper directly.
-        cfg = tmp_path / "treatment.yaml"
-        cfg.write_text("scorer: mine\n")
-
-        # Wrap: call the real impl for non-output.json paths.
-        original = sim2real._atomic_write_json
-
-        def patched(path, data):
-            if path.name == "translation_output.json":
-                raise OSError("simulated: disk full")
-            return original(path, data)
-
-        monkeypatch.setattr(sim2real, "_atomic_write_json", patched)
-
+        monkeypatch.chdir(tmp_path)
+        cfg = self._cfg(tmp_path, "foo")
+        # Simulate an OSError from _register_translation by making the workspace
+        # translations dir a file (blocks mkdir).
+        ws = tmp_path / "workspace" / "translations"
+        ws.parent.mkdir()
+        ws.write_text("")  # occupy the path with a regular file
         rc = sim2real.main([
-            "--experiment-root", str(tmp_path),
             "translation", "register",
-            "--algorithm", "softreflective",
-            "--image", "ghcr.io/foo:v1",
-            "--config", str(cfg),
+            "--algorithm", f"foo=img:v1@{cfg}",
         ])
         assert rc == 2
-        captured = capsys.readouterr()
-        assert "error:" in captured.err
-        assert "disk full" in captured.err
+        # Not a Python traceback.
+        assert "Traceback" not in capsys.readouterr().err
 
 
 class TestUseCommand:
@@ -918,9 +1030,7 @@ class TestAssembleCommand:
             b"    inferenceExtension:\n      pluginsConfigFile: sr.yaml\n"
         )
         thash, _ = sim2real._register_translation(
-            algorithm_name="sr",
-            image_ref="ghcr.io/foo/bar:v1",
-            config_path=cfg,
+            algorithms=[{"name": "sr", "image_ref": "ghcr.io/foo/bar:v1", "config_path": cfg}],
             baseline_config_path=None,
             registered_hash=None,
             now_iso="2026-07-01T14:00:00Z",
@@ -1074,61 +1184,75 @@ class TestAssembleCommand:
 
 
 class TestAliasCollision:
-    def _seed_register(self, tmp_path, algo, image, config_yaml):
-        cfg = tmp_path / f"{algo}.yaml"
-        cfg.write_text(config_yaml)
-        thash, status = sim2real._register_translation(
-            algorithm_name=algo,
-            image_ref=image,
-            config_path=cfg,
+    """Alias collision is checked per-algorithm regardless of batch size."""
+
+    def _reg(self, tmp_path, name: str, image: str = "img:v1", config: str = None):
+        cfg = tmp_path / f"{name}_cfg.yaml"
+        cfg.write_text(config if config else f"scorers:\n  - name: {name}\n")
+        return sim2real._register_translation(
+            algorithms=[{"name": name, "image_ref": image, "config_path": cfg}],
             baseline_config_path=None,
             registered_hash=None,
-            now_iso="2026-07-02T14:00:00Z",
+            now_iso="2026-07-05T10:00:00Z",
         )
-        return thash
 
-    def test_same_alias_same_content_is_idempotent(self, tmp_path):
-        h1 = self._seed_register(tmp_path, "algo", "ghcr.io/x:v1", "a: 1\n")
-        h2 = self._seed_register(tmp_path, "algo", "ghcr.io/x:v1", "a: 1\n")
+    def test_same_alias_same_content_is_idempotent(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        h1, _ = self._reg(tmp_path, "foo")
+        h2, s2 = self._reg(tmp_path, "foo")
         assert h1 == h2
+        assert s2 == "idempotent"
 
-    def test_alias_collision_without_force_raises(self, tmp_path):
-        self._seed_register(tmp_path, "algo", "ghcr.io/x:v1", "a: 1\n")
-        cfg = tmp_path / "different.yaml"
-        cfg.write_text("a: 2\n")
+    def test_alias_collision_without_force_raises(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        self._reg(tmp_path, "foo", image="img:v1")
         with pytest.raises(RuntimeError, match="already assigned"):
-            sim2real._register_translation(
-                algorithm_name="algo",
-                image_ref="ghcr.io/x:v1",
-                config_path=cfg,
-                baseline_config_path=None,
-                registered_hash=None,
-                now_iso="2026-07-02T14:00:00Z",
-            )
+            self._reg(tmp_path, "foo", image="img:v2")
 
-    def test_force_reassigns_alias_and_clears_previous(self, tmp_path):
-        from pipeline.lib import translation_ref
-        h_old = self._seed_register(tmp_path, "algo", "ghcr.io/x:v1", "a: 1\n")
-        cfg = tmp_path / "different.yaml"
-        cfg.write_text("a: 2\n")
-        h_new, _status = sim2real._register_translation(
-            algorithm_name="algo",
-            image_ref="ghcr.io/x:v1",
-            config_path=cfg,
+    def test_force_reassigns_alias_and_clears_previous(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        h_old, _ = self._reg(tmp_path, "foo", image="img:v1")
+        # Re-register 'foo' with different content and --force.
+        cfg = tmp_path / "foo_v2.yaml"
+        cfg.write_text("scorers:\n  - name: foo_v2\n")
+        h_new, _ = sim2real._register_translation(
+            algorithms=[{"name": "foo", "image_ref": "img:v2", "config_path": cfg}],
             baseline_config_path=None,
             registered_hash=None,
-            now_iso="2026-07-02T14:00:00Z",
+            now_iso="2026-07-05T11:00:00Z",
             force=True,
         )
         assert h_new != h_old
-        # New translation carries the alias.
-        assert translation_ref.find_by_alias("algo") == h_new
-        # Old translation's alias is null; it's still reachable by hash.
-        old_data = translation_ref.read_translation_output(
-            layout.translation_output_path(h_old)
+        # Previous translation's alias cleared.
+        old_tout = json.loads(
+            (Path("workspace") / "translations" / h_old / "translation_output.json").read_text()
         )
-        assert old_data["alias"] is None
-        assert layout.translation_dir(h_old).exists()
+        assert old_tout["alias"] is None
+        # New translation owns the alias.
+        new_tout = json.loads(
+            (Path("workspace") / "translations" / h_new / "translation_output.json").read_text()
+        )
+        assert new_tout["alias"] == "foo"
+
+    def test_batched_alias_collision_on_one_of_N_algos(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        # Pre-existing single-algo translation with alias 'foo'.
+        self._reg(tmp_path, "foo", image="img:v1")
+        # Now try to register a BATCHED translation whose members include 'foo'.
+        c_foo = tmp_path / "foo_batched.yaml"
+        c_foo.write_text("scorers:\n  - name: foo_b\n")
+        c_bar = tmp_path / "bar.yaml"
+        c_bar.write_text("scorers:\n  - name: bar\n")
+        with pytest.raises(RuntimeError, match="already assigned"):
+            sim2real._register_translation(
+                algorithms=[
+                    {"name": "foo", "image_ref": "img:v3", "config_path": c_foo},
+                    {"name": "bar", "image_ref": "img:v4", "config_path": c_bar},
+                ],
+                baseline_config_path=None,
+                registered_hash=None,
+                now_iso="2026-07-05T11:00:00Z",
+            )
 
 
 class TestAssembleResolvesAlias:
@@ -1139,9 +1263,7 @@ class TestAssembleResolvesAlias:
         cfg = tmp_path / "algo.yaml"
         cfg.write_text("scenario: []\n")
         thash, _ = sim2real._register_translation(
-            algorithm_name="my-algo",
-            image_ref="ghcr.io/x:v1",
-            config_path=cfg,
+            algorithms=[{"name": "my-algo", "image_ref": "ghcr.io/x:v1", "config_path": cfg}],
             baseline_config_path=None,
             registered_hash=None,
             now_iso="2026-07-02T14:00:00Z",

--- a/pipeline/tests/test_sim2real.py
+++ b/pipeline/tests/test_sim2real.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -217,299 +218,331 @@ class TestComputeTranslationHash:
 
 class TestBuildSchemas:
     def test_translation_output_schema(self):
-        # Updated to step-2 shape: image_ref/image_digest live per-algo.
         out = sim2real._build_translation_output(
-            algorithm_name="softreflective",
-            image_ref="ghcr.io/foo:v1",
-            image_digest=None,
-            config_path="generated/softreflective/softreflective_config.yaml",
-            translation_hash="a" * 64,
+            algorithms=[
+                {
+                    "name": "algo1",
+                    "image_ref": "sha256:aa",
+                    "image_digest": "sha256:aa",
+                    "config_path": "generated/algo1/algo1_config.yaml",
+                },
+            ],
+            translation_hash="h" * 64,
             source="byo",
-            alias="softreflective",
-            created_at="2026-07-01T14:00:00Z",
+            alias="algo1",
+            created_at="2026-07-05T10:00:00Z",
         )
-        assert out == {
-            "version": 1,
-            "translation_hash": "a" * 64,
-            "source": "byo",
-            "alias": "softreflective",
-            "algorithms": [{
-                "name": "softreflective",
-                "source_path": None,
-                "source_sha256": None,
-                "config_path": "generated/softreflective/softreflective_config.yaml",
-                "image_ref": "ghcr.io/foo:v1",
-                "image_digest": None,
-            }],
-            "created_at": "2026-07-01T14:00:00Z",
-        }
+        assert out["version"] == 1
+        assert out["translation_hash"] == "h" * 64
+        assert out["source"] == "byo"
+        assert out["alias"] == "algo1"
+        assert out["created_at"] == "2026-07-05T10:00:00Z"
+        assert len(out["algorithms"]) == 1
+        entry = out["algorithms"][0]
+        assert entry["name"] == "algo1"
+        assert entry["source_path"] is None
+        assert entry["source_sha256"] is None
+        assert entry["config_path"] == "generated/algo1/algo1_config.yaml"
+        assert entry["image_ref"] == "sha256:aa"
+        assert entry["image_digest"] == "sha256:aa"
+
+    def test_translation_output_batched_n2(self):
+        out = sim2real._build_translation_output(
+            algorithms=[
+                {"name": "a", "image_ref": "img1", "image_digest": None, "config_path": "generated/a/a_config.yaml"},
+                {"name": "b", "image_ref": "img2", "image_digest": None, "config_path": "generated/b/b_config.yaml"},
+            ],
+            translation_hash="h" * 64,
+            source="byo",
+            alias=None,
+            created_at="2026-07-05T10:00:00Z",
+        )
+        assert out["alias"] is None
+        assert [e["name"] for e in out["algorithms"]] == ["a", "b"]
 
     def test_registered_schema_with_digest(self):
         reg = sim2real._build_registered(
-            image_ref="ghcr.io/foo@sha256:" + "b" * 64,
-            image_digest="sha256:" + "b" * 64,
-            registered_at="2026-07-01T14:00:00Z",
+            [
+                {"name": "algo1", "image_ref": "reg/img@sha256:" + "a" * 64, "image_digest": "sha256:" + "a" * 64},
+            ],
+            "2026-07-05T10:00:00Z",
         )
-        assert reg == {
-            "version": 1,
-            "image_ref": "ghcr.io/foo@sha256:" + "b" * 64,
-            "image_digest": "sha256:" + "b" * 64,
-            "source": "byo",
-            "registered_at": "2026-07-01T14:00:00Z",
-        }
+        assert reg["version"] == 1
+        assert reg["source"] == "byo"
+        assert reg["registered_at"] == "2026-07-05T10:00:00Z"
+        assert reg["algorithms"] == [
+            {"name": "algo1", "image_ref": "reg/img@sha256:" + "a" * 64, "image_digest": "sha256:" + "a" * 64},
+        ]
 
     def test_registered_schema_offline(self):
         reg = sim2real._build_registered(
-            image_ref="ghcr.io/foo:v1",
-            image_digest=None,
-            registered_at="2026-07-01T14:00:00Z",
+            [
+                {"name": "a", "image_ref": "ghcr.io/foo:v1", "image_digest": None},
+            ],
+            "2026-07-05T10:00:00Z",
         )
-        assert reg["image_digest"] is None
-        assert reg["image_ref"] == "ghcr.io/foo:v1"
-
-
-class TestBuildTranslationOutputV2:
-    def test_new_schema_shape(self):
-        out = sim2real._build_translation_output(
-            algorithm_name="softreflective",
-            image_ref="ghcr.io/x/sr:v1",
-            image_digest="sha256:aa",
-            config_path="generated/softreflective/softreflective_config.yaml",
-            translation_hash="a" * 64,
-            source="byo",
-            alias="softreflective",
-            created_at="2026-07-02T14:00:00Z",
-        )
-        # Top-level image_ref removed; now per-algo.
-        assert "image_ref" not in out
-        assert "image_digest" not in out
-        assert out["alias"] == "softreflective"
-        assert out["source"] == "byo"
-        assert out["version"] == 1
-        assert out["translation_hash"] == "a" * 64
-        assert out["created_at"] == "2026-07-02T14:00:00Z"
-        assert len(out["algorithms"]) == 1
-        algo = out["algorithms"][0]
-        assert algo["name"] == "softreflective"
-        assert algo["image_ref"] == "ghcr.io/x/sr:v1"
-        assert algo["image_digest"] == "sha256:aa"
-        assert algo["config_path"] == \
-            "generated/softreflective/softreflective_config.yaml"
-        assert algo["source_path"] is None
-        assert algo["source_sha256"] is None
+        assert reg["algorithms"][0]["image_digest"] is None
 
 
 class TestRegisterTranslation:
-    def _write_overlay(self, tmp_path, content=b"scorer: mine\n"):
-        p = tmp_path / "treatment.yaml"
-        p.write_bytes(content)
-        return p
+    def _algo(self, tmp_path, name: str, image: str = None, config: str = None) -> dict:
+        """Build an AlgorithmSpec, writing the config file on the way in."""
+        cfg = tmp_path / f"{name}_config.yaml"
+        cfg.write_text(config if config else f"scorers:\n  - name: {name}\n")
+        return {
+            "name": name,
+            "image_ref": image or "ghcr.io/foo/bar:v1",
+            "config_path": cfg,
+        }
 
-    def test_creates_translation_dir_and_files(self, tmp_path):
-        cfg = self._write_overlay(tmp_path)
+    def test_creates_translation_dir_and_files_n1(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        algo = self._algo(tmp_path, "algo1")
+        now = "2026-07-05T10:00:00Z"
         thash, status = sim2real._register_translation(
-            algorithm_name="softreflective",
-            image_ref="ghcr.io/foo:v1",
-            config_path=cfg,
+            algorithms=[algo],
             baseline_config_path=None,
             registered_hash=None,
-            now_iso="2026-07-01T14:00:00Z",
+            now_iso=now,
         )
         assert status == "created"
-        assert len(thash) == 64
-        assert layout.translation_output_path(thash).exists()
-        assert layout.registered_path(thash).exists()
-        assert layout.generated_config_path(thash, "softreflective").exists()
+        tdir = Path("workspace") / "translations" / thash
+        assert (tdir / "translation_output.json").exists()
+        assert (tdir / "registered.json").exists()
+        assert (tdir / "generated" / "algo1" / "algo1_config.yaml").exists()
 
-    def test_translation_output_contents(self, tmp_path):
-        # Step-2 schema: image_ref lives per-algo; alias at top level.
-        cfg = self._write_overlay(tmp_path)
-        thash, _ = sim2real._register_translation(
-            algorithm_name="softreflective",
-            image_ref="ghcr.io/foo:v1",
-            config_path=cfg,
+    def test_creates_translation_dir_and_files_n2(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        algos = [self._algo(tmp_path, "foo"), self._algo(tmp_path, "bar")]
+        thash, status = sim2real._register_translation(
+            algorithms=algos,
             baseline_config_path=None,
             registered_hash=None,
-            now_iso="2026-07-01T14:00:00Z",
+            now_iso="2026-07-05T10:00:00Z",
         )
-        out = json.loads(layout.translation_output_path(thash).read_text())
-        assert out["source"] == "byo"
-        assert out["alias"] == "softreflective"
-        assert out["translation_hash"] == thash
-        assert out["version"] == 1
-        assert len(out["algorithms"]) == 1
-        algo = out["algorithms"][0]
-        assert algo["name"] == "softreflective"
-        assert algo["image_ref"] == "ghcr.io/foo:v1"
+        assert status == "created"
+        tdir = Path("workspace") / "translations" / thash
+        assert (tdir / "generated" / "foo" / "foo_config.yaml").exists()
+        assert (tdir / "generated" / "bar" / "bar_config.yaml").exists()
+        tout = json.loads((tdir / "translation_output.json").read_text())
+        names = sorted(a["name"] for a in tout["algorithms"])
+        assert names == ["bar", "foo"]
 
-    def test_registered_records_digest_when_present(self, tmp_path):
-        cfg = self._write_overlay(tmp_path)
-        ref = "ghcr.io/foo@sha256:" + "a" * 64
+    def test_alias_field_null_for_batched(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        algos = [self._algo(tmp_path, "foo"), self._algo(tmp_path, "bar")]
         thash, _ = sim2real._register_translation(
-            algorithm_name="softreflective",
-            image_ref=ref,
-            config_path=cfg,
+            algorithms=algos,
             baseline_config_path=None,
             registered_hash=None,
-            now_iso="2026-07-01T14:00:00Z",
+            now_iso="2026-07-05T10:00:00Z",
         )
-        reg = json.loads(layout.registered_path(thash).read_text())
-        assert reg["image_digest"] == "sha256:" + "a" * 64
+        tout = json.loads((Path("workspace") / "translations" / thash / "translation_output.json").read_text())
+        assert tout["alias"] is None
 
-    def test_registered_null_digest_when_tag_only(self, tmp_path):
-        cfg = self._write_overlay(tmp_path)
+    def test_alias_field_set_for_n1(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        algo = self._algo(tmp_path, "solo")
         thash, _ = sim2real._register_translation(
-            algorithm_name="softreflective",
-            image_ref="ghcr.io/foo:v1",
-            config_path=cfg,
+            algorithms=[algo],
             baseline_config_path=None,
             registered_hash=None,
-            now_iso="2026-07-01T14:00:00Z",
+            now_iso="2026-07-05T10:00:00Z",
         )
-        reg = json.loads(layout.registered_path(thash).read_text())
-        assert reg["image_digest"] is None
+        tout = json.loads((Path("workspace") / "translations" / thash / "translation_output.json").read_text())
+        assert tout["alias"] == "solo"
 
-    def test_writes_treatment_overlay(self, tmp_path):
-        cfg = self._write_overlay(tmp_path, content=b"scorer: custom\n")
+    def test_translation_output_algorithms_shape(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        algos = [self._algo(tmp_path, "foo", image="reg/img@sha256:" + "a" * 64)]
         thash, _ = sim2real._register_translation(
-            algorithm_name="softreflective",
-            image_ref="ghcr.io/foo:v1",
-            config_path=cfg,
+            algorithms=algos,
             baseline_config_path=None,
             registered_hash=None,
-            now_iso="2026-07-01T14:00:00Z",
+            now_iso="2026-07-05T10:00:00Z",
         )
-        assert (
-            layout.generated_config_path(thash, "softreflective").read_bytes()
-            == b"scorer: custom\n"
-        )
+        tout = json.loads((Path("workspace") / "translations" / thash / "translation_output.json").read_text())
+        entry = tout["algorithms"][0]
+        assert entry["name"] == "foo"
+        assert entry["image_ref"] == "reg/img@sha256:" + "a" * 64
+        assert entry["image_digest"] == "sha256:" + "a" * 64
+        assert entry["config_path"] == "generated/foo/foo_config.yaml"
+        assert entry["source_path"] is None
+        assert entry["source_sha256"] is None
 
-    def test_writes_baseline_config_when_provided(self, tmp_path):
-        cfg = self._write_overlay(tmp_path)
-        baseline = tmp_path / "baseline.yaml"
-        baseline.write_bytes(b"baseline: config\n")
+    def test_registered_records_all_algorithms(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        algos = [
+            self._algo(tmp_path, "foo", image="reg/img@sha256:" + "a" * 64),
+            self._algo(tmp_path, "bar", image="reg/img2:v1"),
+        ]
         thash, _ = sim2real._register_translation(
-            algorithm_name="softreflective",
-            image_ref="ghcr.io/foo:v1",
-            config_path=cfg,
+            algorithms=algos,
+            baseline_config_path=None,
+            registered_hash=None,
+            now_iso="2026-07-05T10:00:00Z",
+        )
+        reg = json.loads((Path("workspace") / "translations" / thash / "registered.json").read_text())
+        assert reg["version"] == 1
+        assert reg["source"] == "byo"
+        # Batched registered.json carries N entries under 'algorithms'.
+        entries = {e["name"]: e for e in reg["algorithms"]}
+        assert entries["foo"]["image_digest"] == "sha256:" + "a" * 64
+        assert entries["bar"]["image_digest"] is None
+
+    def test_writes_all_treatment_overlays_verbatim(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        algos = [
+            self._algo(tmp_path, "foo", config="foo_body: 1\n"),
+            self._algo(tmp_path, "bar", config="bar_body: 2\n"),
+        ]
+        thash, _ = sim2real._register_translation(
+            algorithms=algos,
+            baseline_config_path=None,
+            registered_hash=None,
+            now_iso="2026-07-05T10:00:00Z",
+        )
+        tdir = Path("workspace") / "translations" / thash
+        assert (tdir / "generated" / "foo" / "foo_config.yaml").read_text() == "foo_body: 1\n"
+        assert (tdir / "generated" / "bar" / "bar_config.yaml").read_text() == "bar_body: 2\n"
+
+    def test_baseline_config_written_once(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        baseline = tmp_path / "base.yaml"
+        baseline.write_text("baseline: yes\n")
+        algos = [self._algo(tmp_path, "foo"), self._algo(tmp_path, "bar")]
+        thash, _ = sim2real._register_translation(
+            algorithms=algos,
             baseline_config_path=baseline,
             registered_hash=None,
-            now_iso="2026-07-01T14:00:00Z",
+            now_iso="2026-07-05T10:00:00Z",
         )
-        gen_baseline = layout.translation_dir(thash) / "generated" / "baseline_config.yaml"
-        assert gen_baseline.read_bytes() == b"baseline: config\n"
+        tdir = Path("workspace") / "translations" / thash
+        assert (tdir / "generated" / "baseline_config.yaml").read_text() == "baseline: yes\n"
 
-    def test_idempotent_second_call_same_inputs(self, tmp_path):
-        cfg = self._write_overlay(tmp_path)
-        args = dict(
-            algorithm_name="softreflective",
-            image_ref="ghcr.io/foo:v1",
-            config_path=cfg,
+    def test_idempotent_second_call_same_inputs(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        algos = [self._algo(tmp_path, "foo"), self._algo(tmp_path, "bar")]
+        h1, s1 = sim2real._register_translation(
+            algorithms=algos,
             baseline_config_path=None,
             registered_hash=None,
-            now_iso="2026-07-01T14:00:00Z",
+            now_iso="2026-07-05T10:00:00Z",
         )
-        h1, s1 = sim2real._register_translation(**args)
-        h2, s2 = sim2real._register_translation(**args)
+        # Second call: same algorithms in same order.
+        h2, s2 = sim2real._register_translation(
+            algorithms=algos,
+            baseline_config_path=None,
+            registered_hash=None,
+            now_iso="2026-07-05T11:00:00Z",
+        )
         assert h1 == h2
         assert s1 == "created"
         assert s2 == "idempotent"
 
-    def test_hash_collision_different_algorithm_errors(self, tmp_path):
-        cfg = self._write_overlay(tmp_path)
-        thash, _ = sim2real._register_translation(
-            algorithm_name="softreflective",
-            image_ref="ghcr.io/foo:v1",
-            config_path=cfg,
+    def test_idempotent_different_order_same_hash(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        algos1 = [self._algo(tmp_path, "foo"), self._algo(tmp_path, "bar")]
+        algos2 = [algos1[1], algos1[0]]  # reversed
+        h1, _ = sim2real._register_translation(
+            algorithms=algos1,
             baseline_config_path=None,
             registered_hash=None,
-            now_iso="2026-07-01T14:00:00Z",
+            now_iso="2026-07-05T10:00:00Z",
         )
-        # Corrupt the existing translation_output.json to name a different algo.
-        out_path = layout.translation_output_path(thash)
-        out = json.loads(out_path.read_text())
-        out["algorithms"] = [{"name": "otheralgo"}]
-        out_path.write_text(json.dumps(out))
-        with pytest.raises(ValueError, match="algorithm name mismatch"):
+        h2, s2 = sim2real._register_translation(
+            algorithms=algos2,
+            baseline_config_path=None,
+            registered_hash=None,
+            now_iso="2026-07-05T11:00:00Z",
+        )
+        assert h1 == h2
+        assert s2 == "idempotent"
+
+    def test_registered_hash_mismatch_errors(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        algo = self._algo(tmp_path, "foo")
+        with pytest.raises(RuntimeError, match="--registered-hash mismatch"):
             sim2real._register_translation(
-                algorithm_name="softreflective",
-                image_ref="ghcr.io/foo:v1",
-                config_path=cfg,
+                algorithms=[algo],
                 baseline_config_path=None,
-                registered_hash=None,
-                now_iso="2026-07-01T14:00:00Z",
+                registered_hash="deadbeef",
+                now_iso="2026-07-05T10:00:00Z",
             )
 
-    def test_registered_hash_mismatch_errors(self, tmp_path):
-        cfg = self._write_overlay(tmp_path)
-        with pytest.raises(RuntimeError, match="registered-hash mismatch"):
-            sim2real._register_translation(
-                algorithm_name="softreflective",
-                image_ref="ghcr.io/foo:v1",
-                config_path=cfg,
-                baseline_config_path=None,
-                registered_hash="deadbeef" * 8,
-                now_iso="2026-07-01T14:00:00Z",
-            )
-
-    def test_registered_hash_match_succeeds(self, tmp_path):
-        cfg = self._write_overlay(tmp_path)
-        expected = sim2real._compute_translation_hash(
-            "ghcr.io/foo:v1", cfg.read_bytes(), "softreflective"
+    def test_registered_hash_match_succeeds(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        algo = self._algo(tmp_path, "foo")
+        # Compute expected hash by running once and reading it back.
+        expected, _ = sim2real._register_translation(
+            algorithms=[algo],
+            baseline_config_path=None,
+            registered_hash=None,
+            now_iso="2026-07-05T10:00:00Z",
         )
+        # Second call with matching hash succeeds (idempotent).
         thash, status = sim2real._register_translation(
-            algorithm_name="softreflective",
-            image_ref="ghcr.io/foo:v1",
-            config_path=cfg,
+            algorithms=[algo],
             baseline_config_path=None,
             registered_hash=expected,
-            now_iso="2026-07-01T14:00:00Z",
+            now_iso="2026-07-05T11:00:00Z",
         )
         assert thash == expected
-        assert status == "created"
+        assert status == "idempotent"
 
-    def test_partial_write_missing_registered_json_raises(self, tmp_path):
-        # Simulate: an earlier register wrote translation_output.json but
-        # died before writing registered.json (disk full, killed, etc.).
-        cfg = self._write_overlay(tmp_path)
+    def test_partial_write_missing_registered_json_raises(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        algo = self._algo(tmp_path, "foo")
         thash, _ = sim2real._register_translation(
-            algorithm_name="softreflective",
-            image_ref="ghcr.io/foo:v1",
-            config_path=cfg,
+            algorithms=[algo],
             baseline_config_path=None,
             registered_hash=None,
-            now_iso="2026-07-01T14:00:00Z",
+            now_iso="2026-07-05T10:00:00Z",
         )
-        layout.registered_path(thash).unlink()
+        (Path("workspace") / "translations" / thash / "registered.json").unlink()
         with pytest.raises(RuntimeError, match="incomplete"):
             sim2real._register_translation(
-                algorithm_name="softreflective",
-                image_ref="ghcr.io/foo:v1",
-                config_path=cfg,
+                algorithms=[algo],
                 baseline_config_path=None,
                 registered_hash=None,
-                now_iso="2026-07-01T14:00:00Z",
+                now_iso="2026-07-05T11:00:00Z",
             )
 
-    def test_partial_write_missing_generated_config_raises(self, tmp_path):
-        cfg = self._write_overlay(tmp_path)
+    def test_partial_write_missing_generated_config_raises(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        algo = self._algo(tmp_path, "foo")
         thash, _ = sim2real._register_translation(
-            algorithm_name="softreflective",
-            image_ref="ghcr.io/foo:v1",
-            config_path=cfg,
+            algorithms=[algo],
             baseline_config_path=None,
             registered_hash=None,
-            now_iso="2026-07-01T14:00:00Z",
+            now_iso="2026-07-05T10:00:00Z",
         )
-        layout.generated_config_path(thash, "softreflective").unlink()
+        (Path("workspace") / "translations" / thash / "generated" / "foo" / "foo_config.yaml").unlink()
         with pytest.raises(RuntimeError, match="incomplete"):
             sim2real._register_translation(
-                algorithm_name="softreflective",
-                image_ref="ghcr.io/foo:v1",
-                config_path=cfg,
+                algorithms=[algo],
                 baseline_config_path=None,
                 registered_hash=None,
-                now_iso="2026-07-01T14:00:00Z",
+                now_iso="2026-07-05T11:00:00Z",
+            )
+
+    def test_partial_write_missing_one_of_N_algos_raises(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        algos = [self._algo(tmp_path, "foo"), self._algo(tmp_path, "bar")]
+        thash, _ = sim2real._register_translation(
+            algorithms=algos,
+            baseline_config_path=None,
+            registered_hash=None,
+            now_iso="2026-07-05T10:00:00Z",
+        )
+        # Delete one of the per-algo directories so its overlay is missing.
+        (Path("workspace") / "translations" / thash / "generated" / "bar" / "bar_config.yaml").unlink()
+        with pytest.raises(RuntimeError, match="incomplete"):
+            sim2real._register_translation(
+                algorithms=algos,
+                baseline_config_path=None,
+                registered_hash=None,
+                now_iso="2026-07-05T11:00:00Z",
             )
 
 


### PR DESCRIPTION
## Summary

Extends `sim2real translation register` to accept N algorithms in one call via a repeatable `--algorithm <name>=<image-ref>@<config-path>` flag, so the upcoming `/sim2real-bootstrap --byo` (#499) can emit ONE register command for a multi-algorithm BYO run and `sim2real assemble --translation <hash>` continues to consume a single translation dir.

**New:**
- Repeatable `--algorithm NAME=IMAGE@CONFIG` grammar. First-`=` + rightmost-`@` split rule (documented in `pipeline/README.md`).
- Batched translation-hash formula: `sha256(canonical-json(sorted-by-name list of {name, image, config-sha}))`. Order-invariant.
- `registered.json`'s image-ref fields move under a per-algorithm `algorithms` list; the on-read shim in `translation_ref.read_translation_output` continues to normalize legacy step-1 top-level fields, so any pre-existing step-1 shape on disk remains readable.

**Kept working (deprecated):**
- `--algorithm NAME --image REF --config PATH` as the N=1 legacy form. Deprecation warning emitted to stderr. Removal is a step-5+ follow-up.

**Non-goals:** no changes to `sim2real assemble`, `sim2real translate`, `sim2real build`, or the manifest schema (that's PR-1 / #497).

## Notes for reviewers

- The N=1 hash under the new formula differs from N=1 under the step-1 formula (design section on the batched hash formula covers this — no long-lived registrations exist yet, so the break is acceptable).
- Alias policy: N=1 keeps `alias = algorithm_name` (matches step-1). N>1 has `alias = null` — batched translations are referenced by hash. Alias-collision checks still fire per-algorithm regardless of N, so a batched register whose members shadow an existing alias errors with the same shape as single-algo.
- Overlay paths containing `@` cannot be represented (structural consequence of rightmost-`@` split). Overlay paths containing `=` are supported.
- `_build_registered`'s shape has changed (image-refs moved into a per-algo list). No other module writes `registered.json`; the shim only affects reads of `translation_output.json`.

## Docs sweep

- Updated `pipeline/README.md`: rewrote the "Register a translation" section with new `--algorithm NAME=IMAGE@CONFIG` grammar as preferred, deprecated form preserved as legacy, hash formula documented, workspace-artifacts table updated to note batched shape.
- Updated the quick-start "3. Register a translation" example at line ~494 to use the new form and added a cross-reference to the full section.
- `.claude/skills/sim2real-bootstrap/SKILL.md` still shows the old form — its refresh is scoped to PR-4 (#500) per the epic.
- `docs/epics/step-*/design.md` — historical epic design docs left untouched.
- `docs/superpowers/plans/` — historical planning docs left untouched.
- `pipeline/lib/*.py` error-message references to `sim2real translation register` are informational strings, not grammar docs — left as-is.

Closes #498