### PR TITLE
step-4 PR 3: `/sim2real-bootstrap --byo` mode

### DIFF
--- a/.claude/skills/sim2real-bootstrap/SKILL.md
+++ b/.claude/skills/sim2real-bootstrap/SKILL.md
@@ -1,25 +1,30 @@
 ---
 name: sim2real-bootstrap
 description: |
-  Bootstrap a BLIS-generated experiment folder into a sim2real transfer bundle.
-  Use when an experiment folder has algorithms/, workloads/, and config but lacks
-  transfer.yaml, baselines/, or a component submodule. Derives and assembles all
-  artifacts needed for the sim2real pipeline (transfer.yaml, baseline scenarios,
-  component submodule, workload selection) with user approval at each gate.
-argument-hint: "[experiment-folder-path]"
+  Bootstrap an experiment repo into a sim2real transfer bundle. Two modes:
+  (1) BLIS mode (default) — for BLIS-generated folders with algorithms/,
+      workloads/, and config; derives transfer.yaml, baselines/, and a
+      component submodule with user approval at each gate.
+  (2) --byo mode — for operators arriving with pre-built EPP images plus a
+      full baseline scenario and per-algorithm overlays; scaffolds
+      transfer.yaml with `byo: true` markers and emits a copy-pasteable
+      batched `sim2real translation register` command.
+argument-hint: "[experiment-folder-path] [--byo ...]"
 user-invocable: true
 ---
 
 # sim2real-bootstrap
 
-Turn a BLIS-generated experiment folder into a pipeline-ready sim2real bundle.
+Turn an experiment folder into a pipeline-ready sim2real bundle. This skill has two modes:
 
-> For pre-built EPP images without BLIS-format inputs (no `algorithms/*.go`, no
-> `config.md`), use `--byo` mode instead — the operator supplies a baseline
-> scenario and per-algorithm overlays directly, and bootstrap emits a batched
-> `sim2real translation register` command.
+- **BLIS mode (default)** — the operator has a BLIS-generated experiment folder (with `algorithms/*.go`, `workloads/*.yaml`, and either `config.md` or `top3_selection.json`). Bootstrap parses those inputs, derives a component submodule, generates baseline scenarios, and emits `transfer.yaml`. Documented in Tasks 0-6 below.
+- **`--byo` mode** — the operator has a pre-built EPP image (or several), a full baseline scenario YAML, and per-algorithm overlay YAMLs, but no BLIS artifacts. Bootstrap copies those files into canonical experiment-repo locations, emits `transfer.yaml` with per-algorithm `byo: true` markers, and prints a batched `sim2real translation register` command. Documented in the BYO section below.
 
-## Arguments
+## Dispatch
+
+If any of `--byo`, `--baseline`, `--algorithm`, `--algorithm-image`, `--algorithm-config`, `--scenario`, `--force`, or `--non-interactive` appears in `$ARGUMENTS`, dispatch to the BYO branch (see the `--byo` mode section). Otherwise dispatch to BLIS mode (Tasks 0-6).
+
+## Arguments (BLIS mode)
 
 `$ARGUMENTS` is the path to the experiment folder. Defaults to the current directory if omitted.
 
@@ -432,17 +437,87 @@ to produce the plugin sources, then `sim2real build` compiles them into images):
        /sim2real-check --run <run_name>
 ```
 
-If the operator instead has pre-built EPP images on hand (no skill-driven
-translation), they can skip steps 2-5 and register the images directly with
-the batched register form:
+For pre-built EPP images (no skill-driven translation), see the [`--byo` mode](#--byo-mode) section below — the operator supplies baseline + overlays directly and bootstrap emits a batched `translation register` command that skips steps 2-5 above.
+
+## `--byo` mode
+
+Use `--byo` when the operator has a pre-built EPP image (or several), a full baseline scenario YAML, and per-algorithm overlay YAMLs, but no BLIS artifacts. Bootstrap copies the operator's files into canonical experiment-repo locations, emits `transfer.yaml` with `byo: true` per-algorithm markers (no `component:` — BYO has no submodule), and prints a batched `sim2real translation register` command.
+
+### Invocation
+
+```bash
+python3 "$SKILL_DIR/byo.py" \
+    --byo \
+    --baseline <name>=<scenario-path> \
+    --algorithm <name> [--algorithm <name>]... \
+    --algorithm-image <name>=<image-ref> [--algorithm-image ...]... \
+    --algorithm-config <name>=<overlay-path> [--algorithm-config ...]... \
+    [--scenario <name>] [--force] [--non-interactive]
+```
+
+The BYO branch is implemented in `byo.py` (bundled with this skill). SKILL.md's role is to accept operator input (structured args OR natural-language prose), collect any missing fields, and hand off to `byo.py`.
+
+### Input collection (interactive TTY)
+
+Operators may invoke the skill in either shape:
+
+1. **Structured args** — the invocation above, verbatim.
+2. **Natural language** — e.g., *"bootstrap --byo with baseline at /path/baseline.yaml, algorithm foo image ghcr.io/foo:tag config /path/foo.yaml, algorithm bar image ghcr.io/bar@sha256:... config /path/bar.yaml"*. Parse the description into structured args (algorithm/image/config triples + baseline).
+
+If any required field is missing after parsing, prompt with plain-text numbered prompts (one prompt per missing field). Example prompts:
 
 ```
