### PR TITLE
transfer.yaml: emit `# Available fragments` comment near `defaults.disable`

### DIFF
--- a/.claude/skills/sim2real-bootstrap/SKILL.md
+++ b/.claude/skills/sim2real-bootstrap/SKILL.md
@@ -349,11 +349,25 @@ context:
 defaults:
   disable: []
   # Available fragments (filename stems in baselines/defaults/):
+  #   - epp-verbosity
+  #   - externally-managed-gateway
   #   - llm-d-rbac
   #   - preserve-request-id
-  #   - epp-verbosity
-  #   - vllm-logging
   #   - routing-proxy-resources
+  #   - vllm-logging
+```
+
+The `# Available fragments` comment lists every YAML filename stem currently in
+`<experiment-root>/baselines/defaults/` (populated by Task 4b from
+`templates/defaults/`). Regenerate the list from what actually got copied — do
+NOT copy the enumeration above verbatim if `templates/defaults/` has changed
+since this SKILL.md was written:
+
+```bash
+ls "$EXPERIMENT_ROOT/baselines/defaults/"*.yaml \
+    | xargs -n1 basename \
+    | sed 's/\.yaml$//' \
+    | sort
 ```
 
 **Constraints:**

--- a/.claude/skills/sim2real-bootstrap/byo.py
+++ b/.claude/skills/sim2real-bootstrap/byo.py
@@ -613,11 +613,74 @@ def build_transfer_yaml(
     }
 
 
+def _inject_available_fragments_comment(yaml_text: str, available_stems: list[str]) -> str:
+    """Insert an ``# Available fragments`` comment block after ``defaults.disable``.
+
+    PyYAML's ``safe_dump`` cannot emit comments, but the operator-facing
+    ``transfer.yaml`` should document which filename stems live in
+    ``baselines/defaults/`` so a reader knows what values are legal in the
+    ``defaults.disable`` list. This helper post-processes the serialized YAML
+    text: it locates the ``defaults.disable`` block and inserts one
+    ``# Available fragments…`` comment plus one ``#   - <stem>`` per fragment
+    immediately after the list.
+
+    Idempotent-safe against re-invocation only in the sense that the caller
+    controls ``yaml_text`` — we do not deduplicate an existing comment block.
+    Callers pass freshly-serialized YAML.
+    """
+    if not available_stems:
+        return yaml_text
+    comment_lines = [
+        "  # Available fragments (filename stems in baselines/defaults/):",
+    ] + [f"  #   - {stem}" for stem in sorted(available_stems)]
+
+    lines = yaml_text.split("\n")
+    # Find the ``disable:`` line under a top-level ``defaults:`` key. YAML
+    # emitted by safe_dump with sort_keys=False + default_flow_style=False
+    # produces predictable indentation: top-level keys at column 0, nested
+    # keys at 2-space indent.
+    disable_idx = -1
+    in_defaults = False
+    for i, line in enumerate(lines):
+        if line == "defaults:" or line.startswith("defaults:"):
+            in_defaults = True
+            continue
+        if in_defaults:
+            if line.startswith("  disable:"):
+                disable_idx = i
+                break
+            if line and not line.startswith(" "):
+                # Left the defaults block before finding disable — nothing to do.
+                return yaml_text
+    if disable_idx < 0:
+        return yaml_text
+
+    # Walk forward from disable_idx: the list ends at the first line that is
+    # neither blank nor indented with ``  -`` / ``  `` at 2+ spaces where the
+    # first non-space char is ``-``.
+    list_end = disable_idx
+    for j in range(disable_idx + 1, len(lines)):
+        line = lines[j]
+        if line.startswith("  - "):
+            list_end = j
+            continue
+        # Any other line — top-level key, blank line, or unindented content —
+        # ends the list.
+        break
+    else:
+        list_end = len(lines) - 1
+
+    lines[list_end + 1:list_end + 1] = comment_lines
+    return "\n".join(lines)
+
+
 def write_transfer_yaml(exp_root: Path, doc: dict, force: bool, non_interactive: bool) -> Path:
     """Serialize doc and write atomically to ``<exp-root>/transfer.yaml``."""
     dst = _check_dest_inside(exp_root / "transfer.yaml", exp_root)
     _decide_dest(dst, force, non_interactive)
     text = yaml.safe_dump(doc, sort_keys=False, default_flow_style=False)
