### PR TITLE
step-4 PR 4: BLIS-mode sim2real-bootstrap SKILL.md refresh

### DIFF
--- a/.claude/skills/sim2real-bootstrap/SKILL.md
+++ b/.claude/skills/sim2real-bootstrap/SKILL.md
@@ -424,7 +424,7 @@ to produce the plugin sources, then `sim2real build` compiles them into images):
   4. Validate the skill's outputs:
        python pipeline/sim2real.py translate --resume
   5. Build per-algorithm images:
-       python pipeline/sim2real.py build
+       python pipeline/sim2real.py build --translation <hash>
   6. Assemble a run:
        python pipeline/sim2real.py assemble \
          --translation <hash> --cluster <cluster_id> --run <run_name>

--- a/.claude/skills/sim2real-bootstrap/SKILL.md
+++ b/.claude/skills/sim2real-bootstrap/SKILL.md
@@ -14,6 +14,11 @@ user-invocable: true
 
 Turn a BLIS-generated experiment folder into a pipeline-ready sim2real bundle.
 
+> For pre-built EPP images without BLIS-format inputs (no `algorithms/*.go`, no
+> `config.md`), use `--byo` mode instead — the operator supplies a baseline
+> scenario and per-algorithm overlays directly, and bootstrap emits a batched
+> `sim2real translation register` command.
+
 ## Arguments
 
 `$ARGUMENTS` is the path to the experiment folder. Defaults to the current directory if omitted.
@@ -41,7 +46,11 @@ The experiment folder MUST contain:
 ## Task Execution
 
 Use TaskCreate to track progress. Execute tasks sequentially; each
-derive-and-approve task MUST pause for user confirmation via AskUserQuestion.
+derive-and-approve task MUST pause and ask the operator to confirm the
+derived values before proceeding. Present the derived values, then ask
+a plain-text numbered question — e.g. *"Proceed with these values? (1)
+yes  (2) revise <field>  (3) abort"* — and wait for a reply. Do NOT use
+`AskUserQuestion`.
 
 ---
 
@@ -105,7 +114,7 @@ LATEST_RELEASE=$(git tag --sort=-version:refname | grep -v rc | head -1)
 # If no: use commit from folder docs or latest main
 ```
 
-**Present to user with AskUserQuestion:**
+**Present to user with a plain-text numbered prompt** (do NOT use `AskUserQuestion`):
 ```
 Derived target component:
   repo: <url>
@@ -114,7 +123,14 @@ Derived target component:
     - latest release: <tag> (interfaces present? yes/no)
     - folder-pinned commit: <ref> (interfaces present? yes/no)
     - recommended: <chosen ref> (<reason>)
+
+Pick a ref:
+  (1) latest release (<tag>)
+  (2) folder-pinned commit (<ref>)
+  (3) revise (specify a different ref)
+  (4) abort
 ```
+Wait for the operator's reply before proceeding.
 
 If >1 candidate found, halt and report — bootstrap supports only one target.
 
@@ -396,15 +412,37 @@ Exit code 0 and all fields printed = success.
 
 Tell the user:
 ```
-Bootstrap complete. Next steps:
-  1. Run: python pipeline/setup.py --experiment-root $EXPERIMENT_ROOT
-  2. Register a translation:
-       python pipeline/sim2real.py translation register \
-         --algorithm NAME --image REF --config PATH_TO_TREATMENT_OVERLAY
-  3. Assemble a run:
+Bootstrap complete. Next steps (skill-driven translation flow — BLIS output has
+algorithms[].source, so `sim2real translate` runs the /sim2real-translate skill
+to produce the plugin sources, then `sim2real build` compiles them into images):
+
+  1. Configure the workspace:
+       python pipeline/setup.py --experiment-root $EXPERIMENT_ROOT
+  2. Checkpoint the translation:
+       python pipeline/sim2real.py translate
+  3. Run the /sim2real-translate skill to produce plugin sources for each algorithm.
+  4. Validate the skill's outputs:
+       python pipeline/sim2real.py translate --resume
+  5. Build per-algorithm images:
+       python pipeline/sim2real.py build
+  6. Assemble a run:
        python pipeline/sim2real.py assemble \
