### PR TITLE
pairkey: parser module + _load_pairs iteration integration (#509)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,8 @@ jobs:
             pipeline/tests/test_translation_ref.py \
             pipeline/tests/test_translate.py \
             pipeline/tests/test_build.py \
+            pipeline/tests/test_pairkey.py \
+            pipeline/tests/test_load_pairs.py \
             .claude/skills/sim2real-analyze/tests/ \
             .claude/skills/sim2real-bootstrap/tests/ \
             .claude/skills/sim2real-translate/tests/ \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,8 @@ python -m pytest pipeline/ \
   pipeline/tests/test_translation_ref.py \
   pipeline/tests/test_translate.py \
   pipeline/tests/test_build.py \
+  pipeline/tests/test_pairkey.py \
+  pipeline/tests/test_load_pairs.py \
   .claude/skills/sim2real-analyze/tests/ \
   .claude/skills/sim2real-bootstrap/tests/ \
   .claude/skills/sim2real-translate/tests/ \

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -51,6 +51,7 @@ def _c(code: str, text: str) -> str:
 
 from pipeline.lib import build, cluster_ops, layout
 from pipeline.lib.log import info, ok, warn, err
+from pipeline.lib.pairkey import parse_pair_key
 from pipeline.lib.redact import redact_yaml_file, redact_yaml_tree
 
 
@@ -1870,10 +1871,41 @@ def _load_pairs(cluster_dir: Path) -> dict:
     """Discover all (workload, package) pairs from pipelinerun-*.yaml at cluster/ root.
 
     Returns dict keyed by "wl-" + filename stem (minus "pipelinerun-" prefix).
+    Thin wrapper over ``_load_pairs_with_errors``; the malformed-key count is
+    discarded here. Callers that need the count should call
+    ``_load_pairs_with_errors`` directly.
     """
-    pairs = {}
+    pairs, _ = _load_pairs_with_errors(cluster_dir)
+    return pairs
+
+
+def _load_pairs_with_errors(cluster_dir: Path) -> tuple[dict, int]:
+    """Discover pairs and report how many keys did not match the new grammar.
+
+    Returns ``(pairs, malformed_count)``. ``pairs`` has the same dict shape as
+    ``_load_pairs`` returns. ``malformed_count`` counts pair keys whose
+    filename-derived string does not parse under the canonical grammar
+    (see ``pipeline/lib/pairkey.py``).
+
+    Entries whose key parses gain an ``iteration`` field (int, >= 1).
+    Legacy keys without an ``|iN`` suffix parse as ``iteration=1``.
+
+    Deviation from the design's literal loader-layer policy (drop with
+    WARN): during the step-5 rollout, PR 2 (``assemble`` filename
+    reshape) has not yet landed, so on-disk filenames still produce
+    keys that fail the new grammar (e.g. ``wl-smoke-baseline``
+    from ``pipelinerun-smoke-baseline.yaml``). Dropping them here would
+    break every downstream command until PR 2 lands and existing runs
+    are re-assembled. Instead this loader keeps the entry (without an
+    ``iteration`` field) and reports the count so operators — and, in a
+    later PR, ``_cmd_status`` — can surface it. Once PR 2 lands and
+    runs are re-assembled, ``malformed_count`` should trend to zero and
+    the WARN/drop semantics can be tightened without behavior change.
+    """
+    pairs: dict = {}
+    malformed_count = 0
     if not cluster_dir.exists():
-        return pairs
+        return pairs, malformed_count
     for pr_path in sorted(cluster_dir.glob("pipelinerun-*.yaml")):
         try:
             pr_data = yaml.safe_load(pr_path.read_text())
@@ -1882,7 +1914,7 @@ def _load_pairs(cluster_dir: Path) -> dict:
             workload = params.get("workloadName", "")
             package = params.get("phase", "")
             key = "wl-" + pr_path.stem.removeprefix("pipelinerun-")
-            pairs[key] = {
+            entry: dict = {
                 "workload": workload,
                 "package": package,
                 "pr_name": pr_name,
@@ -1890,10 +1922,17 @@ def _load_pairs(cluster_dir: Path) -> dict:
                 "namespace": pr_data.get("metadata", {}).get("namespace", ""),
                 "scenario_content": params.get("scenarioContent"),
             }
+            try:
+                parts = parse_pair_key(key)
+            except ValueError:
+                malformed_count += 1
+            else:
+                entry["iteration"] = parts.iteration
+            pairs[key] = entry
         except Exception as e:
             warn(f"Skipping {pr_path.name}: {e}")
             continue
-    return pairs
+    return pairs, malformed_count
 
 
 def _uninstall_orphaned_helm(key: str, namespace: str) -> None:

--- a/pipeline/lib/pairkey.py
+++ b/pipeline/lib/pairkey.py
@@ -1,0 +1,133 @@
+"""Pair-key parser for the sim2real ConfigMap key model (step-5).
+
+Grammar (canonical form):
+
+    pair_key := "wl-" workload "|" package [ "|" iter ]
+    workload := [a-z0-9]([a-z0-9-]*[a-z0-9])?     # kebab-case, no leading/trailing hyphen
+    package  := [a-z0-9]([a-z0-9-]*[a-z0-9])?     # same as workload
+    iter     := "i" [1-9][0-9]*                   # positive decimal, no leading zeros
+
+The ``wl-`` prefix is a literal marker, not part of the workload name;
+``PairKeyParts.workload`` stores the workload without it. Metadata keys
+(``_meta``, ``_notes``) are not pair keys and must be filtered out
+upstream (typically via ``deploy._is_pair_key``) before parsing.
+
+Legacy pair keys (no ``|iN`` suffix) parse as ``iteration=1``. The
+canonical rendering emitted by ``PairKeyParts.to_key`` always includes
+the ``|iN`` suffix — legacy input round-trips to a canonical form.
+
+Malformed keys raise ``ValueError`` with a message naming the offending
+key. Callers that want tolerance (e.g. ``deploy._load_pairs``) wrap
+``parse_pair_key`` in a try/except.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+_IDENT = r"[a-z0-9](?:[a-z0-9-]*[a-z0-9])?"
+_ITER_SUFFIX = r"i[1-9][0-9]*"
+_PAIR_KEY_RE = re.compile(
+    rf"^wl-(?P<workload>{_IDENT})\|(?P<package>{_IDENT})(?:\|(?P<iter>{_ITER_SUFFIX}))?$"
+)
+
+
+@dataclass(frozen=True)
+class PairKeyParts:
+    """Structural view of a canonical pair key.
+
+    ``workload`` and ``package`` are kebab-case identifiers with no
+    ``wl-`` prefix and no leading/trailing hyphens. ``iteration`` is a
+    positive integer (>= 1). Legacy keys without an ``|iN`` suffix
+    parse to ``iteration=1``.
+    """
+
+    workload: str
+    package: str
+    iteration: int
+
+    def to_key(self) -> str:
+        """Reconstruct the canonical pair-key string.
+
+        Always emits the ``|iN`` suffix, even for iteration 1. This
+        normalizes legacy input to the canonical form.
+        """
+        return f"wl-{self.workload}|{self.package}|i{self.iteration}"
+
+
+def parse_pair_key(key: str) -> PairKeyParts:
+    """Parse ``key`` per the grammar above.
+
+    Legacy keys (no ``|iN`` suffix) parse as ``iteration=1``. Raises
+    ``ValueError`` with a message naming ``key`` on any grammar
+    violation (empty parts, uppercase characters, embedded ``|``
+    inside a component, ``i0`` or ``i01`` iteration, missing ``wl-``
+    prefix, extra segments).
+
+    Callers should filter metadata keys (``_meta``, ``_notes``) with a
+    predicate such as ``deploy._is_pair_key`` before calling this.
+    """
+    if not isinstance(key, str):
+        raise ValueError(f"malformed pair key {key!r}: expected str")
+    m = _PAIR_KEY_RE.match(key)
+    if not m:
+        raise ValueError(f"malformed pair key {key!r}: does not match grammar")
+    iter_group = m.group("iter")
+    iteration = int(iter_group[1:]) if iter_group else 1
+    return PairKeyParts(
+        workload=m.group("workload"),
+        package=m.group("package"),
+        iteration=iteration,
+    )
+
+
+def parse_iteration_spec(spec: str) -> set[int]:
+    """Parse an ``--iteration`` filter spec into a set of iteration ints.
+
+    Supported syntax (list + range):
+
+        "2"        -> {2}
+        "1,3"      -> {1, 3}
+        "1-3"      -> {1, 2, 3}
+        "1,3-5"    -> {1, 3, 4, 5}
+
+    Whitespace around commas and hyphens is tolerated. Raises
+    ``ValueError`` on empty spec, non-positive integers (``0``,
+    negative), reversed ranges (``5-1``), non-integer tokens (``abc``),
+    or malformed tokens (leading zeros, empty range endpoint).
+    """
+    if not isinstance(spec, str):
+        raise ValueError(f"malformed iteration spec {spec!r}: expected str")
+    stripped = spec.strip()
+    if not stripped:
+        raise ValueError(f"malformed iteration spec {spec!r}: empty")
+    result: set[int] = set()
+    for token in stripped.split(","):
+        token = token.strip()
+        if not token:
+            raise ValueError(f"malformed iteration spec {spec!r}: empty token")
+        if "-" in token:
+            parts = [p.strip() for p in token.split("-")]
+            if len(parts) != 2 or not parts[0] or not parts[1]:
+                raise ValueError(f"malformed iteration spec {spec!r}: bad range {token!r}")
+            lo = _parse_positive_int(parts[0], spec)
+            hi = _parse_positive_int(parts[1], spec)
+            if lo > hi:
+                raise ValueError(f"malformed iteration spec {spec!r}: reversed range {token!r}")
+            result.update(range(lo, hi + 1))
+        else:
+            result.add(_parse_positive_int(token, spec))
+    return result
+
+
+def _parse_positive_int(token: str, spec: str) -> int:
+    """Parse a positive decimal integer with no leading zeros.
+
+    ``spec`` is the caller's full spec string, quoted verbatim in error
+    messages so operators can trace the offending input.
+    """
+    if not re.fullmatch(r"[1-9][0-9]*", token):
+        raise ValueError(f"malformed iteration spec {spec!r}: bad integer {token!r}")
+    return int(token)

--- a/pipeline/tests/test_load_pairs.py
+++ b/pipeline/tests/test_load_pairs.py
@@ -1,0 +1,157 @@
+"""Tests for the parser-aware behavior of pipeline.deploy._load_pairs.
+
+Covers the step-5 PR 1 integration: iteration field on entries whose key
+parses under the new grammar; malformed_count on the ``_load_pairs_with_errors``
+variant for keys that don't parse. Existing round-trip coverage of the
+YAML-reading side of ``_load_pairs`` lives in ``test_deploy_run.py``.
+"""
+
+import yaml as _yaml
+
+
+def _write_pr(cluster_dir, filename, *, workload, package):
+    """Write a minimal pipelinerun-*.yaml at cluster_dir/filename."""
+    pr = {
+        "apiVersion": "tekton.dev/v1",
+        "kind": "PipelineRun",
+        "metadata": {"name": f"{package}-{workload}-run1", "namespace": "sim2real-0"},
+        "spec": {"params": [
+            {"name": "workloadName", "value": f"wl-{workload}"},
+            {"name": "phase", "value": package},
+        ]},
+    }
+    (cluster_dir / filename).write_text(_yaml.dump(pr))
+
+
+class TestLoadPairsIterationField:
+    """Entries whose key parses under the new grammar gain an iteration field."""
+
+    def test_new_shape_legacy_iteration_1(self, tmp_path):
+        """New-shape pipe-separated filename (no |iN) → iteration=1."""
+        from pipeline.deploy import _load_pairs
+        _write_pr(tmp_path, "pipelinerun-chat-mid|sim2real-ac.yaml",
+                  workload="chat-mid", package="sim2real-ac")
+
+        pairs = _load_pairs(tmp_path)
+
+        assert "wl-chat-mid|sim2real-ac" in pairs
+        assert pairs["wl-chat-mid|sim2real-ac"]["iteration"] == 1
+
+    def test_new_shape_with_suffix(self, tmp_path):
+        """|iN suffix parses to that iteration."""
+        from pipeline.deploy import _load_pairs
+        _write_pr(tmp_path, "pipelinerun-chat-mid|sim2real-ac|i3.yaml",
+                  workload="chat-mid", package="sim2real-ac")
+
+        pairs = _load_pairs(tmp_path)
+
+        assert pairs["wl-chat-mid|sim2real-ac|i3"]["iteration"] == 3
+
+    def test_legacy_dash_shape_no_iteration_field(self, tmp_path):
+        """Legacy dash-separated filename → key does not parse → no iteration field.
+
+        Entry is still returned so downstream commands keep working during
+        the multi-PR rollout. PR 2 aligns filename shape to pipe-separated;
+        at that point the iteration field will always be populated.
+        """
+        from pipeline.deploy import _load_pairs
+        _write_pr(tmp_path, "pipelinerun-smoke-baseline.yaml",
+                  workload="smoke", package="baseline")
+
+        pairs = _load_pairs(tmp_path)
+
+        assert "wl-smoke-baseline" in pairs
+        assert "iteration" not in pairs["wl-smoke-baseline"]
+
+    def test_existing_fields_preserved(self, tmp_path):
+        """workload/package/pr_name/pr_path/namespace/scenario_content unchanged."""
+        from pipeline.deploy import _load_pairs
+        _write_pr(tmp_path, "pipelinerun-chat|pkg.yaml",
+                  workload="chat", package="pkg")
+
+        pairs = _load_pairs(tmp_path)
+        entry = pairs["wl-chat|pkg"]
+
+        assert entry["workload"] == "wl-chat"
+        assert entry["package"] == "pkg"
+        assert entry["pr_name"] == "pkg-chat-run1"
+        assert entry["namespace"] == "sim2real-0"
+        assert entry["pr_path"].endswith("pipelinerun-chat|pkg.yaml")
+
+
+class TestLoadPairsWithErrors:
+    """The variant returns (pairs, malformed_count) with the correct count."""
+
+    def test_empty_cluster_dir_returns_zero(self, tmp_path):
+        """No pipelinerun files → empty dict, zero malformed."""
+        from pipeline.deploy import _load_pairs_with_errors
+        pairs, malformed = _load_pairs_with_errors(tmp_path)
+        assert pairs == {}
+        assert malformed == 0
+
+    def test_missing_cluster_dir_returns_zero(self, tmp_path):
+        """Non-existent directory → empty dict, zero malformed."""
+        from pipeline.deploy import _load_pairs_with_errors
+        pairs, malformed = _load_pairs_with_errors(tmp_path / "nope")
+        assert pairs == {}
+        assert malformed == 0
+
+    def test_all_new_shape_zero_malformed(self, tmp_path):
+        """New-shape keys parse cleanly → malformed=0."""
+        from pipeline.deploy import _load_pairs_with_errors
+        _write_pr(tmp_path, "pipelinerun-chat|pkg.yaml", workload="chat", package="pkg")
+        _write_pr(tmp_path, "pipelinerun-load|treatment.yaml",
+                  workload="load", package="treatment")
+
+        pairs, malformed = _load_pairs_with_errors(tmp_path)
+
+        assert len(pairs) == 2
+        assert malformed == 0
+        assert all("iteration" in v for v in pairs.values())
+
+    def test_all_legacy_shape_counts_all(self, tmp_path):
+        """All dash-separated legacy keys → malformed count matches file count."""
+        from pipeline.deploy import _load_pairs_with_errors
+        _write_pr(tmp_path, "pipelinerun-smoke-baseline.yaml",
+                  workload="smoke", package="baseline")
+        _write_pr(tmp_path, "pipelinerun-load-treatment.yaml",
+                  workload="load", package="treatment")
+
+        pairs, malformed = _load_pairs_with_errors(tmp_path)
+
+        assert len(pairs) == 2
+        assert malformed == 2
+        assert all("iteration" not in v for v in pairs.values())
+
+    def test_mixed_shape_partial_count(self, tmp_path):
+        """Mixed new + legacy keys → malformed matches only the legacy ones."""
+        from pipeline.deploy import _load_pairs_with_errors
+        _write_pr(tmp_path, "pipelinerun-chat|pkg.yaml", workload="chat", package="pkg")
+        _write_pr(tmp_path, "pipelinerun-load-treatment.yaml",
+                  workload="load", package="treatment")
+
+        pairs, malformed = _load_pairs_with_errors(tmp_path)
+
+        assert len(pairs) == 2
+        assert malformed == 1
+        assert pairs["wl-chat|pkg"]["iteration"] == 1
+        assert "iteration" not in pairs["wl-load-treatment"]
+
+    def test_corrupt_yaml_not_counted_as_malformed_key(self, tmp_path, capsys):
+        """YAML-parse failure is a file-level skip, not a grammar violation.
+
+        Historical behavior (pre-step-5) skips such files with a WARN;
+        the new malformed_count is strictly key-grammar, so YAML crashes
+        do not increment it.
+        """
+        from pipeline.deploy import _load_pairs_with_errors
+        (tmp_path / "pipelinerun-bad.yaml").write_text("{{invalid yaml: [")
+        _write_pr(tmp_path, "pipelinerun-chat|pkg.yaml", workload="chat", package="pkg")
+
+        pairs, malformed = _load_pairs_with_errors(tmp_path)
+
+        assert list(pairs.keys()) == ["wl-chat|pkg"]
+        assert malformed == 0
+        out = capsys.readouterr().out
+        assert "pipelinerun-bad.yaml" in out
+        assert "[WARN]" in out

--- a/pipeline/tests/test_pairkey.py
+++ b/pipeline/tests/test_pairkey.py
@@ -1,0 +1,185 @@
+"""Tests for pipeline/lib/pairkey.py — grammar parser and iteration-spec parser."""
+
+import pytest
+
+from pipeline.lib.pairkey import (
+    PairKeyParts,
+    parse_iteration_spec,
+    parse_pair_key,
+)
+
+
+# ── parse_pair_key ─────────────────────────────────────────────────────────
+
+
+class TestParsePairKeyLegacy:
+    """Legacy pair keys (no |iN suffix) parse as iteration=1."""
+
+    def test_simple_legacy(self):
+        assert parse_pair_key("wl-chat-mid|sim2real-ac") == PairKeyParts(
+            workload="chat-mid", package="sim2real-ac", iteration=1
+        )
+
+    def test_single_char_identifiers(self):
+        assert parse_pair_key("wl-a|b") == PairKeyParts(
+            workload="a", package="b", iteration=1
+        )
+
+    def test_digits_in_identifiers(self):
+        assert parse_pair_key("wl-chat-70b|pkg-v2") == PairKeyParts(
+            workload="chat-70b", package="pkg-v2", iteration=1
+        )
+
+
+class TestParsePairKeyWithSuffix:
+    """Pair keys with |iN suffix parse to that iteration."""
+
+    def test_i1(self):
+        assert parse_pair_key("wl-chat-mid|sim2real-ac|i1") == PairKeyParts(
+            workload="chat-mid", package="sim2real-ac", iteration=1
+        )
+
+    def test_i3(self):
+        assert parse_pair_key("wl-chat-mid|sim2real-ac|i3") == PairKeyParts(
+            workload="chat-mid", package="sim2real-ac", iteration=3
+        )
+
+    def test_i10(self):
+        parts = parse_pair_key("wl-foo|bar|i10")
+        assert parts.iteration == 10
+
+    def test_i100(self):
+        parts = parse_pair_key("wl-foo|bar|i100")
+        assert parts.iteration == 100
+
+
+class TestParsePairKeyGrammarViolations:
+    """Malformed keys raise ValueError naming the offending key."""
+
+    @pytest.mark.parametrize(
+        "bad_key",
+        [
+            "wl-Chat-mid|pkg",        # uppercase in workload
+            "wl-chat-mid|Pkg",        # uppercase in package
+            "wl-chat|pkg|I1",         # uppercase iteration marker
+            "wl-chat|pkg|i01",        # leading zero in iteration
+            "wl-chat|pkg|i0",         # zero iteration (must be >= 1)
+            "wl-chat|pkg|i",          # missing iteration number
+            "wl-chat|pkg|1",          # missing "i" prefix on iteration
+            "wl-|pkg",                # empty workload
+            "wl-chat|",               # empty package
+            "chat-mid|pkg",           # missing "wl-" prefix
+            "wl-chat-mid",            # missing package
+            "wl-chat|pkg|i1|extra",   # trailing segment
+            "wl-chat|pkg|i1|",        # trailing pipe
+            "wl-chat||pkg",           # empty middle segment
+            "wl--chat|pkg",           # leading hyphen after wl-
+            "wl-chat-|pkg",           # trailing hyphen in workload
+            "wl-chat|-pkg",           # leading hyphen in package
+            "wl-chat|pkg-",           # trailing hyphen in package
+            "",                       # empty string
+            "wl-",                    # prefix only
+            "wl-chat|pkg|i1 ",        # trailing whitespace
+            " wl-chat|pkg",           # leading whitespace
+            "wl-chat.mid|pkg",        # dot in workload
+            "wl-chat_mid|pkg",        # underscore in workload
+        ],
+    )
+    def test_malformed_raises(self, bad_key):
+        with pytest.raises(ValueError) as exc_info:
+            parse_pair_key(bad_key)
+        # Message must name the offending key (verbatim, quoted).
+        assert repr(bad_key) in str(exc_info.value)
+
+    def test_non_string_raises(self):
+        with pytest.raises(ValueError):
+            parse_pair_key(None)  # type: ignore[arg-type]
+        with pytest.raises(ValueError):
+            parse_pair_key(123)  # type: ignore[arg-type]
+
+
+class TestPairKeyPartsToKey:
+    """PairKeyParts.to_key() always emits the canonical |iN suffix."""
+
+    def test_iteration_1_gets_suffix(self):
+        parts = PairKeyParts(workload="chat-mid", package="pkg", iteration=1)
+        assert parts.to_key() == "wl-chat-mid|pkg|i1"
+
+    def test_iteration_5(self):
+        parts = PairKeyParts(workload="foo", package="bar", iteration=5)
+        assert parts.to_key() == "wl-foo|bar|i5"
+
+    def test_round_trip_legacy_normalizes(self):
+        """Legacy input normalizes to canonical form via to_key()."""
+        parts = parse_pair_key("wl-chat|pkg")
+        assert parts.to_key() == "wl-chat|pkg|i1"
+
+    def test_round_trip_suffixed(self):
+        parts = parse_pair_key("wl-chat|pkg|i7")
+        assert parts.to_key() == "wl-chat|pkg|i7"
+
+
+# ── parse_iteration_spec ────────────────────────────────────────────────────
+
+
+class TestParseIterationSpecValid:
+    """Valid list + range syntax parses correctly."""
+
+    def test_single_value(self):
+        assert parse_iteration_spec("2") == {2}
+
+    def test_list(self):
+        assert parse_iteration_spec("1,3") == {1, 3}
+
+    def test_range(self):
+        assert parse_iteration_spec("1-3") == {1, 2, 3}
+
+    def test_mixed(self):
+        assert parse_iteration_spec("1,3-5") == {1, 3, 4, 5}
+
+    def test_overlapping_deduplicates(self):
+        assert parse_iteration_spec("1-3,2-4") == {1, 2, 3, 4}
+
+    def test_whitespace_tolerated(self):
+        assert parse_iteration_spec("1, 3-5") == {1, 3, 4, 5}
+        assert parse_iteration_spec(" 2 ") == {2}
+        assert parse_iteration_spec("1 - 3") == {1, 2, 3}
+
+    def test_range_single_point(self):
+        assert parse_iteration_spec("4-4") == {4}
+
+
+class TestParseIterationSpecInvalid:
+    """Malformed specs raise ValueError."""
+
+    @pytest.mark.parametrize(
+        "bad_spec",
+        [
+            "0",           # zero not allowed
+            "-1",          # negative
+            "5-1",         # reversed range
+            "abc",         # non-integer
+            "1,abc",       # non-integer in list
+            "01",          # leading zero
+            "1-01",        # leading zero in range endpoint
+            "1-",          # missing hi
+            "-3",          # missing lo (parses as negative single, not range)
+            "1--3",        # double hyphen
+            "1,,3",        # empty middle token
+            ",",           # only comma
+            "",            # empty string
+            "   ",         # whitespace only
+            "1-2-3",       # three-endpoint range
+            "1.5",         # float
+        ],
+    )
+    def test_malformed_raises(self, bad_spec):
+        with pytest.raises(ValueError) as exc_info:
+            parse_iteration_spec(bad_spec)
+        assert repr(bad_spec) in str(exc_info.value)
+
+    def test_non_string_raises(self):
+        with pytest.raises(ValueError):
+            parse_iteration_spec(None)  # type: ignore[arg-type]
+        with pytest.raises(ValueError):
+            parse_iteration_spec(1)  # type: ignore[arg-type]


### PR DESCRIPTION
Closes #509. Foundation PR (PR 1) for the step-5 epic ([#502](https://github.com/inference-sim/sim2real/issues/502)).

## Scope

- **New module** `pipeline/lib/pairkey.py`:
  - `PairKeyParts` frozen dataclass with `workload`, `package`, `iteration`, and `to_key()` (canonical `wl-<workload>|<package>|iN`).
  - `parse_pair_key(key)` — strict per the design grammar; legacy keys without `|iN` suffix parse as `iteration=1`; malformed keys raise `ValueError` with a message naming the offending input.
  - `parse_iteration_spec(spec)` — list + range syntax (`"2"`, `"1,3"`, `"1-3"`, `"1,3-5"`); rejects `0`, negative, reversed ranges, non-integer tokens, and leading zeros.
- **`pipeline/deploy.py`**:
  - `_is_pair_key` unchanged (metadata-exclusion gate).
  - `_load_pairs` refactored to a thin wrapper over `_load_pairs_with_errors` (returns just the pairs dict).
  - `_load_pairs_with_errors(cluster_dir)` → `(pairs, malformed_count)`. Each entry whose filename-derived key parses under the grammar gains an `iteration` field.
- **Tests**: `pipeline/tests/test_pairkey.py` (60 tests) and `pipeline/tests/test_load_pairs.py` (10 tests). CI workflow and CLAUDE.md updated to include both.

`assemble`, `pipeline.yaml`, and user-facing CLI flags are untouched — those land in PRs 2, 3, 4.

## Deviation from the design's literal loader-layer policy — reviewer attention

The step-5 design [§Strand 1](https://github.com/inference-sim/sim2real/blob/refactor/v2-step-5/docs/epics/step-5/design.md#strand-1--pair-key-parser-rework) says `_load_pairs` should drop malformed keys with a WARN and return only valid pairs. Applied literally to the current tree, this would drop every existing pair-key today: `assemble` currently writes `pipelinerun-<wl>-<pkg>.yaml` (dash-separated), which produces keys like `wl-smoke-baseline` that fail the new pipe-separated grammar. Dropping them would break every downstream `deploy.py` command and every test in `test_deploy_run.py`, `test_deploy_pairs.py`, `test_deploy_reset.py`, etc., before PR 2 lands.

This PR keeps unparseable entries in the returned dict (without an `iteration` field) and reports the count via `_load_pairs_with_errors`. Once PR 2 reshapes `assemble` filenames to the new grammar and existing runs are re-assembled, `malformed_count` should trend to zero and the drop-with-WARN semantics from the design can be tightened without behavior change. Rationale is documented inline on `_load_pairs_with_errors`. No per-key WARN is emitted, since it would fire on every legacy key and read as noise until PR 2 lands.

Alternative considered and rejected: update `assemble` in this PR to write pipe-separated filenames. The design explicitly puts that in PR 2 and the epic ordering commits to landing PR 1 first, so I stayed in scope.

## Verification

```
ruff check pipeline/ .claude/skills/ --select F           # All checks passed
python -m pytest pipeline/ ...                            # 1508 passed, 2 xfailed
```

The full CI-equivalent test list (matching `.github/workflows/test.yml`) passes locally, including the 70 new tests.

## Stale-reference sweep

Grepped `pairkey`, `PairKeyParts`, `parse_pair_key`, `parse_iteration_spec`, `_load_pairs_with_errors` across `**/*.md`, `docs/`, `.claude/skills/`, and `README*`. Only hits are inside `docs/epics/step-5/design.md` (source-of-truth spec — I did not retrofit it) and this PR's own files. `pipeline/README.md`'s pair-key section will be updated in PR 6 per the epic's ordering; nothing referring to a pre-parser world goes stale from PR 1.

## Base

Base: `refactor/v2-step-5` (per the epic's `Base:` line).