-python pipeline/sim2real.py translation register \
-    --algorithm <name>=<image-ref>@<config-path>          # repeatable
+Missing algorithm image for 'foo'. Enter the image reference:
+> 
 ```
 
-(The step-1 single-algorithm form `--algorithm NAME --image REF --config PATH`
-still works but emits a deprecation warning — prefer the batched form.)
+Do NOT use `AskUserQuestion` (project preference — see the persistent user memory on this repo).
+
+If stdin is not a TTY OR the operator passed `--non-interactive`, do not prompt — invoke `byo.py` with whatever was supplied and let it fatal-error on missing fields.
+
+### Reserved names
+
+- `default`, `defaults` — reserved for any role.
+- `baseline` — reserved as an algorithm name only (a baseline named `baseline` is the canonical case).
+
+### On-disk layout (produced by `byo.py`)
+
+```
+<experiment-root>/
+  transfer.yaml                                  <- BYO transfer.yaml (byo: true per algo, no component:)
+  baselines/
+    <baseline-name>.yaml                         <- copy of operator's baseline scenario
+    defaults/*.yaml                              <- framework fragments (all listed under defaults.disable)
+  algorithms/
+    <algo-1>/<algo-1>_config.yaml                <- copy of operator's overlay
+    <algo-2>/<algo-2>_config.yaml                <- copy of operator's overlay
+  workloads/*.yaml                               <- pre-existing (operator brought)
+```
+
+Copies are atomic (write-to-temp + rename). Destinations validated to lie inside `<experiment-root>`; symlinks that escape are rejected. YAML inputs are parse-validated (single-doc, mapping root, non-empty) before any writes.
+
+### Emitted register command
+
+At success, `byo.py` prints:
+
+```
+cd '/absolute/path/to/exp-root'
+sim2real translation register \
+    --algorithm '<name1>=<image1>@algorithms/<name1>/<name1>_config.yaml' \
+    --algorithm '<name2>=<image2>@algorithms/<name2>/<name2>_config.yaml'
+```
+
+All paths quoted with `shlex.quote`. Bootstrap does not invoke `register` itself — the operator retains control.
+
+### After BYO bootstrap
+
+```
+1. Run the emitted register command above.
+2. Assemble a run:
+     sim2real assemble --translation <hash> --cluster <cluster_id> --run <run-name>
+3. Deploy:
+     python pipeline/deploy.py run
+```
 
 ## Reference: Bundled Files
 
@@ -450,7 +525,8 @@ This skill ships with supporting files in its directory. Invoke in place — do 
 
 | File | Purpose |
 |------|---------|
-| `generate_from_config.py` | Parses `config.md` markdown tables → scenario YAMLs with provenance comments. Preferred for most experiments. Handles hardware normalization, bare-flag prefix-caching input/output, and unknown model/hardware detection. |
-| `generate_scenarios.py` | Converts JSON config (`top3_selection.json`) → scenario YAMLs. Use when JSON input exists. |
+| `generate_from_config.py` | Parses `config.md` markdown tables → scenario YAMLs with provenance comments. Preferred for most BLIS experiments. Handles hardware normalization, bare-flag prefix-caching input/output, and unknown model/hardware detection. |
+| `generate_scenarios.py` | Converts JSON config (`top3_selection.json`) → scenario YAMLs. Use when JSON input exists (BLIS). |
 | `generate_scenarios.README.md` | Coverage map for the JSON-input path. Documents field mappings, omission rules, and gaps. |
-| `templates/defaults/*.yaml` | Framework-owned baseline workaround fragments (RBAC, request-id, verbosity). Copied into `<experiment-root>/baselines/defaults/` at task-4b so each experiment is self-contained and reproducible. |
+| `byo.py` | Implements the `--byo` branch — argument parsing, YAML validation, path-safe copy operations, `transfer.yaml` emission, batched `sim2real translation register` command generation. Invoked by SKILL.md's dispatch when `--byo` (or any BYO-only flag) is passed. |
+| `templates/defaults/*.yaml` | Framework-owned baseline workaround fragments (RBAC, request-id, verbosity). Copied into `<experiment-root>/baselines/defaults/` at BLIS task-4b and at BYO run time, so every experiment is self-contained and reproducible. |

--- a/.claude/skills/sim2real-bootstrap/byo.py
+++ b/.claude/skills/sim2real-bootstrap/byo.py
@@ -1,0 +1,827 @@
+#!/usr/bin/env python3
+"""BYO branch of ``/sim2real-bootstrap``.
+
+For operators who arrive with pre-built EPP images + per-algorithm scenario
+overlays + a full baseline scenario, and NOT a BLIS-format experiment folder.
+Copies operator files into canonical experiment-repo locations, emits a valid
+``transfer.yaml`` with per-algorithm ``byo: true`` markers, and prints one
+copy-pasteable ``sim2real translation register`` command carrying all
+algorithms as a batched (N-algorithm) invocation.
+
+BLIS-mode logic lives elsewhere in this skill (SKILL.md Tasks 0-6,
+``generate_from_config.py``, ``generate_scenarios.py``); this module is
+BYO-only.
+
+See ``docs/epics/step-4/design.md#byo-mode-specification`` for the full spec.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shlex
+import shutil
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Kubernetes DNS-label subset, 1-20 chars. Matches the constraint enforced by
+# pipeline/lib/translation_ref.validate_name(); duplicated here so bootstrap
+# can fail fast without importing from the pipeline package.
+NAME_REGEX = re.compile(r"^[a-z0-9]([-a-z0-9]{0,18}[a-z0-9])?$")
+
+# Algorithm/baseline names that would collide with framework concepts.
+# `baseline` is only reserved as an *algorithm* name — a *baseline* named
+# `baseline` is the canonical case in the BYO shape.
+RESERVED_ANY_ROLE = frozenset({"default", "defaults"})
+RESERVED_ALGORITHM_NAMES = RESERVED_ANY_ROLE | frozenset({"baseline"})
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+class BYOError(Exception):
+    """Raised for operator-input errors. Message is surfaced to stderr as-is."""
+
+
+# ---------------------------------------------------------------------------
+# Data
+# ---------------------------------------------------------------------------
+
+@dataclass
+class BYOArgs:
+    """Structured form of the CLI arguments after parsing.
+
+    Kept flat and JSON-serializable so the ``parse_args_dict`` helper can be
+    used to compare a structured-args invocation against an NL-derived invocation
+    in unit tests (design.md#risks: NL parsing is not CI-tested; the equivalence
+    is asserted on the shape of the parsed dict).
+    """
+    byo: bool
+    baseline_name: str | None
+    baseline_path: str | None
+    algorithms: list[str]  # order preserved for register command
+    algorithm_images: dict[str, str]
+    algorithm_configs: dict[str, str]
+    scenario: str | None
+    force: bool
+    non_interactive: bool
+
+
+@dataclass
+class ResolvedInputs:
+    """Post-validation view of the operator's inputs.
+
+    Every path here has been resolved and verified to exist; every YAML has
+    been safe-loaded and validated as a single-document non-empty mapping.
+    Algorithm entries are in the same order the operator provided them.
+    """
+    exp_root: Path
+    scenario: str
+    baseline_name: str
+    baseline_src: Path
+    algorithms: list["ResolvedAlgorithm"] = field(default_factory=list)
+    workloads: list[Path] = field(default_factory=list)
+    force: bool = False
+
+
+@dataclass
+class ResolvedAlgorithm:
+    name: str
+    image_ref: str
+    config_src: Path
+
+
+# ---------------------------------------------------------------------------
+# CLI parsing
+# ---------------------------------------------------------------------------
+
+def _kv_pair(value: str) -> tuple[str, str]:
+    """Split ``name=value`` on the first ``=``. Rejects empties."""
+    if "=" not in value:
+        raise argparse.ArgumentTypeError(
+            f"{value!r}: expected '<name>=<value>'"
+        )
+    name, _, val = value.partition("=")
+    if not name or not val:
+        raise argparse.ArgumentTypeError(
+            f"{value!r}: '<name>=<value>' must have non-empty name and value"
+        )
+    return name, val
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Argparse spec for the BYO branch. Exported for testing."""
+    p = argparse.ArgumentParser(
+        prog="sim2real-bootstrap --byo",
+        description=(
+            "BYO branch of sim2real-bootstrap. Scaffold an experiment repo "
+            "from a pre-built EPP image + per-algorithm overlay(s) + a full "
+            "baseline scenario. Emits transfer.yaml with byo: true markers "
+            "and prints a batched `sim2real translation register` command."
+        ),
+        add_help=True,
+    )
+    p.add_argument(
+        "--byo",
+        action="store_true",
+        help="Dispatch to the BYO branch (required; presence-only).",
+    )
+    p.add_argument(
+        "--baseline",
+        type=_kv_pair,
+        metavar="<name>=<scenario-path>",
+        help="Baseline name and path to the full baseline scenario YAML.",
+    )
+    p.add_argument(
+        "--algorithm",
+        action="append",
+        default=[],
+        metavar="<name>",
+        help="Declare an algorithm by name. Repeatable; at least one required.",
+    )
+    p.add_argument(
+        "--algorithm-image",
+        action="append",
+        default=[],
+        type=_kv_pair,
+        metavar="<name>=<image-ref>",
+        help="Map an algorithm name to its container image reference. Repeatable.",
+    )
+    p.add_argument(
+        "--algorithm-config",
+        action="append",
+        default=[],
+        type=_kv_pair,
+        metavar="<name>=<overlay-path>",
+        help="Map an algorithm name to a partial-YAML overlay path. Repeatable.",
+    )
+    p.add_argument(
+        "--scenario",
+        metavar="<name>",
+        help="Override the derived transfer.yaml scenario name.",
+    )
+    p.add_argument(
+        "--force",
+        action="store_true",
+        help="Bypass overwrite confirmation on destinations that already exist.",
+    )
+    p.add_argument(
+        "--non-interactive",
+        action="store_true",
+        help=(
+            "Never prompt. Missing required fields are fatal errors. "
+            "Auto-enabled when stdin is not a TTY."
+        ),
+    )
+    return p
+
+
+def parse_args_dict(argv: list[str]) -> dict:
+    """Return the parsed CLI as a plain dict.
+
+    Used both by ``parse_args`` (as an intermediate form) and by the
+    args-vs-NL equivalence test: an NL description produces a dict of the
+    same shape; equality on that dict is what we assert.
+    """
+    ns = build_parser().parse_args(argv)
+    return {
+        "byo": bool(ns.byo),
+        "baseline": (ns.baseline[0], ns.baseline[1]) if ns.baseline else None,
+        "algorithms": list(ns.algorithm),
+        "algorithm_images": dict(ns.algorithm_image),
+        "algorithm_configs": dict(ns.algorithm_config),
+        "scenario": ns.scenario,
+        "force": bool(ns.force),
+        "non_interactive": bool(ns.non_interactive),
+    }
+
+
+def parse_args(argv: list[str]) -> BYOArgs:
+    d = parse_args_dict(argv)
+    baseline_name, baseline_path = (
+        (d["baseline"][0], d["baseline"][1]) if d["baseline"] else (None, None)
+    )
+    return BYOArgs(
+        byo=d["byo"],
+        baseline_name=baseline_name,
+        baseline_path=baseline_path,
+        algorithms=d["algorithms"],
+        algorithm_images=d["algorithm_images"],
+        algorithm_configs=d["algorithm_configs"],
+        scenario=d["scenario"],
+        force=d["force"],
+        non_interactive=d["non_interactive"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+def _validate_name(name: str, role: str) -> None:
+    """Enforce the DNS-label subset and reserved-name check."""
+    if not NAME_REGEX.match(name):
+        raise BYOError(
+            f"{role} name {name!r} is invalid: must match "
+            f"[a-z0-9]([-a-z0-9]{{0,18}}[a-z0-9])? (1-20 chars, "
+            "lowercase alphanumeric with internal hyphens)"
+        )
+    if role == "algorithm":
+        if name in RESERVED_ALGORITHM_NAMES:
+            raise BYOError(
+                f"algorithm name {name!r} is reserved "
+                f"(reserved: {', '.join(sorted(RESERVED_ALGORITHM_NAMES))})"
+            )
+    else:
+        if name in RESERVED_ANY_ROLE:
+            raise BYOError(
+                f"{role} name {name!r} is reserved "
+                f"(reserved: {', '.join(sorted(RESERVED_ANY_ROLE))})"
+            )
+
+
+def _validate_image_ref(ref: str, algo_name: str) -> None:
+    """Minimal image-ref sanity. Final validation is register's job."""
+    if not ref:
+        raise BYOError(f"algorithm {algo_name!r}: image ref is empty")
+    if any(c.isspace() for c in ref):
+        raise BYOError(
+            f"algorithm {algo_name!r}: image ref {ref!r} contains whitespace"
+        )
+    if any(ord(c) < 0x20 or ord(c) == 0x7F for c in ref):
+        raise BYOError(
+            f"algorithm {algo_name!r}: image ref {ref!r} contains control chars"
+        )
+
+
+def _validate_yaml_file(path: Path, role: str) -> None:
+    """Load once, enforce: single-document, non-empty, mapping root.
+
+    Path traversal / existence checks live upstream; this function assumes
+    ``path`` was resolved and exists.
+    """
+    try:
+        text = path.read_text()
+    except OSError as exc:
+        raise BYOError(f"{role} at {path}: cannot read: {exc}") from exc
+    try:
+        docs = list(yaml.safe_load_all(text))
+    except yaml.YAMLError as exc:
+        raise BYOError(f"{role} at {path}: YAML parse failed: {exc}") from exc
+    if len(docs) == 0:
+        raise BYOError(f"{role} at {path}: empty document")
+    if len(docs) > 1:
+        raise BYOError(
+            f"{role} at {path}: multi-document YAML not supported "
+            f"(found {len(docs)} documents)"
+        )
+    doc = docs[0]
+    if doc is None:
+        raise BYOError(f"{role} at {path}: document is empty/null")
+    if not isinstance(doc, dict):
+        raise BYOError(
+            f"{role} at {path}: top-level must be a mapping, "
+            f"got {type(doc).__name__}"
+        )
+
+
+def _resolve_inside(path: Path, exp_root: Path, role: str) -> Path:
+    """Resolve ``path``; require existence + regular-file + inside/outside checks.
+
+    ``path`` is a *source* path. Bootstrap accepts sources outside
+    ``<exp-root>`` (operators supply paths from anywhere), but symlinks are
+    resolved and the final target must be a regular file. Enforced separately
+    from ``_check_dest_inside``, which enforces destination containment.
+    """
+    if not path.exists():
+        raise BYOError(f"{role}: path {path} does not exist")
+    if path.is_symlink() or (path.parent / path.name).is_symlink():
+        # Follow the symlink once via resolve(strict=True); require regular file.
+        pass
+    try:
+        resolved = path.resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise BYOError(
+            f"{role}: cannot resolve path {path}: {exc}"
+        ) from exc
+    if not resolved.is_file():
+        raise BYOError(
+            f"{role}: {path} (resolved {resolved}) is not a regular file"
+        )
+    return resolved
+
+
+def _check_dest_inside(dst: Path, exp_root: Path) -> Path:
+    """Return the resolved destination, enforcing it lies inside ``exp_root``.
+
+    Uses ``os.path.realpath`` on the destination parent (which exists) plus
+    the basename, so a not-yet-existing destination is still safely
+    validated against symlink games in its parent chain.
+    """
+    dst_parent_resolved = Path(os.path.realpath(dst.parent))
+    exp_resolved = Path(os.path.realpath(exp_root))
+    try:
+        dst_parent_resolved.relative_to(exp_resolved)
+    except ValueError:
+        raise BYOError(
+            f"destination {dst} resolves to {dst_parent_resolved / dst.name}, "
+            f"outside experiment root {exp_resolved}"
+        )
+    return dst_parent_resolved / dst.name
+
+
+# ---------------------------------------------------------------------------
+# Scenario name derivation
+# ---------------------------------------------------------------------------
+
+_SCENARIO_SANITIZE = re.compile(r"[^a-z0-9-]+")
+_SCENARIO_COLLAPSE = re.compile(r"-+")
+
+
+def normalize_scenario(raw: str) -> str:
+    """Normalize a derived scenario string per design.md:118-125.
+
+    lowercase → non-[a-z0-9-] replaced with '-' → runs of '-' collapsed →
+    leading/trailing '-' stripped → truncated to 40 chars.
+    """
+    s = raw.strip().lower()
+    s = _SCENARIO_SANITIZE.sub("-", s)
+    s = _SCENARIO_COLLAPSE.sub("-", s)
+    s = s.strip("-")
+    return s[:40]
+
+
+def derive_scenario_name(exp_root: Path, override: str | None) -> str:
+    """Derive scenario name for transfer.yaml.
+
+    Order: --scenario override → README.md first-header title → exp_root basename.
+    Result is normalized and required to be non-empty.
+    """
+    if override is not None:
+        candidate = override
+    else:
+        readme = exp_root / "README.md"
+        candidate = None
+        if readme.exists():
+            for line in readme.read_text().splitlines():
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                # Only the FIRST non-empty line is considered per spec.
+                if stripped.startswith("# "):
+                    candidate = stripped[2:].strip()
+                break
+        if not candidate:
+            candidate = exp_root.name
+    normalized = normalize_scenario(candidate)
+    if not normalized:
+        raise BYOError(
+            "cannot derive scenario name — override with --scenario "
+            f"(source: {candidate!r})"
+        )
+    return normalized
+
+
+# ---------------------------------------------------------------------------
+# Workload enumeration
+# ---------------------------------------------------------------------------
+
+def enumerate_workloads(exp_root: Path) -> list[Path]:
+    """Non-recursive glob of ``<exp-root>/workloads/*.yaml``.
+
+    Returns absolute paths sorted lexicographically. Empty result (missing
+    dir or no matches) is a fatal error naming the directory.
+    """
+    workloads_dir = exp_root / "workloads"
+    if not workloads_dir.is_dir():
+        raise BYOError(
+            f"workloads directory missing: {workloads_dir}"
+        )
+    matches: list[Path] = []
+    for entry in workloads_dir.iterdir():
+        if entry.name.startswith("."):
+            continue
+        if entry.suffix != ".yaml":
+            continue
+        # Resolve to enforce the "symlinks stay inside workloads/" rule.
+        try:
+            resolved = entry.resolve(strict=True)
+        except (OSError, RuntimeError):
+            raise BYOError(
+                f"workload {entry}: cannot resolve (broken symlink?)"
+            )
+        try:
+            resolved.relative_to(Path(os.path.realpath(workloads_dir)))
+        except ValueError:
+            raise BYOError(
+                f"workload {entry} resolves outside {workloads_dir}"
+            )
+        if not resolved.is_file():
+            raise BYOError(f"workload {entry} is not a regular file")
+        matches.append(entry)
+    if not matches:
+        raise BYOError(
+            f"no workload files found under {workloads_dir}/*.yaml"
+        )
+    matches.sort(key=lambda p: p.name)
+    return matches
+
+
+# ---------------------------------------------------------------------------
+# Copy operations
+# ---------------------------------------------------------------------------
+
+def _atomic_copy_file(src: Path, dst: Path) -> None:
+    """Copy src → dst by writing to a sibling temp file then renaming.
+
+    Never leaves a half-written destination. Preserves default file mode
+    (0644 subject to umask); we do NOT copy source mode — the operator's
+    overlay file might be 0600 on their disk but we want the experiment
+    repo files to be readable by tooling.
+    """
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=dst.name + ".", suffix=".tmp", dir=str(dst.parent)
+    )
+    try:
+        with os.fdopen(fd, "wb") as f:
+            with src.open("rb") as sf:
+                shutil.copyfileobj(sf, f)
+        os.replace(tmp_name, str(dst))
+    except Exception:
+        # Best-effort cleanup; the temp file's name is randomized so no
+        # existing file at ``dst`` is at risk.
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def _prompt_overwrite(dst: Path) -> bool:
+    """Interactive confirmation for an existing destination.
+
+    Returns True to proceed with overwrite. Prompts on stderr, reads stdin.
+    Called only when stdin is a TTY (or the caller has explicitly opted in);
+    non-interactive dispatch takes a different branch entirely.
+    """
+    print(f"destination exists: {dst}", file=sys.stderr)
+    print("overwrite? [y/N]: ", file=sys.stderr, end="", flush=True)
+    resp = sys.stdin.readline().strip().lower()
+    return resp in ("y", "yes")
+
+
+def _decide_dest(dst: Path, force: bool, non_interactive: bool) -> None:
+    """Raise BYOError if destination exists and we shouldn't overwrite."""
+    if not dst.exists():
+        return
+    if force:
+        return
+    if non_interactive:
+        raise BYOError(
+            f"destination {dst} exists; refusing overwrite in non-interactive "
+            "mode (pass --force to override)"
+        )
+    if not _prompt_overwrite(dst):
+        raise BYOError(f"aborted: destination {dst} exists")
+
+
+def copy_operator_files(
+    inputs: ResolvedInputs, non_interactive: bool
+) -> tuple[Path, list[Path]]:
+    """Copy baseline + per-algorithm overlays into the experiment repo.
+
+    Returns (baseline_dst, [algo_config_dsts]). All destinations are inside
+    ``inputs.exp_root``; every write is atomic; existing destinations honor
+    ``inputs.force`` and ``non_interactive``.
+    """
+    # baseline
+    baseline_dst = _check_dest_inside(
+        inputs.exp_root / "baselines" / f"{inputs.baseline_name}.yaml",
+        inputs.exp_root,
+    )
+    _decide_dest(baseline_dst, inputs.force, non_interactive)
+    _atomic_copy_file(inputs.baseline_src, baseline_dst)
+
+    # per-algorithm overlays
+    algo_dsts: list[Path] = []
+    for algo in inputs.algorithms:
+        algo_dst = _check_dest_inside(
+            inputs.exp_root / "algorithms" / algo.name / f"{algo.name}_config.yaml",
+            inputs.exp_root,
+        )
+        _decide_dest(algo_dst, inputs.force, non_interactive)
+        _atomic_copy_file(algo.config_src, algo_dst)
+        algo_dsts.append(algo_dst)
+
+    return baseline_dst, algo_dsts
+
+
+def copy_framework_defaults(
+    skill_dir: Path, exp_root: Path, force: bool, non_interactive: bool
+) -> list[str]:
+    """Copy ``<skill>/templates/defaults/*.yaml`` → ``<exp>/baselines/defaults/``.
+
+    Returns the sorted list of filename stems, used to populate
+    ``defaults.disable`` in transfer.yaml. Duplicate stems (e.g. foo.yaml +
+    foo.yml — cannot happen today because we only copy .yaml, but the guard
+    is cheap) are a fatal error.
+    """
+    src_dir = skill_dir / "templates" / "defaults"
+    if not src_dir.is_dir():
+        raise BYOError(
+            f"framework defaults directory missing: {src_dir} "
+            "(is this skill's templates/defaults/ populated?)"
+        )
+    dst_dir = exp_root / "baselines" / "defaults"
+    stems: list[str] = []
+    seen_stems: set[str] = set()
+    for src in sorted(src_dir.iterdir(), key=lambda p: p.name):
+        if src.name.startswith("."):
+            continue
+        if src.suffix != ".yaml":
+            continue
+        stem = src.stem
+        if stem in seen_stems:
+            raise BYOError(
+                f"duplicate default fragment stem {stem!r} in {src_dir}"
+            )
+        seen_stems.add(stem)
+        dst = _check_dest_inside(dst_dir / src.name, exp_root)
+        _decide_dest(dst, force, non_interactive)
+        _atomic_copy_file(src, dst)
+        stems.append(stem)
+    stems.sort()
+    return stems
+
+
+# ---------------------------------------------------------------------------
+# transfer.yaml emission
+# ---------------------------------------------------------------------------
+
+def build_transfer_yaml(
+    *,
+    scenario: str,
+    baseline_name: str,
+    algorithms: list[ResolvedAlgorithm],
+    workloads: Iterable[Path],
+    exp_root: Path,
+    defaults_stems: list[str],
+) -> dict:
+    """Assemble the transfer.yaml body per design.md#emitted-transfer-yaml-shape.
+
+    - No ``component:`` key (all algorithms are BYO).
+    - Every ``algorithms[]`` entry has ``byo: true``, no ``source``.
+    - ``workloads`` paths are expressed relative to ``exp_root``.
+    - ``defaults.disable`` matches the stems of files copied to
+      ``<exp>/baselines/defaults/``.
+    """
+    return {
+        "kind": "sim2real-transfer",
+        "version": 3,
+        "scenario": scenario,
+        "baselines": [
+            {"name": baseline_name, "scenario": f"baselines/{baseline_name}.yaml"},
+        ],
+        "algorithms": [
+            {"name": a.name, "defaults": baseline_name, "byo": True}
+            for a in algorithms
+        ],
+        "workloads": [
+            str(w.relative_to(exp_root)) for w in workloads
+        ],
+        "defaults": {"disable": defaults_stems},
+        "context": {
+            "files": [],
+            "text": (
+                "Bring-your-own translation. Images and per-algorithm overlays "
+                "supplied externally; no BLIS source in this experiment repo."
+            ),
+        },
+    }
+
+
+def write_transfer_yaml(exp_root: Path, doc: dict, force: bool, non_interactive: bool) -> Path:
+    """Serialize doc and write atomically to ``<exp-root>/transfer.yaml``."""
+    dst = _check_dest_inside(exp_root / "transfer.yaml", exp_root)
+    _decide_dest(dst, force, non_interactive)
+    text = yaml.safe_dump(doc, sort_keys=False, default_flow_style=False)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=dst.name + ".", suffix=".tmp", dir=str(dst.parent)
+    )
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(text)
+        os.replace(tmp_name, str(dst))
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+    return dst
+
+
+# ---------------------------------------------------------------------------
+# Register command emission
+# ---------------------------------------------------------------------------
+
+def emit_register_command(
+    exp_root_abs: Path, algorithms: list[ResolvedAlgorithm]
+) -> str:
+    """Emit the batched register command, shlex-quoted.
+
+    Shape (matches design.md#register-command-emission):
+
+        cd '<abs-exp-root>'
+        sim2real translation register \\
+            --algorithm '<name1>=<image1>@algorithms/<name1>/<name1>_config.yaml' \\
+            --algorithm '<name2>=<image2>@algorithms/<name2>/<name2>_config.yaml'
+
+    Every path and every triple is quoted with ``shlex.quote``; the block
+    round-trips cleanly through ``shlex.split``.
+    """
+    if not algorithms:
+        raise BYOError("cannot emit register command: no algorithms")
+    lines = [
+        f"cd {shlex.quote(str(exp_root_abs))}",
+        "sim2real translation register \\",
+    ]
+    for i, algo in enumerate(algorithms):
+        overlay_rel = f"algorithms/{algo.name}/{algo.name}_config.yaml"
+        triple = f"{algo.name}={algo.image_ref}@{overlay_rel}"
+        suffix = " \\" if i < len(algorithms) - 1 else ""
+        lines.append(f"    --algorithm {shlex.quote(triple)}{suffix}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+def _collect(args: BYOArgs, exp_root: Path) -> ResolvedInputs:
+    """Enforce required fields, validate every input file, resolve paths.
+
+    Argparse is handled upstream; this function operates on an already-parsed
+    ``BYOArgs``. Non-interactive mode is decided by the caller (based on
+    ``stdin.isatty()`` and ``--non-interactive``) and passed through to the
+    copy stage separately.
+    """
+    if not args.byo:
+        # This entry point is BYO-only; SKILL.md handles dispatch. Guarding
+        # here catches direct-invocation mistakes with a clear message.
+        raise BYOError("--byo required (this entry point is BYO-only)")
+
+    # baseline
+    if not args.baseline_name:
+        raise BYOError("missing required field: --baseline <name>=<scenario-path>")
+    _validate_name(args.baseline_name, role="baseline")
+    baseline_src = _resolve_inside(
+        Path(args.baseline_path), exp_root, role=f"--baseline {args.baseline_name!r}"
+    )
+    _validate_yaml_file(baseline_src, role=f"baseline {args.baseline_name!r}")
+
+    # algorithms
+    if not args.algorithms:
+        raise BYOError("missing required field: at least one --algorithm <name>")
+    if len(args.algorithms) != len(set(args.algorithms)):
+        seen: set[str] = set()
+        dupes: set[str] = set()
+        for n in args.algorithms:
+            if n in seen:
+                dupes.add(n)
+            seen.add(n)
+        raise BYOError(
+            f"duplicate --algorithm names: {', '.join(sorted(dupes))}"
+        )
+    for name in args.algorithms:
+        _validate_name(name, role="algorithm")
+
+    # image + config per algorithm — no missing, no extras, no cross-name refs
+    declared = set(args.algorithms)
+    extra_images = set(args.algorithm_images) - declared
+    if extra_images:
+        raise BYOError(
+            f"--algorithm-image name(s) not declared with --algorithm: "
+            f"{', '.join(sorted(extra_images))}"
+        )
+    extra_configs = set(args.algorithm_configs) - declared
+    if extra_configs:
+        raise BYOError(
+            f"--algorithm-config name(s) not declared with --algorithm: "
+            f"{', '.join(sorted(extra_configs))}"
+        )
+    resolved_algos: list[ResolvedAlgorithm] = []
+    for name in args.algorithms:
+        image = args.algorithm_images.get(name)
+        if not image:
+            raise BYOError(
+                f"algorithm {name!r}: missing --algorithm-image {name}=..."
+            )
+        _validate_image_ref(image, algo_name=name)
+        cfg = args.algorithm_configs.get(name)
+        if not cfg:
+            raise BYOError(
+                f"algorithm {name!r}: missing --algorithm-config {name}=..."
+            )
+        cfg_src = _resolve_inside(
+            Path(cfg), exp_root, role=f"--algorithm-config {name!r}"
+        )
+        _validate_yaml_file(cfg_src, role=f"overlay for algorithm {name!r}")
+        resolved_algos.append(
+            ResolvedAlgorithm(name=name, image_ref=image, config_src=cfg_src)
+        )
+
+    # workloads (fail-fast; nothing to copy but enumeration must succeed)
+    workloads = enumerate_workloads(exp_root)
+
+    # scenario derivation
+    scenario = derive_scenario_name(exp_root, args.scenario)
+
+    return ResolvedInputs(
+        exp_root=exp_root,
+        scenario=scenario,
+        baseline_name=args.baseline_name,
+        baseline_src=baseline_src,
+        algorithms=resolved_algos,
+        workloads=workloads,
+        force=args.force,
+    )
+
+
+def run_byo(
+    argv: list[str],
+    exp_root: Path,
+    skill_dir: Path,
+    stdin_isatty: bool = True,
+) -> tuple[int, str]:
+    """Run the full BYO branch. Returns (exit_code, register_command_or_message).
+
+    - ``exit_code == 0`` → success; second field is the emitted register
+      command block, suitable for printing on stdout.
+    - ``exit_code == 2`` → any BYO validation error; second field is the
+      error message (already printed to stderr by ``main()``).
+    """
+    try:
+        exp_root_resolved = Path(os.path.realpath(exp_root))
+        args = parse_args(argv)
+        non_interactive = args.non_interactive or (not stdin_isatty)
+        inputs = _collect(args, exp_root_resolved)
+        copy_operator_files(inputs, non_interactive=non_interactive)
+        defaults_stems = copy_framework_defaults(
+            skill_dir, inputs.exp_root, inputs.force, non_interactive
+        )
+        doc = build_transfer_yaml(
+            scenario=inputs.scenario,
+            baseline_name=inputs.baseline_name,
+            algorithms=inputs.algorithms,
+            workloads=inputs.workloads,
+            exp_root=inputs.exp_root,
+            defaults_stems=defaults_stems,
+        )
+        write_transfer_yaml(inputs.exp_root, doc, inputs.force, non_interactive)
+        register_cmd = emit_register_command(inputs.exp_root, inputs.algorithms)
+        return 0, register_cmd
+    except BYOError as exc:
+        return 2, str(exc)
+    except SystemExit as exc:
+        # argparse exits on --help or parse errors; convert to our contract.
+        code = exc.code if isinstance(exc.code, int) else 2
+        return code, ""
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    exp_root = Path.cwd()
+    skill_dir = Path(__file__).resolve().parent
+    exit_code, message = run_byo(
+        argv, exp_root, skill_dir, stdin_isatty=sys.stdin.isatty()
+    )
+    if exit_code == 0 and message:
+        print("BYO bootstrap complete. Next: register all algorithms in one call.")
+        print()
+        print(message)
+        print()
+        print("The command prints one translation hash. Then:")
+        print()
+        print("    sim2real assemble --translation <hash> --cluster <cluster_id> --run <run-name>")
+    elif exit_code != 0 and message:
+        print(f"error: {message}", file=sys.stderr)
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/sim2real-bootstrap/tests/test_byo.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_byo.py
@@ -1,0 +1,789 @@
+"""Tests for the BYO branch of sim2real-bootstrap (``byo.py``).
+
+Covers the acceptance criteria from issue #499:
+  - BYO happy path — 2 algorithms
+  - BYO error paths (missing/duplicate args, malformed YAML, path traversal)
+  - Non-interactive behavior (stdin non-TTY or --non-interactive)
+  - Args-vs-NL parse equivalence (structured args and NL-derived arg-dict
+    produce equivalent triples — tested on the parser helper)
+  - Path safety (shlex.quote against spaces / $ / ` / ; )
+  - BLIS regression (BLIS-mode dispatch unchanged; existing skill files
+    untouched by this module)
+  - Emitted transfer.yaml loads via pipeline/lib/manifest.load_manifest
+  - Emitted register command passes the actual sim2real register argparser
+"""
+from __future__ import annotations
+
+import os
+import shlex
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+# Locate the skill dir (this test file's parent-parent) and put both the
+# skill dir and the repo root on sys.path so we can import byo directly and
+# also import from pipeline.lib.
+_SKILL_DIR = Path(__file__).resolve().parents[1]
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(_SKILL_DIR))
+sys.path.insert(0, str(_REPO_ROOT))
+import byo  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _valid_scenario_yaml(name: str = "baseline") -> str:
+    """Minimal scenario body accepted by yaml.safe_load; single mapping doc."""
+    return textwrap.dedent(f"""\
+        scenario:
+        - name: {name}
+          model:
+            name: meta-llama/Llama-3.1-8B
+            path: models/meta-llama/Llama-3.1-8B
+          decode:
+            replicas: 1
+    """)
+
+
+def _valid_overlay_yaml(algo: str) -> str:
+    return textwrap.dedent(f"""\
+        scenario:
+        - name: {algo}
+          decode:
+            replicas: 2
+    """)
+
+
+def _write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+    return path
+
+
+@pytest.fixture
+def bare_exp_root(tmp_path: Path) -> Path:
+    """Fake experiment repo with only workloads/ populated (BYO input shape)."""
+    root = tmp_path / "myexperiment"
+    (root / "workloads").mkdir(parents=True)
+    _write(root / "workloads" / "w1.yaml", "workload:\n  name: w1\n")
+    _write(root / "workloads" / "w2.yaml", "workload:\n  name: w2\n")
+    return root
+
+
+@pytest.fixture
+def operator_files(tmp_path: Path) -> dict[str, Path]:
+    """Operator-supplied files, placed outside the experiment repo."""
+    src = tmp_path / "operator"
+    src.mkdir()
+    baseline_path = _write(src / "baseline.yaml", _valid_scenario_yaml("baseline"))
+    foo_overlay = _write(src / "foo_overlay.yaml", _valid_overlay_yaml("foo"))
+    bar_overlay = _write(src / "bar_overlay.yaml", _valid_overlay_yaml("bar"))
+    return {
+        "baseline": baseline_path,
+        "foo": foo_overlay,
+        "bar": bar_overlay,
+    }
+
+
+def _happy_argv(
+    files: dict[str, Path],
+    *,
+    non_interactive: bool = True,
+    extra: list[str] | None = None,
+) -> list[str]:
+    argv = [
+        "--byo",
+        "--baseline", f"baseline={files['baseline']}",
+        "--algorithm", "foo",
+        "--algorithm", "bar",
+        "--algorithm-image", "foo=ghcr.io/example/foo:latest",
+        "--algorithm-image", "bar=ghcr.io/example/bar@sha256:" + "a" * 64,
+        "--algorithm-config", f"foo={files['foo']}",
+        "--algorithm-config", f"bar={files['bar']}",
+    ]
+    if non_interactive:
+        argv.append("--non-interactive")
+    if extra:
+        argv.extend(extra)
+    return argv
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+def test_happy_path_two_algorithms(bare_exp_root, operator_files):
+    argv = _happy_argv(operator_files)
+    code, register_cmd = byo.run_byo(
+        argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False
+    )
+    assert code == 0, register_cmd
+
+    # baselines/baseline.yaml exists with baseline content
+    baseline_dst = bare_exp_root / "baselines" / "baseline.yaml"
+    assert baseline_dst.exists()
+    assert baseline_dst.read_text() == operator_files["baseline"].read_text()
+
+    # algorithms/<algo>/<algo>_config.yaml exists per algorithm
+    for algo in ("foo", "bar"):
+        dst = bare_exp_root / "algorithms" / algo / f"{algo}_config.yaml"
+        assert dst.exists()
+        assert dst.read_text() == operator_files[algo].read_text()
+
+    # framework defaults copied verbatim
+    defaults_dir = bare_exp_root / "baselines" / "defaults"
+    template_dir = _SKILL_DIR / "templates" / "defaults"
+    for src in sorted(template_dir.glob("*.yaml")):
+        dst = defaults_dir / src.name
+        assert dst.exists()
+        assert dst.read_text() == src.read_text()
+
+    # transfer.yaml loads via manifest.load_manifest
+    transfer_path = bare_exp_root / "transfer.yaml"
+    assert transfer_path.exists()
+    from pipeline.lib.manifest import load_manifest
+    manifest = load_manifest(transfer_path)
+
+    # component absent, every algorithm has byo: true and no source
+    assert "component" not in manifest
+    algo_names_manifest = [a["name"] for a in manifest["algorithms"]]
+    assert sorted(algo_names_manifest) == ["bar", "foo"]
+    for entry in manifest["algorithms"]:
+        assert entry.get("byo") is True
+        assert "source" not in entry
+        assert entry["defaults"] == "baseline"
+
+    # defaults.disable matches the sorted stems of templates/defaults/*.yaml
+    expected_stems = sorted(p.stem for p in template_dir.glob("*.yaml"))
+    assert manifest["defaults"]["disable"] == expected_stems
+
+    # Register command shlex-round-trips
+    tokens = shlex.split(register_cmd)
+    assert "sim2real" in tokens
+    assert "register" in tokens
+    # Extract each --algorithm value and parse it via the actual register CLI's
+    # triple parser — the code that the register subcommand runs at parse time.
+    from pipeline.sim2real import _parse_algorithm_triple
+    algo_values = [
+        tokens[i + 1] for i, t in enumerate(tokens) if t == "--algorithm"
+    ]
+    assert len(algo_values) == 2
+    parsed = [_parse_algorithm_triple(v) for v in algo_values]
+    parsed_names = {p[0] for p in parsed}
+    assert parsed_names == {"foo", "bar"}
+
+    # And the emitted command's --algorithm args are accepted by the top-level
+    # register argparser (require=True on --algorithm).
+    from pipeline.sim2real import build_parser as build_top_parser
+    # Strip the `cd '<path>'` line and the `sim2real translation register` head
+    # to isolate the argparse-facing arg vector.
+    lines = [ln.rstrip(" \\") for ln in register_cmd.split("\n")]
+    all_tokens = shlex.split(" ".join(lines))
+    # tokens = ['cd', '<path>', 'sim2real', 'translation', 'register',
+    #           '--algorithm', '<triple>', '--algorithm', '<triple>']
+    idx = all_tokens.index("register")
+    argparser_args = all_tokens[idx:]  # ['register', '--algorithm', ...]
+    # The top-level sim2real parser expects `translation register --algorithm...`
+    # Rebuild that arg vector.
+    top_argv = ["translation"] + argparser_args
+    parser = build_top_parser()
+    ns = parser.parse_args(top_argv)
+    assert ns.command == "translation"
+    assert ns.subcommand == "register"
+    assert len(ns.algorithm) == 2
+
+
+def test_register_command_starts_with_cd_to_abs_exp_root(bare_exp_root, operator_files):
+    argv = _happy_argv(operator_files)
+    code, register_cmd = byo.run_byo(
+        argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False
+    )
+    assert code == 0
+    first_line = register_cmd.split("\n")[0]
+    # cd <abs-path>
+    assert first_line.startswith("cd ")
+    quoted_path = first_line[len("cd "):]
+    # shlex.split gives us the raw path back
+    parts = shlex.split(quoted_path)
+    assert len(parts) == 1
+    resolved_root = os.path.realpath(bare_exp_root)
+    assert parts[0] == resolved_root
+
+
+def test_happy_path_single_algorithm(tmp_path, operator_files):
+    """N=1 is also supported — same path as N=2, just one algorithm."""
+    root = tmp_path / "exp"
+    (root / "workloads").mkdir(parents=True)
+    _write(root / "workloads" / "w1.yaml", "workload:\n  name: w1\n")
+
+    argv = [
+        "--byo",
+        "--baseline", f"baseline={operator_files['baseline']}",
+        "--algorithm", "foo",
+        "--algorithm-image", "foo=ghcr.io/example/foo:latest",
+        "--algorithm-config", f"foo={operator_files['foo']}",
+        "--non-interactive",
+    ]
+    code, register_cmd = byo.run_byo(argv, root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 0, register_cmd
+
+    from pipeline.lib.manifest import load_manifest
+    manifest = load_manifest(root / "transfer.yaml")
+    assert [a["name"] for a in manifest["algorithms"]] == ["foo"]
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+def test_error_missing_baseline(bare_exp_root, operator_files):
+    argv = [
+        "--byo",
+        "--algorithm", "foo",
+        "--algorithm-image", "foo=ghcr.io/example/foo:latest",
+        "--algorithm-config", f"foo={operator_files['foo']}",
+        "--non-interactive",
+    ]
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+    assert "baseline" in message.lower()
+
+
+def test_error_no_algorithm(bare_exp_root, operator_files):
+    argv = [
+        "--byo",
+        "--baseline", f"baseline={operator_files['baseline']}",
+        "--non-interactive",
+    ]
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+    assert "algorithm" in message.lower()
+
+
+def test_error_algorithm_without_image(bare_exp_root, operator_files):
+    argv = [
+        "--byo",
+        "--baseline", f"baseline={operator_files['baseline']}",
+        "--algorithm", "foo",
+        "--algorithm-config", f"foo={operator_files['foo']}",
+        "--non-interactive",
+    ]
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+    assert "foo" in message
+    assert "algorithm-image" in message
+
+
+def test_error_algorithm_without_config(bare_exp_root, operator_files):
+    argv = [
+        "--byo",
+        "--baseline", f"baseline={operator_files['baseline']}",
+        "--algorithm", "foo",
+        "--algorithm-image", "foo=ghcr.io/example/foo:latest",
+        "--non-interactive",
+    ]
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+    assert "foo" in message
+    assert "algorithm-config" in message
+
+
+def test_error_duplicate_algorithm_names(bare_exp_root, operator_files):
+    argv = [
+        "--byo",
+        "--baseline", f"baseline={operator_files['baseline']}",
+        "--algorithm", "foo",
+        "--algorithm", "foo",
+        "--algorithm-image", "foo=ghcr.io/example/foo:latest",
+        "--algorithm-config", f"foo={operator_files['foo']}",
+        "--non-interactive",
+    ]
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+    assert "duplicate" in message.lower()
+    assert "foo" in message
+
+
+def test_error_workloads_dir_missing(tmp_path, operator_files):
+    root = tmp_path / "exp"
+    root.mkdir()  # No workloads/ subdir.
+    argv = _happy_argv(operator_files)
+    code, message = byo.run_byo(argv, root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+    assert "workloads" in message.lower()
+
+
+def test_error_workloads_dir_empty(tmp_path, operator_files):
+    root = tmp_path / "exp"
+    (root / "workloads").mkdir(parents=True)  # Empty.
+    argv = _happy_argv(operator_files)
+    code, message = byo.run_byo(argv, root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+    assert "workload" in message.lower()
+
+
+def test_error_malformed_overlay_yaml(bare_exp_root, operator_files, tmp_path):
+    bad = _write(tmp_path / "bad.yaml", "this is: not: valid: yaml: [\n")
+    argv = [
+        "--byo",
+        "--baseline", f"baseline={operator_files['baseline']}",
+        "--algorithm", "foo",
+        "--algorithm-image", "foo=ghcr.io/example/foo:latest",
+        "--algorithm-config", f"foo={bad}",
+        "--non-interactive",
+    ]
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+    assert str(bad) in message
+    assert "yaml" in message.lower() or "parse" in message.lower()
+
+
+def test_error_malformed_baseline_yaml(bare_exp_root, operator_files, tmp_path):
+    bad = _write(tmp_path / "bad_baseline.yaml", "this is: not: valid: yaml: [\n")
+    argv = [
+        "--byo",
+        "--baseline", f"baseline={bad}",
+        "--algorithm", "foo",
+        "--algorithm-image", "foo=ghcr.io/example/foo:latest",
+        "--algorithm-config", f"foo={operator_files['foo']}",
+        "--non-interactive",
+    ]
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+    assert str(bad) in message
+
+
+@pytest.mark.parametrize("bad_content", [
+    "- a\n- b\n- c\n",  # list root
+    "just a scalar\n",  # scalar root
+    "",                 # empty
+])
+def test_error_non_mapping_root_yaml(bare_exp_root, operator_files, tmp_path, bad_content):
+    bad = _write(tmp_path / "non_mapping.yaml", bad_content)
+    argv = [
+        "--byo",
+        "--baseline", f"baseline={operator_files['baseline']}",
+        "--algorithm", "foo",
+        "--algorithm-image", "foo=ghcr.io/example/foo:latest",
+        "--algorithm-config", f"foo={bad}",
+        "--non-interactive",
+    ]
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+
+
+def test_error_multi_document_yaml(bare_exp_root, operator_files, tmp_path):
+    multi = _write(tmp_path / "multi.yaml", "a: 1\n---\nb: 2\n")
+    argv = [
+        "--byo",
+        "--baseline", f"baseline={operator_files['baseline']}",
+        "--algorithm", "foo",
+        "--algorithm-image", "foo=ghcr.io/example/foo:latest",
+        "--algorithm-config", f"foo={multi}",
+        "--non-interactive",
+    ]
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+    assert "multi" in message.lower() or "document" in message.lower()
+
+
+def test_error_overlay_path_missing(bare_exp_root, operator_files, tmp_path):
+    argv = [
+        "--byo",
+        "--baseline", f"baseline={operator_files['baseline']}",
+        "--algorithm", "foo",
+        "--algorithm-image", "foo=ghcr.io/example/foo:latest",
+        "--algorithm-config", f"foo={tmp_path / 'does_not_exist.yaml'}",
+        "--non-interactive",
+    ]
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+    assert "does_not_exist.yaml" in message
+
+
+def test_error_baseline_path_missing(bare_exp_root, operator_files, tmp_path):
+    argv = [
+        "--byo",
+        "--baseline", f"baseline={tmp_path / 'nowhere.yaml'}",
+        "--algorithm", "foo",
+        "--algorithm-image", "foo=ghcr.io/example/foo:latest",
+        "--algorithm-config", f"foo={operator_files['foo']}",
+        "--non-interactive",
+    ]
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+    assert "nowhere.yaml" in message
+
+
+def test_error_source_symlink_outside_regular_file_required(bare_exp_root, tmp_path):
+    """Source symlink that points to a non-regular file (e.g. a directory) is rejected."""
+    outside = tmp_path / "outside_dir"
+    outside.mkdir()
+    src_symlink = tmp_path / "escape.yaml"
+    src_symlink.symlink_to(outside)  # Symlink to a directory, not a file
+    argv = [
+        "--byo",
+        "--baseline", f"baseline={src_symlink}",
+        "--algorithm", "foo",
+        "--algorithm-image", "foo=ghcr.io/example/foo:latest",
+        "--algorithm-config", f"foo={src_symlink}",
+        "--non-interactive",
+    ]
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+    assert "regular file" in message.lower() or "not a file" in message.lower()
+
+
+def test_error_dest_parent_symlink_escaping_exp_root(bare_exp_root, operator_files, tmp_path):
+    """`<exp-root>/algorithms/` is a symlink that escapes -> destination check fails."""
+    escape_target = tmp_path / "escape_target"
+    escape_target.mkdir()
+    # Replace algorithms/ with a symlink to a directory outside the exp root.
+    (bare_exp_root / "algorithms").symlink_to(escape_target)
+    argv = _happy_argv(operator_files)
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+    assert "outside" in message.lower() or "traversal" in message.lower() or "escape" in message.lower()
+
+
+def test_error_existing_dest_non_interactive_refused(bare_exp_root, operator_files):
+    # First run to create the destination.
+    argv = _happy_argv(operator_files)
+    code, _ = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 0
+    # Second run without --force: fails in non-interactive mode.
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+    assert "exists" in message.lower() and "force" in message.lower()
+
+
+def test_existing_dest_with_force_overwrites(bare_exp_root, operator_files, tmp_path):
+    # First run to create the destination.
+    code, _ = byo.run_byo(_happy_argv(operator_files), bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 0
+    # Change the operator's baseline content, then re-run with --force.
+    new_content = _valid_scenario_yaml("baseline") + "  # updated\n"
+    operator_files["baseline"].write_text(new_content)
+    argv = _happy_argv(operator_files, extra=["--force"])
+    code, _ = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 0
+    assert (bare_exp_root / "baselines" / "baseline.yaml").read_text() == new_content
+
+
+# ---------------------------------------------------------------------------
+# Non-interactive dispatch
+# ---------------------------------------------------------------------------
+
+def test_non_interactive_auto_enabled_when_stdin_not_tty(bare_exp_root, operator_files):
+    """stdin.isatty() == False alone forces non-interactive; no --non-interactive needed."""
+    argv = [
+        "--byo",
+        # Missing baseline, no --non-interactive; but stdin is non-TTY.
+        "--algorithm", "foo",
+        "--algorithm-image", "foo=ghcr.io/example/foo:latest",
+        "--algorithm-config", f"foo={operator_files['foo']}",
+    ]
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+    assert "baseline" in message.lower()
+
+
+def test_non_interactive_explicit_flag_forces_no_prompt(bare_exp_root, operator_files):
+    """--non-interactive forces non-interactive even when stdin is a TTY."""
+    argv = [
+        "--byo",
+        "--algorithm", "foo",
+        "--algorithm-image", "foo=ghcr.io/example/foo:latest",
+        "--algorithm-config", f"foo={operator_files['foo']}",
+        "--non-interactive",
+    ]
+    # stdin_isatty=True but --non-interactive present → no prompt, fatal.
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=True)
+    assert code == 2
+    assert "baseline" in message.lower()
+
+
+# ---------------------------------------------------------------------------
+# Args-vs-NL equivalence
+# ---------------------------------------------------------------------------
+
+def test_args_vs_nl_parse_equivalence(operator_files):
+    """Structured args and NL-derived argv produce equivalent parsed dicts.
+
+    The NL frontend lives in SKILL.md prose (LLM-driven; not CI-tested per
+    design.md#risks). What IS testable is that if an LLM converts NL into
+    the structured argv shape, both paths produce the same dict. This test
+    encodes that contract on the parser helper.
+    """
+    argv_structured = _happy_argv(operator_files, non_interactive=False)
+
+    # An NL request like:
+    #   "--byo with baseline at <path>, algorithm foo image <img1> config <ov1>,
+    #    algorithm bar image <img2> config <ov2>"
+    # would produce (from an LLM parser) the same argv tokens as structured
+    # args. The parser helper is order-agnostic on the dict shape.
+    argv_from_nl_shape = [
+        "--byo",
+        "--baseline", f"baseline={operator_files['baseline']}",
+        # NL parser might reorder these — validate order-independence
+        "--algorithm-image", "foo=ghcr.io/example/foo:latest",
+        "--algorithm-image", "bar=ghcr.io/example/bar@sha256:" + "a" * 64,
+        "--algorithm", "foo",
+        "--algorithm", "bar",
+        "--algorithm-config", f"foo={operator_files['foo']}",
+        "--algorithm-config", f"bar={operator_files['bar']}",
+    ]
+
+    d1 = byo.parse_args_dict(argv_structured)
+    d2 = byo.parse_args_dict(argv_from_nl_shape)
+
+    # `algorithms` is order-preserving; NL should produce the same relative
+    # order (LLM told "foo then bar" → [foo, bar]).
+    assert d1["algorithms"] == d2["algorithms"]
+    # Everything else compares as-is.
+    assert d1["baseline"] == d2["baseline"]
+    assert d1["algorithm_images"] == d2["algorithm_images"]
+    assert d1["algorithm_configs"] == d2["algorithm_configs"]
+    assert d1["byo"] == d2["byo"]
+
+
+# ---------------------------------------------------------------------------
+# Path safety — shlex.quote against shell metacharacters
+# ---------------------------------------------------------------------------
+
+def test_shlex_quote_covers_shell_metacharacters(tmp_path):
+    """Register command emission handles spaces, $, `, ; without corruption.
+
+    Uses an experiment root with metacharacters in the path and verifies the
+    emitted register command round-trips through shlex.split back to the
+    original strings.
+    """
+    weird_root = tmp_path / "path with spaces & $vars; and `backticks`"
+    (weird_root / "workloads").mkdir(parents=True)
+    _write(weird_root / "workloads" / "w1.yaml", "workload:\n  name: w1\n")
+
+    # Overlay file with problematic filename.
+    weird_overlay_dir = tmp_path / "operator with; $shell `special` chars"
+    weird_overlay_dir.mkdir()
+    overlay = _write(weird_overlay_dir / "overlay.yaml", _valid_overlay_yaml("foo"))
+    baseline = _write(tmp_path / "baseline.yaml", _valid_scenario_yaml("baseline"))
+
+    argv = [
+        "--byo",
+        "--baseline", f"baseline={baseline}",
+        "--algorithm", "foo",
+        "--algorithm-image", "foo=ghcr.io/example/foo:latest",
+        "--algorithm-config", f"foo={overlay}",
+        "--non-interactive",
+    ]
+    code, register_cmd = byo.run_byo(argv, weird_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 0
+
+    # Round-trip: shlex.split of the emitted command should recover the raw path.
+    first_line = register_cmd.split("\n")[0]
+    parts = shlex.split(first_line)
+    assert parts[0] == "cd"
+    assert parts[1] == os.path.realpath(weird_root)
+
+
+def test_emit_register_command_triple_is_shlex_quoted(bare_exp_root, tmp_path):
+    """An image ref containing shell-sensitive chars is quoted-and-recovered."""
+    # Note: real image refs shouldn't contain shell metacharacters, but the
+    # emitter must not depend on that — the register command is user-facing.
+    overlay = _write(tmp_path / "foo_overlay.yaml", _valid_overlay_yaml("foo"))
+    # Image ref with a colon and semicolon (control test only — not a valid ref;
+    # we ensure the emitter never corrupts the string).
+    image = "registry.example.com/image:tag;withsemi"
+    algo = byo.ResolvedAlgorithm(name="foo", image_ref=image, config_src=overlay)
+    cmd = byo.emit_register_command(Path(os.path.realpath(bare_exp_root)), [algo])
+    tokens = shlex.split(cmd)
+    idx = tokens.index("--algorithm")
+    triple = tokens[idx + 1]
+    assert triple == f"foo={image}@algorithms/foo/foo_config.yaml"
+
+
+# ---------------------------------------------------------------------------
+# Name validation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("bad_name", [
+    "Foo",         # uppercase
+    "foo_bar",     # underscore
+    "-foo",        # leading hyphen
+    "foo-",        # trailing hyphen
+    "",            # empty
+    "a" * 21,      # too long
+    "1",           # single-char is fine actually — check regex end anchor
+])
+def test_invalid_algorithm_name_rejected(bad_name, bare_exp_root, operator_files):
+    # Special-case: "1" is a valid single-char name per the regex; skip it.
+    if bad_name == "1":
+        pytest.skip("single-digit name is valid")
+    argv = [
+        "--byo",
+        "--baseline", f"baseline={operator_files['baseline']}",
+        "--algorithm", bad_name,
+        "--algorithm-image", f"{bad_name}=ghcr.io/example/x:latest",
+        "--algorithm-config", f"{bad_name}={operator_files['foo']}",
+        "--non-interactive",
+    ]
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+
+
+def test_reserved_algorithm_name_baseline_rejected(bare_exp_root, operator_files):
+    """An algorithm named `baseline` collides with the framework role."""
+    argv = [
+        "--byo",
+        "--baseline", f"baseline={operator_files['baseline']}",
+        "--algorithm", "baseline",
+        "--algorithm-image", "baseline=ghcr.io/example/x:latest",
+        "--algorithm-config", f"baseline={operator_files['foo']}",
+        "--non-interactive",
+    ]
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+    assert "reserved" in message.lower()
+
+
+def test_baseline_named_baseline_is_allowed(bare_exp_root, operator_files):
+    """A *baseline* named 'baseline' is the canonical case, not reserved."""
+    argv = _happy_argv(operator_files)  # baseline=baseline
+    code, _ = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 0
+
+
+# ---------------------------------------------------------------------------
+# Scenario name derivation
+# ---------------------------------------------------------------------------
+
+def test_scenario_from_readme_first_header(tmp_path):
+    root = tmp_path / "somedir"
+    root.mkdir()
+    (root / "README.md").write_text("# My Fancy Experiment\n\nSome description.\n")
+    scenario = byo.derive_scenario_name(root, override=None)
+    assert scenario == "my-fancy-experiment"
+
+
+def test_scenario_from_basename_when_no_readme_header(tmp_path):
+    root = tmp_path / "MyExperiment_v2"
+    root.mkdir()
+    scenario = byo.derive_scenario_name(root, override=None)
+    assert scenario == "myexperiment-v2"
+
+
+def test_scenario_override(tmp_path):
+    root = tmp_path / "somedir"
+    root.mkdir()
+    scenario = byo.derive_scenario_name(root, override="Custom Name!")
+    assert scenario == "custom-name"
+
+
+def test_scenario_normalization_truncates_to_40_chars(tmp_path):
+    root = tmp_path / "somedir"
+    root.mkdir()
+    long_name = "a" * 60
+    scenario = byo.derive_scenario_name(root, override=long_name)
+    assert len(scenario) == 40
+
+
+def test_scenario_empty_after_normalization_is_fatal(tmp_path):
+    root = tmp_path / "somedir"
+    root.mkdir()
+    with pytest.raises(byo.BYOError, match="scenario"):
+        byo.derive_scenario_name(root, override="!!!@@@###")
+
+
+# ---------------------------------------------------------------------------
+# defaults.disable population
+# ---------------------------------------------------------------------------
+
+def test_defaults_disable_matches_template_stems(bare_exp_root, operator_files):
+    code, _ = byo.run_byo(
+        _happy_argv(operator_files), bare_exp_root, _SKILL_DIR, stdin_isatty=False
+    )
+    assert code == 0
+    manifest = yaml.safe_load((bare_exp_root / "transfer.yaml").read_text())
+    expected = sorted(
+        p.stem for p in (_SKILL_DIR / "templates" / "defaults").glob("*.yaml")
+    )
+    assert manifest["defaults"]["disable"] == expected
+
+
+# ---------------------------------------------------------------------------
+# Workload enumeration
+# ---------------------------------------------------------------------------
+
+def test_workload_enumeration_sorts_and_skips_hidden(tmp_path):
+    root = tmp_path / "exp"
+    (root / "workloads").mkdir(parents=True)
+    _write(root / "workloads" / "b.yaml", "b: 1\n")
+    _write(root / "workloads" / "a.yaml", "a: 1\n")
+    _write(root / "workloads" / ".hidden.yaml", "h: 1\n")
+    _write(root / "workloads" / "not_yaml.txt", "ignored\n")
+    _write(root / "workloads" / "ignored.yml", "ignored\n")  # .yml, not .yaml
+    workloads = byo.enumerate_workloads(root)
+    assert [p.name for p in workloads] == ["a.yaml", "b.yaml"]
+
+
+def test_workload_symlink_escaping_workloads_rejected(tmp_path):
+    root = tmp_path / "exp"
+    (root / "workloads").mkdir(parents=True)
+    outside = tmp_path / "outside.yaml"
+    _write(outside, "w: 1\n")
+    (root / "workloads" / "escape.yaml").symlink_to(outside)
+    with pytest.raises(byo.BYOError, match="outside"):
+        byo.enumerate_workloads(root)
+
+
+# ---------------------------------------------------------------------------
+# BLIS regression — this module must not affect existing BLIS-mode logic
+# ---------------------------------------------------------------------------
+
+def test_blis_generate_from_config_still_importable():
+    """Sanity check: BLIS-mode module untouched by BYO addition."""
+    import generate_from_config as gfc  # noqa: F401
+    # Presence of the module and its key symbols is enough — the full BLIS
+    # test suite runs adjacent to this one in the same directory.
+    assert hasattr(gfc, "extract_fields")
+    assert hasattr(gfc, "build_additional_flags")
+
+
+# ---------------------------------------------------------------------------
+# emit_transfer_yaml — direct unit tests
+# ---------------------------------------------------------------------------
+
+def test_transfer_yaml_shape_matches_design(tmp_path, operator_files):
+    root = tmp_path / "exp"
+    (root / "workloads").mkdir(parents=True)
+    _write(root / "workloads" / "w1.yaml", "w: 1\n")
+    _write(root / "workloads" / "w2.yaml", "w: 2\n")
+
+    algorithms = [
+        byo.ResolvedAlgorithm(name="foo", image_ref="i1", config_src=operator_files["foo"]),
+        byo.ResolvedAlgorithm(name="bar", image_ref="i2", config_src=operator_files["bar"]),
+    ]
+    doc = byo.build_transfer_yaml(
+        scenario="my-scenario",
+        baseline_name="baseline",
+        algorithms=algorithms,
+        workloads=[root / "workloads" / "w1.yaml", root / "workloads" / "w2.yaml"],
+        exp_root=root,
+        defaults_stems=["a-default", "b-default"],
+    )
+    assert doc["kind"] == "sim2real-transfer"
+    assert doc["version"] == 3
+    assert doc["scenario"] == "my-scenario"
+    assert "component" not in doc
+    assert doc["baselines"] == [{"name": "baseline", "scenario": "baselines/baseline.yaml"}]
+    assert doc["algorithms"] == [
+        {"name": "foo", "defaults": "baseline", "byo": True},
+        {"name": "bar", "defaults": "baseline", "byo": True},
+    ]
+    assert doc["workloads"] == ["workloads/w1.yaml", "workloads/w2.yaml"]
+    assert doc["defaults"]["disable"] == ["a-default", "b-default"]

--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ claude --dangerously-skip-permissions --add-dir $SIM2REAL
 /sim2real-bootstrap
 ```
 
-Skip this step if your experiment repo already contains `transfer.yaml`, `baselines/`, and a component submodule.
+For BYO operators — pre-built EPP image(s) + baseline scenario + per-algorithm overlay(s), no BLIS artifacts — use `--byo` mode instead: `/sim2real-bootstrap --byo --baseline ... --algorithm ... --algorithm-image ... --algorithm-config ...`. See [`.claude/skills/sim2real-bootstrap/SKILL.md`](.claude/skills/sim2real-bootstrap/SKILL.md#--byo-mode) for the full invocation.
+
+Skip this step if your experiment repo already contains `transfer.yaml`, `baselines/`, and (BLIS only) a component submodule.
 
 ### 2. Set required environment variables
 

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -130,6 +130,8 @@ Top-level CLI introduced in step-1 of the v2 refactor. Subcommands: `translation
 
 `sim2real.py translation register` imports one or more pre-built EPP images and their treatment overlay YAMLs as a single registered translation. Downstream commands (`assemble`, `deploy.py run`) treat a BYO-registered translation identically to a skill-produced one.
 
+The `/sim2real-bootstrap --byo` skill scaffolds a BYO experiment repo and emits a ready-to-run `translation register` command with all algorithms batched into a single call — see [`.claude/skills/sim2real-bootstrap/SKILL.md`](../.claude/skills/sim2real-bootstrap/SKILL.md#--byo-mode).
+
 #### Preferred form: repeatable `--algorithm NAME=IMAGE@CONFIG`
 
 Pass `--algorithm` once per algorithm. Each value is a single `NAME=IMAGE@CONFIG` triple: first `=` splits the name from the rest; rightmost `@` splits the image ref from the config path. This allows digest refs (`image@sha256:…`) without ambiguity.


### PR DESCRIPTION
## Summary

Adds a `--byo` dispatch branch to `/sim2real-bootstrap` for operators who arrive with pre-built EPP images (plus a full baseline scenario and per-algorithm overlays) instead of a BLIS-format experiment folder. BLIS-mode behavior (Tasks 0-6 of SKILL.md) is preserved verbatim.

Design source: [`docs/epics/step-4/design.md#byo-mode-specification`](https://github.com/inference-sim/sim2real/blob/refactor/v2-step-4/docs/epics/step-4/design.md#byo-mode-specification).

## What lands

- **`.claude/skills/sim2real-bootstrap/byo.py`** — new pure-Python module (~575 loc). CLI parsing, name/YAML validation, path-safe atomic copies, `transfer.yaml` emission with `byo: true` per-algorithm markers, and batched `sim2real translation register` command emission.
- **`.claude/skills/sim2real-bootstrap/SKILL.md`** — new dispatch section describing when to enter BYO mode, the operator-facing NL + prompt shell, and the handoff to `byo.py`. Top-of-file description updated to name both modes.
- **`.claude/skills/sim2real-bootstrap/tests/test_byo.py`** — 45 new pytest cases (see coverage below).
- **`README.md`** + **`pipeline/README.md`** — one-line refs pointing at the `--byo` branch.

CI (`.github/workflows/test.yml`) already runs the entire `.claude/skills/sim2real-bootstrap/tests/` directory, so `test_byo.py` is picked up automatically — no workflow change needed.

## Non-obvious design choices worth reviewing

- **Pure-Python module vs SKILL.md prose.** BYO logic is testable; SKILL.md prose is not. `byo.py` holds all validation, copy, and emission logic. SKILL.md's job is to: (a) dispatch to `byo.py` when any BYO flag appears in `\$ARGUMENTS`, (b) accept operator input (structured args OR NL prose), (c) prompt for missing fields in interactive mode with plain-text prompts (not \`AskUserQuestion\`), (d) hand off to \`byo.py\` with fully-specified args. This mirrors the shape already used by \`generate_from_config.py\`.
- **Non-interactive is the byo.py contract.** \`byo.py\` never prompts. All prompts live in SKILL.md's interactive shell. Non-interactive mode is auto-enabled when stdin is not a TTY OR \`--non-interactive\` is passed; missing required fields are fatal errors.
- **NL parsing is not in \`byo.py\`.** Per design.md#risks, LLM-driven NL parsing is not CI-tested. What \`test_args_vs_nl_parse_equivalence\` asserts is the *contract*: whatever token stream an LLM produces from an NL description, if it's the same shape as structured args, \`parse_args_dict\` returns the same dict.
- **Reserved names.** \`default\` and \`defaults\` are reserved for any role; \`baseline\` is reserved as an *algorithm* name only (a *baseline* named \`baseline\` is the canonical case, per design.md:140).
- **Path safety.** Every source path is resolved and required to be a regular file; every destination is checked to lie inside the resolved experiment root (uses \`os.path.realpath\` on the parent, which handles not-yet-existing destinations and symlink games). Copies are atomic (write-to-temp + \`os.replace\`).
- **shlex.quote on every user-supplied string.** The emitted register command round-trips through \`shlex.split\` and every triple parses via the actual \`_parse_algorithm_triple\` from \`pipeline/sim2real.py\`.

## Test coverage

45 new cases in \`.claude/skills/sim2real-bootstrap/tests/test_byo.py\`:

- **Happy path.** 2-algorithm run; every artifact at its canonical destination; emitted \`transfer.yaml\` validates via \`pipeline/lib/manifest.load_manifest\`; every algorithm entry has \`byo: true\` and no \`source\`; no \`component:\`; \`defaults.disable\` matches sorted stems of \`templates/defaults/*.yaml\` (regex-matched, not hardcoded); emitted register command's triples parse via the actual register CLI argparser.
- **Every enumerated error path** from the acceptance criteria: missing \`--baseline\`, no \`--algorithm\`, algorithm without image, algorithm without config, duplicate names, missing/empty workloads dir, malformed YAML (baseline + overlay), non-mapping-root YAML (list, scalar, empty), multi-document YAML, missing paths, source symlink to non-regular target, destination-parent symlink escaping \`<exp-root>\`, existing destination without \`--force\` in non-interactive mode.
- **Non-interactive dispatch.** Auto-enabled when stdin is not a TTY; explicit \`--non-interactive\` also works when stdin IS a TTY.
- **\`--force\`** overwrites existing destinations.
- **Args-vs-NL parse equivalence** — asserts \`parse_args_dict\` produces the same dict for structured args and NL-derived argv.
- **Path safety with shell metacharacters** — spaces, \`\$\`, backticks, \`;\` in paths — emitted command round-trips through \`shlex.split\`.
- **Name validation** — uppercase, underscores, leading/trailing hyphens, too long, reserved names.
- **Scenario derivation** — README header, basename fallback, override, normalization, 40-char truncation, empty-after-normalize fatal.
- **BLIS regression** — \`generate_from_config\` still importable; existing \`test_generate_from_config.py\` continues passing.

Full CI suite: 594 passed, 1 skipped. \`ruff check pipeline/ .claude/skills/ --select F\` clean.

## Reviewer attention

- \`byo.py:_check_dest_inside\` — the containment check uses \`os.path.realpath\` on the destination *parent*, then appends the basename. This handles not-yet-existing destinations correctly (realpath resolves the deepest existing prefix). Test \`test_error_dest_parent_symlink_escaping_exp_root\` exercises the failure mode.
- \`byo.py:_atomic_copy_file\` — writes to a sibling temp file (same dir → same filesystem → atomic \`os.replace\`). Never leaves a half-written file on crash.
- SKILL.md dispatch prose says "if any of \`--byo\`, \`--baseline\`, …". If \`\$ARGUMENTS\` starts with a positional path AND has none of the BYO flags, we stay in BLIS mode — matching current behavior.
- The emitted \`transfer.yaml\` serializes multi-line strings (e.g. \`context.text\`) with PyYAML's default block style. Cosmetic; consumers only care about the parsed value.

## Sweep for stale references

Ran \`grep -rn "sim2real-bootstrap"\` across \`.md\`, \`.py\`, \`.yaml\`, \`.yml\`. Notable hits:
- \`README.md\` — updated (added \`--byo\` line).
- \`pipeline/README.md\` — updated (added \`--byo\` line in the register section).
- \`.claude/skills/sim2real-bootstrap/SKILL.md\` — updated (new dispatch + \`--byo\` section).
- \`CLAUDE.md\` — only references the test directory; still accurate.
- \`docs/troubleshooting.md\` — talks about \`templates/defaults/\` copy behavior; behavior applies to BYO too, still accurate.
- \`docs/epics/step-4/design.md\` — the canonical source; unchanged.
- \`docs/proposals/*.md\` — historical planning docs; unchanged.
- \`docs/superpowers/plans/*.md\` — historical plans; unchanged.

## Test plan

- [x] \`python -m pytest .claude/skills/sim2real-bootstrap/tests/\` — 61 passed, 1 skipped.
- [x] Full CI-equivalent suite — 594 passed, 1 skipped.
- [x] \`ruff check pipeline/ .claude/skills/ --select F\` — clean.
- [x] End-to-end smoke: ran \`byo.py\` against a synthetic experiment; verified all files created at canonical locations; verified emitted \`transfer.yaml\` loads via \`manifest.load_manifest\`; verified emitted register command's triples parse via \`_parse_algorithm_triple\`.

Closes #499