-         --translation HASH --cluster CLUSTER_ID --run RUN_NAME
+         --translation <hash> --cluster <cluster_id> --run <run_name>
+  7. Validate against a real cluster (after `deploy.py run` + `deploy.py collect`):
+       /sim2real-check --run <run_name>
 ```
+
+If the operator instead has pre-built EPP images on hand (no skill-driven
+translation), they can skip steps 2-5 and register the images directly with
+the batched register form:
+
+```
+python pipeline/sim2real.py translation register \
+    --algorithm <name>=<image-ref>@<config-path>          # repeatable
+```
+
+(The step-1 single-algorithm form `--algorithm NAME --image REF --config PATH`
+still works but emits a deprecation warning — prefer the batched form.)
 
 ## Reference: Bundled Files
 


### PR DESCRIPTION
Closes #500. Part of epic #496.

## Summary

Three targeted edits to `.claude/skills/sim2real-bootstrap/SKILL.md`. No semantic changes to bootstrap Tasks 0-6. `generate_from_config.py`, `generate_scenarios.py`, `generate_scenarios.README.md`, and `templates/` are untouched.

1. **Swap two `AskUserQuestion` sites for plain-text numbered prompts.** SKILL.md line 44 (Task Execution general instruction) and line 108 (Task 1 concrete example). Semantic outcome identical — operator confirms derived values before bootstrap proceeds. Matches step-3's `sim2real-check` precedent and the persistent project preference against `AskUserQuestion`.

2. **Add top-of-file cross-reference to `--byo` mode.** One-line pointer so operators arriving via either the BLIS or the `--byo` entry point can find the other. Per epic design, PR-4 (this one) may land before PR-3 (which introduces `--byo` in the same file); a brief window where the pointer references a not-yet-present branch is expected.

3. **Refresh "After Bootstrap" for CLI drift after steps 0-3.** The prior section had two drifts against the current CLI surface:
   - BLIS-bootstrap outputs (with `algorithms[].source`) feed the step-2 skill-driven translation flow — `sim2real translate → /sim2real-translate → sim2real translate --resume → sim2real build → sim2real assemble`. The prior section skipped `translate` and `build` entirely and pointed at the BYO-only `translation register` path, which doesn't consume BLIS output shape.
   - `sim2real-check --run <name>` (step-3 addition) was missing from the flow.
   - The retained `translation register` reference (now positioned as an alternative "if operator has pre-built EPP images") used the deprecated step-1 single-algorithm form `--algorithm NAME --image REF --config PATH`. Updated to the batched form `--algorithm <name>=<image-ref>@<config-path>` per PR-2 (#503). The deprecated form is called out as still working with a deprecation warning.

## Verification

- `pytest .claude/skills/sim2real-bootstrap/tests/` → 19 passed (regression check).
- `ruff check .claude/skills/ --select F` → clean.
- Manual re-read: Tasks 0, 1, 2, 3, 4, 4b, 5, 6 all present, in order, unchanged in shape.

## Reviewer attention

- The "After Bootstrap" section is now considerably longer than before because it walks through the full BLIS-mode downstream chain (7 steps) instead of the abbreviated 3-step version. This matches the epic design (`sim2real translate → translation register → assemble → sim2real-check`) and the accurate current CLI surface. If a briefer summary is preferred, we can trim.
- Reviewers may notice the plain-text prompt phrasing is illustrative (`"Proceed with these values? (1) yes  (2) revise <field>  (3) abort"`) rather than prescriptive — deliberate, since concrete options vary per task. Semantic contract is unchanged.

## Sweep for stale references

Grepped `AskUserQuestion` and the deprecated register form across `.claude/skills/`, `docs/`, `pipeline/`, `README*`:

- All other `.claude/skills/` uses of `AskUserQuestion` are negative references ("do NOT use AskUserQuestion" in sim2real-check SKILL.md) — no drift.
- `pipeline/setup.py:337-346` still prints "Next steps" using the deprecated `--algorithm NAME --image REF --config PATH` form and omits `sim2real-check`. **Out of scope for this issue** (scope is strictly `SKILL.md`) — flagging as a follow-up drift candidate.
- `docs/epics/step-4/design.md` and `pipeline/README.md:155` mention the deprecated form explicitly labeled as "deprecated" — accurate, no change needed.

## Base

Base: `refactor/v2-step-4` (epic branch, per issue body).