+    available_stems = list(doc.get("defaults", {}).get("disable") or [])
+    text = _inject_available_fragments_comment(text, available_stems)
     dst.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_name = tempfile.mkstemp(
         prefix=dst.name + ".", suffix=".tmp", dir=str(dst.parent)

--- a/.claude/skills/sim2real-bootstrap/tests/test_byo.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_byo.py
@@ -715,6 +715,73 @@ def test_defaults_disable_matches_template_stems(bare_exp_root, operator_files):
     assert manifest["defaults"]["disable"] == expected
 
 
+def test_transfer_yaml_carries_available_fragments_comment(bare_exp_root, operator_files):
+    """The emitted transfer.yaml text documents the fragment inventory as a comment
+    block immediately after `defaults.disable`. Stems match sorted templates/defaults/*.yaml
+    (regex-matched, not hardcoded — future additions don't require a test edit)."""
+    code, _ = byo.run_byo(
+        _happy_argv(operator_files), bare_exp_root, _SKILL_DIR, stdin_isatty=False
+    )
+    assert code == 0
+    text = (bare_exp_root / "transfer.yaml").read_text()
+    expected_stems = sorted(
+        p.stem for p in (_SKILL_DIR / "templates" / "defaults").glob("*.yaml")
+    )
+
+    # Header comment appears
+    assert "# Available fragments (filename stems in baselines/defaults/):" in text
+
+    # One `#   - <stem>` line per available stem
+    for stem in expected_stems:
+        assert f"#   - {stem}" in text, f"missing stem comment for {stem}"
+
+    # Header appears AFTER `defaults.disable` list and BEFORE the next
+    # top-level key (`context:`) — protects against a regression that would
+    # place it in the wrong section.
+    lines = text.split("\n")
+    header_idx = next(
+        i for i, ln in enumerate(lines)
+        if "Available fragments" in ln
+    )
+    disable_idx = next(i for i, ln in enumerate(lines) if ln == "  disable:")
+    context_idx = next(i for i, ln in enumerate(lines) if ln == "context:")
+    assert disable_idx < header_idx < context_idx
+
+
+def test_inject_available_fragments_comment_no_op_on_empty(tmp_path):
+    """Empty available_stems list: helper is a no-op (nothing to document)."""
+    yaml_text = "defaults:\n  disable: []\nother: 1\n"
+    result = byo._inject_available_fragments_comment(yaml_text, [])
+    assert result == yaml_text
+
+
+def test_inject_available_fragments_comment_sorts_input():
+    """Even if the caller passes an unsorted list, comment stems come out sorted."""
+    yaml_text = "defaults:\n  disable:\n  - b\n  - a\n  - c\ncontext: {}\n"
+    result = byo._inject_available_fragments_comment(yaml_text, ["c", "a", "b"])
+    # Expected order: a, b, c
+    a_idx = result.index("#   - a")
+    b_idx = result.index("#   - b")
+    c_idx = result.index("#   - c")
+    assert a_idx < b_idx < c_idx
+
+
+def test_inject_available_fragments_comment_does_not_break_yaml_parse():
+    """After injection, yaml.safe_load must still parse the text to the same dict
+    (comments are semantically transparent, but this guards against accidental
+    corruption of the surrounding list)."""
+    original_doc = {
+        "kind": "sim2real-transfer",
+        "version": 3,
+        "defaults": {"disable": ["one", "two"]},
+        "context": {"files": []},
+    }
+    yaml_text = yaml.safe_dump(original_doc, sort_keys=False, default_flow_style=False)
+    injected = byo._inject_available_fragments_comment(yaml_text, ["one", "two"])
+    reparsed = yaml.safe_load(injected)
+    assert reparsed == original_doc
+
+
 # ---------------------------------------------------------------------------
 # Workload enumeration
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Emit an `# Available fragments (filename stems in baselines/defaults/):` comment block near `defaults.disable` in every generated `transfer.yaml`, so a reader can see the legal values without cross-referencing `baselines/defaults/` by hand.

Two producers fixed:
1. **BYO mode** (`.claude/skills/sim2real-bootstrap/byo.py`) — before this PR, `yaml.safe_dump` output had no comments at all.
2. **BLIS-mode template** (`.claude/skills/sim2real-bootstrap/SKILL.md` Task 5) — had the block but it was stale (5 stems in ad-hoc order; `templates/defaults/` today has 6 including `externally-managed-gateway`).

Closes #507.

## Approach

`byo.py`: added `_inject_available_fragments_comment(yaml_text, available_stems)` that finds the `defaults.disable` list in the safe_dump output and injects the comment block right after it, before the next top-level key. Called from `write_transfer_yaml`. Text-level post-processing rather than a YAML-library-with-comment-support switch — keeps the dependency footprint the same (PyYAML only, no `ruamel.yaml`).

Round-trip safety: after injection, `yaml.safe_load(text)` still returns the same dict (asserted in `test_inject_available_fragments_comment_does_not_break_yaml_parse`), and `pipeline/lib/manifest.load_manifest` accepts the output.

SKILL.md: refreshed the Task 5 example to list all 6 current fragments alphabetized, and added a one-line snippet showing how to regenerate the enumeration (`ls baselines/defaults/*.yaml | ...`) so future operators aren't tempted to copy a possibly-stale hand-written list.

## Tests

`.claude/skills/sim2real-bootstrap/tests/test_byo.py` — 4 new cases:
- Emitted `transfer.yaml` contains the header comment and one `#   - <stem>` line per file in `templates/defaults/`, block positioned between `defaults.disable` and `context:`.
- Helper is a no-op on empty stem list.
- Helper sorts input regardless of caller-supplied order.
- Injected YAML text still `yaml.safe_load`s to the same dict as the pre-injection text.

Stems are regex-matched against `templates/defaults/` — future additions to that directory don't require test edits.

Full CI-equivalent suite: **598 passed, 1 skipped**. `ruff check pipeline/ .claude/skills/ --select F`: **clean**.

## Reviewer attention

- `_inject_available_fragments_comment` parses safe_dump's line format. If PyYAML's default emission style ever changes (e.g. adopts flow style for lists or a different indent), the helper falls through to `return yaml_text` unchanged — a silent no-op. That's a soft-fail path worth knowing about; the round-trip test would still pass but the comment wouldn't appear. The alternative (hard-fail with an assertion) felt too brittle for a documentation feature.
- The BLIS-mode SKILL.md refresh is prose-only — the LLM rendering the template into a real `transfer.yaml` will produce whatever is transcribed. No enforcement mechanism for BLIS-mode staleness beyond the refreshed example + the regeneration snippet.

## Test plan

- [x] `python -m pytest .claude/skills/sim2real-bootstrap/tests/test_byo.py -v` → 49 passed, 1 skipped.
- [x] Full CI-equivalent suite → 598 passed, 1 skipped.
- [x] `ruff check pipeline/ .claude/skills/ --select F` → clean.
- [x] Smoke: ran `byo.run_byo` against a synthetic experiment; inspected emitted `transfer.yaml` — comment block appears in the expected location; `yaml.safe_load` round-trips.