### PR TITLE
fix(assemble): restore `_align_overlay_name` — kills phantom facebook/opt-125m deployment (#516)

### DIFF
--- a/pipeline/lib/assemble_run.py
+++ b/pipeline/lib/assemble_run.py
@@ -261,6 +261,36 @@ def write_run_metadata(run_dir: Path, meta: dict) -> Path:
     return out
 
 
+def _align_overlay_name(base: dict, overlay: dict) -> dict:
+    """Realign overlay's ``scenario[0].name`` to match base to prevent list-merge duplication.
+
+    The ``deep_merge`` list strategy in ``pipeline/lib/values.py`` picks ``name``
+    as the merge key when every entry on both sides carries it, then merges list
+    items by identity on that key. Framework-default fragments under
+    ``baselines/defaults/*.yaml`` are authored as ``scenario: - name: defaults``
+    (a placeholder — see each fragment's top-of-file comment "scenario[0].name
+    is realigned to the experiment baseline at merge time"). If the baseline
+    entry is named anything other than ``defaults`` (i.e. every real experiment),
+    a naive merge would append the defaults content as a second, unwanted
+    scenario entry — and llm-d-benchmark's templater would then render it as a
+    separate deployment carrying the framework-default model
+    (``facebook/opt-125m``) instead of the intended model. See issue #516.
+
+    Copies the overlay's first scenario name from the base's first scenario name
+    when both are non-empty and differ. Mutates and returns ``overlay``.
+
+    Ported verbatim from ``pipeline/lib/assemble.py:_align_overlay_name`` on
+    ``main`` — dropped by step-2's ``assemble.py`` → ``assemble_run.py`` rename.
+    """
+    base_scenarios = base.get("scenario", [])
+    overlay_scenarios = overlay.get("scenario", [])
+    if base_scenarios and overlay_scenarios:
+        base_name = base_scenarios[0].get("name", "")
+        if base_name and overlay_scenarios[0].get("name", "") != base_name:
+            overlay_scenarios[0]["name"] = base_name
+    return overlay
+
+
 def resolve_baseline(
     *,
     bundle_path: Path,
@@ -273,6 +303,13 @@ def resolve_baseline(
     ``baselines/defaults/`` directory). ``overlay_path`` may be ``None`` or
     point at a non-existent file (BYO baseline without a baseline overlay).
     Bundle is required — a missing bundle raises AssembleError.
+
+    Before the merge, ``framework_defaults[scenario][0].name`` is realigned
+    to the bundle's ``scenario[0].name`` so both sides collapse into a single
+    scenario entry (see ``_align_overlay_name``). Without this, a defaults
+    overlay named ``defaults`` and a baseline named anything else produce two
+    scenario entries — an intended one plus a phantom one that inherits the
+    llm-d-benchmark framework-default model (issue #516).
     """
     if not bundle_path.exists():
         raise AssembleError(f"baseline scenario not found: {bundle_path}")
@@ -282,7 +319,8 @@ def resolve_baseline(
         if overlay_path is not None and overlay_path.exists()
         else {}
     )
-    resolved = deep_merge(copy.deepcopy(framework_defaults), bundle)
+    aligned_defaults = _align_overlay_name(bundle, copy.deepcopy(framework_defaults))
+    resolved = deep_merge(aligned_defaults, bundle)
     resolved = deep_merge(resolved, overlay)
     return resolved
 

--- a/pipeline/tests/test_assemble_run.py
+++ b/pipeline/tests/test_assemble_run.py
@@ -265,6 +265,104 @@ class TestResolveScenarios:
                 framework_defaults={},
             )
 
+    def test_framework_defaults_named_defaults_merge_into_baseline_entry(self, tmp_path):
+        """Regression test for issue #516.
+
+        Framework-default fragments under ``baselines/defaults/*.yaml`` are
+        authored with a placeholder ``scenario[0].name = "defaults"``. When the
+        experiment's baseline entry is named anything else (i.e. every real
+        experiment), the two must still merge into a SINGLE scenario entry —
+        otherwise llm-d-benchmark templates the placeholder as an independent
+        deployment inheriting the framework-default model (facebook/opt-125m).
+
+        Before the fix, ``resolve_baseline`` produced two scenario entries
+        (``[{name: defaults, ...}, {name: <baseline>, ...}]``) and a phantom
+        facebook/opt-125m deployment materialized alongside the intended one.
+        """
+        bundle = {
+            "scenario": [{
+                "name": "sr",
+                "model": {"name": "Qwen/Qwen3-14B", "path": "models/Qwen"},
+                "decode": {"replicas": 2},
+            }],
+        }
+        framework_defaults = {
+            "scenario": [{
+                "name": "defaults",  # placeholder; realigned at merge time
+                "gateway": {"externallyManaged": True},
+                "inferenceExtension": {"verbosity": "5"},
+                "extraObjects": [{"apiVersion": "v1", "kind": "Role",
+                                  "metadata": {"name": "epp-role"}}],
+            }],
+        }
+        bundle_path = tmp_path / "sr.yaml"
+        self._write(bundle_path, bundle)
+
+        resolved = assemble_run.resolve_baseline(
+            bundle_path=bundle_path,
+            overlay_path=None,
+            framework_defaults=framework_defaults,
+        )
+
+        # 1) Single scenario entry, carrying the baseline's name (not "defaults").
+        assert len(resolved["scenario"]) == 1
+        entry = resolved["scenario"][0]
+        assert entry["name"] == "sr"
+
+        # 2) Baseline content preserved (model + decode).
+        assert entry["model"]["name"] == "Qwen/Qwen3-14B"
+        assert entry["decode"]["replicas"] == 2
+
+        # 3) Framework-defaults content merged in.
+        assert entry["gateway"]["externallyManaged"] is True
+        assert entry["inferenceExtension"]["verbosity"] == "5"
+        assert entry["extraObjects"] == [
+            {"apiVersion": "v1", "kind": "Role",
+             "metadata": {"name": "epp-role"}}
+        ]
+
+    def test_framework_defaults_no_op_when_names_already_match(self, tmp_path):
+        """When both sides already have matching names, no realignment needed."""
+        bundle = {"scenario": [{"name": "same", "a": 1}]}
+        framework_defaults = {"scenario": [{"name": "same", "b": 2}]}
+        bundle_path = tmp_path / "b.yaml"
+        self._write(bundle_path, bundle)
+        resolved = assemble_run.resolve_baseline(
+            bundle_path=bundle_path,
+            overlay_path=None,
+            framework_defaults=framework_defaults,
+        )
+        assert resolved == {"scenario": [{"name": "same", "a": 1, "b": 2}]}
+
+    def test_framework_defaults_empty_scenario_no_op(self, tmp_path):
+        """Empty framework_defaults must not corrupt the bundle."""
+        bundle = {"scenario": [{"name": "sr", "a": 1}]}
+        bundle_path = tmp_path / "b.yaml"
+        self._write(bundle_path, bundle)
+        resolved = assemble_run.resolve_baseline(
+            bundle_path=bundle_path,
+            overlay_path=None,
+            framework_defaults={},
+        )
+        assert resolved == bundle
+
+    def test_align_overlay_name_does_not_mutate_caller_state(self, tmp_path):
+        """resolve_baseline must not mutate the caller's framework_defaults dict."""
+        bundle = {"scenario": [{"name": "sr"}]}
+        framework_defaults = {"scenario": [{"name": "defaults", "x": 1}]}
+        original_snapshot = {
+            "scenario": [{"name": "defaults", "x": 1}],
+        }
+        bundle_path = tmp_path / "b.yaml"
+        self._write(bundle_path, bundle)
+        assemble_run.resolve_baseline(
+            bundle_path=bundle_path,
+            overlay_path=None,
+            framework_defaults=framework_defaults,
+        )
+        # Caller's dict is untouched — the helper deep-copies before renaming.
+        assert framework_defaults == original_snapshot
+
 
 class TestInjectHfSecret:
     def test_sets_secret_name_on_each_entry(self):


### PR DESCRIPTION
## Summary

Restores the `_align_overlay_name` helper that step-2's `pipeline/lib/assemble.py` → `assemble_run.py` refactor dropped. Without it, framework-default fragments merge as a **second scenario entry** instead of into the baseline entry — and llm-d-benchmark then templates that phantom entry with its framework-default model (`facebook/opt-125m`), deploying a second model alongside every intended one.

Closes #516.

## Concrete evidence of the regression

Same `transfer.yaml` shape (baseline entry named `softreflective` on main / `sr` on step-4):

- **Main branch** (`kalantar-msb/soft-reflective/workspace/runs/sr-mk/cluster/softreflective.yaml`): single scenario entry `name: softreflective` — correct.
- **refactor/v2-step-4** (before this PR): `scenario: [{name: defaults, ...}, {name: sr, ...}]` — two entries; the `defaults` entry has no `model:` override so llm-d-benchmark defaults it to `facebook/opt-125m`.

Cluster-side effect (namespaces `kalantar-0` and `kalantar-1`):
```
download-model-facebook-*-opt-125m-*  Completed
download-model-qwen-*-wen3-14b-*      Completed
```
Both models materialized. This is what the user observed and reported.

## Root cause

Main-branch `pipeline/lib/assemble.py:31-44` shipped a helper `_align_overlay_name` that rewrote the overlay's `scenario[0].name` to match the base's `scenario[0].name` before deep-merge, so the two sides collapse into a single entry. Every fragment under `.claude/skills/sim2real-bootstrap/templates/defaults/*.yaml` explicitly counts on this — top-of-file comment:

> `# scenario[0].name is realigned to the experiment baseline at merge time.`

Step-2 renamed `assemble.py` → `assemble_run.py` but did NOT carry `_align_overlay_name` over. `pipeline/lib/values.py:_detect_list_key` picks `name` as the merge key (both sides have it), sees the names differ (`defaults` vs `sr`), and merges as separate list items. Nothing since step-2 has fixed it.

## The fix

`pipeline/lib/assemble_run.py`:

- Added `_align_overlay_name(base, overlay)` — verbatim port from `main:pipeline/lib/assemble.py:31-44` with an expanded docstring naming the regression path and issue #516.
- Wired into `resolve_baseline`: `aligned_defaults = _align_overlay_name(bundle, copy.deepcopy(framework_defaults))` before the `deep_merge`. The `deepcopy` protects the caller's dict from mutation.

## Tests

`pipeline/tests/test_assemble_run.py::TestResolveScenarios`, four new cases:

- **`test_framework_defaults_named_defaults_merge_into_baseline_entry`** — the exact regression scenario. Framework defaults named `defaults` + baseline named `sr` → one entry named `sr`, both sides' content present. Would have caught this regression when step-2 landed.
- **`test_framework_defaults_no_op_when_names_already_match`** — no-op branch is safe.
- **`test_framework_defaults_empty_scenario_no_op`** — empty defaults preserve bundle.
- **`test_align_overlay_name_does_not_mutate_caller_state`** — caller's `framework_defaults` dict is not mutated (deepcopy inside `resolve_baseline`).

Full CI-equivalent suite: **598 passed, 1 skipped**. Ruff `--select F` clean.

## Reviewer attention

- The helper name and shape match main verbatim so a bisect/blame across the step-2 rename shows the two side-by-side.
- Tests are targeted at `resolve_baseline` — the merge point where the regression manifested. Not testing `load_defaults_overlay` (which never had this concern) or higher-level `assemble` orchestration (already covered by `TestAssembleRun`).
- No changes to public API surface (no new exports, no signature changes). Consumers of `resolve_baseline` see the corrected merge behavior automatically.

## Test plan

- [x] `python -m pytest pipeline/tests/test_assemble_run.py -v` → 49 passed
- [x] Full CI-equivalent suite → 598 passed, 1 skipped
- [x] `ruff check pipeline/ .claude/skills/ --select F` → clean
- [ ] (manual, after merge) Rerun `sim2real assemble` + `deploy.py run` on user's experiment → single `download-model-*` job per namespace, no facebook/opt-125m