### PR TITLE
Epic: step-4 — sim2real-bootstrap port + --byo mode — close #496

### DIFF
--- a/.claude/skills/sim2real-bootstrap/SKILL.md
+++ b/.claude/skills/sim2real-bootstrap/SKILL.md
@@ -14,6 +14,11 @@ user-invocable: true
 
 Turn a BLIS-generated experiment folder into a pipeline-ready sim2real bundle.
 
+> For pre-built EPP images without BLIS-format inputs (no `algorithms/*.go`, no
+> `config.md`), use `--byo` mode instead — the operator supplies a baseline
+> scenario and per-algorithm overlays directly, and bootstrap emits a batched
+> `sim2real translation register` command.
+
 ## Arguments
 
 `$ARGUMENTS` is the path to the experiment folder. Defaults to the current directory if omitted.
@@ -41,7 +46,11 @@ The experiment folder MUST contain:
 ## Task Execution
 
 Use TaskCreate to track progress. Execute tasks sequentially; each
-derive-and-approve task MUST pause for user confirmation via AskUserQuestion.
+derive-and-approve task MUST pause and ask the operator to confirm the
+derived values before proceeding. Present the derived values, then ask
+a plain-text numbered question — e.g. *"Proceed with these values? (1)
+yes  (2) revise <field>  (3) abort"* — and wait for a reply. Do NOT use
+`AskUserQuestion`.
 
 ---
 
@@ -105,7 +114,7 @@ LATEST_RELEASE=$(git tag --sort=-version:refname | grep -v rc | head -1)
 # If no: use commit from folder docs or latest main
 ```
 
-**Present to user with AskUserQuestion:**
+**Present to user with a plain-text numbered prompt** (do NOT use `AskUserQuestion`):
 ```
 Derived target component:
   repo: <url>
@@ -114,7 +123,14 @@ Derived target component:
     - latest release: <tag> (interfaces present? yes/no)
     - folder-pinned commit: <ref> (interfaces present? yes/no)
     - recommended: <chosen ref> (<reason>)
+
+Pick a ref:
+  (1) latest release (<tag>)
+  (2) folder-pinned commit (<ref>)
+  (3) revise (specify a different ref)
+  (4) abort
 ```
+Wait for the operator's reply before proceeding.
 
 If >1 candidate found, halt and report — bootstrap supports only one target.
 
@@ -396,15 +412,37 @@ Exit code 0 and all fields printed = success.
 
 Tell the user:
 ```
-Bootstrap complete. Next steps:
-  1. Run: python pipeline/setup.py --experiment-root $EXPERIMENT_ROOT
-  2. Register a translation:
-       python pipeline/sim2real.py translation register \
-         --algorithm NAME --image REF --config PATH_TO_TREATMENT_OVERLAY
-  3. Assemble a run:
+Bootstrap complete. Next steps (skill-driven translation flow — BLIS output has
+algorithms[].source, so `sim2real translate` runs the /sim2real-translate skill
+to produce the plugin sources, then `sim2real build` compiles them into images):
+
+  1. Configure the workspace:
+       python pipeline/setup.py --experiment-root $EXPERIMENT_ROOT
+  2. Checkpoint the translation:
+       python pipeline/sim2real.py translate
+  3. Run the /sim2real-translate skill to produce plugin sources for each algorithm.
+  4. Validate the skill's outputs:
+       python pipeline/sim2real.py translate --resume
+  5. Build per-algorithm images:
+       python pipeline/sim2real.py build --translation <hash>
+  6. Assemble a run:
        python pipeline/sim2real.py assemble \
-         --translation HASH --cluster CLUSTER_ID --run RUN_NAME
+         --translation <hash> --cluster <cluster_id> --run <run_name>
+  7. Validate against a real cluster (after `deploy.py run` + `deploy.py collect`):
+       /sim2real-check --run <run_name>
 ```
+
+If the operator instead has pre-built EPP images on hand (no skill-driven
+translation), they can skip steps 2-5 and register the images directly with
+the batched register form:
+
+```
+python pipeline/sim2real.py translation register \
+    --algorithm <name>=<image-ref>@<config-path>          # repeatable
+```
+
+(The step-1 single-algorithm form `--algorithm NAME --image REF --config PATH`
+still works but emits a deprecation warning — prefer the batched form.)
 
 ## Reference: Bundled Files
 

--- a/.claude/skills/sim2real-bootstrap/SKILL.md
+++ b/.claude/skills/sim2real-bootstrap/SKILL.md
@@ -1,25 +1,30 @@
 ---
 name: sim2real-bootstrap
 description: |
-  Bootstrap a BLIS-generated experiment folder into a sim2real transfer bundle.
-  Use when an experiment folder has algorithms/, workloads/, and config but lacks
-  transfer.yaml, baselines/, or a component submodule. Derives and assembles all
-  artifacts needed for the sim2real pipeline (transfer.yaml, baseline scenarios,
-  component submodule, workload selection) with user approval at each gate.
-argument-hint: "[experiment-folder-path]"
+  Bootstrap an experiment repo into a sim2real transfer bundle. Two modes:
+  (1) BLIS mode (default) — for BLIS-generated folders with algorithms/,
+      workloads/, and config; derives transfer.yaml, baselines/, and a
+      component submodule with user approval at each gate.
+  (2) --byo mode — for operators arriving with pre-built EPP images plus a
+      full baseline scenario and per-algorithm overlays; scaffolds
+      transfer.yaml with `byo: true` markers and emits a copy-pasteable
+      batched `sim2real translation register` command.
+argument-hint: "[experiment-folder-path] [--byo ...]"
 user-invocable: true
 ---
 
 # sim2real-bootstrap
 
-Turn a BLIS-generated experiment folder into a pipeline-ready sim2real bundle.
+Turn an experiment folder into a pipeline-ready sim2real bundle. This skill has two modes:
 
-> For pre-built EPP images without BLIS-format inputs (no `algorithms/*.go`, no
-> `config.md`), use `--byo` mode instead — the operator supplies a baseline
-> scenario and per-algorithm overlays directly, and bootstrap emits a batched
-> `sim2real translation register` command.
+- **BLIS mode (default)** — the operator has a BLIS-generated experiment folder (with `algorithms/*.go`, `workloads/*.yaml`, and either `config.md` or `top3_selection.json`). Bootstrap parses those inputs, derives a component submodule, generates baseline scenarios, and emits `transfer.yaml`. Documented in Tasks 0-6 below.
+- **`--byo` mode** — the operator has a pre-built EPP image (or several), a full baseline scenario YAML, and per-algorithm overlay YAMLs, but no BLIS artifacts. Bootstrap copies those files into canonical experiment-repo locations, emits `transfer.yaml` with per-algorithm `byo: true` markers, and prints a batched `sim2real translation register` command. Documented in the BYO section below.
 
-## Arguments
+## Dispatch
+
+If any of `--byo`, `--baseline`, `--algorithm`, `--algorithm-image`, `--algorithm-config`, `--scenario`, `--force`, or `--non-interactive` appears in `$ARGUMENTS`, dispatch to the BYO branch (see the `--byo` mode section). Otherwise dispatch to BLIS mode (Tasks 0-6).
+
+## Arguments (BLIS mode)
 
 `$ARGUMENTS` is the path to the experiment folder. Defaults to the current directory if omitted.
 
@@ -432,17 +437,87 @@ to produce the plugin sources, then `sim2real build` compiles them into images):
        /sim2real-check --run <run_name>
 ```
 
-If the operator instead has pre-built EPP images on hand (no skill-driven
-translation), they can skip steps 2-5 and register the images directly with
-the batched register form:
+For pre-built EPP images (no skill-driven translation), see the [`--byo` mode](#--byo-mode) section below — the operator supplies baseline + overlays directly and bootstrap emits a batched `translation register` command that skips steps 2-5 above.
+
+## `--byo` mode
+
+Use `--byo` when the operator has a pre-built EPP image (or several), a full baseline scenario YAML, and per-algorithm overlay YAMLs, but no BLIS artifacts. Bootstrap copies the operator's files into canonical experiment-repo locations, emits `transfer.yaml` with `byo: true` per-algorithm markers (no `component:` — BYO has no submodule), and prints a batched `sim2real translation register` command.
+
+### Invocation
+
+```bash
+python3 "$SKILL_DIR/byo.py" \
+    --byo \
+    --baseline <name>=<scenario-path> \
+    --algorithm <name> [--algorithm <name>]... \
+    --algorithm-image <name>=<image-ref> [--algorithm-image ...]... \
+    --algorithm-config <name>=<overlay-path> [--algorithm-config ...]... \
+    [--scenario <name>] [--force] [--non-interactive]
+```
+
+The BYO branch is implemented in `byo.py` (bundled with this skill). SKILL.md's role is to accept operator input (structured args OR natural-language prose), collect any missing fields, and hand off to `byo.py`.
+
+### Input collection (interactive TTY)
+
+Operators may invoke the skill in either shape:
+
+1. **Structured args** — the invocation above, verbatim.
+2. **Natural language** — e.g., *"bootstrap --byo with baseline at /path/baseline.yaml, algorithm foo image ghcr.io/foo:tag config /path/foo.yaml, algorithm bar image ghcr.io/bar@sha256:... config /path/bar.yaml"*. Parse the description into structured args (algorithm/image/config triples + baseline).
+
+If any required field is missing after parsing, prompt with plain-text numbered prompts (one prompt per missing field). Example prompts:
 
 ```
-python pipeline/sim2real.py translation register \
-    --algorithm <name>=<image-ref>@<config-path>          # repeatable
+Missing algorithm image for 'foo'. Enter the image reference:
+> 
 ```
 
-(The step-1 single-algorithm form `--algorithm NAME --image REF --config PATH`
-still works but emits a deprecation warning — prefer the batched form.)
+Do NOT use `AskUserQuestion` (project preference — see the persistent user memory on this repo).
+
+If stdin is not a TTY OR the operator passed `--non-interactive`, do not prompt — invoke `byo.py` with whatever was supplied and let it fatal-error on missing fields.
+
+### Reserved names
+
+- `default`, `defaults` — reserved for any role.
+- `baseline` — reserved as an algorithm name only (a baseline named `baseline` is the canonical case).
+
+### On-disk layout (produced by `byo.py`)
+
+```
+<experiment-root>/
+  transfer.yaml                                  <- BYO transfer.yaml (byo: true per algo, no component:)
+  baselines/
+    <baseline-name>.yaml                         <- copy of operator's baseline scenario
+    defaults/*.yaml                              <- framework fragments (all listed under defaults.disable)
+  algorithms/
+    <algo-1>/<algo-1>_config.yaml                <- copy of operator's overlay
+    <algo-2>/<algo-2>_config.yaml                <- copy of operator's overlay
+  workloads/*.yaml                               <- pre-existing (operator brought)
+```
+
+Copies are atomic (write-to-temp + rename). Destinations validated to lie inside `<experiment-root>`; symlinks that escape are rejected. YAML inputs are parse-validated (single-doc, mapping root, non-empty) before any writes.
+
+### Emitted register command
+
+At success, `byo.py` prints:
+
+```
+cd '/absolute/path/to/exp-root'
+sim2real translation register \
+    --algorithm '<name1>=<image1>@algorithms/<name1>/<name1>_config.yaml' \
+    --algorithm '<name2>=<image2>@algorithms/<name2>/<name2>_config.yaml'
+```
+
+All paths quoted with `shlex.quote`. Bootstrap does not invoke `register` itself — the operator retains control.
+
+### After BYO bootstrap
+
+```
+1. Run the emitted register command above.
+2. Assemble a run:
+     sim2real assemble --translation <hash> --cluster <cluster_id> --run <run-name>
+3. Deploy:
+     python pipeline/deploy.py run
+```
 
 ## Reference: Bundled Files
 
@@ -450,7 +525,8 @@ This skill ships with supporting files in its directory. Invoke in place — do 
 
 | File | Purpose |
 |------|---------|
-| `generate_from_config.py` | Parses `config.md` markdown tables → scenario YAMLs with provenance comments. Preferred for most experiments. Handles hardware normalization, bare-flag prefix-caching input/output, and unknown model/hardware detection. |
-| `generate_scenarios.py` | Converts JSON config (`top3_selection.json`) → scenario YAMLs. Use when JSON input exists. |
+| `generate_from_config.py` | Parses `config.md` markdown tables → scenario YAMLs with provenance comments. Preferred for most BLIS experiments. Handles hardware normalization, bare-flag prefix-caching input/output, and unknown model/hardware detection. |
+| `generate_scenarios.py` | Converts JSON config (`top3_selection.json`) → scenario YAMLs. Use when JSON input exists (BLIS). |
 | `generate_scenarios.README.md` | Coverage map for the JSON-input path. Documents field mappings, omission rules, and gaps. |
-| `templates/defaults/*.yaml` | Framework-owned baseline workaround fragments (RBAC, request-id, verbosity). Copied into `<experiment-root>/baselines/defaults/` at task-4b so each experiment is self-contained and reproducible. |
+| `byo.py` | Implements the `--byo` branch — argument parsing, YAML validation, path-safe copy operations, `transfer.yaml` emission, batched `sim2real translation register` command generation. Invoked by SKILL.md's dispatch when `--byo` (or any BYO-only flag) is passed. |
+| `templates/defaults/*.yaml` | Framework-owned baseline workaround fragments (RBAC, request-id, verbosity). Copied into `<experiment-root>/baselines/defaults/` at BLIS task-4b and at BYO run time, so every experiment is self-contained and reproducible. |

--- a/.claude/skills/sim2real-bootstrap/SKILL.md
+++ b/.claude/skills/sim2real-bootstrap/SKILL.md
@@ -349,11 +349,25 @@ context:
 defaults:
   disable: []
   # Available fragments (filename stems in baselines/defaults/):
+  #   - epp-verbosity
+  #   - externally-managed-gateway
   #   - llm-d-rbac
   #   - preserve-request-id
-  #   - epp-verbosity
-  #   - vllm-logging
   #   - routing-proxy-resources
+  #   - vllm-logging
+```
+
+The `# Available fragments` comment lists every YAML filename stem currently in
+`<experiment-root>/baselines/defaults/` (populated by Task 4b from
+`templates/defaults/`). Regenerate the list from what actually got copied — do
+NOT copy the enumeration above verbatim if `templates/defaults/` has changed
+since this SKILL.md was written:
+
+```bash
+ls "$EXPERIMENT_ROOT/baselines/defaults/"*.yaml \
+    | xargs -n1 basename \
+    | sed 's/\.yaml$//' \
+    | sort
 ```
 
 **Constraints:**

--- a/.claude/skills/sim2real-bootstrap/byo.py
+++ b/.claude/skills/sim2real-bootstrap/byo.py
@@ -1,0 +1,827 @@
+#!/usr/bin/env python3
+"""BYO branch of ``/sim2real-bootstrap``.
+
+For operators who arrive with pre-built EPP images + per-algorithm scenario
+overlays + a full baseline scenario, and NOT a BLIS-format experiment folder.
+Copies operator files into canonical experiment-repo locations, emits a valid
+``transfer.yaml`` with per-algorithm ``byo: true`` markers, and prints one
+copy-pasteable ``sim2real translation register`` command carrying all
+algorithms as a batched (N-algorithm) invocation.
+
+BLIS-mode logic lives elsewhere in this skill (SKILL.md Tasks 0-6,
+``generate_from_config.py``, ``generate_scenarios.py``); this module is
+BYO-only.
+
+See ``docs/epics/step-4/design.md#byo-mode-specification`` for the full spec.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shlex
+import shutil
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Kubernetes DNS-label subset, 1-20 chars. Matches the constraint enforced by
+# pipeline/lib/translation_ref.validate_name(); duplicated here so bootstrap
+# can fail fast without importing from the pipeline package.
+NAME_REGEX = re.compile(r"^[a-z0-9]([-a-z0-9]{0,18}[a-z0-9])?$")
+
+# Algorithm/baseline names that would collide with framework concepts.
+# `baseline` is only reserved as an *algorithm* name — a *baseline* named
+# `baseline` is the canonical case in the BYO shape.
+RESERVED_ANY_ROLE = frozenset({"default", "defaults"})
+RESERVED_ALGORITHM_NAMES = RESERVED_ANY_ROLE | frozenset({"baseline"})
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+class BYOError(Exception):
+    """Raised for operator-input errors. Message is surfaced to stderr as-is."""
+
+
+# ---------------------------------------------------------------------------
+# Data
+# ---------------------------------------------------------------------------
+
+@dataclass
+class BYOArgs:
+    """Structured form of the CLI arguments after parsing.
+
+    Kept flat and JSON-serializable so the ``parse_args_dict`` helper can be
+    used to compare a structured-args invocation against an NL-derived invocation
+    in unit tests (design.md#risks: NL parsing is not CI-tested; the equivalence
+    is asserted on the shape of the parsed dict).
+    """
+    byo: bool
+    baseline_name: str | None
+    baseline_path: str | None
+    algorithms: list[str]  # order preserved for register command
+    algorithm_images: dict[str, str]
+    algorithm_configs: dict[str, str]
+    scenario: str | None
+    force: bool
+    non_interactive: bool
+
+
+@dataclass
+class ResolvedInputs:
+    """Post-validation view of the operator's inputs.
+
+    Every path here has been resolved and verified to exist; every YAML has
+    been safe-loaded and validated as a single-document non-empty mapping.
+    Algorithm entries are in the same order the operator provided them.
+    """
+    exp_root: Path
+    scenario: str
+    baseline_name: str
+    baseline_src: Path
+    algorithms: list["ResolvedAlgorithm"] = field(default_factory=list)
+    workloads: list[Path] = field(default_factory=list)
+    force: bool = False
+
+
+@dataclass
+class ResolvedAlgorithm:
+    name: str
+    image_ref: str
+    config_src: Path
+
+
+# ---------------------------------------------------------------------------
+# CLI parsing
+# ---------------------------------------------------------------------------
+
+def _kv_pair(value: str) -> tuple[str, str]:
+    """Split ``name=value`` on the first ``=``. Rejects empties."""
+    if "=" not in value:
+        raise argparse.ArgumentTypeError(
+            f"{value!r}: expected '<name>=<value>'"
+        )
+    name, _, val = value.partition("=")
+    if not name or not val:
+        raise argparse.ArgumentTypeError(
+            f"{value!r}: '<name>=<value>' must have non-empty name and value"
+        )
+    return name, val
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Argparse spec for the BYO branch. Exported for testing."""
+    p = argparse.ArgumentParser(
+        prog="sim2real-bootstrap --byo",
+        description=(
+            "BYO branch of sim2real-bootstrap. Scaffold an experiment repo "
+            "from a pre-built EPP image + per-algorithm overlay(s) + a full "
+            "baseline scenario. Emits transfer.yaml with byo: true markers "
+            "and prints a batched `sim2real translation register` command."
+        ),
+        add_help=True,
+    )
+    p.add_argument(
+        "--byo",
+        action="store_true",
+        help="Dispatch to the BYO branch (required; presence-only).",
+    )
+    p.add_argument(
+        "--baseline",
+        type=_kv_pair,
+        metavar="<name>=<scenario-path>",
+        help="Baseline name and path to the full baseline scenario YAML.",
+    )
+    p.add_argument(
+        "--algorithm",
+        action="append",
+        default=[],
+        metavar="<name>",
+        help="Declare an algorithm by name. Repeatable; at least one required.",
+    )
+    p.add_argument(
+        "--algorithm-image",
+        action="append",
+        default=[],
+        type=_kv_pair,
+        metavar="<name>=<image-ref>",
+        help="Map an algorithm name to its container image reference. Repeatable.",
+    )
+    p.add_argument(
+        "--algorithm-config",
+        action="append",
+        default=[],
+        type=_kv_pair,
+        metavar="<name>=<overlay-path>",
+        help="Map an algorithm name to a partial-YAML overlay path. Repeatable.",
+    )
+    p.add_argument(
+        "--scenario",
+        metavar="<name>",
+        help="Override the derived transfer.yaml scenario name.",
+    )
+    p.add_argument(
+        "--force",
+        action="store_true",
+        help="Bypass overwrite confirmation on destinations that already exist.",
+    )
+    p.add_argument(
+        "--non-interactive",
+        action="store_true",
+        help=(
+            "Never prompt. Missing required fields are fatal errors. "
+            "Auto-enabled when stdin is not a TTY."
+        ),
+    )
+    return p
+
+
+def parse_args_dict(argv: list[str]) -> dict:
+    """Return the parsed CLI as a plain dict.
+
+    Used both by ``parse_args`` (as an intermediate form) and by the
+    args-vs-NL equivalence test: an NL description produces a dict of the
+    same shape; equality on that dict is what we assert.
+    """
+    ns = build_parser().parse_args(argv)
+    return {
+        "byo": bool(ns.byo),
+        "baseline": (ns.baseline[0], ns.baseline[1]) if ns.baseline else None,
+        "algorithms": list(ns.algorithm),
+        "algorithm_images": dict(ns.algorithm_image),
+        "algorithm_configs": dict(ns.algorithm_config),
+        "scenario": ns.scenario,
+        "force": bool(ns.force),
+        "non_interactive": bool(ns.non_interactive),
+    }
+
+
+def parse_args(argv: list[str]) -> BYOArgs:
+    d = parse_args_dict(argv)
+    baseline_name, baseline_path = (
+        (d["baseline"][0], d["baseline"][1]) if d["baseline"] else (None, None)
+    )
+    return BYOArgs(
+        byo=d["byo"],
+        baseline_name=baseline_name,
+        baseline_path=baseline_path,
+        algorithms=d["algorithms"],
+        algorithm_images=d["algorithm_images"],
+        algorithm_configs=d["algorithm_configs"],
+        scenario=d["scenario"],
+        force=d["force"],
+        non_interactive=d["non_interactive"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+def _validate_name(name: str, role: str) -> None:
+    """Enforce the DNS-label subset and reserved-name check."""
+    if not NAME_REGEX.match(name):
+        raise BYOError(
+            f"{role} name {name!r} is invalid: must match "
+            f"[a-z0-9]([-a-z0-9]{{0,18}}[a-z0-9])? (1-20 chars, "
+            "lowercase alphanumeric with internal hyphens)"
+        )
+    if role == "algorithm":
+        if name in RESERVED_ALGORITHM_NAMES:
+            raise BYOError(
+                f"algorithm name {name!r} is reserved "
+                f"(reserved: {', '.join(sorted(RESERVED_ALGORITHM_NAMES))})"
+            )
+    else:
+        if name in RESERVED_ANY_ROLE:
+            raise BYOError(
+                f"{role} name {name!r} is reserved "
+                f"(reserved: {', '.join(sorted(RESERVED_ANY_ROLE))})"
+            )
+
+
+def _validate_image_ref(ref: str, algo_name: str) -> None:
+    """Minimal image-ref sanity. Final validation is register's job."""
+    if not ref:
+        raise BYOError(f"algorithm {algo_name!r}: image ref is empty")
+    if any(c.isspace() for c in ref):
+        raise BYOError(
+            f"algorithm {algo_name!r}: image ref {ref!r} contains whitespace"
+        )
+    if any(ord(c) < 0x20 or ord(c) == 0x7F for c in ref):
+        raise BYOError(
+            f"algorithm {algo_name!r}: image ref {ref!r} contains control chars"
+        )
+
+
+def _validate_yaml_file(path: Path, role: str) -> None:
+    """Load once, enforce: single-document, non-empty, mapping root.
+
+    Path traversal / existence checks live upstream; this function assumes
+    ``path`` was resolved and exists.
+    """
+    try:
+        text = path.read_text()
+    except OSError as exc:
+        raise BYOError(f"{role} at {path}: cannot read: {exc}") from exc
+    try:
+        docs = list(yaml.safe_load_all(text))
+    except yaml.YAMLError as exc:
+        raise BYOError(f"{role} at {path}: YAML parse failed: {exc}") from exc
+    if len(docs) == 0:
+        raise BYOError(f"{role} at {path}: empty document")
+    if len(docs) > 1:
+        raise BYOError(
+            f"{role} at {path}: multi-document YAML not supported "
+            f"(found {len(docs)} documents)"
+        )
+    doc = docs[0]
+    if doc is None:
+        raise BYOError(f"{role} at {path}: document is empty/null")
+    if not isinstance(doc, dict):
+        raise BYOError(
+            f"{role} at {path}: top-level must be a mapping, "
+            f"got {type(doc).__name__}"
+        )
+
+
+def _resolve_inside(path: Path, exp_root: Path, role: str) -> Path:
+    """Resolve ``path``; require existence + regular-file + inside/outside checks.
+
+    ``path`` is a *source* path. Bootstrap accepts sources outside
+    ``<exp-root>`` (operators supply paths from anywhere), but symlinks are
+    resolved and the final target must be a regular file. Enforced separately
+    from ``_check_dest_inside``, which enforces destination containment.
+    """
+    if not path.exists():
+        raise BYOError(f"{role}: path {path} does not exist")
+    if path.is_symlink() or (path.parent / path.name).is_symlink():
+        # Follow the symlink once via resolve(strict=True); require regular file.
+        pass
+    try:
+        resolved = path.resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise BYOError(
+            f"{role}: cannot resolve path {path}: {exc}"
+        ) from exc
+    if not resolved.is_file():
+        raise BYOError(
+            f"{role}: {path} (resolved {resolved}) is not a regular file"
+        )
+    return resolved
+
+
+def _check_dest_inside(dst: Path, exp_root: Path) -> Path:
+    """Return the resolved destination, enforcing it lies inside ``exp_root``.
+
+    Uses ``os.path.realpath`` on the destination parent (which exists) plus
+    the basename, so a not-yet-existing destination is still safely
+    validated against symlink games in its parent chain.
+    """
+    dst_parent_resolved = Path(os.path.realpath(dst.parent))
+    exp_resolved = Path(os.path.realpath(exp_root))
+    try:
+        dst_parent_resolved.relative_to(exp_resolved)
+    except ValueError:
+        raise BYOError(
+            f"destination {dst} resolves to {dst_parent_resolved / dst.name}, "
+            f"outside experiment root {exp_resolved}"
+        )
+    return dst_parent_resolved / dst.name
+
+
+# ---------------------------------------------------------------------------
+# Scenario name derivation
+# ---------------------------------------------------------------------------
+
+_SCENARIO_SANITIZE = re.compile(r"[^a-z0-9-]+")
+_SCENARIO_COLLAPSE = re.compile(r"-+")
+
+
+def normalize_scenario(raw: str) -> str:
+    """Normalize a derived scenario string per design.md:118-125.
+
+    lowercase → non-[a-z0-9-] replaced with '-' → runs of '-' collapsed →
+    leading/trailing '-' stripped → truncated to 40 chars.
+    """
+    s = raw.strip().lower()
+    s = _SCENARIO_SANITIZE.sub("-", s)
+    s = _SCENARIO_COLLAPSE.sub("-", s)
+    s = s.strip("-")
+    return s[:40]
+
+
+def derive_scenario_name(exp_root: Path, override: str | None) -> str:
+    """Derive scenario name for transfer.yaml.
+
+    Order: --scenario override → README.md first-header title → exp_root basename.
+    Result is normalized and required to be non-empty.
+    """
+    if override is not None:
+        candidate = override
+    else:
+        readme = exp_root / "README.md"
+        candidate = None
+        if readme.exists():
+            for line in readme.read_text().splitlines():
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                # Only the FIRST non-empty line is considered per spec.
+                if stripped.startswith("# "):
+                    candidate = stripped[2:].strip()
+                break
+        if not candidate:
+            candidate = exp_root.name
+    normalized = normalize_scenario(candidate)
+    if not normalized:
+        raise BYOError(
+            "cannot derive scenario name — override with --scenario "
+            f"(source: {candidate!r})"
+        )
+    return normalized
+
+
+# ---------------------------------------------------------------------------
+# Workload enumeration
+# ---------------------------------------------------------------------------
+
+def enumerate_workloads(exp_root: Path) -> list[Path]:
+    """Non-recursive glob of ``<exp-root>/workloads/*.yaml``.
+
+    Returns absolute paths sorted lexicographically. Empty result (missing
+    dir or no matches) is a fatal error naming the directory.
+    """
+    workloads_dir = exp_root / "workloads"
+    if not workloads_dir.is_dir():
+        raise BYOError(
+            f"workloads directory missing: {workloads_dir}"
+        )
+    matches: list[Path] = []
+    for entry in workloads_dir.iterdir():
+        if entry.name.startswith("."):
+            continue
+        if entry.suffix != ".yaml":
+            continue
+        # Resolve to enforce the "symlinks stay inside workloads/" rule.
+        try:
+            resolved = entry.resolve(strict=True)
+        except (OSError, RuntimeError):
+            raise BYOError(
+                f"workload {entry}: cannot resolve (broken symlink?)"
+            )
+        try:
+            resolved.relative_to(Path(os.path.realpath(workloads_dir)))
+        except ValueError:
+            raise BYOError(
+                f"workload {entry} resolves outside {workloads_dir}"
+            )
+        if not resolved.is_file():
+            raise BYOError(f"workload {entry} is not a regular file")
+        matches.append(entry)
+    if not matches:
+        raise BYOError(
+            f"no workload files found under {workloads_dir}/*.yaml"
+        )
+    matches.sort(key=lambda p: p.name)
+    return matches
+
+
+# ---------------------------------------------------------------------------
+# Copy operations
+# ---------------------------------------------------------------------------
+
+def _atomic_copy_file(src: Path, dst: Path) -> None:
+    """Copy src → dst by writing to a sibling temp file then renaming.
+
+    Never leaves a half-written destination. Preserves default file mode
+    (0644 subject to umask); we do NOT copy source mode — the operator's
+    overlay file might be 0600 on their disk but we want the experiment
+    repo files to be readable by tooling.
+    """
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=dst.name + ".", suffix=".tmp", dir=str(dst.parent)
+    )
+    try:
+        with os.fdopen(fd, "wb") as f:
+            with src.open("rb") as sf:
+                shutil.copyfileobj(sf, f)
+        os.replace(tmp_name, str(dst))
+    except Exception:
+        # Best-effort cleanup; the temp file's name is randomized so no
+        # existing file at ``dst`` is at risk.
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def _prompt_overwrite(dst: Path) -> bool:
+    """Interactive confirmation for an existing destination.
+
+    Returns True to proceed with overwrite. Prompts on stderr, reads stdin.
+    Called only when stdin is a TTY (or the caller has explicitly opted in);
+    non-interactive dispatch takes a different branch entirely.
+    """
+    print(f"destination exists: {dst}", file=sys.stderr)
+    print("overwrite? [y/N]: ", file=sys.stderr, end="", flush=True)
+    resp = sys.stdin.readline().strip().lower()
+    return resp in ("y", "yes")
+
+
+def _decide_dest(dst: Path, force: bool, non_interactive: bool) -> None:
+    """Raise BYOError if destination exists and we shouldn't overwrite."""
+    if not dst.exists():
+        return
+    if force:
+        return
+    if non_interactive:
+        raise BYOError(
+            f"destination {dst} exists; refusing overwrite in non-interactive "
+            "mode (pass --force to override)"
+        )
+    if not _prompt_overwrite(dst):
+        raise BYOError(f"aborted: destination {dst} exists")
+
+
+def copy_operator_files(
+    inputs: ResolvedInputs, non_interactive: bool
+) -> tuple[Path, list[Path]]:
+    """Copy baseline + per-algorithm overlays into the experiment repo.
+
+    Returns (baseline_dst, [algo_config_dsts]). All destinations are inside
+    ``inputs.exp_root``; every write is atomic; existing destinations honor
+    ``inputs.force`` and ``non_interactive``.
+    """
+    # baseline
+    baseline_dst = _check_dest_inside(
+        inputs.exp_root / "baselines" / f"{inputs.baseline_name}.yaml",
+        inputs.exp_root,
+    )
+    _decide_dest(baseline_dst, inputs.force, non_interactive)
+    _atomic_copy_file(inputs.baseline_src, baseline_dst)
+
+    # per-algorithm overlays
+    algo_dsts: list[Path] = []
+    for algo in inputs.algorithms:
+        algo_dst = _check_dest_inside(
+            inputs.exp_root / "algorithms" / algo.name / f"{algo.name}_config.yaml",
+            inputs.exp_root,
+        )
+        _decide_dest(algo_dst, inputs.force, non_interactive)
+        _atomic_copy_file(algo.config_src, algo_dst)
+        algo_dsts.append(algo_dst)
+
+    return baseline_dst, algo_dsts
+
+
+def copy_framework_defaults(
+    skill_dir: Path, exp_root: Path, force: bool, non_interactive: bool
+) -> list[str]:
+    """Copy ``<skill>/templates/defaults/*.yaml`` → ``<exp>/baselines/defaults/``.
+
+    Returns the sorted list of filename stems, used to populate
+    ``defaults.disable`` in transfer.yaml. Duplicate stems (e.g. foo.yaml +
+    foo.yml — cannot happen today because we only copy .yaml, but the guard
+    is cheap) are a fatal error.
+    """
+    src_dir = skill_dir / "templates" / "defaults"
+    if not src_dir.is_dir():
+        raise BYOError(
+            f"framework defaults directory missing: {src_dir} "
+            "(is this skill's templates/defaults/ populated?)"
+        )
+    dst_dir = exp_root / "baselines" / "defaults"
+    stems: list[str] = []
+    seen_stems: set[str] = set()
+    for src in sorted(src_dir.iterdir(), key=lambda p: p.name):
+        if src.name.startswith("."):
+            continue
+        if src.suffix != ".yaml":
+            continue
+        stem = src.stem
+        if stem in seen_stems:
+            raise BYOError(
+                f"duplicate default fragment stem {stem!r} in {src_dir}"
+            )
+        seen_stems.add(stem)
+        dst = _check_dest_inside(dst_dir / src.name, exp_root)
+        _decide_dest(dst, force, non_interactive)
+        _atomic_copy_file(src, dst)
+        stems.append(stem)
+    stems.sort()
+    return stems
+
+
+# ---------------------------------------------------------------------------
+# transfer.yaml emission
+# ---------------------------------------------------------------------------
+
+def build_transfer_yaml(
+    *,
+    scenario: str,
+    baseline_name: str,
+    algorithms: list[ResolvedAlgorithm],
+    workloads: Iterable[Path],
+    exp_root: Path,
+    defaults_stems: list[str],
+) -> dict:
+    """Assemble the transfer.yaml body per design.md#emitted-transfer-yaml-shape.
+
+    - No ``component:`` key (all algorithms are BYO).
+    - Every ``algorithms[]`` entry has ``byo: true``, no ``source``.
+    - ``workloads`` paths are expressed relative to ``exp_root``.
+    - ``defaults.disable`` matches the stems of files copied to
+      ``<exp>/baselines/defaults/``.
+    """
+    return {
+        "kind": "sim2real-transfer",
+        "version": 3,
+        "scenario": scenario,
+        "baselines": [
+            {"name": baseline_name, "scenario": f"baselines/{baseline_name}.yaml"},
+        ],
+        "algorithms": [
+            {"name": a.name, "defaults": baseline_name, "byo": True}
+            for a in algorithms
+        ],
+        "workloads": [
+            str(w.relative_to(exp_root)) for w in workloads
+        ],
+        "defaults": {"disable": defaults_stems},
+        "context": {
+            "files": [],
+            "text": (
+                "Bring-your-own translation. Images and per-algorithm overlays "
+                "supplied externally; no BLIS source in this experiment repo."
+            ),
+        },
+    }
+
+
+def write_transfer_yaml(exp_root: Path, doc: dict, force: bool, non_interactive: bool) -> Path:
+    """Serialize doc and write atomically to ``<exp-root>/transfer.yaml``."""
+    dst = _check_dest_inside(exp_root / "transfer.yaml", exp_root)
+    _decide_dest(dst, force, non_interactive)
+    text = yaml.safe_dump(doc, sort_keys=False, default_flow_style=False)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=dst.name + ".", suffix=".tmp", dir=str(dst.parent)
+    )
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(text)
+        os.replace(tmp_name, str(dst))
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+    return dst
+
+
+# ---------------------------------------------------------------------------
+# Register command emission
+# ---------------------------------------------------------------------------
+
+def emit_register_command(
+    exp_root_abs: Path, algorithms: list[ResolvedAlgorithm]
+) -> str:
+    """Emit the batched register command, shlex-quoted.
+
+    Shape (matches design.md#register-command-emission):
+
+        cd '<abs-exp-root>'
+        sim2real translation register \\
+            --algorithm '<name1>=<image1>@algorithms/<name1>/<name1>_config.yaml' \\
+            --algorithm '<name2>=<image2>@algorithms/<name2>/<name2>_config.yaml'
+
+    Every path and every triple is quoted with ``shlex.quote``; the block
+    round-trips cleanly through ``shlex.split``.
+    """
+    if not algorithms:
+        raise BYOError("cannot emit register command: no algorithms")
+    lines = [
+        f"cd {shlex.quote(str(exp_root_abs))}",
+        "sim2real translation register \\",
+    ]
+    for i, algo in enumerate(algorithms):
+        overlay_rel = f"algorithms/{algo.name}/{algo.name}_config.yaml"
+        triple = f"{algo.name}={algo.image_ref}@{overlay_rel}"
+        suffix = " \\" if i < len(algorithms) - 1 else ""
+        lines.append(f"    --algorithm {shlex.quote(triple)}{suffix}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+def _collect(args: BYOArgs, exp_root: Path) -> ResolvedInputs:
+    """Enforce required fields, validate every input file, resolve paths.
+
+    Argparse is handled upstream; this function operates on an already-parsed
+    ``BYOArgs``. Non-interactive mode is decided by the caller (based on
+    ``stdin.isatty()`` and ``--non-interactive``) and passed through to the
+    copy stage separately.
+    """
+    if not args.byo:
+        # This entry point is BYO-only; SKILL.md handles dispatch. Guarding
+        # here catches direct-invocation mistakes with a clear message.
+        raise BYOError("--byo required (this entry point is BYO-only)")
+
+    # baseline
+    if not args.baseline_name:
+        raise BYOError("missing required field: --baseline <name>=<scenario-path>")
+    _validate_name(args.baseline_name, role="baseline")
+    baseline_src = _resolve_inside(
+        Path(args.baseline_path), exp_root, role=f"--baseline {args.baseline_name!r}"
+    )
+    _validate_yaml_file(baseline_src, role=f"baseline {args.baseline_name!r}")
+
+    # algorithms
+    if not args.algorithms:
+        raise BYOError("missing required field: at least one --algorithm <name>")
+    if len(args.algorithms) != len(set(args.algorithms)):
+        seen: set[str] = set()
+        dupes: set[str] = set()
+        for n in args.algorithms:
+            if n in seen:
+                dupes.add(n)
+            seen.add(n)
+        raise BYOError(
+            f"duplicate --algorithm names: {', '.join(sorted(dupes))}"
+        )
+    for name in args.algorithms:
+        _validate_name(name, role="algorithm")
+
+    # image + config per algorithm — no missing, no extras, no cross-name refs
+    declared = set(args.algorithms)
+    extra_images = set(args.algorithm_images) - declared
+    if extra_images:
+        raise BYOError(
+            f"--algorithm-image name(s) not declared with --algorithm: "
+            f"{', '.join(sorted(extra_images))}"
+        )
+    extra_configs = set(args.algorithm_configs) - declared
+    if extra_configs:
+        raise BYOError(
+            f"--algorithm-config name(s) not declared with --algorithm: "
+            f"{', '.join(sorted(extra_configs))}"
+        )
+    resolved_algos: list[ResolvedAlgorithm] = []
+    for name in args.algorithms:
+        image = args.algorithm_images.get(name)
+        if not image:
+            raise BYOError(
+                f"algorithm {name!r}: missing --algorithm-image {name}=..."
+            )
+        _validate_image_ref(image, algo_name=name)
+        cfg = args.algorithm_configs.get(name)
+        if not cfg:
+            raise BYOError(
+                f"algorithm {name!r}: missing --algorithm-config {name}=..."
+            )
+        cfg_src = _resolve_inside(
+            Path(cfg), exp_root, role=f"--algorithm-config {name!r}"
+        )
+        _validate_yaml_file(cfg_src, role=f"overlay for algorithm {name!r}")
+        resolved_algos.append(
+            ResolvedAlgorithm(name=name, image_ref=image, config_src=cfg_src)
+        )
+
+    # workloads (fail-fast; nothing to copy but enumeration must succeed)
+    workloads = enumerate_workloads(exp_root)
+
+    # scenario derivation
+    scenario = derive_scenario_name(exp_root, args.scenario)
+
+    return ResolvedInputs(
+        exp_root=exp_root,
+        scenario=scenario,
+        baseline_name=args.baseline_name,
+        baseline_src=baseline_src,
+        algorithms=resolved_algos,
+        workloads=workloads,
+        force=args.force,
+    )
+
+
+def run_byo(
+    argv: list[str],
+    exp_root: Path,
+    skill_dir: Path,
+    stdin_isatty: bool = True,
+) -> tuple[int, str]:
+    """Run the full BYO branch. Returns (exit_code, register_command_or_message).
+
+    - ``exit_code == 0`` → success; second field is the emitted register
+      command block, suitable for printing on stdout.
+    - ``exit_code == 2`` → any BYO validation error; second field is the
+      error message (already printed to stderr by ``main()``).
+    """
+    try:
+        exp_root_resolved = Path(os.path.realpath(exp_root))
+        args = parse_args(argv)
+        non_interactive = args.non_interactive or (not stdin_isatty)
+        inputs = _collect(args, exp_root_resolved)
+        copy_operator_files(inputs, non_interactive=non_interactive)
+        defaults_stems = copy_framework_defaults(
+            skill_dir, inputs.exp_root, inputs.force, non_interactive
+        )
+        doc = build_transfer_yaml(
+            scenario=inputs.scenario,
+            baseline_name=inputs.baseline_name,
+            algorithms=inputs.algorithms,
+            workloads=inputs.workloads,
+            exp_root=inputs.exp_root,
+            defaults_stems=defaults_stems,
+        )
+        write_transfer_yaml(inputs.exp_root, doc, inputs.force, non_interactive)
+        register_cmd = emit_register_command(inputs.exp_root, inputs.algorithms)
+        return 0, register_cmd
+    except BYOError as exc:
+        return 2, str(exc)
+    except SystemExit as exc:
+        # argparse exits on --help or parse errors; convert to our contract.
+        code = exc.code if isinstance(exc.code, int) else 2
+        return code, ""
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    exp_root = Path.cwd()
+    skill_dir = Path(__file__).resolve().parent
+    exit_code, message = run_byo(
+        argv, exp_root, skill_dir, stdin_isatty=sys.stdin.isatty()
+    )
+    if exit_code == 0 and message:
+        print("BYO bootstrap complete. Next: register all algorithms in one call.")
+        print()
+        print(message)
+        print()
+        print("The command prints one translation hash. Then:")
+        print()
+        print("    sim2real assemble --translation <hash> --cluster <cluster_id> --run <run-name>")
+    elif exit_code != 0 and message:
+        print(f"error: {message}", file=sys.stderr)
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/sim2real-bootstrap/byo.py
+++ b/.claude/skills/sim2real-bootstrap/byo.py
@@ -613,11 +613,74 @@ def build_transfer_yaml(
     }
 
 
+def _inject_available_fragments_comment(yaml_text: str, available_stems: list[str]) -> str:
+    """Insert an ``# Available fragments`` comment block after ``defaults.disable``.
+
+    PyYAML's ``safe_dump`` cannot emit comments, but the operator-facing
+    ``transfer.yaml`` should document which filename stems live in
+    ``baselines/defaults/`` so a reader knows what values are legal in the
+    ``defaults.disable`` list. This helper post-processes the serialized YAML
+    text: it locates the ``defaults.disable`` block and inserts one
+    ``# Available fragments…`` comment plus one ``#   - <stem>`` per fragment
+    immediately after the list.
+
+    Idempotent-safe against re-invocation only in the sense that the caller
+    controls ``yaml_text`` — we do not deduplicate an existing comment block.
+    Callers pass freshly-serialized YAML.
+    """
+    if not available_stems:
+        return yaml_text
+    comment_lines = [
+        "  # Available fragments (filename stems in baselines/defaults/):",
+    ] + [f"  #   - {stem}" for stem in sorted(available_stems)]
+
+    lines = yaml_text.split("\n")
+    # Find the ``disable:`` line under a top-level ``defaults:`` key. YAML
+    # emitted by safe_dump with sort_keys=False + default_flow_style=False
+    # produces predictable indentation: top-level keys at column 0, nested
+    # keys at 2-space indent.
+    disable_idx = -1
+    in_defaults = False
+    for i, line in enumerate(lines):
+        if line == "defaults:" or line.startswith("defaults:"):
+            in_defaults = True
+            continue
+        if in_defaults:
+            if line.startswith("  disable:"):
+                disable_idx = i
+                break
+            if line and not line.startswith(" "):
+                # Left the defaults block before finding disable — nothing to do.
+                return yaml_text
+    if disable_idx < 0:
+        return yaml_text
+
+    # Walk forward from disable_idx: the list ends at the first line that is
+    # neither blank nor indented with ``  -`` / ``  `` at 2+ spaces where the
+    # first non-space char is ``-``.
+    list_end = disable_idx
+    for j in range(disable_idx + 1, len(lines)):
+        line = lines[j]
+        if line.startswith("  - "):
+            list_end = j
+            continue
+        # Any other line — top-level key, blank line, or unindented content —
+        # ends the list.
+        break
+    else:
+        list_end = len(lines) - 1
+
+    lines[list_end + 1:list_end + 1] = comment_lines
+    return "\n".join(lines)
+
+
 def write_transfer_yaml(exp_root: Path, doc: dict, force: bool, non_interactive: bool) -> Path:
     """Serialize doc and write atomically to ``<exp-root>/transfer.yaml``."""
     dst = _check_dest_inside(exp_root / "transfer.yaml", exp_root)
     _decide_dest(dst, force, non_interactive)
     text = yaml.safe_dump(doc, sort_keys=False, default_flow_style=False)
+    available_stems = list(doc.get("defaults", {}).get("disable") or [])
+    text = _inject_available_fragments_comment(text, available_stems)
     dst.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_name = tempfile.mkstemp(
         prefix=dst.name + ".", suffix=".tmp", dir=str(dst.parent)

--- a/.claude/skills/sim2real-bootstrap/tests/test_byo.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_byo.py
@@ -715,6 +715,73 @@ def test_defaults_disable_matches_template_stems(bare_exp_root, operator_files):
     assert manifest["defaults"]["disable"] == expected
 
 
+def test_transfer_yaml_carries_available_fragments_comment(bare_exp_root, operator_files):
+    """The emitted transfer.yaml text documents the fragment inventory as a comment
+    block immediately after `defaults.disable`. Stems match sorted templates/defaults/*.yaml
+    (regex-matched, not hardcoded — future additions don't require a test edit)."""
+    code, _ = byo.run_byo(
+        _happy_argv(operator_files), bare_exp_root, _SKILL_DIR, stdin_isatty=False
+    )
+    assert code == 0
+    text = (bare_exp_root / "transfer.yaml").read_text()
+    expected_stems = sorted(
+        p.stem for p in (_SKILL_DIR / "templates" / "defaults").glob("*.yaml")
+    )
+
+    # Header comment appears
+    assert "# Available fragments (filename stems in baselines/defaults/):" in text
+
+    # One `#   - <stem>` line per available stem
+    for stem in expected_stems:
+        assert f"#   - {stem}" in text, f"missing stem comment for {stem}"
+
+    # Header appears AFTER `defaults.disable` list and BEFORE the next
+    # top-level key (`context:`) — protects against a regression that would
+    # place it in the wrong section.
+    lines = text.split("\n")
+    header_idx = next(
+        i for i, ln in enumerate(lines)
+        if "Available fragments" in ln
+    )
+    disable_idx = next(i for i, ln in enumerate(lines) if ln == "  disable:")
+    context_idx = next(i for i, ln in enumerate(lines) if ln == "context:")
+    assert disable_idx < header_idx < context_idx
+
+
+def test_inject_available_fragments_comment_no_op_on_empty(tmp_path):
+    """Empty available_stems list: helper is a no-op (nothing to document)."""
+    yaml_text = "defaults:\n  disable: []\nother: 1\n"
+    result = byo._inject_available_fragments_comment(yaml_text, [])
+    assert result == yaml_text
+
+
+def test_inject_available_fragments_comment_sorts_input():
+    """Even if the caller passes an unsorted list, comment stems come out sorted."""
+    yaml_text = "defaults:\n  disable:\n  - b\n  - a\n  - c\ncontext: {}\n"
+    result = byo._inject_available_fragments_comment(yaml_text, ["c", "a", "b"])
+    # Expected order: a, b, c
+    a_idx = result.index("#   - a")
+    b_idx = result.index("#   - b")
+    c_idx = result.index("#   - c")
+    assert a_idx < b_idx < c_idx
+
+
+def test_inject_available_fragments_comment_does_not_break_yaml_parse():
+    """After injection, yaml.safe_load must still parse the text to the same dict
+    (comments are semantically transparent, but this guards against accidental
+    corruption of the surrounding list)."""
+    original_doc = {
+        "kind": "sim2real-transfer",
+        "version": 3,
+        "defaults": {"disable": ["one", "two"]},
+        "context": {"files": []},
+    }
+    yaml_text = yaml.safe_dump(original_doc, sort_keys=False, default_flow_style=False)
+    injected = byo._inject_available_fragments_comment(yaml_text, ["one", "two"])
+    reparsed = yaml.safe_load(injected)
+    assert reparsed == original_doc
+
+
 # ---------------------------------------------------------------------------
 # Workload enumeration
 # ---------------------------------------------------------------------------

--- a/.claude/skills/sim2real-bootstrap/tests/test_byo.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_byo.py
@@ -1,0 +1,789 @@
+"""Tests for the BYO branch of sim2real-bootstrap (``byo.py``).
+
+Covers the acceptance criteria from issue #499:
+  - BYO happy path — 2 algorithms
+  - BYO error paths (missing/duplicate args, malformed YAML, path traversal)
+  - Non-interactive behavior (stdin non-TTY or --non-interactive)
+  - Args-vs-NL parse equivalence (structured args and NL-derived arg-dict
+    produce equivalent triples — tested on the parser helper)
+  - Path safety (shlex.quote against spaces / $ / ` / ; )
+  - BLIS regression (BLIS-mode dispatch unchanged; existing skill files
+    untouched by this module)
+  - Emitted transfer.yaml loads via pipeline/lib/manifest.load_manifest
+  - Emitted register command passes the actual sim2real register argparser
+"""
+from __future__ import annotations
+
+import os
+import shlex
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+# Locate the skill dir (this test file's parent-parent) and put both the
+# skill dir and the repo root on sys.path so we can import byo directly and
+# also import from pipeline.lib.
+_SKILL_DIR = Path(__file__).resolve().parents[1]
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(_SKILL_DIR))
+sys.path.insert(0, str(_REPO_ROOT))
+import byo  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _valid_scenario_yaml(name: str = "baseline") -> str:
+    """Minimal scenario body accepted by yaml.safe_load; single mapping doc."""
+    return textwrap.dedent(f"""\
+        scenario:
+        - name: {name}
+          model:
+            name: meta-llama/Llama-3.1-8B
+            path: models/meta-llama/Llama-3.1-8B
+          decode:
+            replicas: 1
+    """)
+
+
+def _valid_overlay_yaml(algo: str) -> str:
+    return textwrap.dedent(f"""\
+        scenario:
+        - name: {algo}
+          decode:
+            replicas: 2
+    """)
+
+
+def _write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+    return path
+
+
+@pytest.fixture
+def bare_exp_root(tmp_path: Path) -> Path:
+    """Fake experiment repo with only workloads/ populated (BYO input shape)."""
+    root = tmp_path / "myexperiment"
+    (root / "workloads").mkdir(parents=True)
+    _write(root / "workloads" / "w1.yaml", "workload:\n  name: w1\n")
+    _write(root / "workloads" / "w2.yaml", "workload:\n  name: w2\n")
+    return root
+
+
+@pytest.fixture
+def operator_files(tmp_path: Path) -> dict[str, Path]:
+    """Operator-supplied files, placed outside the experiment repo."""
+    src = tmp_path / "operator"
+    src.mkdir()
+    baseline_path = _write(src / "baseline.yaml", _valid_scenario_yaml("baseline"))
+    foo_overlay = _write(src / "foo_overlay.yaml", _valid_overlay_yaml("foo"))
+    bar_overlay = _write(src / "bar_overlay.yaml", _valid_overlay_yaml("bar"))
+    return {
+        "baseline": baseline_path,
+        "foo": foo_overlay,
+        "bar": bar_overlay,
+    }
+
+
+def _happy_argv(
+    files: dict[str, Path],
+    *,
+    non_interactive: bool = True,
+    extra: list[str] | None = None,
+) -> list[str]:
+    argv = [
+        "--byo",
+        "--baseline", f"baseline={files['baseline']}",
+        "--algorithm", "foo",
+        "--algorithm", "bar",
+        "--algorithm-image", "foo=ghcr.io/example/foo:latest",
+        "--algorithm-image", "bar=ghcr.io/example/bar@sha256:" + "a" * 64,
+        "--algorithm-config", f"foo={files['foo']}",
+        "--algorithm-config", f"bar={files['bar']}",
+    ]
+    if non_interactive:
+        argv.append("--non-interactive")
+    if extra:
+        argv.extend(extra)
+    return argv
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+def test_happy_path_two_algorithms(bare_exp_root, operator_files):
+    argv = _happy_argv(operator_files)
+    code, register_cmd = byo.run_byo(
+        argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False
+    )
+    assert code == 0, register_cmd
+
+    # baselines/baseline.yaml exists with baseline content
+    baseline_dst = bare_exp_root / "baselines" / "baseline.yaml"
+    assert baseline_dst.exists()
+    assert baseline_dst.read_text() == operator_files["baseline"].read_text()
+
+    # algorithms/<algo>/<algo>_config.yaml exists per algorithm
+    for algo in ("foo", "bar"):
+        dst = bare_exp_root / "algorithms" / algo / f"{algo}_config.yaml"
+        assert dst.exists()
+        assert dst.read_text() == operator_files[algo].read_text()
+
+    # framework defaults copied verbatim
+    defaults_dir = bare_exp_root / "baselines" / "defaults"
+    template_dir = _SKILL_DIR / "templates" / "defaults"
+    for src in sorted(template_dir.glob("*.yaml")):
+        dst = defaults_dir / src.name
+        assert dst.exists()
+        assert dst.read_text() == src.read_text()
+
+    # transfer.yaml loads via manifest.load_manifest
+    transfer_path = bare_exp_root / "transfer.yaml"
+    assert transfer_path.exists()
+    from pipeline.lib.manifest import load_manifest
+    manifest = load_manifest(transfer_path)
+
+    # component absent, every algorithm has byo: true and no source
+    assert "component" not in manifest
+    algo_names_manifest = [a["name"] for a in manifest["algorithms"]]
+    assert sorted(algo_names_manifest) == ["bar", "foo"]
+    for entry in manifest["algorithms"]:
+        assert entry.get("byo") is True
+        assert "source" not in entry
+        assert entry["defaults"] == "baseline"
+
+    # defaults.disable matches the sorted stems of templates/defaults/*.yaml
+    expected_stems = sorted(p.stem for p in template_dir.glob("*.yaml"))
+    assert manifest["defaults"]["disable"] == expected_stems
+
+    # Register command shlex-round-trips
+    tokens = shlex.split(register_cmd)
+    assert "sim2real" in tokens
+    assert "register" in tokens
+    # Extract each --algorithm value and parse it via the actual register CLI's
+    # triple parser — the code that the register subcommand runs at parse time.
+    from pipeline.sim2real import _parse_algorithm_triple
+    algo_values = [
+        tokens[i + 1] for i, t in enumerate(tokens) if t == "--algorithm"
+    ]
+    assert len(algo_values) == 2
+    parsed = [_parse_algorithm_triple(v) for v in algo_values]
+    parsed_names = {p[0] for p in parsed}
+    assert parsed_names == {"foo", "bar"}
+
+    # And the emitted command's --algorithm args are accepted by the top-level
+    # register argparser (require=True on --algorithm).
+    from pipeline.sim2real import build_parser as build_top_parser
+    # Strip the `cd '<path>'` line and the `sim2real translation register` head
+    # to isolate the argparse-facing arg vector.
+    lines = [ln.rstrip(" \\") for ln in register_cmd.split("\n")]
+    all_tokens = shlex.split(" ".join(lines))
+    # tokens = ['cd', '<path>', 'sim2real', 'translation', 'register',
+    #           '--algorithm', '<triple>', '--algorithm', '<triple>']
+    idx = all_tokens.index("register")
+    argparser_args = all_tokens[idx:]  # ['register', '--algorithm', ...]
+    # The top-level sim2real parser expects `translation register --algorithm...`
+    # Rebuild that arg vector.
+    top_argv = ["translation"] + argparser_args
+    parser = build_top_parser()
+    ns = parser.parse_args(top_argv)
+    assert ns.command == "translation"
+    assert ns.subcommand == "register"
+    assert len(ns.algorithm) == 2
+
+
+def test_register_command_starts_with_cd_to_abs_exp_root(bare_exp_root, operator_files):
+    argv = _happy_argv(operator_files)
+    code, register_cmd = byo.run_byo(
+        argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False
+    )
+    assert code == 0
+    first_line = register_cmd.split("\n")[0]
+    # cd <abs-path>
+    assert first_line.startswith("cd ")
+    quoted_path = first_line[len("cd "):]
+    # shlex.split gives us the raw path back
+    parts = shlex.split(quoted_path)
+    assert len(parts) == 1
+    resolved_root = os.path.realpath(bare_exp_root)
+    assert parts[0] == resolved_root
+
+
+def test_happy_path_single_algorithm(tmp_path, operator_files):
+    """N=1 is also supported — same path as N=2, just one algorithm."""
+    root = tmp_path / "exp"
+    (root / "workloads").mkdir(parents=True)
+    _write(root / "workloads" / "w1.yaml", "workload:\n  name: w1\n")
+
+    argv = [
+        "--byo",
+        "--baseline", f"baseline={operator_files['baseline']}",
+        "--algorithm", "foo",
+        "--algorithm-image", "foo=ghcr.io/example/foo:latest",
+        "--algorithm-config", f"foo={operator_files['foo']}",
+        "--non-interactive",
+    ]
+    code, register_cmd = byo.run_byo(argv, root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 0, register_cmd
+
+    from pipeline.lib.manifest import load_manifest
+    manifest = load_manifest(root / "transfer.yaml")
+    assert [a["name"] for a in manifest["algorithms"]] == ["foo"]
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+def test_error_missing_baseline(bare_exp_root, operator_files):
+    argv = [
+        "--byo",
+        "--algorithm", "foo",
+        "--algorithm-image", "foo=ghcr.io/example/foo:latest",
+        "--algorithm-config", f"foo={operator_files['foo']}",
+        "--non-interactive",
+    ]
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+    assert "baseline" in message.lower()
+
+
+def test_error_no_algorithm(bare_exp_root, operator_files):
+    argv = [
+        "--byo",
+        "--baseline", f"baseline={operator_files['baseline']}",
+        "--non-interactive",
+    ]
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+    assert "algorithm" in message.lower()
+
+
+def test_error_algorithm_without_image(bare_exp_root, operator_files):
+    argv = [
+        "--byo",
+        "--baseline", f"baseline={operator_files['baseline']}",
+        "--algorithm", "foo",
+        "--algorithm-config", f"foo={operator_files['foo']}",
+        "--non-interactive",
+    ]
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+    assert "foo" in message
+    assert "algorithm-image" in message
+
+
+def test_error_algorithm_without_config(bare_exp_root, operator_files):
+    argv = [
+        "--byo",
+        "--baseline", f"baseline={operator_files['baseline']}",
+        "--algorithm", "foo",
+        "--algorithm-image", "foo=ghcr.io/example/foo:latest",
+        "--non-interactive",
+    ]
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+    assert "foo" in message
+    assert "algorithm-config" in message
+
+
+def test_error_duplicate_algorithm_names(bare_exp_root, operator_files):
+    argv = [
+        "--byo",
+        "--baseline", f"baseline={operator_files['baseline']}",
+        "--algorithm", "foo",
+        "--algorithm", "foo",
+        "--algorithm-image", "foo=ghcr.io/example/foo:latest",
+        "--algorithm-config", f"foo={operator_files['foo']}",
+        "--non-interactive",
+    ]
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+    assert "duplicate" in message.lower()
+    assert "foo" in message
+
+
+def test_error_workloads_dir_missing(tmp_path, operator_files):
+    root = tmp_path / "exp"
+    root.mkdir()  # No workloads/ subdir.
+    argv = _happy_argv(operator_files)
+    code, message = byo.run_byo(argv, root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+    assert "workloads" in message.lower()
+
+
+def test_error_workloads_dir_empty(tmp_path, operator_files):
+    root = tmp_path / "exp"
+    (root / "workloads").mkdir(parents=True)  # Empty.
+    argv = _happy_argv(operator_files)
+    code, message = byo.run_byo(argv, root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+    assert "workload" in message.lower()
+
+
+def test_error_malformed_overlay_yaml(bare_exp_root, operator_files, tmp_path):
+    bad = _write(tmp_path / "bad.yaml", "this is: not: valid: yaml: [\n")
+    argv = [
+        "--byo",
+        "--baseline", f"baseline={operator_files['baseline']}",
+        "--algorithm", "foo",
+        "--algorithm-image", "foo=ghcr.io/example/foo:latest",
+        "--algorithm-config", f"foo={bad}",
+        "--non-interactive",
+    ]
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+    assert str(bad) in message
+    assert "yaml" in message.lower() or "parse" in message.lower()
+
+
+def test_error_malformed_baseline_yaml(bare_exp_root, operator_files, tmp_path):
+    bad = _write(tmp_path / "bad_baseline.yaml", "this is: not: valid: yaml: [\n")
+    argv = [
+        "--byo",
+        "--baseline", f"baseline={bad}",
+        "--algorithm", "foo",
+        "--algorithm-image", "foo=ghcr.io/example/foo:latest",
+        "--algorithm-config", f"foo={operator_files['foo']}",
+        "--non-interactive",
+    ]
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+    assert str(bad) in message
+
+
+@pytest.mark.parametrize("bad_content", [
+    "- a\n- b\n- c\n",  # list root
+    "just a scalar\n",  # scalar root
+    "",                 # empty
+])
+def test_error_non_mapping_root_yaml(bare_exp_root, operator_files, tmp_path, bad_content):
+    bad = _write(tmp_path / "non_mapping.yaml", bad_content)
+    argv = [
+        "--byo",
+        "--baseline", f"baseline={operator_files['baseline']}",
+        "--algorithm", "foo",
+        "--algorithm-image", "foo=ghcr.io/example/foo:latest",
+        "--algorithm-config", f"foo={bad}",
+        "--non-interactive",
+    ]
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+
+
+def test_error_multi_document_yaml(bare_exp_root, operator_files, tmp_path):
+    multi = _write(tmp_path / "multi.yaml", "a: 1\n---\nb: 2\n")
+    argv = [
+        "--byo",
+        "--baseline", f"baseline={operator_files['baseline']}",
+        "--algorithm", "foo",
+        "--algorithm-image", "foo=ghcr.io/example/foo:latest",
+        "--algorithm-config", f"foo={multi}",
+        "--non-interactive",
+    ]
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+    assert "multi" in message.lower() or "document" in message.lower()
+
+
+def test_error_overlay_path_missing(bare_exp_root, operator_files, tmp_path):
+    argv = [
+        "--byo",
+        "--baseline", f"baseline={operator_files['baseline']}",
+        "--algorithm", "foo",
+        "--algorithm-image", "foo=ghcr.io/example/foo:latest",
+        "--algorithm-config", f"foo={tmp_path / 'does_not_exist.yaml'}",
+        "--non-interactive",
+    ]
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+    assert "does_not_exist.yaml" in message
+
+
+def test_error_baseline_path_missing(bare_exp_root, operator_files, tmp_path):
+    argv = [
+        "--byo",
+        "--baseline", f"baseline={tmp_path / 'nowhere.yaml'}",
+        "--algorithm", "foo",
+        "--algorithm-image", "foo=ghcr.io/example/foo:latest",
+        "--algorithm-config", f"foo={operator_files['foo']}",
+        "--non-interactive",
+    ]
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+    assert "nowhere.yaml" in message
+
+
+def test_error_source_symlink_outside_regular_file_required(bare_exp_root, tmp_path):
+    """Source symlink that points to a non-regular file (e.g. a directory) is rejected."""
+    outside = tmp_path / "outside_dir"
+    outside.mkdir()
+    src_symlink = tmp_path / "escape.yaml"
+    src_symlink.symlink_to(outside)  # Symlink to a directory, not a file
+    argv = [
+        "--byo",
+        "--baseline", f"baseline={src_symlink}",
+        "--algorithm", "foo",
+        "--algorithm-image", "foo=ghcr.io/example/foo:latest",
+        "--algorithm-config", f"foo={src_symlink}",
+        "--non-interactive",
+    ]
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+    assert "regular file" in message.lower() or "not a file" in message.lower()
+
+
+def test_error_dest_parent_symlink_escaping_exp_root(bare_exp_root, operator_files, tmp_path):
+    """`<exp-root>/algorithms/` is a symlink that escapes -> destination check fails."""
+    escape_target = tmp_path / "escape_target"
+    escape_target.mkdir()
+    # Replace algorithms/ with a symlink to a directory outside the exp root.
+    (bare_exp_root / "algorithms").symlink_to(escape_target)
+    argv = _happy_argv(operator_files)
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+    assert "outside" in message.lower() or "traversal" in message.lower() or "escape" in message.lower()
+
+
+def test_error_existing_dest_non_interactive_refused(bare_exp_root, operator_files):
+    # First run to create the destination.
+    argv = _happy_argv(operator_files)
+    code, _ = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 0
+    # Second run without --force: fails in non-interactive mode.
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+    assert "exists" in message.lower() and "force" in message.lower()
+
+
+def test_existing_dest_with_force_overwrites(bare_exp_root, operator_files, tmp_path):
+    # First run to create the destination.
+    code, _ = byo.run_byo(_happy_argv(operator_files), bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 0
+    # Change the operator's baseline content, then re-run with --force.
+    new_content = _valid_scenario_yaml("baseline") + "  # updated\n"
+    operator_files["baseline"].write_text(new_content)
+    argv = _happy_argv(operator_files, extra=["--force"])
+    code, _ = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 0
+    assert (bare_exp_root / "baselines" / "baseline.yaml").read_text() == new_content
+
+
+# ---------------------------------------------------------------------------
+# Non-interactive dispatch
+# ---------------------------------------------------------------------------
+
+def test_non_interactive_auto_enabled_when_stdin_not_tty(bare_exp_root, operator_files):
+    """stdin.isatty() == False alone forces non-interactive; no --non-interactive needed."""
+    argv = [
+        "--byo",
+        # Missing baseline, no --non-interactive; but stdin is non-TTY.
+        "--algorithm", "foo",
+        "--algorithm-image", "foo=ghcr.io/example/foo:latest",
+        "--algorithm-config", f"foo={operator_files['foo']}",
+    ]
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+    assert "baseline" in message.lower()
+
+
+def test_non_interactive_explicit_flag_forces_no_prompt(bare_exp_root, operator_files):
+    """--non-interactive forces non-interactive even when stdin is a TTY."""
+    argv = [
+        "--byo",
+        "--algorithm", "foo",
+        "--algorithm-image", "foo=ghcr.io/example/foo:latest",
+        "--algorithm-config", f"foo={operator_files['foo']}",
+        "--non-interactive",
+    ]
+    # stdin_isatty=True but --non-interactive present → no prompt, fatal.
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=True)
+    assert code == 2
+    assert "baseline" in message.lower()
+
+
+# ---------------------------------------------------------------------------
+# Args-vs-NL equivalence
+# ---------------------------------------------------------------------------
+
+def test_args_vs_nl_parse_equivalence(operator_files):
+    """Structured args and NL-derived argv produce equivalent parsed dicts.
+
+    The NL frontend lives in SKILL.md prose (LLM-driven; not CI-tested per
+    design.md#risks). What IS testable is that if an LLM converts NL into
+    the structured argv shape, both paths produce the same dict. This test
+    encodes that contract on the parser helper.
+    """
+    argv_structured = _happy_argv(operator_files, non_interactive=False)
+
+    # An NL request like:
+    #   "--byo with baseline at <path>, algorithm foo image <img1> config <ov1>,
+    #    algorithm bar image <img2> config <ov2>"
+    # would produce (from an LLM parser) the same argv tokens as structured
+    # args. The parser helper is order-agnostic on the dict shape.
+    argv_from_nl_shape = [
+        "--byo",
+        "--baseline", f"baseline={operator_files['baseline']}",
+        # NL parser might reorder these — validate order-independence
+        "--algorithm-image", "foo=ghcr.io/example/foo:latest",
+        "--algorithm-image", "bar=ghcr.io/example/bar@sha256:" + "a" * 64,
+        "--algorithm", "foo",
+        "--algorithm", "bar",
+        "--algorithm-config", f"foo={operator_files['foo']}",
+        "--algorithm-config", f"bar={operator_files['bar']}",
+    ]
+
+    d1 = byo.parse_args_dict(argv_structured)
+    d2 = byo.parse_args_dict(argv_from_nl_shape)
+
+    # `algorithms` is order-preserving; NL should produce the same relative
+    # order (LLM told "foo then bar" → [foo, bar]).
+    assert d1["algorithms"] == d2["algorithms"]
+    # Everything else compares as-is.
+    assert d1["baseline"] == d2["baseline"]
+    assert d1["algorithm_images"] == d2["algorithm_images"]
+    assert d1["algorithm_configs"] == d2["algorithm_configs"]
+    assert d1["byo"] == d2["byo"]
+
+
+# ---------------------------------------------------------------------------
+# Path safety — shlex.quote against shell metacharacters
+# ---------------------------------------------------------------------------
+
+def test_shlex_quote_covers_shell_metacharacters(tmp_path):
+    """Register command emission handles spaces, $, `, ; without corruption.
+
+    Uses an experiment root with metacharacters in the path and verifies the
+    emitted register command round-trips through shlex.split back to the
+    original strings.
+    """
+    weird_root = tmp_path / "path with spaces & $vars; and `backticks`"
+    (weird_root / "workloads").mkdir(parents=True)
+    _write(weird_root / "workloads" / "w1.yaml", "workload:\n  name: w1\n")
+
+    # Overlay file with problematic filename.
+    weird_overlay_dir = tmp_path / "operator with; $shell `special` chars"
+    weird_overlay_dir.mkdir()
+    overlay = _write(weird_overlay_dir / "overlay.yaml", _valid_overlay_yaml("foo"))
+    baseline = _write(tmp_path / "baseline.yaml", _valid_scenario_yaml("baseline"))
+
+    argv = [
+        "--byo",
+        "--baseline", f"baseline={baseline}",
+        "--algorithm", "foo",
+        "--algorithm-image", "foo=ghcr.io/example/foo:latest",
+        "--algorithm-config", f"foo={overlay}",
+        "--non-interactive",
+    ]
+    code, register_cmd = byo.run_byo(argv, weird_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 0
+
+    # Round-trip: shlex.split of the emitted command should recover the raw path.
+    first_line = register_cmd.split("\n")[0]
+    parts = shlex.split(first_line)
+    assert parts[0] == "cd"
+    assert parts[1] == os.path.realpath(weird_root)
+
+
+def test_emit_register_command_triple_is_shlex_quoted(bare_exp_root, tmp_path):
+    """An image ref containing shell-sensitive chars is quoted-and-recovered."""
+    # Note: real image refs shouldn't contain shell metacharacters, but the
+    # emitter must not depend on that — the register command is user-facing.
+    overlay = _write(tmp_path / "foo_overlay.yaml", _valid_overlay_yaml("foo"))
+    # Image ref with a colon and semicolon (control test only — not a valid ref;
+    # we ensure the emitter never corrupts the string).
+    image = "registry.example.com/image:tag;withsemi"
+    algo = byo.ResolvedAlgorithm(name="foo", image_ref=image, config_src=overlay)
+    cmd = byo.emit_register_command(Path(os.path.realpath(bare_exp_root)), [algo])
+    tokens = shlex.split(cmd)
+    idx = tokens.index("--algorithm")
+    triple = tokens[idx + 1]
+    assert triple == f"foo={image}@algorithms/foo/foo_config.yaml"
+
+
+# ---------------------------------------------------------------------------
+# Name validation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("bad_name", [
+    "Foo",         # uppercase
+    "foo_bar",     # underscore
+    "-foo",        # leading hyphen
+    "foo-",        # trailing hyphen
+    "",            # empty
+    "a" * 21,      # too long
+    "1",           # single-char is fine actually — check regex end anchor
+])
+def test_invalid_algorithm_name_rejected(bad_name, bare_exp_root, operator_files):
+    # Special-case: "1" is a valid single-char name per the regex; skip it.
+    if bad_name == "1":
+        pytest.skip("single-digit name is valid")
+    argv = [
+        "--byo",
+        "--baseline", f"baseline={operator_files['baseline']}",
+        "--algorithm", bad_name,
+        "--algorithm-image", f"{bad_name}=ghcr.io/example/x:latest",
+        "--algorithm-config", f"{bad_name}={operator_files['foo']}",
+        "--non-interactive",
+    ]
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+
+
+def test_reserved_algorithm_name_baseline_rejected(bare_exp_root, operator_files):
+    """An algorithm named `baseline` collides with the framework role."""
+    argv = [
+        "--byo",
+        "--baseline", f"baseline={operator_files['baseline']}",
+        "--algorithm", "baseline",
+        "--algorithm-image", "baseline=ghcr.io/example/x:latest",
+        "--algorithm-config", f"baseline={operator_files['foo']}",
+        "--non-interactive",
+    ]
+    code, message = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 2
+    assert "reserved" in message.lower()
+
+
+def test_baseline_named_baseline_is_allowed(bare_exp_root, operator_files):
+    """A *baseline* named 'baseline' is the canonical case, not reserved."""
+    argv = _happy_argv(operator_files)  # baseline=baseline
+    code, _ = byo.run_byo(argv, bare_exp_root, _SKILL_DIR, stdin_isatty=False)
+    assert code == 0
+
+
+# ---------------------------------------------------------------------------
+# Scenario name derivation
+# ---------------------------------------------------------------------------
+
+def test_scenario_from_readme_first_header(tmp_path):
+    root = tmp_path / "somedir"
+    root.mkdir()
+    (root / "README.md").write_text("# My Fancy Experiment\n\nSome description.\n")
+    scenario = byo.derive_scenario_name(root, override=None)
+    assert scenario == "my-fancy-experiment"
+
+
+def test_scenario_from_basename_when_no_readme_header(tmp_path):
+    root = tmp_path / "MyExperiment_v2"
+    root.mkdir()
+    scenario = byo.derive_scenario_name(root, override=None)
+    assert scenario == "myexperiment-v2"
+
+
+def test_scenario_override(tmp_path):
+    root = tmp_path / "somedir"
+    root.mkdir()
+    scenario = byo.derive_scenario_name(root, override="Custom Name!")
+    assert scenario == "custom-name"
+
+
+def test_scenario_normalization_truncates_to_40_chars(tmp_path):
+    root = tmp_path / "somedir"
+    root.mkdir()
+    long_name = "a" * 60
+    scenario = byo.derive_scenario_name(root, override=long_name)
+    assert len(scenario) == 40
+
+
+def test_scenario_empty_after_normalization_is_fatal(tmp_path):
+    root = tmp_path / "somedir"
+    root.mkdir()
+    with pytest.raises(byo.BYOError, match="scenario"):
+        byo.derive_scenario_name(root, override="!!!@@@###")
+
+
+# ---------------------------------------------------------------------------
+# defaults.disable population
+# ---------------------------------------------------------------------------
+
+def test_defaults_disable_matches_template_stems(bare_exp_root, operator_files):
+    code, _ = byo.run_byo(
+        _happy_argv(operator_files), bare_exp_root, _SKILL_DIR, stdin_isatty=False
+    )
+    assert code == 0
+    manifest = yaml.safe_load((bare_exp_root / "transfer.yaml").read_text())
+    expected = sorted(
+        p.stem for p in (_SKILL_DIR / "templates" / "defaults").glob("*.yaml")
+    )
+    assert manifest["defaults"]["disable"] == expected
+
+
+# ---------------------------------------------------------------------------
+# Workload enumeration
+# ---------------------------------------------------------------------------
+
+def test_workload_enumeration_sorts_and_skips_hidden(tmp_path):
+    root = tmp_path / "exp"
+    (root / "workloads").mkdir(parents=True)
+    _write(root / "workloads" / "b.yaml", "b: 1\n")
+    _write(root / "workloads" / "a.yaml", "a: 1\n")
+    _write(root / "workloads" / ".hidden.yaml", "h: 1\n")
+    _write(root / "workloads" / "not_yaml.txt", "ignored\n")
+    _write(root / "workloads" / "ignored.yml", "ignored\n")  # .yml, not .yaml
+    workloads = byo.enumerate_workloads(root)
+    assert [p.name for p in workloads] == ["a.yaml", "b.yaml"]
+
+
+def test_workload_symlink_escaping_workloads_rejected(tmp_path):
+    root = tmp_path / "exp"
+    (root / "workloads").mkdir(parents=True)
+    outside = tmp_path / "outside.yaml"
+    _write(outside, "w: 1\n")
+    (root / "workloads" / "escape.yaml").symlink_to(outside)
+    with pytest.raises(byo.BYOError, match="outside"):
+        byo.enumerate_workloads(root)
+
+
+# ---------------------------------------------------------------------------
+# BLIS regression — this module must not affect existing BLIS-mode logic
+# ---------------------------------------------------------------------------
+
+def test_blis_generate_from_config_still_importable():
+    """Sanity check: BLIS-mode module untouched by BYO addition."""
+    import generate_from_config as gfc  # noqa: F401
+    # Presence of the module and its key symbols is enough — the full BLIS
+    # test suite runs adjacent to this one in the same directory.
+    assert hasattr(gfc, "extract_fields")
+    assert hasattr(gfc, "build_additional_flags")
+
+
+# ---------------------------------------------------------------------------
+# emit_transfer_yaml — direct unit tests
+# ---------------------------------------------------------------------------
+
+def test_transfer_yaml_shape_matches_design(tmp_path, operator_files):
+    root = tmp_path / "exp"
+    (root / "workloads").mkdir(parents=True)
+    _write(root / "workloads" / "w1.yaml", "w: 1\n")
+    _write(root / "workloads" / "w2.yaml", "w: 2\n")
+
+    algorithms = [
+        byo.ResolvedAlgorithm(name="foo", image_ref="i1", config_src=operator_files["foo"]),
+        byo.ResolvedAlgorithm(name="bar", image_ref="i2", config_src=operator_files["bar"]),
+    ]
+    doc = byo.build_transfer_yaml(
+        scenario="my-scenario",
+        baseline_name="baseline",
+        algorithms=algorithms,
+        workloads=[root / "workloads" / "w1.yaml", root / "workloads" / "w2.yaml"],
+        exp_root=root,
+        defaults_stems=["a-default", "b-default"],
+    )
+    assert doc["kind"] == "sim2real-transfer"
+    assert doc["version"] == 3
+    assert doc["scenario"] == "my-scenario"
+    assert "component" not in doc
+    assert doc["baselines"] == [{"name": "baseline", "scenario": "baselines/baseline.yaml"}]
+    assert doc["algorithms"] == [
+        {"name": "foo", "defaults": "baseline", "byo": True},
+        {"name": "bar", "defaults": "baseline", "byo": True},
+    ]
+    assert doc["workloads"] == ["workloads/w1.yaml", "workloads/w2.yaml"]
+    assert doc["defaults"]["disable"] == ["a-default", "b-default"]

--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ claude --dangerously-skip-permissions --add-dir $SIM2REAL
 /sim2real-bootstrap
 ```
 
-Skip this step if your experiment repo already contains `transfer.yaml`, `baselines/`, and a component submodule.
+For BYO operators — pre-built EPP image(s) + baseline scenario + per-algorithm overlay(s), no BLIS artifacts — use `--byo` mode instead: `/sim2real-bootstrap --byo --baseline ... --algorithm ... --algorithm-image ... --algorithm-config ...`. See [`.claude/skills/sim2real-bootstrap/SKILL.md`](.claude/skills/sim2real-bootstrap/SKILL.md#--byo-mode) for the full invocation.
+
+Skip this step if your experiment repo already contains `transfer.yaml`, `baselines/`, and (BLIS only) a component submodule.
 
 ### 2. Set required environment variables
 

--- a/docs/epics/step-4/design.md
+++ b/docs/epics/step-4/design.md
@@ -1,0 +1,446 @@
+# Epic step-4 — `sim2real-bootstrap` port + `--byo` mode
+
+## Overview
+
+Port the `/sim2real-bootstrap` skill (`.claude/skills/sim2real-bootstrap/`) to work cleanly with the three-dimensional workspace produced by steps 0-2, and add a new `--byo` mode for operators who arrive with pre-built EPP images (plus a full baseline scenario and per-algorithm overlays) instead of a BLIS-format experiment folder. Bootstrap's job — scaffold the inputs the sim2real pipeline expects (`transfer.yaml`, `baselines/`, `algorithms/` layout, workload selection, and optionally a component submodule) — is preserved verbatim; what changes is (a) which task branches fire and (b) which schema shape the emitted `transfer.yaml` takes.
+
+Three work strands, one epic:
+
+- **`--byo` mode in bootstrap.** New. BYO operators bring: N pre-built EPP images, N per-algorithm scenario overlays, and one full baseline scenario. They do NOT bring `algorithms/*.go`, `config.md`, `top3_selection.json`, or a component submodule. Bootstrap collects these inputs (args or natural-language description, prompt for anything missing, fatal on missing fields in non-interactive contexts), copies them into canonical locations inside the experiment repo, emits a valid `transfer.yaml` with `component:` omitted and per-algorithm `byo: true` markers, and prints one copy-pasteable `sim2real translation register` command (batched, single translation containing all N algorithms).
+
+- **`sim2real translation register` batched-algorithm mode.** Extend the CLI so one register invocation can register N algorithms into a single translation (each with its own image ref + overlay). Necessary so multi-algorithm BYO runs into a single translation hash that `sim2real assemble --translation <hash>` can consume unchanged. The current single-algorithm shape (step-1 MVP) becomes the N=1 case of the new batched shape.
+
+- **BLIS-mode refresh.** Preserve current bootstrap semantics (Tasks 0-6 in the existing SKILL.md); make three targeted updates: replace `AskUserQuestion` sites with plain-text numbered prompts (project-wide precedent from step-3 and a persistent user preference), audit that bootstrap's outputs still feed step-2 (`translation register`, `translate`, `assemble`) and step-3 (`sim2real-check`) cleanly, and refresh SKILL.md prose where step-0/1/2/3 CLI surface drift has occurred.
+
+## Sources
+
+- `docs/proposals/incremental-implementation-plan.md#step-4` — canonical scope: port `/sim2real-bootstrap` + add `--byo` mode. Explicitly excludes a shipped workload library ("Don't ship a workload library yet — customers can hand-provide workloads for now").
+- `docs/proposals/incremental-implementation-plan-addendum.md#step-4` — scope reality: bootstrap has substantial code (not just SKILL.md); `--byo` interactive-vs-stub ratio and tolerant-parser scope were open questions; `transfer.yaml` schema must declare `component:` optional (a constraint that may need a step-0 amendment).
+- Prior epics landing on `refactor/v2`: **step-0** (workspace + cluster provisioning; `transfer.yaml` schema v3), **step-1** (BYO MVP via single-algorithm `sim2real translation register`), **step-2** (skill-driven translation, `sim2real translate`, `sim2real translation register`), **step-3** (`sim2real-check` port).
+
+## Design decisions (resolved during intake + external review)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| BYO operator profile | Pre-built EPP image(s) + full baseline scenario + per-algorithm overlay(s). No BLIS artifacts. | Aligns with step-1's `translation register` flow; the operator brings the artifacts a completed translation would have produced. |
+| BYO input collection — argument grammar | Three repeatable flags: `--algorithm <name>` (defines an algo), `--algorithm-image <name>=<ref>` (maps a name to its image), `--algorithm-config <name>=<path>` (maps a name to its overlay). Plus `--baseline <name>=<scenario-path>`. | Digest image refs use `@` (`image@sha256:...`); overloading `@` for `image@overlay` is ambiguous. Split-flag grammar is unambiguous and shell-safe. |
+| BYO input collection — natural language | Skill also accepts NL like *"--byo with baseline foo at /path/bar.yaml, algorithm quartic image ghcr.io/... config /path/z.yaml, algorithm softreflective ..."*. LLM parses into the structured triple set. | Args make it scriptable; NL makes first-time invocation ergonomic. Users overwhelmingly prefer NL for one-shot invocations. |
+| Prompting behavior | Plain-text numbered prompts for missing fields (no `AskUserQuestion`). If stdin is not a TTY, missing required fields are fatal errors naming what's missing. `--force` bypasses overwrite prompts. | Matches step-3; project has a persistent user preference against `AskUserQuestion`. Non-interactive fail-fast keeps CI/scripted usage sane. |
+| Multi-algorithm BYO | Supported via `sim2real translation register` batched mode (single register call registers all N algorithms into one translation). Bootstrap emits exactly one register command per BYO run. `sim2real assemble --translation <hash>` unchanged (consumes the one multi-algorithm translation). | Aligns BYO with BLIS's `translate` output shape; `assemble`'s single-translation contract stays intact. |
+| Per-algorithm overlay shape | Delta overlays (partial YAML that deep-merges onto the baseline during `assemble`). Full-scenario files are tolerated — they just override everything. Merge semantics owned by `assemble`, not bootstrap. | Matches what `translation register --config <path>` already consumes. Bootstrap parse-validates the file (safe_load, mapping) but does not merge. |
+| Baseline scenario shape | Full scenario. Operator supplies one baseline. Multi-baseline is not in scope for step-4 (matches step-2/3 assumptions). | Matches today's `baselines/*.yaml` convention. |
+| `defaults.disable` in BYO | Populated at bootstrap time from the sorted stems of `*.yaml` files copied from `templates/defaults/`. Duplicate stems (e.g. `foo.yaml` + `foo.yml`) are fatal. | Framework fragments would silently overwrite an operator's baseline otherwise; deterministic sort makes diffs stable. |
+| Framework defaults directory | Copied into `<exp-root>/baselines/defaults/` in BYO too. All listed under `defaults.disable`. | Same on-disk layout as BLIS; operator can un-disable individual fragments without re-bootstrapping. |
+| `component:` in BYO `transfer.yaml` | Omitted. Schema loosening: `component:` optional when *all* algorithms carry `byo: true`. | BYO has no submodule to pin. Loosening scoped to BYO markers keeps BLIS validation strict. |
+| `algorithms[].source:` in BYO `transfer.yaml` | Omitted for BYO algorithms. Schema loosening: `source:` optional per-entry when that entry carries `byo: true`. | Same reasoning. Absence of `byo: true` still requires `source:` (BLIS mistakes stay fail-fast at load time). |
+| Explicit BYO discriminator | `algorithms[i].byo: true` per-entry marker (new field, defaults to `false` / absent). | Per-algorithm granularity supports future mixed-mode manifests (some BLIS, some BYO); keeps the schema loosening explicit and reviewer-visible. |
+| Register CLI grammar for batched mode | New shape: `sim2real translation register --algorithm <name>=<image>@<config>` (repeatable). The step-1 single-algorithm invocation form is deprecated but kept working as the N=1 case. | Batch is unambiguous with `--algorithm` repeatable; overlay-per-algo shell-quoted. |
+| Register hash for multi-algorithm | `translation_hash = sha256(sorted-canonical-serialize([{name, image_digest_or_ref, config_bytes} for each algo]))`. Deterministic in algorithm-set membership; hash is unchanged if algorithms are re-ordered on the command line. | Preserves determinism; supports idempotent re-registration. |
+| Register command emission | At end of `--byo` run, print one copy-pasteable `sim2real translation register` command carrying all N algorithms. Bootstrap does not invoke register itself. All paths in the emitted command are quoted with `shlex.quote`; the block is prefixed by `cd <abs-exp-root> && ` so the emitted command runs against the intended experiment repo regardless of the operator's CWD. | Keeps bootstrap side-effect-free at the workspace level; `shlex.quote` prevents shell-injection risk from operator-supplied paths. |
+| `AskUserQuestion` in SKILL.md | Replace with plain-text numbered prompts throughout (both BLIS and BYO paths). | Consistent with step-3. |
+| `generate_from_config.py` / `generate_scenarios.py` | Untouched. | BLIS-only paths; the port doesn't need to change the parsers. |
+| Tolerant BLIS parser (addendum #18) | Out of scope. | Not on the critical path; step-4 focus is BYO + refresh. |
+| `--stub-all` fast path (addendum #17) | Not needed. | BYO operator brings baseline + overlays themselves; no fields require stubbing. |
+| Rollout | Four PRs. PR-1: schema `byo:` marker + validator update + manifest tests. PR-2: `translation register` batched-algorithm mode. PR-3: BYO bootstrap (blocked by PR-1 and PR-2). PR-4: BLIS SKILL.md refresh (independent). | Schema and register CLI are independent and can land in parallel; BYO bootstrap depends on both. |
+| Test level | "Solid" — regression + happy-path + core error paths + schema tests + command-specific validation. No full end-to-end integration test in this epic. | Enough to survive drift; step-5+ will re-shape assumptions. |
+
+## Architecture
+
+### Data flow — BLIS mode (regression, minimal change)
+
+```
+BLIS-output experiment folder
+    (algorithms/*.go, config.md, top3_selection.json, workloads/*.yaml, README.md)
+        ↓
+/sim2real-bootstrap  (Tasks 0-6, unchanged shape; plain-text prompts replace AskUserQuestion)
+    ↓
+Experiment repo scaffolded:
+    transfer.yaml       (kind: sim2real-transfer, version: 3, component: <submodule>,
+                         algorithms[].source: <path.go>, no byo: markers)
+    baselines/*.yaml   (generated by generate_from_config.py OR generate_scenarios.py)
+    baselines/defaults/*.yaml   (copied from templates/defaults/)
+    workloads/*.yaml    (operator's own; enumerated by bootstrap)
+    <component>/        (submodule pinned at derived ref)
+        ↓
+Existing step-2/3 flow: `sim2real translate` → `translation register` → `assemble` → `sim2real-check`
+```
+
+### Data flow — `--byo` mode (new)
+
+```
+Operator invokes (structured args):
+    /sim2real-bootstrap --byo \
+        --baseline baseline=/path/to/baseline.yaml \
+        --algorithm softreflective --algorithm quartic \
+        --algorithm-image softreflective=ghcr.io/foo/softreflective:tag \
+        --algorithm-image quartic=ghcr.io/foo/quartic@sha256:abcd... \
+        --algorithm-config softreflective=/path/to/softreflective_overlay.yaml \
+        --algorithm-config quartic=/path/to/quartic_overlay.yaml
+
+Or in natural language, e.g.:
+    /sim2real-bootstrap --byo with baseline at /path/baseline.yaml,
+    algorithm softreflective image ghcr.io/foo/softreflective:tag config
+    /path/softreflective.yaml, algorithm quartic image ...
+
+Anything missing → plain-text prompts (interactive TTY) or fatal errors
+(non-TTY / --non-interactive).
+        ↓
+Bootstrap collects the (name, image-ref, overlay-path) triples + (baseline-name, scenario-path)
+        ↓
+On-disk copies into experiment repo (atomic write-and-rename; safe against traversal):
+    <exp-root>/baselines/baseline.yaml                                    <- copy of operator's baseline scenario
+    <exp-root>/baselines/defaults/*.yaml                                  <- framework fragments (unchanged)
+    <exp-root>/algorithms/softreflective/softreflective_config.yaml       <- copy of overlay
+    <exp-root>/algorithms/quartic/quartic_config.yaml                     <- copy of overlay
+    <exp-root>/workloads/*.yaml                                           <- enumerated as-is (operator brought)
+        ↓
+Bootstrap emits transfer.yaml (BYO shape — see next section; algorithms carry byo: true)
+        ↓
+Bootstrap prints one copy-pasteable register command:
+
+    cd '/abs/path/to/exp-root'
+    sim2real translation register \
+        --algorithm 'softreflective=ghcr.io/foo/softreflective:tag@algorithms/softreflective/softreflective_config.yaml' \
+        --algorithm 'quartic=ghcr.io/foo/quartic@sha256:abcd...@algorithms/quartic/quartic_config.yaml'
+
+Then: sim2real assemble --translation <hash> --cluster <id> --run <name>
+        ↓
+No translate / build step — BYO images are already built. `assemble` consumes the one
+multi-algorithm translation registered above.
+```
+
+## `--byo` mode specification
+
+### Experiment root discovery
+
+Bootstrap treats the current working directory as `<exp-root>` when `--byo` is invoked. It does not search parent directories. All emitted paths are relative to `<exp-root>`. The register-command block starts with `cd <abs-exp-root>` so the operator can copy-paste from any shell without worrying about their current directory.
+
+### Scenario name derivation
+
+`transfer.yaml`'s top-level `scenario:` is derived as follows, first match wins:
+
+1. If a `README.md` exists at `<exp-root>/README.md` and its first non-empty line is a `# Title` header, use the title text.
+2. Else use `basename(<exp-root>)`.
+
+Whatever is derived is then normalized: lowercased, non-`[a-z0-9-]` chars replaced with `-`, runs of `-` collapsed to one, leading and trailing `-` trimmed, truncated to 40 chars. Empty result after normalization is a fatal error (`--scenario <name>` override supported).
+
+### Invocation surface
+
+Skill argument parsing (in SKILL.md prose):
+
+- `--byo` — mode flag. Presence dispatches to the BYO branch; absence keeps existing BLIS behavior.
+- `--baseline <name>=<scenario-path>` — one required. `<name>` matches `^[a-z0-9]([-a-z0-9]{0,18}[a-z0-9])?$` (Kubernetes DNS-label subset, 1-20 chars; hyphens allowed except at boundaries). `<scenario-path>` is a filesystem path (absolute or CWD-relative) to a full baseline scenario YAML.
+- `--algorithm <name>` — repeatable, at least one required. Same `<name>` constraint as baseline. Declares the algorithm exists.
+- `--algorithm-image <name>=<ref>` — repeatable, one per declared algorithm. `<ref>` is a full container image reference. Minimal validation: non-empty, no whitespace, no control characters; final validation deferred to `translation register`.
+- `--algorithm-config <name>=<overlay-path>` — repeatable, one per declared algorithm. `<overlay-path>` points to a partial YAML overlay.
+- `--scenario <name>` — optional override for the derived scenario name.
+- `--force` — bypass overwrite confirmation on destination files that already exist.
+- `--non-interactive` — assume the invocation is scripted; missing required fields are fatal errors instead of prompts. Auto-enabled when stdin is not a TTY.
+
+Reserved algorithm/baseline names (fatal if requested): `default`, `defaults`, `baseline` collides with a per-algorithm `--baseline` name (the *baseline* named `baseline` is allowed; a *treatment algorithm* named `baseline` is not).
+
+Natural-language equivalent: operator can describe the same triples and baseline in prose. The skill's prompt logic parses the description into the structured argument set (LLM in the loop), then prompts plain-text for any missing field. Non-interactive contexts require args — NL is prompt-time only.
+
+### On-disk copy layout
+
+Bootstrap COPIES the operator's files into canonical experiment-repo locations. Originals are left intact:
+
+| Source | Destination | Rationale |
+|---|---|---|
+| Operator's baseline scenario | `<exp-root>/baselines/<baseline-name>.yaml` | Matches BLIS convention; downstream (`translate`, `assemble`) reads `baselines/` verbatim. |
+| Operator's per-algorithm overlay | `<exp-root>/algorithms/<algo-name>/<algo-name>_config.yaml` | Matches the shape `translation register` writes under `workspace/translations/<hash>/generated/<algo>/`; makes the register command's `--algorithm ...=<config>` path readable from `<exp-root>`. |
+| `<skill-dir>/templates/defaults/*.yaml` | `<exp-root>/baselines/defaults/*.yaml` | Same as BLIS mode. Copied for self-containment; all listed under `defaults.disable` so they don't apply. |
+| `<exp-root>/workloads/*.yaml` | Not copied (already operator-owned in experiment repo) | Bootstrap only enumerates and lists in transfer.yaml. |
+
+**Copy semantics:**
+- Source path is resolved; must be a regular file (symlinks resolved once, target must be a regular file).
+- Destination parent directory is resolved; must lie inside resolved `<exp-root>`. Traversal via `..`, symlink games, or absolute paths are rejected.
+- Destination file existing → prompt in interactive mode; fatal in non-interactive mode; bypassed by `--force`.
+- Write is atomic: write to a sibling temp file, then rename. Prevents half-written files on crash.
+
+**YAML parse-validation at copy time (bootstrap, not downstream):**
+- File readable + `yaml.safe_load` succeeds.
+- Top-level document is a mapping (not a list, scalar, or null).
+- Multi-document YAML (`---` separators) is rejected.
+- Empty document is rejected.
+
+The above applies to both the baseline scenario and each per-algorithm overlay. Deep-merge semantics between them are owned entirely by `sim2real assemble` — bootstrap parse-validates but does not merge.
+
+### Workload enumeration
+
+Non-recursive glob `<exp-root>/workloads/*.yaml`. Symlinks resolved and required to remain inside `<exp-root>/workloads/`. Hidden files (leading `.`) skipped. Sort by lexicographic filename. Duplicate basenames are impossible (filesystem). If the resulting list is empty (missing directory or no matches), fatal error naming the directory.
+
+`.yml`-extension files are ignored — this matches BLIS's current behavior in Task 4. If real-world usage surfaces `.yml` files, a follow-up can add the extension; not in scope for step-4.
+
+### `defaults.disable` population
+
+Enumerate stems (`Path.stem`) of `*.yaml` files copied into `<exp-root>/baselines/defaults/` at bootstrap time. Hidden files skipped. Sorted alphabetically. Duplicate stems (from a hypothetical `foo.yaml` + `foo.yml` pair — cannot happen today because `.yml` is not copied but the check is cheap) are a fatal error.
+
+Rationale: framework can add or remove fragments in a future release and BYO `transfer.yaml` stays in sync.
+
+### Emitted `transfer.yaml` shape (BYO)
+
+```yaml
+kind: sim2real-transfer
+version: 3
+
+scenario: <derived from experiment folder name / README title, normalized>
+
+# component: absent — BYO has no submodule (validator allows this when all algorithms
+# carry byo: true; see "Schema addition" section)
+
+baselines:
+  - name: baseline
+    scenario: baselines/baseline.yaml
+
+algorithms:
+  - name: softreflective
+    defaults: baseline
+    byo: true
+    # source: absent — BYO has no .go source
+  - name: quartic
+    defaults: baseline
+    byo: true
+
+workloads:
+  - workloads/w1.yaml
+  - workloads/w2.yaml
+  - workloads/w3.yaml
+
+defaults:
+  disable:
+    # Populated from the actual filename stems in <exp-root>/baselines/defaults/
+    # at bootstrap time. As of writing, that directory contains:
+    - epp-verbosity
+    - externally-managed-gateway
+    - llm-d-rbac
+    - preserve-request-id
+    - routing-proxy-resources
+    - vllm-logging
+
+context:
+  files: []
+  text: |
+    Bring-your-own translation. Images and per-algorithm overlays supplied
+    externally; no BLIS source in this experiment repo.
+```
+
+### Register command emission
+
+At the end of a `--byo` run, bootstrap prints ONE `sim2real translation register` command carrying all algorithms (batched mode — see the register-CLI section below). Paths are quoted with `shlex.quote`; the block is prefixed with `cd` to the absolute experiment root so paste order is CWD-agnostic:
+
+```
+Next: register all algorithms in one call.
+
+    cd '/absolute/path/to/exp-root'
+    sim2real translation register \
+        --algorithm 'softreflective=ghcr.io/foo/softreflective:tag@algorithms/softreflective/softreflective_config.yaml' \
+        --algorithm 'quartic=ghcr.io/foo/quartic@sha256:abcd...@algorithms/quartic/quartic_config.yaml'
+
+The command prints one translation hash. Then:
+
+    sim2real assemble --translation <hash> --cluster <cluster_id> --run <run-name>
+```
+
+Bootstrap does not invoke register itself. This keeps bootstrap side-effect-free at the workspace level — the operator retains control over which translations to actually register and can inspect the emitted scaffolding first.
+
+## `sim2real translation register` batched-algorithm mode
+
+### CLI surface
+
+Extend the register subcommand to accept the algorithm/image/config triples in one call. Grammar:
+
+```
+sim2real translation register --algorithm <name>=<image-ref>@<config-path> [--algorithm ...]
+                              [--baseline-config <path>]
+                              [--force] [--registered-hash HASH]
+```
+
+- `--algorithm <name>=<image-ref>@<config-path>` — repeatable, at least one required.
+  - `<name>` matches the same regex as bootstrap (Kubernetes DNS-label subset, 1-20 chars).
+  - `<image-ref>` may contain `@` (digest-form refs). Parser splits the triple on the **rightmost** `=` and then the **rightmost** `@` in the remaining substring. This is the only unambiguous split. Overlay paths containing `@` are rejected (fatal, with an error naming the constraint). Overlay paths containing `=` are supported (only the rightmost `=` splits).
+  - `<config-path>` is a filesystem path (absolute or CWD-relative) to a YAML overlay.
+- Deprecated single-algorithm form (step-1): `--algorithm NAME --image REF --config PATH` — kept working as a legacy invocation that produces an N=1 registration. Emitted deprecation warning to stderr, no functional change. Removal is a step-5+ follow-up.
+- `--baseline-config <path>` unchanged.
+- `--force`, `--registered-hash` unchanged.
+
+### Translation hash for batched registration
+
+For an N-algorithm registration, `translation_hash` is:
+
+```
+sha256(canonical-json([
+    {"name": <name>, "image": <digest-or-ref>, "config": <sha256(config-bytes)>}
+    for each algorithm, sorted by name
+]))
+```
+
+Deterministic in the algorithm set — reordering `--algorithm` on the command line doesn't change the hash. Idempotent — re-running the same set produces the same hash and hits the existing "already registered, no-op" path. Adding a new algorithm to a previously-registered set produces a different hash (registered as a new translation).
+
+The step-1 single-algorithm hash formula was `sha256(digest_or_ref, config_bytes, algorithm_name)`. The new formula collapses to the same shape for N=1 with canonical-json framing — hash values will change (breaks any existing on-disk single-algorithm registrations from step-1). Mitigation: step-1 was very recently landed; no long-lived translation registrations exist in production yet. A one-line note in the PR body: "existing `workspace/translations/<hash>/` from step-1 will be re-registered under a new hash."
+
+### On-disk shape
+
+Unchanged from step-1: one translation dir at `workspace/translations/<hash>/`, containing:
+- `translation_output.json` — algorithm index + provenance. Now carries N algorithm entries instead of 1.
+- `registered.json` — image refs + digests. Now carries N entries.
+- `generated/<algo>/<algo>_config.yaml` — verbatim copy of each overlay. One directory per algorithm.
+
+## Schema addition (`pipeline/lib/manifest.py`)
+
+### The `byo: true` per-algorithm marker
+
+Add an optional per-entry field:
+
+```yaml
+algorithms:
+  - name: softreflective
+    defaults: baseline
+    byo: true
+```
+
+Validator changes:
+
+1. **`byo: true` implies `source:` optional.** Today's required-field loop at approximately `pipeline/lib/manifest.py:80-90` iterates `("name", "source", "defaults")` for each algorithm. After: if `entry.get("byo") is True`, skip the `source` check. `name` and `defaults` remain required for every entry.
+2. **`component:` optional when all algorithms are `byo: true`.** Today's check at `pipeline/lib/manifest.py:160-171` requires `component` when any algorithm is declared. After: if every algorithm entry has `byo: true`, `component:` may be absent (unchanged if any algorithm is BLIS-shape).
+3. **Mixed manifests are allowed at the loader level** — a manifest may declare some BLIS algorithms and some BYO algorithms. Downstream commands may or may not support mixed mode (see "Command-specific validation" below).
+
+Non-BYO algorithm entries still require `source:` (BLIS mistakes stay fail-fast at load time). Non-BYO manifests still require `component:`.
+
+### Command-specific validation
+
+Loader permissiveness is paired with per-command validation so BYO-appropriate absences don't silently break BLIS-appropriate commands:
+
+- **`sim2real translate`** — reads `algorithms[].source` to locate `.go` files. If any selected algorithm has no `source:`, error: *"cannot translate algorithm '<name>' — no `source:` in transfer.yaml (BYO algorithm; use `sim2real translation register` directly)."*
+- **`sim2real build`** — reads `component:` to determine the base image. If `component:` is absent (all-BYO manifest), error: *"nothing to build — this transfer.yaml declares no component (all algorithms are BYO; images are pre-built)."*
+- **`sim2real translation register`** — does not read `algorithms[].source` or `component:`. Unchanged.
+- **`sim2real assemble`** — reads `algorithms[].name` and `algorithms[].defaults`. Does not need `source:` or `component:` when the referenced translation supplies images. Unchanged.
+- **`sim2real-check`** (step-3) — does not read `algorithms[].source` or `component:`. Unchanged.
+
+Each of these guardrails is covered by a targeted test in PR-1 (loader) and PR-2 (register) — see the testing plan below.
+
+## BLIS-mode refresh
+
+Preserve Tasks 0-6 of the current SKILL.md verbatim except for three touches:
+
+1. **`AskUserQuestion` → plain-text numbered prompts.** Two sites in current SKILL.md (line 44 general instruction, line 108 Task 1 concrete example). Same semantics: operator confirms derived values before bootstrap proceeds. Same output shape; only the prompt mechanism changes.
+
+2. **Path-audit prose.** Verify SKILL.md's references to downstream commands (`translate`, `translation register`, `assemble`, `sim2real-check`) match the current CLI surface after steps 0-3. If any drift is found (e.g., a flag renamed), correct in this PR. This is a prose refresh, not a semantic change.
+
+3. **Cross-reference to `--byo`.** Add a one-line note near the top of SKILL.md pointing at the BYO branch: *"For pre-built images without BLIS-format inputs, use `--byo` mode (see below)."* Keeps the two modes discoverable from either entry point.
+
+`generate_from_config.py` and `generate_scenarios.py` are untouched. `generate_scenarios.README.md` is touched only if the audit surfaces inaccuracies.
+
+## Testing plan
+
+### Level: "Solid" — regression + happy-path + core error paths + schema + command-specific validation tests
+
+Not full end-to-end integration; that overlaps with step-1/2 test coverage and is likely to change in step-5+.
+
+### PR-1 tests (`byo: true` marker + validator)
+
+In `pipeline/tests/test_manifest.py` (or new file if it does not exist):
+
+- **Schema — new field acceptance.** `algorithms[i].byo: true` with `source:` absent → loads successfully.
+- **Schema — non-BYO still strict.** `algorithms[i].byo: false` (or absent) with `source:` absent → error naming `source`.
+- **Schema — component optional when all algos byo.** `component:` absent, all `algorithms[].byo: true` → loads.
+- **Schema — component still required when mixed.** One BYO algo + one BLIS algo, `component:` absent → error naming `component`.
+- **Schema — component required when no byo.** All BLIS algorithms, `component:` absent → error (unchanged regression).
+- **Schema — byo type check.** `byo:` present but not boolean → error naming the field and its type.
+
+Command-specific validation guards:
+- **`sim2real translate` BYO guard.** Attempt to translate an algorithm marked `byo: true` → error naming the algorithm and the reason (no `source:` to translate).
+- **`sim2real build` all-BYO guard.** Attempt to build a manifest with all algorithms `byo: true` (no `component:`) → error naming the reason (nothing to build).
+- **`sim2real translation register` BYO manifest read.** Load a BYO manifest through `manifest.load_manifest`, verify no field is dereferenced that a BYO entry omits.
+
+### PR-2 tests (batched `translation register`)
+
+In `pipeline/tests/test_sim2real.py` (or a new `test_translation_register_batched.py`):
+
+- **Happy path — 2 algorithms.** Register two algorithms in one call → one translation dir with two algorithm entries in `translation_output.json`, two overlay files under `generated/`, deterministic hash.
+- **Happy path — 1 algorithm (deprecated form).** Old-style `--algorithm N --image R --config P` → equivalent registration, deprecation warning on stderr.
+- **Rightmost-`@`-in-image-ref.** Register with `--algorithm foo=registry.io/img@sha256:deadbeef@algorithms/foo/foo_config.yaml` → image ref parsed as `registry.io/img@sha256:deadbeef`, config path as `algorithms/foo/foo_config.yaml`.
+- **Overlay path containing `@`.** `--algorithm foo=img:tag@path@with@ats` → fatal error naming the constraint.
+- **Duplicate algorithm names.** Two `--algorithm foo=...` triples → fatal.
+- **Idempotent re-registration.** Same triples in different order → same hash, "already registered, no-op" path.
+- **Alias-collision handling.** Reuse existing single-algorithm collision-detection path; verify batched invocations that collide behave identically.
+- **Malformed overlay.** Register with a config path whose YAML fails `safe_load` → fatal, error names the file and parse issue.
+
+### PR-3 tests (BYO bootstrap)
+
+New file `.claude/skills/sim2real-bootstrap/tests/test_byo.py` (or extension of the existing tests directory):
+
+- **BYO happy path — 2 algorithms.** Fake experiment repo (bare — only `workloads/` populated), operator inputs supplied as args, bootstrap runs to completion. Assert:
+  - `<exp-root>/baselines/<name>.yaml` exists with baseline scenario content.
+  - `<exp-root>/algorithms/<algo>/<algo>_config.yaml` exists per algorithm.
+  - `<exp-root>/baselines/defaults/*.yaml` copied from templates.
+  - Emitted `transfer.yaml` loads successfully via `manifest.load_manifest` (integration with PR-1's `byo:` marker).
+  - `defaults.disable` matches all filenames in `templates/defaults/` at test time (regex-matched, not hardcoded).
+  - No `component:` key. Every `algorithms[]` entry has `byo: true` and no `source` key.
+  - Emitted register command is one line (batched), well-formed, `shlex`-quoted (test asserts round-trip through `shlex.split`).
+
+- **BYO error paths.**
+  - Missing `--baseline` → error naming the missing field.
+  - No `--algorithm` at all → error.
+  - `--algorithm foo` with no `--algorithm-image foo=...` → error naming `foo` and the missing field.
+  - `--algorithm foo` with no `--algorithm-config foo=...` → error naming `foo` and the missing field.
+  - Duplicate `--algorithm` names → error.
+  - Missing `<exp-root>/workloads/` or empty → error naming the directory.
+  - Malformed overlay YAML → error naming the file and parse issue.
+  - Malformed baseline YAML → same.
+  - Non-mapping-root YAML (list, scalar, empty) for either baseline or overlay → error.
+  - Multi-document YAML for either → error.
+  - Baseline/overlay path doesn't exist → error naming the path.
+  - Path-traversal in overlay dest (via source symlink pointing outside `<exp-root>`, or dest that resolves outside) → refused.
+  - Overwrite refused when destination file exists and neither TTY-confirmation nor `--force` present.
+
+- **Args-vs-NL parse.** If argument parsing is extracted into a small helper, unit-test structured args and NL-derived arg-dict produce equivalent triples.
+
+- **Register command well-formedness.** Emitted register command passes `sim2real translation register --help`-compatible argparse (integration test: invoke the register argparser on the emitted args, assert it accepts them).
+
+### PR-4 tests (BLIS refresh)
+
+Regression only. Existing `tests/test_generate_from_config.py` continues passing. Add one new case if the `AskUserQuestion` swap warrants a prompt-parsing test (probably not — the prose change doesn't have code to exercise).
+
+## Demo criteria
+
+Two flows validated end-to-end at epic close (evidence attached to the epic):
+
+1. **BLIS-source regression.** Start from a BLIS-output experiment folder, run `/sim2real-bootstrap` in BLIS mode. Produce a `transfer.yaml` + `baselines/` + workload selection that step-2's `sim2real translate` + `sim2real translation register` consume cleanly. Proceed through `sim2real assemble` and `sim2real-check --run <name>` to a full validation report. Same output as before the epic — no user-visible drift.
+
+2. **BYO new flow — multi-algorithm.** Start from a bare experiment repo (only `workloads/` populated). Run `/sim2real-bootstrap --byo --baseline baseline=<...> --algorithm foo --algorithm bar --algorithm-image foo=<...> --algorithm-image bar=<...> --algorithm-config foo=<...> --algorithm-config bar=<...>`. Produce a valid `transfer.yaml` (with `byo: true` per algo, `component:` absent) + `baselines/` + `algorithms/` layout. Run the emitted `sim2real translation register` command (single call, both algorithms in one translation). Then `sim2real assemble --translation <hash> --run <name>` produces deployable YAMLs. Then `sim2real-check --run <name>` renders a validation report against a real-cluster smoke run. Fixture-based test coverage plus a single real-cluster smoke.
+
+## Out of scope / deferred
+
+- **Workload library shipping.** Plan says not yet; operator-provided.
+- **Interactive-vs-stub UX ratio (addendum #17).** Moot with the resolved BYO shape — operator brings baseline + overlays, so there is nothing to stub. `--stub-all` fast path also moot.
+- **Tolerant BLIS parser (addendum #18).** `generate_from_config.py` and `generate_scenarios.py` are untouched. If real BLIS-format drift is observed post-epic, file a follow-up.
+- **Multi-baseline in BYO.** One baseline per BYO run. Matches step-2/3's single-baseline assumption (deferred to a future multi-baseline epic covering steps 3-5).
+- **Removing the step-1 deprecated single-algorithm `register` invocation.** Kept working with a deprecation warning in step-4; removal is a step-5+ cleanup.
+- **`sim2real assemble` accepting multiple `--translation` refs.** Not needed with the batched-register design — one translation per BYO run.
+- **Bootstrap invoking `register` automatically.** Explicit non-goal: bootstrap stays side-effect-free at the workspace level. Operator runs the emitted register command themselves.
+- **Dry-run mode for bootstrap.** Nice-to-have; deferred to a follow-up if operators want it.
+- **`.yml`-extension workloads/defaults.** Only `.yaml` matches. If observed in the wild, a follow-up can broaden the glob.
+- **Absolute-paths-internally / relative-paths-in-manifest split.** Emitted `transfer.yaml` uses experiment-repo-relative paths for portability; bootstrap's internal work uses resolved absolute paths for safety. Documented above; no separate spec section.
+- **`generate_scenarios.README.md` refresh.** Touched only if drift is surfaced during PR-1 or PR-3.
+
+## Rollout — four PRs
+
+- **PR-1 — Schema `byo: true` marker + validator + command-specific guards.** `pipeline/lib/manifest.py` adds the `byo:` field; validator loosens `source:` and `component:` per the rules above; new tests. Adds command-specific validation in `translate` (require source) and `build` (require component), with tests. Small (~2 files changed, ~10 test cases added). Lands first — unblocks PR-3.
+- **PR-2 — `sim2real translation register` batched-algorithm mode.** New `--algorithm <name>=<image>@<config>` repeatable flag; new multi-algorithm hash formula; new tests; deprecation warning on the step-1 single-algo form. Medium (~1 file changed + tests + doc note in `pipeline/README.md`). Independent of PR-1 — the register command doesn't need the schema marker; the schema marker is a bootstrap-side / manifest-side concern. Lands in parallel with PR-1.
+- **PR-3 — BYO bootstrap.** New `--byo` branch in `sim2real-bootstrap/SKILL.md`, argument parsing (args + NL + plain-text prompts for missing, `--non-interactive` + `--force` for scripted use), on-disk copy logic + destination validation, `defaults.disable` population from `templates/defaults/` filenames, batched register-command emission with `shlex.quote`, BYO happy-path + error-path tests, top-level `README.md` + `pipeline/README.md` refs to `--byo`. Blocked by both PR-1 (schema) and PR-2 (register CLI). Larger PR.
+- **PR-4 — BLIS-mode SKILL.md refresh.** `AskUserQuestion` → plain-text prompt swap (2 sites), path-audit prose, cross-reference note to `--byo`. Independent — can land any time after PR-1 (or before, if we're willing to have a brief window where the top-line prose references `--byo` before it exists in the SKILL.md branch). Small PR.
+
+Dependency order: `{PR-1, PR-2}` parallel → PR-3 (needs both) → PR-4 (any time; simplest to land last for a clean SKILL.md diff).
+
+## Risks
+
+- **Schema addition needs downstream command guards.** The `byo:` marker is a loosening at the loader level; without command-specific guards, a BYO manifest reaching `translate` or `build` would silently mis-process. Mitigation: PR-1 adds those guards + tests. If a downstream command is missed, its bug will surface at the demo — treat as a hotfix follow-up rather than expanding step-4 scope.
+- **Register hash formula change breaks step-1 registrations.** Existing `workspace/translations/<hash>/` from step-1 will be re-registered under a new hash after PR-2 lands. Mitigation: step-1 shipped recently; no long-lived registrations exist yet. Documented in PR-2 body. If a real user has one, they re-run register.
+- **BLIS regression is silent** until an operator runs a full BLIS flow. Coverage relies on the existing `test_generate_from_config.py` + PR-3's interop check. If real drift is found post-epic, promote to a follow-up issue.
+- **Copy vs reference for overlay files.** Bootstrap copies the operator's overlay into `<exp-root>/algorithms/<name>/<name>_config.yaml`; subsequent edits to the operator's original path do NOT propagate. Mitigation: SKILL.md's post-run summary names the copy destinations and points the operator at them as canonical going forward.
+- **Register-command drift.** The register-command emission prose in SKILL.md carries the register CLI grammar. If PR-2's grammar changes late in review, the bootstrap prose goes stale silently. Mitigation: PR-3 includes an integration test that parses the emitted command through the actual register argparser — if register drifts, the test fails.
+- **Path-traversal via operator-supplied paths.** Overlay/baseline paths from args are copied into `<exp-root>`. Bootstrap validates each resolved destination is inside resolved `<exp-root>` and rejects symlinks that escape. PR-3's tests include traversal, symlink-outside, and existing-symlink-destination cases.
+- **NL parsing is nondeterministic across LLM runs.** The natural-language operator input path relies on the LLM to convert prose into structured args. Reproducibility isn't guaranteed across model versions. Mitigation: only the structured parser is tested in CI; NL is treated as an ergonomic front-end, not a stable contract. Non-interactive contexts require args (NL rejected).
+- **Shell-quoting bugs in emitted register commands.** Paths with spaces, backticks, `$(...)`, or dollar-signs could produce dangerous copy-paste output. Mitigation: `shlex.quote` on every emitted path/argument; PR-3 tests include a "paths with spaces + shell metacharacters" case that round-trips through `shlex.split`.
+- **`--algorithm name=image@config` grammar edge cases.** Overlay paths containing `@` are rejected; overlay paths containing `=` are supported via rightmost-split. If real BYO overlays turn out to routinely use `@` in filenames, revisit the grammar. Mitigation: PR-2 tests exercise both cases and document the constraint in the register `--help` text.

--- a/docs/superpowers/plans/2026-07-05-issue-497-byo-marker-schema.md
+++ b/docs/superpowers/plans/2026-07-05-issue-497-byo-marker-schema.md
@@ -1,0 +1,702 @@
+# Issue #497: schema `byo: true` marker + validator + command-specific guards
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add per-algorithm `byo: true` marker to the v3 `transfer.yaml` schema, loosen the validator so BYO entries can omit `source:` and all-BYO manifests can omit `component:`, and add explicit guards in `sim2real translate` / `sim2real build` so BLIS-only commands fail with actionable messages on BYO-shaped manifests.
+
+**Architecture:** The change lands in three places. (1) `pipeline/lib/manifest.py` gets a new optional `byo` bool per algorithm entry, and two validator loosens — the per-algo required-field loop skips `source` when `byo is True`, and `_validate_v3_fields`'s `component` requirement changes from "any algorithm" to "any non-BYO algorithm". (2) `pipeline/sim2real.py` gains two per-command guards: `_cmd_translate` errors on any BYO algorithm, and `_cmd_build` loads `transfer.yaml` (with the same discovery fallback `_cmd_translate` uses) and errors if `component:` is absent. (3) Tests + README note.
+
+**Tech Stack:** Python 3, PyYAML, pytest.
+
+## Global Constraints
+
+- Non-BYO entries still require `source:`. Non-BYO manifests still require `component:`. BLIS validation stays strict.
+- Error messages verbatim from the issue acceptance criteria — do not paraphrase.
+- Preserve existing tests (regression); no drift in surface area outside what the issue names.
+- Lint: `ruff check pipeline/ --select F` must stay clean.
+- File paths: this session runs inside the worktree at `.claude/worktrees/issue-497-byo-marker-schema/`. Every path in every step must include that substring.
+
+---
+
+### Task 1: Schema — accept, type-check, and document the `byo: true` marker
+
+**Files:**
+- Modify: `pipeline/lib/manifest.py:80-90` (per-algorithm required-field loop)
+- Test: `pipeline/tests/test_manifest.py` (add tests after the existing algorithms-block tests)
+
+**Interfaces:**
+- Consumes: nothing new
+- Produces: loader accepts `algorithms[i].byo: true|false` (bool); type-check errors on non-bool; when `byo is True`, `source:` becomes optional for that entry; `name` and `defaults` remain required for every entry
+
+- [ ] **Step 1: Write failing tests for `byo` acceptance, type check, and BYO-entry source loosening**
+
+Append to `pipeline/tests/test_manifest.py`:
+
+```python
+# ── byo: true per-algorithm marker (v3 schema addition) ─────────────────
+
+def test_byo_true_algorithm_loads_without_source(tmp_path):
+    """`algorithms[i].byo: true` makes `source:` optional for that entry.
+
+    Non-BYO manifests still need `component:`, so keep the MINIMAL_V3
+    component block; loosening `component:` is exercised separately.
+    """
+    data = {
+        **MINIMAL_V3,
+        "algorithms": [
+            {"name": "byoalgo", "defaults": "baseline", "byo": True},
+        ],
+    }
+    path = _write_manifest(tmp_path, data)
+    m = load_manifest(path)
+    assert m["algorithms"][0]["name"] == "byoalgo"
+    assert m["algorithms"][0]["byo"] is True
+    assert "source" not in m["algorithms"][0]
+
+
+def test_byo_false_algorithm_still_requires_source(tmp_path):
+    """`byo: false` (or absent) leaves `source:` required — regression."""
+    data = {
+        **MINIMAL_V3,
+        "algorithms": [
+            {"name": "treatment", "defaults": "baseline", "byo": False},
+        ],
+    }
+    path = _write_manifest(tmp_path, data)
+    with pytest.raises(ManifestError, match="algorithms.*source"):
+        load_manifest(path)
+
+
+def test_byo_absent_algorithm_still_requires_source(tmp_path):
+    """Absent `byo:` behaves identically to `byo: false` — regression."""
+    data = {
+        **MINIMAL_V3,
+        "algorithms": [
+            {"name": "treatment", "defaults": "baseline"},
+        ],
+    }
+    path = _write_manifest(tmp_path, data)
+    with pytest.raises(ManifestError, match="algorithms.*source"):
+        load_manifest(path)
+
+
+@pytest.mark.parametrize("bad_value", ["true", 1, 0, [True], {"v": True}])
+def test_byo_must_be_boolean(tmp_path, bad_value):
+    """Non-bool `byo:` is rejected with an error naming the field and type."""
+    data = {
+        **MINIMAL_V3,
+        "algorithms": [
+            {"name": "byoalgo", "defaults": "baseline", "byo": bad_value,
+             "source": "sim2real_golden/routers/router_adaptive_v2.go"},
+        ],
+    }
+    path = _write_manifest(tmp_path, data)
+    with pytest.raises(ManifestError, match="byo.*bool"):
+        load_manifest(path)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest pipeline/tests/test_manifest.py -v -k "byo"`
+Expected: FAIL — either the tests fail because the loader rejects `byo`, or because the loosening isn't in place.
+
+- [ ] **Step 3: Implement the schema change in `pipeline/lib/manifest.py`**
+
+Replace the algorithms required-field loop at approximately `pipeline/lib/manifest.py:80-90`. The current loop is:
+
+```python
+        for i, entry in enumerate(algos):
+            if not isinstance(entry, dict):
+                raise ManifestError(f"algorithms[{i}] must be a mapping")
+            for f in ("name", "source", "defaults"):
+                if f not in entry:
+                    raise ManifestError(f"algorithms[{i}] missing required field: {f}")
+            _validate_package_name(entry["name"], f"algorithms[{i}]")
+            if entry["name"] in seen_algo_names:
+                raise ManifestError(f"algorithms: duplicate name '{entry['name']}'")
+            seen_algo_names.add(entry["name"])
+```
+
+Replace with:
+
+```python
+        for i, entry in enumerate(algos):
+            if not isinstance(entry, dict):
+                raise ManifestError(f"algorithms[{i}] must be a mapping")
+            # `byo: true` marker (v3 schema addition). Bool type; if True,
+            # `source:` is optional for this entry (per-command validation
+            # in sim2real.py rejects BYO manifests where a `.go` source
+            # is actually needed).
+            byo = entry.get("byo", False)
+            if "byo" in entry and not isinstance(byo, bool):
+                raise ManifestError(
+                    f"algorithms[{i}].byo must be a bool, got {type(byo).__name__}"
+                )
+            required = ("name", "defaults") if byo else ("name", "source", "defaults")
+            for f in required:
+                if f not in entry:
+                    raise ManifestError(f"algorithms[{i}] missing required field: {f}")
+            _validate_package_name(entry["name"], f"algorithms[{i}]")
+            if entry["name"] in seen_algo_names:
+                raise ManifestError(f"algorithms: duplicate name '{entry['name']}'")
+            seen_algo_names.add(entry["name"])
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest pipeline/tests/test_manifest.py -v -k "byo"`
+Expected: PASS (all four tests).
+
+- [ ] **Step 5: Run the full manifest test file to check for regressions**
+
+Run: `.venv/bin/python -m pytest pipeline/tests/test_manifest.py -v`
+Expected: All tests pass (existing tests unchanged behavior).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/kalantar/projects/go.workspace/src/github.com/inference-sim/sim2real/.claude/worktrees/issue-497-byo-marker-schema
+git add pipeline/lib/manifest.py pipeline/tests/test_manifest.py
+git commit -m "manifest: accept optional \`byo: true\` per-algorithm marker
+
+Loosen the algorithms required-field loop so an entry marked
+\`byo: true\` may omit \`source:\`. \`name\` and \`defaults\` remain
+required for every entry. Non-bool \`byo:\` values are rejected with
+an error naming the field and its type.
+
+Refs #497"
+```
+
+---
+
+### Task 2: Schema — `component:` optional when all algorithms are BYO
+
+**Files:**
+- Modify: `pipeline/lib/manifest.py:160-171` (component requirement in `_validate_v3_fields`)
+- Test: `pipeline/tests/test_manifest.py` (add tests after Task 1's block)
+
+**Interfaces:**
+- Consumes: `entry.get("byo") is True` marker from Task 1
+- Produces: `component:` is optional when every algorithm entry carries `byo: true`; mixed manifests (any non-BYO algo) still require `component:`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `pipeline/tests/test_manifest.py`:
+
+```python
+def test_component_optional_when_all_algorithms_byo(tmp_path):
+    """`component:` may be absent when every algorithm carries `byo: true`."""
+    data = {k: v for k, v in MINIMAL_V3.items() if k != "component"}
+    data["algorithms"] = [
+        {"name": "byoa", "defaults": "baseline", "byo": True},
+        {"name": "byob", "defaults": "baseline", "byo": True},
+    ]
+    path = _write_manifest(tmp_path, data)
+    m = load_manifest(path)
+    assert "component" not in m
+    assert len(m["algorithms"]) == 2
+
+
+def test_component_required_when_mixed_byo_and_blis(tmp_path):
+    """`component:` still required when any algorithm is non-BYO."""
+    data = {k: v for k, v in MINIMAL_V3.items() if k != "component"}
+    data["algorithms"] = [
+        {"name": "byoalgo", "defaults": "baseline", "byo": True},
+        {"name": "blisalgo", "defaults": "baseline",
+         "source": "sim2real_golden/routers/router_adaptive_v2.go"},
+    ]
+    path = _write_manifest(tmp_path, data)
+    with pytest.raises(ManifestError, match="component.*required"):
+        load_manifest(path)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest pipeline/tests/test_manifest.py -v -k "component_optional_when_all_algorithms_byo or component_required_when_mixed"`
+Expected: FAIL — the all-BYO test currently fails because `_validate_v3_fields` errors on missing `component:` whenever algorithms is non-empty.
+
+- [ ] **Step 3: Implement the component-requirement loosening**
+
+In `pipeline/lib/manifest.py`, replace the `has_algorithms` block inside `_validate_v3_fields`. Current:
+
+```python
+    # component (required only when algorithms are present)
+    component = data.get("component")
+    has_algorithms = bool(data.get("algorithms"))
+
+    if component is None:
+        if has_algorithms:
+            raise ManifestError(
+                "component is required when algorithms are specified"
+            )
+        # Remove explicit null so downstream .get("component", {}) returns {} not None
+        data.pop("component", None)
+```
+
+Replace with:
+
+```python
+    # component (required only when at least one algorithm is BLIS-shape;
+    # all-BYO manifests may omit component: since BYO images are pre-built).
+    component = data.get("component")
+    algos = data.get("algorithms") or []
+    has_blis_algorithm = any(algo.get("byo") is not True for algo in algos)
+
+    if component is None:
+        if has_blis_algorithm:
+            raise ManifestError(
+                "component is required when non-BYO algorithms are specified"
+            )
+        # Remove explicit null so downstream .get("component", {}) returns {} not None
+        data.pop("component", None)
+```
+
+**Note:** the error message changes from `"component is required when algorithms are specified"` to `"component is required when non-BYO algorithms are specified"`. Existing test `test_component_required_when_algorithms_present` matches on `"component.*required.*algorithms"` — this regex still matches. Verify.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest pipeline/tests/test_manifest.py -v -k "byo or component"`
+Expected: All pass, including existing `test_component_required_when_algorithms_present` (regex still matches the new message).
+
+- [ ] **Step 5: Run the full manifest test file**
+
+Run: `.venv/bin/python -m pytest pipeline/tests/test_manifest.py -v`
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/kalantar/projects/go.workspace/src/github.com/inference-sim/sim2real/.claude/worktrees/issue-497-byo-marker-schema
+git add pipeline/lib/manifest.py pipeline/tests/test_manifest.py
+git commit -m "manifest: make \`component:\` optional when all algorithms are BYO
+
+The component submodule exists to source-build BLIS-generated
+algorithm images; BYO operators bring pre-built images and have no
+submodule to pin. Loosen \`_validate_v3_fields\` so \`component:\` is
+required only when at least one algorithm entry is non-BYO. Mixed
+manifests (any \`byo: false\`/absent entry) still require it.
+
+Refs #497"
+```
+
+---
+
+### Task 3: `sim2real translate` — BYO algorithm guard
+
+**Files:**
+- Modify: `pipeline/sim2real.py` `_cmd_translate` (around line 600, after `declared_algos = ...`)
+- Test: `pipeline/tests/test_translate.py` (append to file)
+
+**Interfaces:**
+- Consumes: manifest with `algorithms[].byo: true`
+- Produces: exit code 2 + exact error message on stderr when any algorithm is BYO
+
+- [ ] **Step 1: Write failing test**
+
+Append to `pipeline/tests/test_translate.py`:
+
+```python
+# ── BYO guard (issue #497) ────────────────────────────────────────────────
+
+
+class TestTranslateByoGuard:
+    """`sim2real translate` refuses to run on BYO algorithms — the BYO
+    path is `sim2real translation register`, not `translate`."""
+
+    def _write_byo_manifest(self, tmp_path):
+        exp = tmp_path
+        (exp / "algorithms").mkdir(exist_ok=True)
+        manifest = {
+            "kind": "sim2real-transfer",
+            "version": 3,
+            "scenario": "byo-scenario",
+            "baselines": [{"name": "base", "scenario": "baseline-scenario"}],
+            "algorithms": [
+                {"name": "byoalgo", "defaults": "base", "byo": True},
+            ],
+            "context": {"text": "", "files": []},
+        }
+        path = exp / "transfer.yaml"
+        path.write_text(yaml.safe_dump(manifest))
+        return path
+
+    def test_all_byo_manifest_errors(self, tmp_path, capsys):
+        self._write_byo_manifest(tmp_path)
+        assert _run_translate([]) == 2
+        err = capsys.readouterr().err
+        assert "cannot translate algorithm 'byoalgo'" in err
+        assert "sim2real translation register" in err
+
+    def test_mixed_manifest_errors_on_byo_algo(self, tmp_path, capsys):
+        """One BYO + one BLIS algorithm → still errors, naming the BYO one."""
+        exp = tmp_path
+        (exp / "algorithms").mkdir(exist_ok=True)
+        (exp / "algorithms" / "blisalgo.py").write_text("# stub\n")
+        manifest = {
+            "kind": "sim2real-transfer",
+            "version": 3,
+            "scenario": "mixed-scenario",
+            "baselines": [{"name": "base", "scenario": "baseline-scenario"}],
+            "algorithms": [
+                {"name": "byoalgo", "defaults": "base", "byo": True},
+                {"name": "blisalgo", "defaults": "base",
+                 "source": "algorithms/blisalgo.py"},
+            ],
+            "component": {"repo": "example.com/x/y", "kind": "scorer"},
+            "context": {"text": "", "files": []},
+        }
+        (exp / "transfer.yaml").write_text(yaml.safe_dump(manifest))
+        assert _run_translate([]) == 2
+        err = capsys.readouterr().err
+        assert "cannot translate algorithm 'byoalgo'" in err
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest pipeline/tests/test_translate.py::TestTranslateByoGuard -v`
+Expected: FAIL — with the schema loosened but no guard yet, the loader lets the BYO manifest through; then either `_cmd_translate` completes (all-BYO test) or errors with a different message (missing `source:` file, since slicer skips it — actually it may succeed and write a checkpoint, which is exactly the silent-misprocess bug this guard prevents).
+
+- [ ] **Step 3: Implement the guard**
+
+In `pipeline/sim2real.py` `_cmd_translate`, after the algorithms-declared check:
+
+```python
+    declared_algos = manifest.get("algorithms") or []
+    if not declared_algos:
+        print("error: transfer.yaml has no algorithms declared", file=sys.stderr)
+        return 2
+    for algo in declared_algos:
+        try:
+            translation_ref.validate_name(algo.get("name", ""))
+        except translation_ref.ValidationError as exc:
+            print(f"error: invalid algorithm name: {exc}", file=sys.stderr)
+            return 2
+```
+
+Add immediately after, before the `slicer.translation_hash_with_sources` call:
+
+```python
+    # BYO algorithms are registered directly via `sim2real translation
+    # register`; they have no `source:` for the skill-driven translate
+    # pipeline to work on. Error early with a pointer to the right command
+    # rather than silently writing a checkpoint with zero-source algorithms.
+    for algo in declared_algos:
+        if algo.get("byo") is True:
+            print(
+                f"error: cannot translate algorithm '{algo['name']}' — no "
+                f"`source:` in transfer.yaml (BYO algorithm; use "
+                f"`sim2real translation register` directly).",
+                file=sys.stderr,
+            )
+            return 2
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest pipeline/tests/test_translate.py::TestTranslateByoGuard -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the whole `test_translate.py` for regressions**
+
+Run: `.venv/bin/python -m pytest pipeline/tests/test_translate.py -v`
+Expected: All pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/kalantar/projects/go.workspace/src/github.com/inference-sim/sim2real/.claude/worktrees/issue-497-byo-marker-schema
+git add pipeline/sim2real.py pipeline/tests/test_translate.py
+git commit -m "sim2real translate: reject BYO algorithms with pointer to \`register\`
+
+The skill-driven \`translate\` pipeline consumes \`algorithms[].source\`
+(reads bytes, hashes, and passes to the skill). BYO algorithms have
+no such source. With the schema loosening in the prior commits, an
+all-BYO manifest would otherwise pass validation and produce a
+zero-source checkpoint that silently misrepresents intent.
+
+Guard early in \`_cmd_translate\`; error mentions the algorithm name
+and points at \`sim2real translation register\`.
+
+Refs #497"
+```
+
+---
+
+### Task 4: `sim2real build` — all-BYO manifest guard
+
+**Files:**
+- Modify: `pipeline/sim2real.py` `_cmd_build` (around line 838, right after `exp_root` is derived)
+- Test: `pipeline/tests/test_build.py` (append)
+
+**Interfaces:**
+- Consumes: manifest with `component:` absent
+- Produces: exit code 2 + exact error message on stderr
+
+- [ ] **Step 1: Write failing test**
+
+Append to `pipeline/tests/test_build.py`. First, check the file's imports and any shared fixture — the existing `TestSim2realBuildPrereqs` class already uses `_make_workspace` and calls `sim2real.main([...])`. Follow that pattern:
+
+```python
+class TestSim2realBuildByoGuard:
+    """Issue #497: `sim2real build` on an all-BYO manifest errors early —
+    BYO images are pre-built, so there's nothing for `build` to do."""
+
+    def test_all_byo_manifest_errors_without_component(self, tmp_path, capsys):
+        _make_workspace(tmp_path)
+        # Write an all-BYO transfer.yaml (no component:, all algos byo: true)
+        manifest = {
+            "kind": "sim2real-transfer",
+            "version": 3,
+            "scenario": "byo-scenario",
+            "baselines": [{"name": "base", "scenario": "baseline-scenario"}],
+            "algorithms": [
+                {"name": "byoalgo", "defaults": "base", "byo": True},
+            ],
+            "context": {"text": "", "files": []},
+        }
+        (tmp_path / "transfer.yaml").write_text(yaml.safe_dump(manifest))
+        with patch("pipeline.lib.build.shutil.which",
+                   return_value="/usr/bin/skopeo"):
+            rc = sim2real.main([
+                "--experiment-root", str(tmp_path),
+                "build", "--translation", "byo-scenario",
+            ])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "nothing to build" in err
+        assert "all algorithms are BYO" in err
+```
+
+Then check `test_build.py`'s imports include `yaml` and `patch`:
+
+Run: `.venv/bin/python -c "import ast; t=ast.parse(open('pipeline/tests/test_build.py').read()); print([n.names[0].name for n in ast.walk(t) if isinstance(n, ast.Import)])"`
+
+If `yaml` isn't imported, add `import yaml` near the top of the file (alongside the existing `import json`).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest pipeline/tests/test_build.py::TestSim2realBuildByoGuard -v`
+Expected: FAIL — the current `_cmd_build` doesn't read `transfer.yaml` and will proceed to `translation_ref.resolve_translation_ref` which errors with a different, generic message.
+
+- [ ] **Step 3: Implement the guard**
+
+In `pipeline/sim2real.py` `_cmd_build`, insert AFTER the `exp_root` derivation and BEFORE `layout.set_experiment_root(...)`:
+
+```python
+def _cmd_build(args) -> int:
+    """..."""
+    from pipeline.lib import build, cluster_ops, translation_ref
+
+    exp_root = (
+        Path(args.experiment_root).resolve()
+        if args.experiment_root
+        else Path.cwd()
+    )
+    # BYO guard (issue #497): if a transfer.yaml is discoverable and
+    # declares no `component:` (all algorithms marked `byo: true`), the
+    # images are pre-built and there is nothing to build. Error early
+    # rather than proceeding to build.check_skopeo / translation resolve.
+    from pipeline.lib import manifest as _manifest
+    manifest_path = exp_root / "transfer.yaml"
+    if not manifest_path.exists():
+        manifest_path = exp_root / "config" / "transfer.yaml"
+    if manifest_path.exists():
+        try:
+            _mf = _manifest.load_manifest(manifest_path)
+        except _manifest.ManifestError:
+            # Malformed manifest: let the downstream translation path
+            # produce its own error message rather than short-circuiting
+            # here on a manifest-parse failure.
+            _mf = None
+        if _mf is not None and "component" not in _mf:
+            print(
+                "error: nothing to build — this transfer.yaml declares no "
+                "component (all algorithms are BYO; images are pre-built).",
+                file=sys.stderr,
+            )
+            return 2
+
+    layout.set_experiment_root(str(exp_root))
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest pipeline/tests/test_build.py::TestSim2realBuildByoGuard -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the whole `test_build.py` for regressions**
+
+Run: `.venv/bin/python -m pytest pipeline/tests/test_build.py -v`
+Expected: All pass. (Existing tests pass their own transfer.yaml with `component:` present — the guard is a no-op for them.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/kalantar/projects/go.workspace/src/github.com/inference-sim/sim2real/.claude/worktrees/issue-497-byo-marker-schema
+git add pipeline/sim2real.py pipeline/tests/test_build.py
+git commit -m "sim2real build: reject all-BYO manifests up front
+
+If \`transfer.yaml\` is discoverable and declares no \`component:\`
+(the all-BYO shape enabled by the prior schema commit), there is
+nothing for \`build\` to do — BYO images are pre-built. Error early
+with the message the issue mandates, before touching skopeo or
+translation resolution.
+
+If the manifest is unparseable, defer to the downstream path so its
+error message wins.
+
+Refs #497"
+```
+
+---
+
+### Task 5: `sim2real translation register` / `assemble` BYO regression check
+
+**Files:**
+- Test: `pipeline/tests/test_manifest.py` (add one integration-style test)
+
+**Interfaces:**
+- Consumes: BYO manifest through `manifest.load_manifest`
+- Produces: assurance that the loader returns a dict with no missing keys downstream register/assemble would dereference
+
+- [ ] **Step 1: Write regression test**
+
+Append to `pipeline/tests/test_manifest.py`:
+
+```python
+def test_byo_manifest_loads_cleanly_for_downstream(tmp_path):
+    """A BYO manifest through `load_manifest` produces a dict whose
+    downstream consumers (`translation register`, `assemble`) can access
+    without dereferencing a field the BYO entry omits.
+
+    Issue #497 acceptance: "regression test: load a BYO manifest
+    through `manifest.load_manifest` and verify no field a BYO entry
+    omits is dereferenced." The dereferenced fields today are
+    `algorithms[i].name`, `algorithms[i].defaults`, and (for
+    register-batched mode in a later PR) `algorithms[i].byo`. This
+    test asserts those exist; `source:` and `component:` should be
+    absent.
+    """
+    data = {k: v for k, v in MINIMAL_V3.items() if k != "component"}
+    data["algorithms"] = [
+        {"name": "byoa", "defaults": "baseline", "byo": True},
+    ]
+    path = _write_manifest(tmp_path, data)
+    m = load_manifest(path)
+    assert m["algorithms"][0]["name"] == "byoa"
+    assert m["algorithms"][0]["defaults"] == "baseline"
+    assert m["algorithms"][0]["byo"] is True
+    assert "source" not in m["algorithms"][0]
+    assert "component" not in m
+    # cross-reference to baseline still enforced (regression):
+    assert m["algorithms"][0]["defaults"] in {b["name"] for b in m["baselines"]}
+```
+
+- [ ] **Step 2: Run test to verify it passes (after Tasks 1+2)**
+
+Run: `.venv/bin/python -m pytest pipeline/tests/test_manifest.py::test_byo_manifest_loads_cleanly_for_downstream -v`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/kalantar/projects/go.workspace/src/github.com/inference-sim/sim2real/.claude/worktrees/issue-497-byo-marker-schema
+git add pipeline/tests/test_manifest.py
+git commit -m "test: BYO manifest loads cleanly for downstream register/assemble
+
+Regression test called out in issue #497 acceptance criteria:
+loading a BYO-shaped manifest through \`manifest.load_manifest\`
+must not require the caller to dereference \`source:\` or
+\`component:\`. Asserts the fields register/assemble actually read
+(algorithm \`name\`, \`defaults\`, \`byo\`) are present and the
+BYO-omitted fields are absent.
+
+Refs #497"
+```
+
+---
+
+### Task 6: README note about `byo:` marker
+
+**Files:**
+- Modify: `pipeline/README.md` — the v3 schema reference near line 37 or the manifest section near line 179
+
+**Interfaces:**
+- Consumes: nothing
+- Produces: one-paragraph note operators can find via grep for `byo`
+
+- [ ] **Step 1: Read the current manifest-reference area of `pipeline/README.md`**
+
+Read: `pipeline/README.md` around lines 37 and 175-190 (the two places `manifest.py` and `component`/`algorithms` are named).
+
+- [ ] **Step 2: Add a short prose note**
+
+Append the following paragraph to the "Manifest & Layout" area (or immediately after line 37's schema reference — the exact anchor is left to the implementer, but the target is a place operators actually read). Suggested location: at the end of the paragraph that names the v3 schema fields.
+
+```markdown
+### Per-algorithm `byo:` marker
+
+An algorithm entry may carry `byo: true` to indicate the image is
+pre-built and the entry has no BLIS-format source. When present:
+
+- `algorithms[i].source:` is optional for that entry (the loader
+  otherwise requires it).
+- Top-level `component:` is optional when every algorithm entry
+  carries `byo: true` (BYO manifests have no submodule to pin).
+
+`sim2real translate` and `sim2real build` refuse to run on a BYO
+entry / all-BYO manifest respectively — use `sim2real translation
+register` to attach the pre-built image directly. `sim2real
+assemble` and `sim2real-check` treat BYO entries the same as BLIS
+entries at the consumption boundary.
+```
+
+- [ ] **Step 3: Verify the paragraph is well-formed and slotted in the right place**
+
+Run: `grep -n "byo:" pipeline/README.md`
+Expected: at least one hit in a manifest-reference section, no orphan hits outside the schema-reference area.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/kalantar/projects/go.workspace/src/github.com/inference-sim/sim2real/.claude/worktrees/issue-497-byo-marker-schema
+git add pipeline/README.md
+git commit -m "docs(pipeline): document per-algorithm \`byo:\` marker
+
+Short reference in \`pipeline/README.md\` covering the two schema
+loosenings (per-entry \`source:\`, top-level \`component:\`) and
+which downstream commands accept vs reject BYO shapes.
+
+Refs #497"
+```
+
+---
+
+### Task 7: Final verification
+
+- [ ] **Step 1: Run the entire pipeline test suite**
+
+Run: `.venv/bin/python -m pytest pipeline/ -v`
+Expected: 0 failures. Note test count; must match pre-change count + the new tests added in Tasks 1-5 (approximately 7 new tests total).
+
+- [ ] **Step 2: Lint check**
+
+Run: `.venv/bin/ruff check pipeline/ --select F`
+Expected: 0 findings.
+
+- [ ] **Step 3: Sweep for stale references**
+
+Run: `grep -rn "component is required when algorithms are specified" .claude/worktrees/issue-497-byo-marker-schema/ 2>/dev/null | grep -v -E "^\\.claude/worktrees/issue-497-byo-marker-schema/\\.git/"`
+Expected: 0 hits (the error message was updated in Task 2; nothing else in the repo should have quoted the old wording).
+
+Run: `grep -rn "algorithms\\[.\\]\\.source" .claude/worktrees/issue-497-byo-marker-schema/pipeline/ .claude/worktrees/issue-497-byo-marker-schema/docs/ 2>/dev/null | grep -v ".git/"`
+Expected: hits are limited to places that discuss the BLIS shape or the translation-slice design (slicer.py, design doc); no incorrect "required" claims.
+
+Grep for accidental worktree escapes:
+
+Run: `git -C /Users/kalantar/projects/go.workspace/src/github.com/inference-sim/sim2real status`
+Expected: clean — only the worktree branch shows changes.
+
+- [ ] **Step 4: Manual trace against issue acceptance criteria**
+
+Walk each of the eight acceptance bullets in issue #497 and confirm the corresponding test or code change exists. If any bullet has no coverage, add it before pushing.

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -34,11 +34,20 @@ python pipeline/deploy.py      --experiment-root ../admission-control
 ```
 
 The experiment repo must contain:
-- `transfer.yaml` (or `config/transfer.yaml` for backward compat) — v3 schema with `component`, `baselines`, `algorithms`, `workloads` fields
+- `transfer.yaml` (or `config/transfer.yaml` for backward compat) — v3 schema with `baselines`, `algorithms`, `workloads` fields; `component:` required unless every algorithm carries `byo: true` (see [Per-algorithm `byo:` marker](#per-algorithm-byo-marker) below)
 - `baselines/<name>.yaml` — llmdbenchmark-style scenario file per baseline (referenced from `transfer.yaml:baselines[].scenario`)
 - `baselines/defaults/*.yaml` (optional) — framework workaround fragments merged as an overlay under each baseline (opt out via `defaults.disable`)
 - `workloads/` directory referenced from `transfer.yaml:workloads`
 - `workspace/` in `.gitignore`
+
+### Per-algorithm `byo:` marker
+
+An algorithm entry may carry `byo: true` to indicate the image is pre-built and the entry has no BLIS-format source. When present:
+
+- `algorithms[i].source:` is optional for that entry (the loader otherwise requires it).
+- Top-level `component:` is optional when *every* algorithm entry carries `byo: true` — BYO manifests have no submodule to pin. Mixed manifests (any non-BYO entry) still require `component:`.
+
+`sim2real translate` refuses to run on a BYO entry (there is no `.go` source for the skill to translate) and `sim2real build` refuses to run on an all-BYO manifest (there is nothing to build). Attach pre-built BYO images with `sim2real translation register` directly. `sim2real assemble` and `sim2real-check` treat BYO entries the same as BLIS entries at the consumption boundary.
 
 `pipeline/pipeline.yaml` is the static Tekton Pipeline definition (applied by `cluster.py provision`; `sim2real assemble` generates PipelineRuns that reference it).
 

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -27,7 +27,7 @@ python pipeline/cluster.py provision <cluster_id> --namespaces NS1,NS2,...
 # Per-workspace + per-run cycle:
 python pipeline/setup.py       --experiment-root ../admission-control
 python pipeline/sim2real.py translation register \
-    --algorithm <name> --image <ref> --config <treatment-overlay-path>
+    --algorithm <name>=<image-ref>@<config-path>
 python pipeline/sim2real.py assemble \
     --translation <hash> --cluster <cluster_id> --run <run_name>
 python pipeline/deploy.py      --experiment-root ../admission-control
@@ -128,9 +128,36 @@ Top-level CLI introduced in step-1 of the v2 refactor. Subcommands: `translation
 
 ### Register a translation (BYO)
 
-`sim2real.py translation register` imports a pre-built EPP image and its treatment overlay YAML as a registered translation. Downstream commands (`assemble`, `deploy.py run`) treat a BYO-registered translation identically to a skill-produced one.
+`sim2real.py translation register` imports one or more pre-built EPP images and their treatment overlay YAMLs as a single registered translation. Downstream commands (`assemble`, `deploy.py run`) treat a BYO-registered translation identically to a skill-produced one.
+
+#### Preferred form: repeatable `--algorithm NAME=IMAGE@CONFIG`
+
+Pass `--algorithm` once per algorithm. Each value is a single `NAME=IMAGE@CONFIG` triple: first `=` splits the name from the rest; rightmost `@` splits the image ref from the config path. This allows digest refs (`image@sha256:…`) without ambiguity.
 
 ```bash
+# N=2 example
+python pipeline/sim2real.py translation register \
+    --algorithm softreflective=ghcr.io/org/sr-router:v1@overlays/sr.yaml \
+    --algorithm eager=ghcr.io/org/eager-router@sha256:<64-hex-digest>@overlays/eager.yaml \
+    [--baseline-config path/to/baseline-overlay.yaml] \
+    [--registered-hash <expected-sha256-hex>] \
+    [--experiment-root PATH]
+```
+
+| Flag | Required | Notes |
+|------|----------|-------|
+| `--algorithm NAME=IMAGE@CONFIG` | yes (repeatable) | `NAME` follows `[A-Za-z0-9][A-Za-z0-9._-]*`, max 128 chars, no `.` / `..`. `IMAGE` is the registry ref. `CONFIG` is the treatment overlay YAML path. Rightmost `@` is the split point, so digest refs (e.g. `image@sha256:abc`) work. **Overlay paths containing `@` cannot be represented** (structural constraint — the `@` would be misread as part of the image ref). Overlay paths containing `=` are supported. |
+| `--baseline-config PATH` | no | Baseline overlay YAML, if the translation needs one. |
+| `--registered-hash HASH` | no | Assert the computed `translation_hash` equals this value; error if not. |
+| `--force` | no | Reassign an alias if another translation already owns it. Applies per-algorithm for any N — use `--force` whenever any algorithm name in the batch was previously used as an alias by a different translation. For N>1 the newly-registered translation itself has `alias=null` (batched translations are referenced by hash); `--force` only clears the colliding aliases on the previous owners. |
+| `--experiment-root PATH` | no | Defaults to cwd. |
+
+#### Deprecated form: `--algorithm NAME --image REF --config PATH`
+
+The step-1 single-algorithm form still works as the N=1 case but **is deprecated**. A deprecation warning is emitted to stderr. Removal is targeted for step-5+.
+
+```bash
+# Deprecated — prefer the NAME=IMAGE@CONFIG form above
 python pipeline/sim2real.py translation register \
     --algorithm softreflective \
     --image ghcr.io/kalantar-msb/sr-router:some-tag \
@@ -140,33 +167,28 @@ python pipeline/sim2real.py translation register \
     [--experiment-root PATH]
 ```
 
-| Flag | Required | Notes |
-|------|----------|-------|
-| `--algorithm NAME` | yes | `[A-Za-z0-9][A-Za-z0-9._-]*`, max 128 chars, reject `.` / `..`. Also written as the translation's `alias`. Single algorithm per call. |
-| `--image REF` | yes | Registry ref. If it contains `@sha256:HEX`, that digest is recorded; otherwise `image_digest` is `null` with a warning. |
-| `--config PATH` | yes | Treatment overlay YAML. Validated as YAML before any writes. |
-| `--baseline-config PATH` | no | Baseline overlay YAML, if the translation needs one. |
-| `--registered-hash HASH` | no | Assert the computed `translation_hash` equals this value; error if not. |
-| `--force` | no | Reassign the alias (`--algorithm` value) if another translation already owns it. Clears the alias on the previous translation atomically. |
-| `--experiment-root PATH` | no | Defaults to cwd. |
-
 **Outputs** — under `workspace/translations/<translation_hash>/`:
 
-- `translation_output.json` — algorithm index + provenance (v1 schema). Includes `alias` (top-level, same value as `--algorithm`) and per-algorithm `image_ref` / `image_digest` inside `algorithms[i]`. Step-1 legacy files (top-level `image_ref`) remain readable via a compatibility shim in `pipeline/lib/translation_ref.py`.
-- `registered.json` — image ref + digest (BYO-only audit trail; v1 schema).
-- `generated/<algorithm>/<algorithm>_config.yaml` — the treatment overlay content.
+- `translation_output.json` — algorithm index + provenance. Top-level `alias` (set to the algorithm name for N=1; `null` for N>1). Per-algorithm `image_ref` / `image_digest` inside `algorithms[i]`. Step-1 legacy files (top-level `image_ref`) remain readable via a compatibility shim in `pipeline/lib/translation_ref.py`.
+- `registered.json` — per-algorithm image refs and digests (BYO-only audit trail; batched shape with an `algorithms` list).
+- `generated/<algorithm>/<algorithm>_config.yaml` — the treatment overlay content, one file per algorithm.
 - `generated/baseline_config.yaml` — present only when `--baseline-config` is given.
 
-**`translation_hash` derivation (BYO):** SHA-256 hex over canonical JSON of `{algorithm_name, config_sha256, image_digest_or_ref}`. Deterministic — same inputs produce the same hash. When the image ref lacks a digest, the raw ref string is substituted for `image_digest_or_ref`, so the hash is stable within the offline session but changes if the same image is later re-registered with a digest ref.
+**`translation_hash` derivation (BYO, batched):** SHA-256 hex over canonical JSON of a list of `{name, image, config}` dicts sorted by `name`, where `config` is the SHA-256 of the overlay file content and `image` is the digest ref if present (otherwise the raw ref string). Order-invariant — registering the same algorithms in a different order produces the same hash.
 
-**Idempotency:** re-registering the same triple (algorithm, image, config content) is a no-op — the existing translation directory is detected, a warning is printed, and exit is 0.
+```
+sha256(canonical-json(sorted-by-name list of {name, image, config}))
+```
+
+**Idempotency:** re-registering the same set of (algorithm, image, config-content) tuples — in any order — is a no-op. The existing translation directory is detected, a warning is printed, and exit is 0.
 
 **Failure modes:**
 
 - `--config` file missing or malformed YAML → exit 2, no writes.
-- Existing translation directory records a different algorithm name (hash collision) → exit 2, no writes.
+- Existing translation directory records different algorithm names (hash collision) → exit 2, no writes.
 - `--registered-hash` given and does not match computed → exit 2, no writes.
-- Another translation already owns the `--algorithm` alias with a different hash → exit 2, no writes; re-run with `--force` to reassign.
+- Another translation already owns an `--algorithm` alias (an algorithm name from the batch collides with an existing translation's alias, on any N) → exit 2, no writes; re-run with `--force` to clear the previous owners' aliases before proceeding.
+- Duplicate algorithm names within a single invocation → exit 2, no writes.
 
 ---
 
@@ -500,14 +522,14 @@ Writes `workspace/setup_config.json` with registry, repo name, and orchestrator 
 ### 3. Register a translation (BYO)
 
 ```bash
+# Preferred: repeatable --algorithm NAME=IMAGE@CONFIG (N algorithms in one call)
 python pipeline/sim2real.py translation register \
-    --algorithm <algorithm> \
-    --image <image-ref> \
-    --config <treatment-overlay-path> \
+    --algorithm <name>=<image-ref>@<config-path> \
+    [--algorithm <name>=<image-ref>@<config-path> ...] \
     --experiment-root <experiment-root>
 ```
 
-Writes `workspace/translations/<hash>/` with `translation_output.json`, `registered.json`, and `generated/<algorithm>/<algorithm>_config.yaml`. Prints the `<hash>` on success.
+Writes `workspace/translations/<hash>/` with `translation_output.json`, `registered.json`, and `generated/<algorithm>/<algorithm>_config.yaml` for each algorithm. Prints the `<hash>` on success. See the [Register a translation](#register-a-translation-byo) section for the full flag reference, the hash formula, and the deprecated single-algorithm form.
 
 ### 4. Assemble the run
 
@@ -627,8 +649,8 @@ All artifacts live under `<experiment-root>/workspace/` (gitignored). Key files:
 | `setup_config.json` (workspace fields: registry, repo_name, orchestrator_image, sim2real_root) | `setup.py` | `deploy.py`, `sim2real.py list runs` |
 | `setup_config.json:current_run` (active run pointer) | `sim2real.py use` | `deploy.py` (default `--run`), `sim2real.py list runs` (active-mark `*`) |
 | `clusters/<id>/cluster_config.json` (cluster fields: cluster_id, namespaces, is_openshift, storage_class, secret_names, workspaces, created_at) | `cluster.py provision` | `sim2real assemble`, `deploy.py`, `lib/remote.py` |
-| `translations/<hash>/translation_output.json` | `sim2real translation register` | `sim2real assemble`, `deploy.py` |
-| `translations/<hash>/registered.json` | `sim2real translation register` | audit trail |
+| `translations/<hash>/translation_output.json` | `sim2real translation register` (batched; N per-algo entries in `algorithms`) | `sim2real assemble`, `deploy.py` |
+| `translations/<hash>/registered.json` | `sim2real translation register` (batched; N per-algo entries in `algorithms`) | audit trail |
 | `translations/<hash>/generated/…` | `sim2real translation register` | `sim2real assemble` |
 | `runs/<run>/run_metadata.json` | `sim2real assemble` | `deploy.py`, `sim2real.py list runs` |
 | `runs/<run>/manifest.assembly.yaml` | `sim2real assemble` | reproducibility / drift detection (step-5) |

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -130,6 +130,8 @@ Top-level CLI introduced in step-1 of the v2 refactor. Subcommands: `translation
 
 `sim2real.py translation register` imports one or more pre-built EPP images and their treatment overlay YAMLs as a single registered translation. Downstream commands (`assemble`, `deploy.py run`) treat a BYO-registered translation identically to a skill-produced one.
 
+The `/sim2real-bootstrap --byo` skill scaffolds a BYO experiment repo and emits a ready-to-run `translation register` command with all algorithms batched into a single call — see [`.claude/skills/sim2real-bootstrap/SKILL.md`](../.claude/skills/sim2real-bootstrap/SKILL.md#--byo-mode).
+
 #### Preferred form: repeatable `--algorithm NAME=IMAGE@CONFIG`
 
 Pass `--algorithm` once per algorithm. Each value is a single `NAME=IMAGE@CONFIG` triple: first `=` splits the name from the rest; rightmost `@` splits the image ref from the config path. This allows digest refs (`image@sha256:…`) without ambiguity.

--- a/pipeline/lib/assemble_run.py
+++ b/pipeline/lib/assemble_run.py
@@ -261,6 +261,36 @@ def write_run_metadata(run_dir: Path, meta: dict) -> Path:
     return out
 
 
+def _align_overlay_name(base: dict, overlay: dict) -> dict:
+    """Realign overlay's ``scenario[0].name`` to match base to prevent list-merge duplication.
+
+    The ``deep_merge`` list strategy in ``pipeline/lib/values.py`` picks ``name``
+    as the merge key when every entry on both sides carries it, then merges list
+    items by identity on that key. Framework-default fragments under
+    ``baselines/defaults/*.yaml`` are authored as ``scenario: - name: defaults``
+    (a placeholder — see each fragment's top-of-file comment "scenario[0].name
+    is realigned to the experiment baseline at merge time"). If the baseline
+    entry is named anything other than ``defaults`` (i.e. every real experiment),
+    a naive merge would append the defaults content as a second, unwanted
+    scenario entry — and llm-d-benchmark's templater would then render it as a
+    separate deployment carrying the framework-default model
+    (``facebook/opt-125m``) instead of the intended model. See issue #516.
+
+    Copies the overlay's first scenario name from the base's first scenario name
+    when both are non-empty and differ. Mutates and returns ``overlay``.
+
+    Ported verbatim from ``pipeline/lib/assemble.py:_align_overlay_name`` on
+    ``main`` — dropped by step-2's ``assemble.py`` → ``assemble_run.py`` rename.
+    """
+    base_scenarios = base.get("scenario", [])
+    overlay_scenarios = overlay.get("scenario", [])
+    if base_scenarios and overlay_scenarios:
+        base_name = base_scenarios[0].get("name", "")
+        if base_name and overlay_scenarios[0].get("name", "") != base_name:
+            overlay_scenarios[0]["name"] = base_name
+    return overlay
+
+
 def resolve_baseline(
     *,
     bundle_path: Path,
@@ -273,6 +303,13 @@ def resolve_baseline(
     ``baselines/defaults/`` directory). ``overlay_path`` may be ``None`` or
     point at a non-existent file (BYO baseline without a baseline overlay).
     Bundle is required — a missing bundle raises AssembleError.
+
+    Before the merge, ``framework_defaults[scenario][0].name`` is realigned
+    to the bundle's ``scenario[0].name`` so both sides collapse into a single
+    scenario entry (see ``_align_overlay_name``). Without this, a defaults
+    overlay named ``defaults`` and a baseline named anything else produce two
+    scenario entries — an intended one plus a phantom one that inherits the
+    llm-d-benchmark framework-default model (issue #516).
     """
     if not bundle_path.exists():
         raise AssembleError(f"baseline scenario not found: {bundle_path}")
@@ -282,7 +319,8 @@ def resolve_baseline(
         if overlay_path is not None and overlay_path.exists()
         else {}
     )
-    resolved = deep_merge(copy.deepcopy(framework_defaults), bundle)
+    aligned_defaults = _align_overlay_name(bundle, copy.deepcopy(framework_defaults))
+    resolved = deep_merge(aligned_defaults, bundle)
     resolved = deep_merge(resolved, overlay)
     return resolved
 

--- a/pipeline/lib/manifest.py
+++ b/pipeline/lib/manifest.py
@@ -80,7 +80,18 @@ def load_manifest(path: "Path | str") -> dict:
         for i, entry in enumerate(algos):
             if not isinstance(entry, dict):
                 raise ManifestError(f"algorithms[{i}] must be a mapping")
-            for f in ("name", "source", "defaults"):
+            # `byo: true` marker (v3 schema addition). Bool type; if True,
+            # `source:` becomes optional for this entry. Non-BYO entries
+            # still require `source:` — per-command validation in
+            # sim2real.py rejects BYO manifests where downstream needs it.
+            byo = entry.get("byo", False)
+            if "byo" in entry and not isinstance(byo, bool):
+                raise ManifestError(
+                    f"algorithms[{i}].byo must be a bool, "
+                    f"got {type(byo).__name__}"
+                )
+            required = ("name", "defaults") if byo else ("name", "source", "defaults")
+            for f in required:
                 if f not in entry:
                     raise ManifestError(f"algorithms[{i}] missing required field: {f}")
             _validate_package_name(entry["name"], f"algorithms[{i}]")
@@ -157,14 +168,16 @@ def load_manifest(path: "Path | str") -> dict:
 def _validate_v3_fields(data: dict) -> None:
     """Validate and apply defaults for v3-specific fields."""
 
-    # component (required only when algorithms are present)
+    # component (required only when at least one algorithm is BLIS-shape;
+    # all-BYO manifests may omit component: since BYO images are pre-built).
     component = data.get("component")
-    has_algorithms = bool(data.get("algorithms"))
+    algos = data.get("algorithms") or []
+    has_blis_algorithm = any(algo.get("byo") is not True for algo in algos)
 
     if component is None:
-        if has_algorithms:
+        if has_blis_algorithm:
             raise ManifestError(
-                "component is required when algorithms are specified"
+                "component is required when non-BYO algorithms are specified"
             )
         # Remove explicit null so downstream .get("component", {}) returns {} not None
         data.pop("component", None)

--- a/pipeline/sim2real.py
+++ b/pipeline/sim2real.py
@@ -62,6 +62,60 @@ def _extract_digest_from_ref(image_ref: str) -> str | None:
     return digest
 
 
+def _parse_algorithm_triple(value: str) -> tuple[str, str, str]:
+    """Parse ``<name>=<image-ref>@<config-path>`` into ``(name, image_ref, config_path)``.
+
+    Splits on the first ``=`` (names cannot contain ``=`` by regex) and
+    then on the rightmost ``@`` in the RHS (digest refs contain ``@``;
+    overlay paths must not contain ``@`` — enforced by rejecting image
+    refs with more than one ``@`` after the split). Config paths
+    containing ``=`` are supported.
+
+    Raises ``argparse.ArgumentTypeError`` on any parse failure.
+    """
+    from pipeline.lib import translation_ref
+    eq_idx = value.find("=")
+    if eq_idx < 0:
+        raise argparse.ArgumentTypeError(
+            f"--algorithm value {value!r} missing '=' "
+            "(expected '<name>=<image-ref>@<config-path>')"
+        )
+    name = value[:eq_idx]
+    rhs = value[eq_idx + 1:]
+    at_idx = rhs.rfind("@")
+    if at_idx < 0:
+        raise argparse.ArgumentTypeError(
+            f"--algorithm value {value!r} missing '@' after '=' "
+            "(expected '<name>=<image-ref>@<config-path>')"
+        )
+    image_ref = rhs[:at_idx]
+    config_path = rhs[at_idx + 1:]
+    if not image_ref:
+        raise argparse.ArgumentTypeError(
+            f"--algorithm value {value!r} has empty image-ref"
+        )
+    if not config_path:
+        raise argparse.ArgumentTypeError(
+            f"--algorithm value {value!r} has empty config-path"
+        )
+    # Valid image refs have at most one '@' (the digest suffix). More than
+    # one '@' in the parsed image ref means the config path likely had a
+    # '@' that rightmost-@ split cannot disambiguate — reject.
+    if image_ref.count("@") > 1:
+        raise argparse.ArgumentTypeError(
+            f"--algorithm value {value!r}: overlay path cannot contain '@' "
+            "(parsed image ref has multiple '@'; the rightmost-@ split rule "
+            "cannot distinguish a digest '@' from a path '@')"
+        )
+    try:
+        translation_ref.validate_name(name)
+    except translation_ref.ValidationError as exc:
+        raise argparse.ArgumentTypeError(
+            f"--algorithm value {value!r} has invalid name: {exc}"
+        ) from exc
+    return name, image_ref, config_path
+
+
 def _clear_alias_on(other_hash: str) -> None:
     """Rewrite ``translations/<other_hash>/translation_output.json`` with ``alias=null``.
 
@@ -78,26 +132,28 @@ def _clear_alias_on(other_hash: str) -> None:
     _atomic_write_json(other_path, data)
 
 
-def _compute_translation_hash(
-    image_digest_or_ref: str,
-    config_bytes: bytes,
-    algorithm_name: str,
-) -> str:
-    """SHA-256 hex over canonical JSON of the three BYO inputs.
+def _compute_translation_hash(entries: list[dict]) -> str:
+    """SHA-256 hex over canonical-JSON of the sorted-by-name algorithm list.
 
-    Design: ``translation_hash = sha256(image_digest_or_ref || config || name)``.
-    Implementation embeds ``sha256(config)`` in a canonical JSON envelope
-    (sorted keys, no whitespace) to prevent boundary-shift collisions
-    from raw concatenation while preserving determinism. Mirrors
-    ``pipeline/lib/slicer.translation_hash``'s canonical-JSON approach.
+    Each entry is ``{"name": str, "image": str, "config_sha": str}`` where
+    ``image`` is the ``sha256:...`` digest when the image ref carried one,
+    else the raw ref. ``config_sha`` is ``sha256(config_bytes).hexdigest()``.
+
+    Order-invariant: entries are sorted by ``name`` before serialization.
+    Deterministic in the algorithm-set membership — same triples in a
+    different order produce the same hash. N=1 uses the same shape as
+    N>1 (list of one entry), superseding the step-1 formula.
     """
-    config_sha = hashlib.sha256(config_bytes).hexdigest()
+    sorted_entries = sorted(entries, key=lambda e: e["name"])
     canonical = json.dumps(
-        {
-            "algorithm_name": algorithm_name,
-            "config_sha256": config_sha,
-            "image_digest_or_ref": image_digest_or_ref,
-        },
+        [
+            {
+                "config": e["config_sha"],
+                "image": e["image"],
+                "name": e["name"],
+            }
+            for e in sorted_entries
+        ],
         sort_keys=True,
         separators=(",", ":"),
         ensure_ascii=False,
@@ -107,20 +163,19 @@ def _compute_translation_hash(
 
 def _build_translation_output(
     *,
-    algorithm_name: str,
-    image_ref: str,
-    image_digest: str | None,
-    config_path: str,
+    algorithms: list[dict],
     translation_hash: str,
     source: str,
     alias: str | None,
     created_at: str,
 ) -> dict:
-    """Build the ``translation_output.json`` body for step-2 schema.
+    """Build the ``translation_output.json`` body — step-2 batched shape.
 
-    Single-algorithm shape (BYO register in this PR). ``image_ref`` and
-    ``image_digest`` live per-algo. ``source_path``/``source_sha256`` are
-    ``None`` for BYO (populated by the skill-driven ``translate`` in PR 3).
+    Each entry in ``algorithms`` is ``{"name", "image_ref", "image_digest",
+    "config_path"}`` (``config_path`` is the relative path
+    ``generated/<name>/<name>_config.yaml``). ``source_path``/``source_sha256``
+    are ``None`` for BYO. ``alias`` is the shared translation-level alias
+    (algorithm name when N==1, ``None`` when N>1).
     """
     return {
         "version": 1,
@@ -129,13 +184,14 @@ def _build_translation_output(
         "alias": alias,
         "algorithms": [
             {
-                "name": algorithm_name,
+                "name": a["name"],
                 "source_path": None,
                 "source_sha256": None,
-                "config_path": config_path,
-                "image_ref": image_ref,
-                "image_digest": image_digest,
+                "config_path": a["config_path"],
+                "image_ref": a["image_ref"],
+                "image_digest": a["image_digest"],
             }
+            for a in algorithms
         ],
         "created_at": created_at,
     }
@@ -260,47 +316,80 @@ def _translate_delete_dir(translation_hash: str) -> None:
 
 
 def _build_registered(
-    image_ref: str,
-    image_digest: str | None,
+    prepared: list[dict],
     registered_at: str,
 ) -> dict:
+    """Build the ``registered.json`` body for a BYO translation.
+
+    Batched shape: N per-algorithm entries under ``algorithms``. For N==1
+    the shape is the same (a list of one). ``prepared`` is the internal
+    per-algorithm record produced by ``_register_translation`` and carries
+    ``name``, ``image_ref``, ``image_digest``.
+    """
     return {
         "version": 1,
-        "image_ref": image_ref,
-        "image_digest": image_digest,
         "source": "byo",
         "registered_at": registered_at,
+        "algorithms": [
+            {
+                "name": p["name"],
+                "image_ref": p["image_ref"],
+                "image_digest": p["image_digest"],
+            }
+            for p in prepared
+        ],
     }
 
 
 def _register_translation(
     *,
-    algorithm_name: str,
-    image_ref: str,
-    config_path: Path,
+    algorithms: list[dict],
     baseline_config_path: Path | None,
     registered_hash: str | None,
     now_iso: str,
     force: bool = False,
 ) -> tuple[str, str]:
-    """Register a BYO translation on disk.
+    """Register a BYO translation on disk (single or batched).
 
-    Returns ``(translation_hash, status)`` where status is either
+    ``algorithms`` is a list of ``AlgorithmSpec`` dicts:
+    ``{"name": str, "image_ref": str, "config_path": Path}``. Caller has
+    already validated names and confirmed each config file exists and
+    parses as YAML — this function does not re-validate.
+
+    Alias policy: when ``len(algorithms) == 1``, the translation's
+    top-level ``alias`` is the sole algorithm's name (matches step-1
+    behavior for N=1). When ``len(algorithms) > 1``, top-level ``alias``
+    is ``None`` — batched translations are referenced by hash. Alias
+    collision is still checked per-algorithm name against
+    ``find_by_alias`` regardless of N (each algo name must not shadow an
+    existing translation's alias unless ``force`` is set, in which case
+    the previous alias is cleared).
+
+    Returns ``(translation_hash, status)`` where ``status`` is
     ``"created"`` (fresh registration) or ``"idempotent"`` (matching
-    translation already existed; no writes performed).
-
-    Raises:
-        RuntimeError: ``--registered-hash`` given and does not match
-            computed; OR alias collision on a different hash without
-            ``force``.
-        ValueError: existing translation dir has the same hash but records
-            a different algorithm name (corrupted state or collision).
+    translation already existed; no writes).
     """
     from pipeline.lib import translation_ref
-    config_bytes = config_path.read_bytes()
-    image_digest = _extract_digest_from_ref(image_ref)
-    digest_or_ref = image_digest if image_digest is not None else image_ref
-    thash = _compute_translation_hash(digest_or_ref, config_bytes, algorithm_name)
+
+    # Prepare per-algorithm derived fields: config bytes, digest, digest_or_ref.
+    prepared: list[dict] = []
+    for a in algorithms:
+        cfg_bytes = a["config_path"].read_bytes()
+        digest = _extract_digest_from_ref(a["image_ref"])
+        prepared.append({
+            "name": a["name"],
+            "image_ref": a["image_ref"],
+            "image_digest": digest,
+            "digest_or_ref": digest if digest is not None else a["image_ref"],
+            "config_bytes": cfg_bytes,
+            "config_sha": hashlib.sha256(cfg_bytes).hexdigest(),
+        })
+
+    # Compute the batched translation hash.
+    thash = _compute_translation_hash([
+        {"name": p["name"], "image": p["digest_or_ref"], "config_sha": p["config_sha"]}
+        for p in prepared
+    ])
 
     if registered_hash is not None and registered_hash != thash:
         raise RuntimeError(
@@ -310,17 +399,21 @@ def _register_translation(
     out_path = layout.translation_output_path(thash)
     if out_path.exists():
         existing = translation_ref.read_translation_output(out_path)
-        existing_algos = [a.get("name") for a in existing.get("algorithms", [])]
-        if algorithm_name not in existing_algos:
+        existing_names = sorted(a.get("name") for a in existing.get("algorithms", []))
+        wanted_names = sorted(p["name"] for p in prepared)
+        if existing_names != wanted_names:
             raise ValueError(
-                f"algorithm name mismatch: translation {thash} records "
-                f"{existing_algos}, refusing to register {algorithm_name!r}"
+                f"algorithm-set mismatch: translation {thash} records "
+                f"{existing_names}, refusing to re-register with {wanted_names} "
+                "(hash collision — investigate)"
             )
-        missing = []
+        # Verify all on-disk artifacts are present; incomplete state → surface.
+        missing: list[str] = []
         if not layout.registered_path(thash).exists():
             missing.append("registered.json")
-        if not layout.generated_config_path(thash, algorithm_name).exists():
-            missing.append(f"generated/{algorithm_name}/{algorithm_name}_config.yaml")
+        for p in prepared:
+            if not layout.generated_config_path(thash, p["name"]).exists():
+                missing.append(f"generated/{p['name']}/{p['name']}_config.yaml")
         if missing:
             raise RuntimeError(
                 f"translation {thash} directory is incomplete (missing: "
@@ -329,39 +422,45 @@ def _register_translation(
             )
         return thash, "idempotent"
 
-    # Alias collision — detect BEFORE creating any new files. Only a
-    # different-hash collision matters; same-hash "collision" fell out
-    # into the idempotent path above.
-    other_hash = translation_ref.find_by_alias(
-        algorithm_name, layout.translations_dir()
-    )
-    if other_hash is not None and other_hash != thash:
-        if not force:
-            raise RuntimeError(
-                f"alias {algorithm_name!r} already assigned to translation "
-                f"{other_hash}; pass --force to reassign"
-            )
-        _clear_alias_on(other_hash)
+    # Alias-collision check per algorithm — must precede any writes.
+    for p in prepared:
+        other = translation_ref.find_by_alias(p["name"], layout.translations_dir())
+        if other is not None and other != thash:
+            if not force:
+                raise RuntimeError(
+                    f"alias {p['name']!r} already assigned to translation "
+                    f"{other}; pass --force to reassign"
+                )
+            _clear_alias_on(other)
 
+    # All checks passed — materialize the translation dir.
     tdir = layout.translation_dir(thash)
-    (tdir / "generated" / algorithm_name).mkdir(parents=True, exist_ok=True)
+    for p in prepared:
+        (tdir / "generated" / p["name"]).mkdir(parents=True, exist_ok=True)
 
-    out = _build_translation_output(
-        algorithm_name=algorithm_name,
-        image_ref=image_ref,
-        image_digest=image_digest,
-        config_path=f"generated/{algorithm_name}/{algorithm_name}_config.yaml",
+    alias = prepared[0]["name"] if len(prepared) == 1 else None
+    tout = _build_translation_output(
+        algorithms=[
+            {
+                "name": p["name"],
+                "image_ref": p["image_ref"],
+                "image_digest": p["image_digest"],
+                "config_path": f"generated/{p['name']}/{p['name']}_config.yaml",
+            }
+            for p in prepared
+        ],
         translation_hash=thash,
         source="byo",
-        alias=algorithm_name,
+        alias=alias,
         created_at=now_iso,
     )
-    _atomic_write_json(out_path, out)
+    _atomic_write_json(out_path, tout)
 
-    reg = _build_registered(image_ref, image_digest, now_iso)
+    reg = _build_registered(prepared, now_iso)
     layout.registered_path(thash).write_text(json.dumps(reg, indent=2) + "\n")
 
-    layout.generated_config_path(thash, algorithm_name).write_bytes(config_bytes)
+    for p in prepared:
+        layout.generated_config_path(thash, p["name"]).write_bytes(p["config_bytes"])
 
     if baseline_config_path is not None:
         (tdir / "generated" / "baseline_config.yaml").write_bytes(
@@ -390,28 +489,40 @@ def build_parser() -> argparse.ArgumentParser:
     translation = sub.add_parser("translation", help="Manage translations")
     tsub = translation.add_subparsers(dest="subcommand", required=True)
 
-    reg = tsub.add_parser("register", help="Register a BYO (pre-built) translation")
+    reg = tsub.add_parser(
+        "register",
+        help="Register one or more BYO (pre-built) translations into a single translation dir",
+    )
     reg.add_argument(
         "--algorithm",
         required=True,
-        type=_validate_algorithm_name,
+        action="append",
+        metavar="ALG",
         help=(
-            "Algorithm name; also written as the translation's alias. "
-            "Must match [A-Za-z0-9][A-Za-z0-9._-]*, max 128 chars; "
-            "'.' and '..' are rejected."
+            "Algorithm spec — repeatable. Preferred form: "
+            "'<name>=<image-ref>@<config-path>' (all fields inline). "
+            "Deprecated form: '<name>' alone, with --image and --config "
+            "supplied separately (N=1 only; emits deprecation warning). "
+            "Names match [A-Za-z0-9][A-Za-z0-9._-]*, max 128 chars."
         ),
     )
     reg.add_argument(
         "--image",
-        required=True,
+        default=None,
         metavar="REF",
-        help="EPP image reference (e.g. ghcr.io/foo/bar:v1 or ...@sha256:...)",
+        help=(
+            "DEPRECATED: EPP image reference. Use the '<name>=<image>@<config>' "
+            "form of --algorithm instead."
+        ),
     )
     reg.add_argument(
         "--config",
-        required=True,
+        default=None,
         metavar="PATH",
-        help="Path to the treatment overlay YAML",
+        help=(
+            "DEPRECATED: Treatment overlay YAML path. Use the "
+            "'<name>=<image>@<config>' form of --algorithm instead."
+        ),
     )
     reg.add_argument(
         "--baseline-config",
@@ -428,7 +539,7 @@ def build_parser() -> argparse.ArgumentParser:
     reg.add_argument(
         "--force",
         action="store_true",
-        help="Reassign the alias (--algorithm) from a previous translation.",
+        help="Reassign an alias from a previous translation.",
     )
 
     asm = sub.add_parser(
@@ -532,20 +643,88 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def _cmd_translation_register(args) -> int:
-    config_path = Path(args.config)
+    # Normalize CLI forms into a list of AlgorithmSpec dicts.
+    algo_values: list[str] = args.algorithm  # action='append' guarantees list
+    algorithms: list[dict] = []
+    if args.image is not None or args.config is not None:
+        # Deprecated form: single --algorithm plus separate --image/--config.
+        if len(algo_values) != 1:
+            print(
+                "error: --image/--config are only valid with a single --algorithm "
+                "in the deprecated form; use --algorithm '<name>=<image>@<config>' "
+                "for multiple algorithms",
+                file=sys.stderr,
+            )
+            return 2
+        if args.image is None or args.config is None:
+            print(
+                "error: deprecated form requires BOTH --image and --config",
+                file=sys.stderr,
+            )
+            return 2
+        if "=" in algo_values[0]:
+            print(
+                f"error: --algorithm value {algo_values[0]!r} appears to be an "
+                "inline triple; do not combine with --image/--config",
+                file=sys.stderr,
+            )
+            return 2
+        from pipeline.lib import translation_ref
+        try:
+            name = translation_ref.validate_name(algo_values[0])
+        except translation_ref.ValidationError as exc:
+            print(f"error: --algorithm: {exc}", file=sys.stderr)
+            return 2
+        algorithms.append({
+            "name": name,
+            "image_ref": args.image,
+            "config_path": Path(args.config),
+        })
+        print(
+            "warning: --image/--config are deprecated; use "
+            "--algorithm '<name>=<image-ref>@<config-path>' instead",
+            file=sys.stderr,
+        )
+    else:
+        # New form: each --algorithm value is an inline triple.
+        for val in algo_values:
+            try:
+                name, image_ref, config_path_str = _parse_algorithm_triple(val)
+            except argparse.ArgumentTypeError as exc:
+                print(f"error: {exc}", file=sys.stderr)
+                return 2
+            algorithms.append({
+                "name": name,
+                "image_ref": image_ref,
+                "config_path": Path(config_path_str),
+            })
+
+    # Duplicate-name check (either form).
+    seen: dict[str, int] = {}
+    for a in algorithms:
+        seen[a["name"]] = seen.get(a["name"], 0) + 1
+    dupes = sorted(n for n, c in seen.items() if c > 1)
+    if dupes:
+        print(
+            f"error: duplicate algorithm name(s) in one register call: "
+            f"{', '.join(dupes)}",
+            file=sys.stderr,
+        )
+        return 2
+
+    # Existence + YAML validation for every config file (fail-fast, no writes).
+    for a in algorithms:
+        cp: Path = a["config_path"]
+        if not cp.exists():
+            print(f"error: config file not found: {cp}", file=sys.stderr)
+            return 2
+        try:
+            yaml.safe_load(cp.read_text())
+        except yaml.YAMLError as exc:
+            print(f"error: {cp} is not valid YAML: {exc}", file=sys.stderr)
+            return 2
+
     baseline_config_path = Path(args.baseline_config) if args.baseline_config else None
-
-    if not config_path.exists():
-        print(f"error: --config file not found: {config_path}", file=sys.stderr)
-        return 2
-
-    # Fail-fast YAML validation. Malformed overlay → error before any writes.
-    try:
-        yaml.safe_load(config_path.read_text())
-    except yaml.YAMLError as e:
-        print(f"error: --config is not valid YAML: {e}", file=sys.stderr)
-        return 2
-
     if baseline_config_path is not None:
         if not baseline_config_path.exists():
             print(
@@ -555,28 +734,21 @@ def _cmd_translation_register(args) -> int:
             return 2
         try:
             yaml.safe_load(baseline_config_path.read_text())
-        except yaml.YAMLError as e:
-            print(f"error: --baseline-config is not valid YAML: {e}", file=sys.stderr)
+        except yaml.YAMLError as exc:
+            print(f"error: --baseline-config is not valid YAML: {exc}", file=sys.stderr)
             return 2
 
     now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     try:
         thash, status = _register_translation(
-            algorithm_name=args.algorithm,
-            image_ref=args.image,
-            config_path=config_path,
+            algorithms=algorithms,
             baseline_config_path=baseline_config_path,
             registered_hash=args.registered_hash,
             now_iso=now_iso,
             force=args.force,
         )
     except (RuntimeError, ValueError, OSError) as e:
-        # OSError covers filesystem faults from mkdir/write_text/write_bytes/
-        # read_bytes inside _register_translation (disk full, permission
-        # denied, missing parent unwritable). Surfacing as the same
-        # `error: ...; return 2` shape used elsewhere keeps failures
-        # consistent with the rest of the command.
         print(f"error: {e}", file=sys.stderr)
         return 2
 
@@ -586,13 +758,13 @@ def _cmd_translation_register(args) -> int:
             file=sys.stderr,
         )
     else:
-        digest = _extract_digest_from_ref(args.image)
-        if digest is None:
-            print(
-                "warning: image_digest recorded as null "
-                "(no @sha256: in --image); hash falls back to using image_ref",
-                file=sys.stderr,
-            )
+        for a in algorithms:
+            if _extract_digest_from_ref(a["image_ref"]) is None:
+                print(
+                    f"warning: image_digest for {a['name']!r} recorded as null "
+                    f"(no @sha256: in image); hash falls back to using image_ref",
+                    file=sys.stderr,
+                )
     print(f"registered translation {thash}")
     return 0
 

--- a/pipeline/sim2real.py
+++ b/pipeline/sim2real.py
@@ -656,6 +656,21 @@ def _cmd_translate(args) -> int:
             print(f"error: invalid algorithm name: {exc}", file=sys.stderr)
             return 2
 
+    # BYO guard (issue #497): BYO algorithms have no `source:` for the
+    # skill-driven translate pipeline. The BYO path is `sim2real
+    # translation register`, which attaches a pre-built image directly.
+    # Error early with a pointer rather than silently writing a
+    # checkpoint whose sources slice omits the BYO entries.
+    for algo in declared_algos:
+        if algo.get("byo") is True:
+            print(
+                f"error: cannot translate algorithm '{algo['name']}' — no "
+                f"`source:` in transfer.yaml (BYO algorithm; use "
+                f"`sim2real translation register` directly).",
+                file=sys.stderr,
+            )
+            return 2
+
     try:
         thash = slicer.translation_hash_with_sources(manifest, exp_root)
     except (_assemble_run_lib.AssembleError, OSError) as exc:
@@ -855,13 +870,35 @@ def _cmd_build(args) -> int:
       - Post-build probe records the digest; probe failure → image_digest
         recorded as null with a warning.
     """
-    from pipeline.lib import build, cluster_ops, translation_ref
+    from pipeline.lib import build, cluster_ops, manifest as _manifest, translation_ref
 
     exp_root = (
         Path(args.experiment_root).resolve()
         if args.experiment_root
         else Path.cwd()
     )
+
+    # BYO guard (issue #497): if a transfer.yaml is discoverable and
+    # declares no `component:` (all algorithms marked `byo: true`), the
+    # images are pre-built and there is nothing to build. Error early
+    # rather than proceeding to skopeo/translation resolution. Unparseable
+    # manifests defer to the downstream path so their error wins.
+    manifest_path = exp_root / "transfer.yaml"
+    if not manifest_path.exists():
+        manifest_path = exp_root / "config" / "transfer.yaml"
+    if manifest_path.exists():
+        try:
+            _mf = _manifest.load_manifest(manifest_path)
+        except _manifest.ManifestError:
+            _mf = None
+        if _mf is not None and "component" not in _mf:
+            print(
+                "error: nothing to build — this transfer.yaml declares no "
+                "component (all algorithms are BYO; images are pre-built).",
+                file=sys.stderr,
+            )
+            return 2
+
     layout.set_experiment_root(str(exp_root))
 
     if not args.skip_build:

--- a/pipeline/tests/test_assemble_run.py
+++ b/pipeline/tests/test_assemble_run.py
@@ -265,6 +265,104 @@ class TestResolveScenarios:
                 framework_defaults={},
             )
 
+    def test_framework_defaults_named_defaults_merge_into_baseline_entry(self, tmp_path):
+        """Regression test for issue #516.
+
+        Framework-default fragments under ``baselines/defaults/*.yaml`` are
+        authored with a placeholder ``scenario[0].name = "defaults"``. When the
+        experiment's baseline entry is named anything else (i.e. every real
+        experiment), the two must still merge into a SINGLE scenario entry —
+        otherwise llm-d-benchmark templates the placeholder as an independent
+        deployment inheriting the framework-default model (facebook/opt-125m).
+
+        Before the fix, ``resolve_baseline`` produced two scenario entries
+        (``[{name: defaults, ...}, {name: <baseline>, ...}]``) and a phantom
+        facebook/opt-125m deployment materialized alongside the intended one.
+        """
+        bundle = {
+            "scenario": [{
+                "name": "sr",
+                "model": {"name": "Qwen/Qwen3-14B", "path": "models/Qwen"},
+                "decode": {"replicas": 2},
+            }],
+        }
+        framework_defaults = {
+            "scenario": [{
+                "name": "defaults",  # placeholder; realigned at merge time
+                "gateway": {"externallyManaged": True},
+                "inferenceExtension": {"verbosity": "5"},
+                "extraObjects": [{"apiVersion": "v1", "kind": "Role",
+                                  "metadata": {"name": "epp-role"}}],
+            }],
+        }
+        bundle_path = tmp_path / "sr.yaml"
+        self._write(bundle_path, bundle)
+
+        resolved = assemble_run.resolve_baseline(
+            bundle_path=bundle_path,
+            overlay_path=None,
+            framework_defaults=framework_defaults,
+        )
+
+        # 1) Single scenario entry, carrying the baseline's name (not "defaults").
+        assert len(resolved["scenario"]) == 1
+        entry = resolved["scenario"][0]
+        assert entry["name"] == "sr"
+
+        # 2) Baseline content preserved (model + decode).
+        assert entry["model"]["name"] == "Qwen/Qwen3-14B"
+        assert entry["decode"]["replicas"] == 2
+
+        # 3) Framework-defaults content merged in.
+        assert entry["gateway"]["externallyManaged"] is True
+        assert entry["inferenceExtension"]["verbosity"] == "5"
+        assert entry["extraObjects"] == [
+            {"apiVersion": "v1", "kind": "Role",
+             "metadata": {"name": "epp-role"}}
+        ]
+
+    def test_framework_defaults_no_op_when_names_already_match(self, tmp_path):
+        """When both sides already have matching names, no realignment needed."""
+        bundle = {"scenario": [{"name": "same", "a": 1}]}
+        framework_defaults = {"scenario": [{"name": "same", "b": 2}]}
+        bundle_path = tmp_path / "b.yaml"
+        self._write(bundle_path, bundle)
+        resolved = assemble_run.resolve_baseline(
+            bundle_path=bundle_path,
+            overlay_path=None,
+            framework_defaults=framework_defaults,
+        )
+        assert resolved == {"scenario": [{"name": "same", "a": 1, "b": 2}]}
+
+    def test_framework_defaults_empty_scenario_no_op(self, tmp_path):
+        """Empty framework_defaults must not corrupt the bundle."""
+        bundle = {"scenario": [{"name": "sr", "a": 1}]}
+        bundle_path = tmp_path / "b.yaml"
+        self._write(bundle_path, bundle)
+        resolved = assemble_run.resolve_baseline(
+            bundle_path=bundle_path,
+            overlay_path=None,
+            framework_defaults={},
+        )
+        assert resolved == bundle
+
+    def test_align_overlay_name_does_not_mutate_caller_state(self, tmp_path):
+        """resolve_baseline must not mutate the caller's framework_defaults dict."""
+        bundle = {"scenario": [{"name": "sr"}]}
+        framework_defaults = {"scenario": [{"name": "defaults", "x": 1}]}
+        original_snapshot = {
+            "scenario": [{"name": "defaults", "x": 1}],
+        }
+        bundle_path = tmp_path / "b.yaml"
+        self._write(bundle_path, bundle)
+        assemble_run.resolve_baseline(
+            bundle_path=bundle_path,
+            overlay_path=None,
+            framework_defaults=framework_defaults,
+        )
+        # Caller's dict is untouched — the helper deep-copies before renaming.
+        assert framework_defaults == original_snapshot
+
 
 class TestInjectHfSecret:
     def test_sets_secret_name_on_each_entry(self):

--- a/pipeline/tests/test_build.py
+++ b/pipeline/tests/test_build.py
@@ -8,6 +8,7 @@ import subprocess
 from unittest.mock import patch
 
 import pytest
+import yaml
 
 from pipeline import sim2real
 from pipeline.lib import build, layout
@@ -768,3 +769,76 @@ class TestSim2realBuildLoop:
         assert rc == 0
         mock_probe.assert_not_called()
         mock_build.assert_not_called()
+
+
+class TestSim2realBuildByoGuard:
+    """Issue #497: `sim2real build` on an all-BYO manifest errors early —
+    BYO images are pre-built, so there is nothing to build."""
+
+    def _write_all_byo_manifest(self, tmp_path):
+        manifest = {
+            "kind": "sim2real-transfer",
+            "version": 3,
+            "scenario": "byo-scenario",
+            "baselines": [{"name": "base", "scenario": "baseline-scenario"}],
+            "algorithms": [
+                {"name": "byoalgo", "defaults": "base", "byo": True},
+            ],
+            "context": {"text": "", "files": []},
+        }
+        (tmp_path / "transfer.yaml").write_text(yaml.safe_dump(manifest))
+
+    def test_all_byo_manifest_errors_without_component(self, tmp_path, capsys):
+        _make_workspace(tmp_path)
+        self._write_all_byo_manifest(tmp_path)
+        with patch("pipeline.lib.build.shutil.which",
+                   return_value="/usr/bin/skopeo"):
+            rc = sim2real.main([
+                "--experiment-root", str(tmp_path),
+                "build", "--translation", "byo-scenario",
+            ])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "nothing to build" in err
+        assert "all algorithms are BYO" in err
+
+    def test_manifest_at_config_path_also_triggers_guard(self, tmp_path, capsys):
+        """Discovery falls back to `config/transfer.yaml` — same guard fires."""
+        _make_workspace(tmp_path)
+        (tmp_path / "config").mkdir()
+        manifest = {
+            "kind": "sim2real-transfer",
+            "version": 3,
+            "scenario": "byo-scenario",
+            "baselines": [{"name": "base", "scenario": "baseline-scenario"}],
+            "algorithms": [
+                {"name": "byoalgo", "defaults": "base", "byo": True},
+            ],
+            "context": {"text": "", "files": []},
+        }
+        (tmp_path / "config" / "transfer.yaml").write_text(yaml.safe_dump(manifest))
+        with patch("pipeline.lib.build.shutil.which",
+                   return_value="/usr/bin/skopeo"):
+            rc = sim2real.main([
+                "--experiment-root", str(tmp_path),
+                "build", "--translation", "byo-scenario",
+            ])
+        assert rc == 2
+        assert "nothing to build" in capsys.readouterr().err
+
+    def test_no_manifest_does_not_short_circuit(self, tmp_path, capsys):
+        """No transfer.yaml → guard is a no-op; downstream error wins."""
+        _make_workspace(tmp_path)
+        # No transfer.yaml written; --translation resolves against an empty
+        # translations dir, giving the "no translations" error path.
+        (tmp_path / "workspace" / "translations").mkdir(parents=True, exist_ok=True)
+        with patch("pipeline.lib.build.shutil.which",
+                   return_value="/usr/bin/skopeo"):
+            rc = sim2real.main([
+                "--experiment-root", str(tmp_path),
+                "build", "--translation", "nope",
+            ])
+        assert rc == 2
+        # Downstream translation-resolver message, NOT the BYO guard.
+        err = capsys.readouterr().err
+        assert "nothing to build" not in err

--- a/pipeline/tests/test_manifest.py
+++ b/pipeline/tests/test_manifest.py
@@ -729,3 +729,117 @@ def test_defaults_block_rejects_unknown_keys(tmp_path):
     path = _write_manifest(tmp_path, data)
     with pytest.raises(ManifestError, match="defaults contains unknown keys.*enable"):
         load_manifest(path)
+
+
+# ── byo: true per-algorithm marker (v3 schema addition, issue #497) ──────
+
+
+def test_byo_true_algorithm_loads_without_source(tmp_path):
+    """`algorithms[i].byo: true` makes `source:` optional for that entry.
+
+    Non-BYO manifests still need `component:`, so keep the MINIMAL_V3
+    component block; loosening `component:` is exercised separately.
+    """
+    data = {
+        **MINIMAL_V3,
+        "algorithms": [
+            {"name": "byoalgo", "defaults": "baseline", "byo": True},
+        ],
+    }
+    path = _write_manifest(tmp_path, data)
+    m = load_manifest(path)
+    assert m["algorithms"][0]["name"] == "byoalgo"
+    assert m["algorithms"][0]["byo"] is True
+    assert "source" not in m["algorithms"][0]
+
+
+def test_byo_false_algorithm_still_requires_source(tmp_path):
+    """`byo: false` leaves `source:` required — regression."""
+    data = {
+        **MINIMAL_V3,
+        "algorithms": [
+            {"name": "treatment", "defaults": "baseline", "byo": False},
+        ],
+    }
+    path = _write_manifest(tmp_path, data)
+    with pytest.raises(ManifestError, match="algorithms.*source"):
+        load_manifest(path)
+
+
+def test_byo_absent_algorithm_still_requires_source(tmp_path):
+    """Absent `byo:` behaves identically to `byo: false` — regression."""
+    data = {
+        **MINIMAL_V3,
+        "algorithms": [
+            {"name": "treatment", "defaults": "baseline"},
+        ],
+    }
+    path = _write_manifest(tmp_path, data)
+    with pytest.raises(ManifestError, match="algorithms.*source"):
+        load_manifest(path)
+
+
+@pytest.mark.parametrize("bad_value", ["true", 1, 0, [True], {"v": True}])
+def test_byo_must_be_boolean(tmp_path, bad_value):
+    """Non-bool `byo:` is rejected with an error naming the field and type."""
+    data = {
+        **MINIMAL_V3,
+        "algorithms": [
+            {"name": "byoalgo", "defaults": "baseline", "byo": bad_value,
+             "source": "sim2real_golden/routers/router_adaptive_v2.go"},
+        ],
+    }
+    path = _write_manifest(tmp_path, data)
+    with pytest.raises(ManifestError, match="byo.*bool"):
+        load_manifest(path)
+
+
+def test_component_optional_when_all_algorithms_byo(tmp_path):
+    """`component:` may be absent when every algorithm carries `byo: true`."""
+    data = {k: v for k, v in MINIMAL_V3.items() if k != "component"}
+    data["algorithms"] = [
+        {"name": "byoa", "defaults": "baseline", "byo": True},
+        {"name": "byob", "defaults": "baseline", "byo": True},
+    ]
+    path = _write_manifest(tmp_path, data)
+    m = load_manifest(path)
+    assert "component" not in m
+    assert len(m["algorithms"]) == 2
+
+
+def test_component_required_when_mixed_byo_and_blis(tmp_path):
+    """`component:` still required when any algorithm is non-BYO."""
+    data = {k: v for k, v in MINIMAL_V3.items() if k != "component"}
+    data["algorithms"] = [
+        {"name": "byoalgo", "defaults": "baseline", "byo": True},
+        {"name": "blisalgo", "defaults": "baseline",
+         "source": "sim2real_golden/routers/router_adaptive_v2.go"},
+    ]
+    path = _write_manifest(tmp_path, data)
+    with pytest.raises(ManifestError, match="component.*required"):
+        load_manifest(path)
+
+
+def test_byo_manifest_loads_cleanly_for_downstream(tmp_path):
+    """A BYO manifest through `load_manifest` produces a dict whose
+    downstream consumers (`translation register`, `assemble`) can access
+    without dereferencing a field the BYO entry omits.
+
+    Issue #497 acceptance: "load a BYO manifest through
+    `manifest.load_manifest` and verify no field a BYO entry omits is
+    dereferenced." Asserts the fields register/assemble actually read
+    (algorithm `name`, `defaults`, `byo`) are present, and `source:` /
+    `component:` are absent.
+    """
+    data = {k: v for k, v in MINIMAL_V3.items() if k != "component"}
+    data["algorithms"] = [
+        {"name": "byoa", "defaults": "baseline", "byo": True},
+    ]
+    path = _write_manifest(tmp_path, data)
+    m = load_manifest(path)
+    assert m["algorithms"][0]["name"] == "byoa"
+    assert m["algorithms"][0]["defaults"] == "baseline"
+    assert m["algorithms"][0]["byo"] is True
+    assert "source" not in m["algorithms"][0]
+    assert "component" not in m
+    assert m["algorithms"][0]["defaults"] in {b["name"] for b in m["baselines"]}

--- a/pipeline/tests/test_sim2real.py
+++ b/pipeline/tests/test_sim2real.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -77,487 +78,746 @@ class TestExtractDigest:
         assert sim2real._extract_digest_from_ref("ghcr.io/foo@sha256:" + "z" * 64) is None
 
 
+class TestParseAlgorithmTriple:
+    def test_simple_triple(self):
+        name, image, cfg = sim2real._parse_algorithm_triple("foo=img:v1@algo.yaml")
+        assert name == "foo"
+        assert image == "img:v1"
+        assert cfg == "algo.yaml"
+
+    def test_digest_ref_uses_rightmost_at(self):
+        name, image, cfg = sim2real._parse_algorithm_triple(
+            "foo=registry.io/img@sha256:" + "d" * 64 + "@algorithms/foo/foo_config.yaml"
+        )
+        assert name == "foo"
+        assert image == "registry.io/img@sha256:" + "d" * 64
+        assert cfg == "algorithms/foo/foo_config.yaml"
+
+    def test_config_path_with_equals_supported(self):
+        name, image, cfg = sim2real._parse_algorithm_triple("foo=img:v1@path=weird.yaml")
+        assert name == "foo"
+        assert image == "img:v1"
+        assert cfg == "path=weird.yaml"
+
+    def test_missing_equals_rejected(self):
+        with pytest.raises(argparse.ArgumentTypeError) as ei:
+            sim2real._parse_algorithm_triple("fooimg@algo.yaml")
+        assert "=" in str(ei.value)
+
+    def test_missing_at_rejected(self):
+        with pytest.raises(argparse.ArgumentTypeError) as ei:
+            sim2real._parse_algorithm_triple("foo=img:v1")
+        assert "@" in str(ei.value)
+
+    def test_empty_image_rejected(self):
+        with pytest.raises(argparse.ArgumentTypeError):
+            sim2real._parse_algorithm_triple("foo=@algo.yaml")
+
+    def test_empty_config_rejected(self):
+        with pytest.raises(argparse.ArgumentTypeError):
+            sim2real._parse_algorithm_triple("foo=img:v1@")
+
+    def test_invalid_name_rejected(self):
+        with pytest.raises(argparse.ArgumentTypeError) as ei:
+            sim2real._parse_algorithm_triple("bad name=img@cfg.yaml")
+        # Message should mention the name-regex constraint.
+        assert "name" in str(ei.value).lower()
+
+    def test_at_in_middle_goes_to_image(self):
+        """Rightmost-@ split rule: any earlier '@' stays in the image ref."""
+        name, image, cfg = sim2real._parse_algorithm_triple("foo=a@b@c.yaml")
+        assert name == "foo"
+        assert image == "a@b"
+        assert cfg == "c.yaml"
+
+    def test_multiple_at_in_image_rejected(self):
+        """Reject values whose parsed image ref has more than one '@'.
+
+        Common cause: user tried to put a '@' in the config path.
+        """
+        with pytest.raises(argparse.ArgumentTypeError) as ei:
+            sim2real._parse_algorithm_triple("foo=img:tag@path@with@ats/overlay.yaml")
+        assert "overlay path cannot contain" in str(ei.value)
+
+
 class TestComputeTranslationHash:
-    def test_is_deterministic(self):
-        h1 = sim2real._compute_translation_hash("sha256:aa", b"config: 1\n", "algo")
-        h2 = sim2real._compute_translation_hash("sha256:aa", b"config: 1\n", "algo")
+    """Batched hash formula (replaces step-1 single-algo formula for all N)."""
+
+    def _e(self, name: str, image: str = "sha256:aa", config: bytes = b"c") -> dict:
+        import hashlib
+        return {
+            "name": name,
+            "image": image,
+            "config_sha": hashlib.sha256(config).hexdigest(),
+        }
+
+    def test_is_deterministic_n1(self):
+        h1 = sim2real._compute_translation_hash([self._e("algo")])
+        h2 = sim2real._compute_translation_hash([self._e("algo")])
         assert h1 == h2
-        assert len(h1) == 64  # sha256 hex length
+        assert len(h1) == 64
+
+    def test_is_deterministic_n2(self):
+        h1 = sim2real._compute_translation_hash([self._e("a"), self._e("b")])
+        h2 = sim2real._compute_translation_hash([self._e("a"), self._e("b")])
+        assert h1 == h2
+        assert len(h1) == 64
+
+    def test_order_invariant(self):
+        h_ab = sim2real._compute_translation_hash([self._e("a"), self._e("b")])
+        h_ba = sim2real._compute_translation_hash([self._e("b"), self._e("a")])
+        assert h_ab == h_ba
 
     def test_changes_with_algorithm_name(self):
-        h1 = sim2real._compute_translation_hash("sha256:aa", b"c", "a")
-        h2 = sim2real._compute_translation_hash("sha256:aa", b"c", "b")
+        h1 = sim2real._compute_translation_hash([self._e("a")])
+        h2 = sim2real._compute_translation_hash([self._e("b")])
         assert h1 != h2
 
-    def test_changes_with_config_content(self):
-        h1 = sim2real._compute_translation_hash("sha256:aa", b"a", "algo")
-        h2 = sim2real._compute_translation_hash("sha256:aa", b"b", "algo")
+    def test_changes_with_config(self):
+        h1 = sim2real._compute_translation_hash([self._e("a", config=b"x")])
+        h2 = sim2real._compute_translation_hash([self._e("a", config=b"y")])
         assert h1 != h2
 
     def test_changes_with_image_ref(self):
-        h1 = sim2real._compute_translation_hash("sha256:aa", b"c", "algo")
-        h2 = sim2real._compute_translation_hash("sha256:bb", b"c", "algo")
+        h1 = sim2real._compute_translation_hash([self._e("a", image="sha256:aa")])
+        h2 = sim2real._compute_translation_hash([self._e("a", image="sha256:bb")])
         assert h1 != h2
 
     def test_offline_ref_produces_stable_hash(self):
-        h1 = sim2real._compute_translation_hash("ghcr.io/foo:v1", b"c", "algo")
-        h2 = sim2real._compute_translation_hash("ghcr.io/foo:v1", b"c", "algo")
+        e = self._e("a", image="ghcr.io/foo:v1")
+        h1 = sim2real._compute_translation_hash([e])
+        h2 = sim2real._compute_translation_hash([e])
         assert h1 == h2
+
+    def test_adding_algo_changes_hash(self):
+        h1 = sim2real._compute_translation_hash([self._e("a")])
+        h2 = sim2real._compute_translation_hash([self._e("a"), self._e("b")])
+        assert h1 != h2
+
+    def test_n1_new_differs_from_n1_old_shape(self):
+        """The new formula wraps entries in a list, so N=1 hashes differ
+        from the step-1 formula (which framed a single dict). Documented
+        break in the design (no long-lived step-1 registrations exist)."""
+        import hashlib
+        import json as _json
+        new_hash = sim2real._compute_translation_hash([self._e("a")])
+        # Old formula: sha256(canonical-json({algorithm_name, config_sha256, image_digest_or_ref}))
+        old_canonical = _json.dumps(
+            {
+                "algorithm_name": "a",
+                "config_sha256": hashlib.sha256(b"c").hexdigest(),
+                "image_digest_or_ref": "sha256:aa",
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
+        old_hash = hashlib.sha256(old_canonical.encode("utf-8")).hexdigest()
+        assert new_hash != old_hash
 
 
 class TestBuildSchemas:
     def test_translation_output_schema(self):
-        # Updated to step-2 shape: image_ref/image_digest live per-algo.
         out = sim2real._build_translation_output(
-            algorithm_name="softreflective",
-            image_ref="ghcr.io/foo:v1",
-            image_digest=None,
-            config_path="generated/softreflective/softreflective_config.yaml",
-            translation_hash="a" * 64,
+            algorithms=[
+                {
+                    "name": "algo1",
+                    "image_ref": "sha256:aa",
+                    "image_digest": "sha256:aa",
+                    "config_path": "generated/algo1/algo1_config.yaml",
+                },
+            ],
+            translation_hash="h" * 64,
             source="byo",
-            alias="softreflective",
-            created_at="2026-07-01T14:00:00Z",
+            alias="algo1",
+            created_at="2026-07-05T10:00:00Z",
         )
-        assert out == {
-            "version": 1,
-            "translation_hash": "a" * 64,
-            "source": "byo",
-            "alias": "softreflective",
-            "algorithms": [{
-                "name": "softreflective",
-                "source_path": None,
-                "source_sha256": None,
-                "config_path": "generated/softreflective/softreflective_config.yaml",
-                "image_ref": "ghcr.io/foo:v1",
-                "image_digest": None,
-            }],
-            "created_at": "2026-07-01T14:00:00Z",
-        }
+        assert out["version"] == 1
+        assert out["translation_hash"] == "h" * 64
+        assert out["source"] == "byo"
+        assert out["alias"] == "algo1"
+        assert out["created_at"] == "2026-07-05T10:00:00Z"
+        assert len(out["algorithms"]) == 1
+        entry = out["algorithms"][0]
+        assert entry["name"] == "algo1"
+        assert entry["source_path"] is None
+        assert entry["source_sha256"] is None
+        assert entry["config_path"] == "generated/algo1/algo1_config.yaml"
+        assert entry["image_ref"] == "sha256:aa"
+        assert entry["image_digest"] == "sha256:aa"
+
+    def test_translation_output_batched_n2(self):
+        out = sim2real._build_translation_output(
+            algorithms=[
+                {"name": "a", "image_ref": "img1", "image_digest": None, "config_path": "generated/a/a_config.yaml"},
+                {"name": "b", "image_ref": "img2", "image_digest": None, "config_path": "generated/b/b_config.yaml"},
+            ],
+            translation_hash="h" * 64,
+            source="byo",
+            alias=None,
+            created_at="2026-07-05T10:00:00Z",
+        )
+        assert out["alias"] is None
+        assert [e["name"] for e in out["algorithms"]] == ["a", "b"]
 
     def test_registered_schema_with_digest(self):
         reg = sim2real._build_registered(
-            image_ref="ghcr.io/foo@sha256:" + "b" * 64,
-            image_digest="sha256:" + "b" * 64,
-            registered_at="2026-07-01T14:00:00Z",
+            [
+                {"name": "algo1", "image_ref": "reg/img@sha256:" + "a" * 64, "image_digest": "sha256:" + "a" * 64},
+            ],
+            "2026-07-05T10:00:00Z",
         )
-        assert reg == {
-            "version": 1,
-            "image_ref": "ghcr.io/foo@sha256:" + "b" * 64,
-            "image_digest": "sha256:" + "b" * 64,
-            "source": "byo",
-            "registered_at": "2026-07-01T14:00:00Z",
-        }
+        assert reg["version"] == 1
+        assert reg["source"] == "byo"
+        assert reg["registered_at"] == "2026-07-05T10:00:00Z"
+        assert reg["algorithms"] == [
+            {"name": "algo1", "image_ref": "reg/img@sha256:" + "a" * 64, "image_digest": "sha256:" + "a" * 64},
+        ]
 
     def test_registered_schema_offline(self):
         reg = sim2real._build_registered(
-            image_ref="ghcr.io/foo:v1",
-            image_digest=None,
-            registered_at="2026-07-01T14:00:00Z",
+            [
+                {"name": "a", "image_ref": "ghcr.io/foo:v1", "image_digest": None},
+            ],
+            "2026-07-05T10:00:00Z",
         )
-        assert reg["image_digest"] is None
-        assert reg["image_ref"] == "ghcr.io/foo:v1"
-
-
-class TestBuildTranslationOutputV2:
-    def test_new_schema_shape(self):
-        out = sim2real._build_translation_output(
-            algorithm_name="softreflective",
-            image_ref="ghcr.io/x/sr:v1",
-            image_digest="sha256:aa",
-            config_path="generated/softreflective/softreflective_config.yaml",
-            translation_hash="a" * 64,
-            source="byo",
-            alias="softreflective",
-            created_at="2026-07-02T14:00:00Z",
-        )
-        # Top-level image_ref removed; now per-algo.
-        assert "image_ref" not in out
-        assert "image_digest" not in out
-        assert out["alias"] == "softreflective"
-        assert out["source"] == "byo"
-        assert out["version"] == 1
-        assert out["translation_hash"] == "a" * 64
-        assert out["created_at"] == "2026-07-02T14:00:00Z"
-        assert len(out["algorithms"]) == 1
-        algo = out["algorithms"][0]
-        assert algo["name"] == "softreflective"
-        assert algo["image_ref"] == "ghcr.io/x/sr:v1"
-        assert algo["image_digest"] == "sha256:aa"
-        assert algo["config_path"] == \
-            "generated/softreflective/softreflective_config.yaml"
-        assert algo["source_path"] is None
-        assert algo["source_sha256"] is None
+        assert reg["algorithms"][0]["image_digest"] is None
 
 
 class TestRegisterTranslation:
-    def _write_overlay(self, tmp_path, content=b"scorer: mine\n"):
-        p = tmp_path / "treatment.yaml"
-        p.write_bytes(content)
-        return p
+    def _algo(self, tmp_path, name: str, image: str = None, config: str = None) -> dict:
+        """Build an AlgorithmSpec, writing the config file on the way in."""
+        cfg = tmp_path / f"{name}_config.yaml"
+        cfg.write_text(config if config else f"scorers:\n  - name: {name}\n")
+        return {
+            "name": name,
+            "image_ref": image or "ghcr.io/foo/bar:v1",
+            "config_path": cfg,
+        }
 
-    def test_creates_translation_dir_and_files(self, tmp_path):
-        cfg = self._write_overlay(tmp_path)
+    def test_creates_translation_dir_and_files_n1(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        algo = self._algo(tmp_path, "algo1")
+        now = "2026-07-05T10:00:00Z"
         thash, status = sim2real._register_translation(
-            algorithm_name="softreflective",
-            image_ref="ghcr.io/foo:v1",
-            config_path=cfg,
+            algorithms=[algo],
             baseline_config_path=None,
             registered_hash=None,
-            now_iso="2026-07-01T14:00:00Z",
+            now_iso=now,
         )
         assert status == "created"
-        assert len(thash) == 64
-        assert layout.translation_output_path(thash).exists()
-        assert layout.registered_path(thash).exists()
-        assert layout.generated_config_path(thash, "softreflective").exists()
+        tdir = Path("workspace") / "translations" / thash
+        assert (tdir / "translation_output.json").exists()
+        assert (tdir / "registered.json").exists()
+        assert (tdir / "generated" / "algo1" / "algo1_config.yaml").exists()
 
-    def test_translation_output_contents(self, tmp_path):
-        # Step-2 schema: image_ref lives per-algo; alias at top level.
-        cfg = self._write_overlay(tmp_path)
-        thash, _ = sim2real._register_translation(
-            algorithm_name="softreflective",
-            image_ref="ghcr.io/foo:v1",
-            config_path=cfg,
+    def test_creates_translation_dir_and_files_n2(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        algos = [self._algo(tmp_path, "foo"), self._algo(tmp_path, "bar")]
+        thash, status = sim2real._register_translation(
+            algorithms=algos,
             baseline_config_path=None,
             registered_hash=None,
-            now_iso="2026-07-01T14:00:00Z",
+            now_iso="2026-07-05T10:00:00Z",
         )
-        out = json.loads(layout.translation_output_path(thash).read_text())
-        assert out["source"] == "byo"
-        assert out["alias"] == "softreflective"
-        assert out["translation_hash"] == thash
-        assert out["version"] == 1
-        assert len(out["algorithms"]) == 1
-        algo = out["algorithms"][0]
-        assert algo["name"] == "softreflective"
-        assert algo["image_ref"] == "ghcr.io/foo:v1"
+        assert status == "created"
+        tdir = Path("workspace") / "translations" / thash
+        assert (tdir / "generated" / "foo" / "foo_config.yaml").exists()
+        assert (tdir / "generated" / "bar" / "bar_config.yaml").exists()
+        tout = json.loads((tdir / "translation_output.json").read_text())
+        names = sorted(a["name"] for a in tout["algorithms"])
+        assert names == ["bar", "foo"]
 
-    def test_registered_records_digest_when_present(self, tmp_path):
-        cfg = self._write_overlay(tmp_path)
-        ref = "ghcr.io/foo@sha256:" + "a" * 64
+    def test_alias_field_null_for_batched(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        algos = [self._algo(tmp_path, "foo"), self._algo(tmp_path, "bar")]
         thash, _ = sim2real._register_translation(
-            algorithm_name="softreflective",
-            image_ref=ref,
-            config_path=cfg,
+            algorithms=algos,
             baseline_config_path=None,
             registered_hash=None,
-            now_iso="2026-07-01T14:00:00Z",
+            now_iso="2026-07-05T10:00:00Z",
         )
-        reg = json.loads(layout.registered_path(thash).read_text())
-        assert reg["image_digest"] == "sha256:" + "a" * 64
+        tout = json.loads((Path("workspace") / "translations" / thash / "translation_output.json").read_text())
+        assert tout["alias"] is None
 
-    def test_registered_null_digest_when_tag_only(self, tmp_path):
-        cfg = self._write_overlay(tmp_path)
+    def test_alias_field_set_for_n1(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        algo = self._algo(tmp_path, "solo")
         thash, _ = sim2real._register_translation(
-            algorithm_name="softreflective",
-            image_ref="ghcr.io/foo:v1",
-            config_path=cfg,
+            algorithms=[algo],
             baseline_config_path=None,
             registered_hash=None,
-            now_iso="2026-07-01T14:00:00Z",
+            now_iso="2026-07-05T10:00:00Z",
         )
-        reg = json.loads(layout.registered_path(thash).read_text())
-        assert reg["image_digest"] is None
+        tout = json.loads((Path("workspace") / "translations" / thash / "translation_output.json").read_text())
+        assert tout["alias"] == "solo"
 
-    def test_writes_treatment_overlay(self, tmp_path):
-        cfg = self._write_overlay(tmp_path, content=b"scorer: custom\n")
+    def test_translation_output_algorithms_shape(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        algos = [self._algo(tmp_path, "foo", image="reg/img@sha256:" + "a" * 64)]
         thash, _ = sim2real._register_translation(
-            algorithm_name="softreflective",
-            image_ref="ghcr.io/foo:v1",
-            config_path=cfg,
+            algorithms=algos,
             baseline_config_path=None,
             registered_hash=None,
-            now_iso="2026-07-01T14:00:00Z",
+            now_iso="2026-07-05T10:00:00Z",
         )
-        assert (
-            layout.generated_config_path(thash, "softreflective").read_bytes()
-            == b"scorer: custom\n"
-        )
+        tout = json.loads((Path("workspace") / "translations" / thash / "translation_output.json").read_text())
+        entry = tout["algorithms"][0]
+        assert entry["name"] == "foo"
+        assert entry["image_ref"] == "reg/img@sha256:" + "a" * 64
+        assert entry["image_digest"] == "sha256:" + "a" * 64
+        assert entry["config_path"] == "generated/foo/foo_config.yaml"
+        assert entry["source_path"] is None
+        assert entry["source_sha256"] is None
 
-    def test_writes_baseline_config_when_provided(self, tmp_path):
-        cfg = self._write_overlay(tmp_path)
-        baseline = tmp_path / "baseline.yaml"
-        baseline.write_bytes(b"baseline: config\n")
+    def test_registered_records_all_algorithms(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        algos = [
+            self._algo(tmp_path, "foo", image="reg/img@sha256:" + "a" * 64),
+            self._algo(tmp_path, "bar", image="reg/img2:v1"),
+        ]
         thash, _ = sim2real._register_translation(
-            algorithm_name="softreflective",
-            image_ref="ghcr.io/foo:v1",
-            config_path=cfg,
+            algorithms=algos,
+            baseline_config_path=None,
+            registered_hash=None,
+            now_iso="2026-07-05T10:00:00Z",
+        )
+        reg = json.loads((Path("workspace") / "translations" / thash / "registered.json").read_text())
+        assert reg["version"] == 1
+        assert reg["source"] == "byo"
+        # Batched registered.json carries N entries under 'algorithms'.
+        entries = {e["name"]: e for e in reg["algorithms"]}
+        assert entries["foo"]["image_digest"] == "sha256:" + "a" * 64
+        assert entries["bar"]["image_digest"] is None
+
+    def test_writes_all_treatment_overlays_verbatim(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        algos = [
+            self._algo(tmp_path, "foo", config="foo_body: 1\n"),
+            self._algo(tmp_path, "bar", config="bar_body: 2\n"),
+        ]
+        thash, _ = sim2real._register_translation(
+            algorithms=algos,
+            baseline_config_path=None,
+            registered_hash=None,
+            now_iso="2026-07-05T10:00:00Z",
+        )
+        tdir = Path("workspace") / "translations" / thash
+        assert (tdir / "generated" / "foo" / "foo_config.yaml").read_text() == "foo_body: 1\n"
+        assert (tdir / "generated" / "bar" / "bar_config.yaml").read_text() == "bar_body: 2\n"
+
+    def test_baseline_config_written_once(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        baseline = tmp_path / "base.yaml"
+        baseline.write_text("baseline: yes\n")
+        algos = [self._algo(tmp_path, "foo"), self._algo(tmp_path, "bar")]
+        thash, _ = sim2real._register_translation(
+            algorithms=algos,
             baseline_config_path=baseline,
             registered_hash=None,
-            now_iso="2026-07-01T14:00:00Z",
+            now_iso="2026-07-05T10:00:00Z",
         )
-        gen_baseline = layout.translation_dir(thash) / "generated" / "baseline_config.yaml"
-        assert gen_baseline.read_bytes() == b"baseline: config\n"
+        tdir = Path("workspace") / "translations" / thash
+        assert (tdir / "generated" / "baseline_config.yaml").read_text() == "baseline: yes\n"
 
-    def test_idempotent_second_call_same_inputs(self, tmp_path):
-        cfg = self._write_overlay(tmp_path)
-        args = dict(
-            algorithm_name="softreflective",
-            image_ref="ghcr.io/foo:v1",
-            config_path=cfg,
+    def test_idempotent_second_call_same_inputs(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        algos = [self._algo(tmp_path, "foo"), self._algo(tmp_path, "bar")]
+        h1, s1 = sim2real._register_translation(
+            algorithms=algos,
             baseline_config_path=None,
             registered_hash=None,
-            now_iso="2026-07-01T14:00:00Z",
+            now_iso="2026-07-05T10:00:00Z",
         )
-        h1, s1 = sim2real._register_translation(**args)
-        h2, s2 = sim2real._register_translation(**args)
+        # Second call: same algorithms in same order.
+        h2, s2 = sim2real._register_translation(
+            algorithms=algos,
+            baseline_config_path=None,
+            registered_hash=None,
+            now_iso="2026-07-05T11:00:00Z",
+        )
         assert h1 == h2
         assert s1 == "created"
         assert s2 == "idempotent"
 
-    def test_hash_collision_different_algorithm_errors(self, tmp_path):
-        cfg = self._write_overlay(tmp_path)
-        thash, _ = sim2real._register_translation(
-            algorithm_name="softreflective",
-            image_ref="ghcr.io/foo:v1",
-            config_path=cfg,
+    def test_idempotent_different_order_same_hash(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        algos1 = [self._algo(tmp_path, "foo"), self._algo(tmp_path, "bar")]
+        algos2 = [algos1[1], algos1[0]]  # reversed
+        h1, _ = sim2real._register_translation(
+            algorithms=algos1,
             baseline_config_path=None,
             registered_hash=None,
-            now_iso="2026-07-01T14:00:00Z",
+            now_iso="2026-07-05T10:00:00Z",
         )
-        # Corrupt the existing translation_output.json to name a different algo.
-        out_path = layout.translation_output_path(thash)
-        out = json.loads(out_path.read_text())
-        out["algorithms"] = [{"name": "otheralgo"}]
-        out_path.write_text(json.dumps(out))
-        with pytest.raises(ValueError, match="algorithm name mismatch"):
+        h2, s2 = sim2real._register_translation(
+            algorithms=algos2,
+            baseline_config_path=None,
+            registered_hash=None,
+            now_iso="2026-07-05T11:00:00Z",
+        )
+        assert h1 == h2
+        assert s2 == "idempotent"
+
+    def test_registered_hash_mismatch_errors(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        algo = self._algo(tmp_path, "foo")
+        with pytest.raises(RuntimeError, match="--registered-hash mismatch"):
             sim2real._register_translation(
-                algorithm_name="softreflective",
-                image_ref="ghcr.io/foo:v1",
-                config_path=cfg,
+                algorithms=[algo],
                 baseline_config_path=None,
-                registered_hash=None,
-                now_iso="2026-07-01T14:00:00Z",
+                registered_hash="deadbeef",
+                now_iso="2026-07-05T10:00:00Z",
             )
 
-    def test_registered_hash_mismatch_errors(self, tmp_path):
-        cfg = self._write_overlay(tmp_path)
-        with pytest.raises(RuntimeError, match="registered-hash mismatch"):
-            sim2real._register_translation(
-                algorithm_name="softreflective",
-                image_ref="ghcr.io/foo:v1",
-                config_path=cfg,
-                baseline_config_path=None,
-                registered_hash="deadbeef" * 8,
-                now_iso="2026-07-01T14:00:00Z",
-            )
-
-    def test_registered_hash_match_succeeds(self, tmp_path):
-        cfg = self._write_overlay(tmp_path)
-        expected = sim2real._compute_translation_hash(
-            "ghcr.io/foo:v1", cfg.read_bytes(), "softreflective"
+    def test_registered_hash_match_succeeds(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        algo = self._algo(tmp_path, "foo")
+        # Compute expected hash by running once and reading it back.
+        expected, _ = sim2real._register_translation(
+            algorithms=[algo],
+            baseline_config_path=None,
+            registered_hash=None,
+            now_iso="2026-07-05T10:00:00Z",
         )
+        # Second call with matching hash succeeds (idempotent).
         thash, status = sim2real._register_translation(
-            algorithm_name="softreflective",
-            image_ref="ghcr.io/foo:v1",
-            config_path=cfg,
+            algorithms=[algo],
             baseline_config_path=None,
             registered_hash=expected,
-            now_iso="2026-07-01T14:00:00Z",
+            now_iso="2026-07-05T11:00:00Z",
         )
         assert thash == expected
-        assert status == "created"
+        assert status == "idempotent"
 
-    def test_partial_write_missing_registered_json_raises(self, tmp_path):
-        # Simulate: an earlier register wrote translation_output.json but
-        # died before writing registered.json (disk full, killed, etc.).
-        cfg = self._write_overlay(tmp_path)
+    def test_partial_write_missing_registered_json_raises(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        algo = self._algo(tmp_path, "foo")
         thash, _ = sim2real._register_translation(
-            algorithm_name="softreflective",
-            image_ref="ghcr.io/foo:v1",
-            config_path=cfg,
+            algorithms=[algo],
             baseline_config_path=None,
             registered_hash=None,
-            now_iso="2026-07-01T14:00:00Z",
+            now_iso="2026-07-05T10:00:00Z",
         )
-        layout.registered_path(thash).unlink()
+        (Path("workspace") / "translations" / thash / "registered.json").unlink()
         with pytest.raises(RuntimeError, match="incomplete"):
             sim2real._register_translation(
-                algorithm_name="softreflective",
-                image_ref="ghcr.io/foo:v1",
-                config_path=cfg,
+                algorithms=[algo],
                 baseline_config_path=None,
                 registered_hash=None,
-                now_iso="2026-07-01T14:00:00Z",
+                now_iso="2026-07-05T11:00:00Z",
             )
 
-    def test_partial_write_missing_generated_config_raises(self, tmp_path):
-        cfg = self._write_overlay(tmp_path)
+    def test_partial_write_missing_generated_config_raises(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        algo = self._algo(tmp_path, "foo")
         thash, _ = sim2real._register_translation(
-            algorithm_name="softreflective",
-            image_ref="ghcr.io/foo:v1",
-            config_path=cfg,
+            algorithms=[algo],
             baseline_config_path=None,
             registered_hash=None,
-            now_iso="2026-07-01T14:00:00Z",
+            now_iso="2026-07-05T10:00:00Z",
         )
-        layout.generated_config_path(thash, "softreflective").unlink()
+        (Path("workspace") / "translations" / thash / "generated" / "foo" / "foo_config.yaml").unlink()
         with pytest.raises(RuntimeError, match="incomplete"):
             sim2real._register_translation(
-                algorithm_name="softreflective",
-                image_ref="ghcr.io/foo:v1",
-                config_path=cfg,
+                algorithms=[algo],
                 baseline_config_path=None,
                 registered_hash=None,
-                now_iso="2026-07-01T14:00:00Z",
+                now_iso="2026-07-05T11:00:00Z",
+            )
+
+    def test_partial_write_missing_one_of_N_algos_raises(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        algos = [self._algo(tmp_path, "foo"), self._algo(tmp_path, "bar")]
+        thash, _ = sim2real._register_translation(
+            algorithms=algos,
+            baseline_config_path=None,
+            registered_hash=None,
+            now_iso="2026-07-05T10:00:00Z",
+        )
+        # Delete one of the per-algo directories so its overlay is missing.
+        (Path("workspace") / "translations" / thash / "generated" / "bar" / "bar_config.yaml").unlink()
+        with pytest.raises(RuntimeError, match="incomplete"):
+            sim2real._register_translation(
+                algorithms=algos,
+                baseline_config_path=None,
+                registered_hash=None,
+                now_iso="2026-07-05T11:00:00Z",
             )
 
 
 class TestBuildParser:
-    def test_parses_translation_register(self):
-        parser = sim2real.build_parser()
-        args = parser.parse_args([
+    def test_parses_new_form_single_algo(self):
+        p = sim2real.build_parser()
+        args = p.parse_args([
             "translation", "register",
-            "--algorithm", "softreflective",
-            "--image", "ghcr.io/foo:v1",
-            "--config", "/tmp/treatment.yaml",
+            "--algorithm", "foo=img:v1@overlay.yaml",
         ])
         assert args.command == "translation"
         assert args.subcommand == "register"
-        assert args.algorithm == "softreflective"
-        assert args.image == "ghcr.io/foo:v1"
-        assert args.config == "/tmp/treatment.yaml"
-        assert args.baseline_config is None
-        assert args.registered_hash is None
+        assert args.algorithm == ["foo=img:v1@overlay.yaml"]
+        assert args.image is None
+        assert args.config is None
+
+    def test_parses_new_form_multi_algo(self):
+        p = sim2real.build_parser()
+        args = p.parse_args([
+            "translation", "register",
+            "--algorithm", "foo=img1@o1.yaml",
+            "--algorithm", "bar=img2@o2.yaml",
+        ])
+        assert args.algorithm == ["foo=img1@o1.yaml", "bar=img2@o2.yaml"]
+
+    def test_parses_deprecated_form(self):
+        p = sim2real.build_parser()
+        args = p.parse_args([
+            "translation", "register",
+            "--algorithm", "foo",
+            "--image", "img:v1",
+            "--config", "overlay.yaml",
+        ])
+        assert args.algorithm == ["foo"]
+        assert args.image == "img:v1"
+        assert args.config == "overlay.yaml"
 
     def test_accepts_baseline_and_registered_hash(self):
-        parser = sim2real.build_parser()
-        args = parser.parse_args([
+        p = sim2real.build_parser()
+        args = p.parse_args([
             "translation", "register",
-            "--algorithm", "softreflective",
-            "--image", "ghcr.io/foo:v1",
-            "--config", "/tmp/treatment.yaml",
-            "--baseline-config", "/tmp/baseline.yaml",
-            "--registered-hash", "abcd" * 16,
+            "--algorithm", "foo=img:v1@overlay.yaml",
+            "--baseline-config", "b.yaml",
+            "--registered-hash", "abc",
+            "--force",
         ])
-        assert args.baseline_config == "/tmp/baseline.yaml"
-        assert args.registered_hash == "abcd" * 16
-
-    def test_rejects_bad_algorithm_name(self):
-        # Leading hyphen fails the shared regex; use it instead of Bad_Name
-        # (uppercase+underscore are now accepted per step-2 widening).
-        parser = sim2real.build_parser()
-        with pytest.raises(SystemExit):
-            parser.parse_args([
-                "translation", "register",
-                "--algorithm", "-bad-name",
-                "--image", "ghcr.io/foo:v1",
-                "--config", "/tmp/treatment.yaml",
-            ])
+        assert args.baseline_config == "b.yaml"
+        assert args.registered_hash == "abc"
+        assert args.force is True
 
 
 class TestMainEndToEnd:
-    def test_happy_path(self, tmp_path, capsys):
-        cfg = tmp_path / "treatment.yaml"
-        cfg.write_text("scorer: mine\n")
+    def _cfg(self, tmp_path, name: str) -> Path:
+        p = tmp_path / f"{name}.yaml"
+        p.write_text(f"scorers:\n  - name: {name}\n")
+        return p
+
+    def test_happy_path_n1_new_form(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = self._cfg(tmp_path, "foo")
         rc = sim2real.main([
-            "--experiment-root", str(tmp_path),
             "translation", "register",
-            "--algorithm", "softreflective",
-            "--image", "ghcr.io/foo:v1",
+            "--algorithm", f"foo=ghcr.io/img:v1@{cfg}",
+        ])
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "registered translation" in captured.out
+        # No deprecation warning under the new form.
+        assert "deprecated" not in captured.err.lower()
+
+    def test_happy_path_n1_deprecated_form(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = self._cfg(tmp_path, "foo")
+        rc = sim2real.main([
+            "translation", "register",
+            "--algorithm", "foo",
+            "--image", "ghcr.io/img:v1",
             "--config", str(cfg),
         ])
         assert rc == 0
         captured = capsys.readouterr()
         assert "registered translation" in captured.out
-        # Warn about null digest since image ref is tag-only.
-        assert "image_digest recorded as null" in captured.err
+        assert "deprecated" in captured.err.lower()
 
-    def test_idempotent_second_run(self, tmp_path):
-        cfg = tmp_path / "treatment.yaml"
-        cfg.write_text("scorer: mine\n")
-        argv = [
-            "--experiment-root", str(tmp_path),
-            "translation", "register",
-            "--algorithm", "softreflective",
-            "--image", "ghcr.io/foo:v1",
-            "--config", str(cfg),
-        ]
-        assert sim2real.main(argv) == 0
-        assert sim2real.main(argv) == 0  # idempotent, still exit 0
-
-    def test_malformed_config_errors_no_writes(self, tmp_path):
-        cfg = tmp_path / "bad.yaml"
-        cfg.write_text("scorer: [unclosed\n")  # invalid YAML
+    def test_happy_path_n2(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        c1 = self._cfg(tmp_path, "foo")
+        c2 = self._cfg(tmp_path, "bar")
         rc = sim2real.main([
-            "--experiment-root", str(tmp_path),
             "translation", "register",
-            "--algorithm", "softreflective",
-            "--image", "ghcr.io/foo:v1",
-            "--config", str(cfg),
-        ])
-        assert rc == 2
-        # No translation dir should have been created.
-        assert not layout.translations_dir().exists() or not any(
-            layout.translations_dir().iterdir()
-        )
-
-    def test_missing_config_errors(self, tmp_path):
-        rc = sim2real.main([
-            "--experiment-root", str(tmp_path),
-            "translation", "register",
-            "--algorithm", "softreflective",
-            "--image", "ghcr.io/foo:v1",
-            "--config", str(tmp_path / "does-not-exist.yaml"),
-        ])
-        assert rc == 2
-
-    def test_registered_hash_mismatch_exits_2(self, tmp_path):
-        cfg = tmp_path / "treatment.yaml"
-        cfg.write_text("scorer: mine\n")
-        rc = sim2real.main([
-            "--experiment-root", str(tmp_path),
-            "translation", "register",
-            "--algorithm", "softreflective",
-            "--image", "ghcr.io/foo:v1",
-            "--config", str(cfg),
-            "--registered-hash", "deadbeef" * 8,
-        ])
-        assert rc == 2
-
-    def test_digest_ref_no_null_warning(self, tmp_path, capsys):
-        cfg = tmp_path / "treatment.yaml"
-        cfg.write_text("scorer: mine\n")
-        rc = sim2real.main([
-            "--experiment-root", str(tmp_path),
-            "translation", "register",
-            "--algorithm", "softreflective",
-            "--image", "ghcr.io/foo@sha256:" + "a" * 64,
-            "--config", str(cfg),
+            "--algorithm", f"foo=ghcr.io/img1:v1@{c1}",
+            "--algorithm", f"bar=ghcr.io/img2:v1@{c2}",
         ])
         assert rc == 0
-        captured = capsys.readouterr()
-        assert "image_digest recorded as null" not in captured.err
+        # Extract the hash from stdout to inspect on-disk shape.
+        out = capsys.readouterr().out.strip()
+        thash = out.rsplit(" ", 1)[-1]
+        tdir = Path("workspace") / "translations" / thash
+        assert (tdir / "generated" / "foo" / "foo_config.yaml").exists()
+        assert (tdir / "generated" / "bar" / "bar_config.yaml").exists()
+        tout = json.loads((tdir / "translation_output.json").read_text())
+        assert sorted(a["name"] for a in tout["algorithms"]) == ["bar", "foo"]
+        assert tout["alias"] is None
+
+    def test_order_invariant_hash(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        c1 = self._cfg(tmp_path, "foo")
+        c2 = self._cfg(tmp_path, "bar")
+        rc1 = sim2real.main([
+            "translation", "register",
+            "--algorithm", f"foo=img1:v1@{c1}",
+            "--algorithm", f"bar=img2:v1@{c2}",
+        ])
+        assert rc1 == 0
+        # Second run — reversed order. Should hit idempotent path.
+        rc2 = sim2real.main([
+            "translation", "register",
+            "--algorithm", f"bar=img2:v1@{c2}",
+            "--algorithm", f"foo=img1:v1@{c1}",
+        ])
+        assert rc2 == 0
+        # Only one translation dir exists.
+        dirs = list((Path("workspace") / "translations").iterdir())
+        assert len(dirs) == 1
+
+    def test_rightmost_at_in_image_ref(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = tmp_path / "algorithms" / "foo" / "foo_config.yaml"
+        cfg.parent.mkdir(parents=True)
+        cfg.write_text("scorers: []\n")
+        image = "registry.io/img@sha256:" + "d" * 64
+        rc = sim2real.main([
+            "translation", "register",
+            "--algorithm", f"foo={image}@{cfg}",
+        ])
+        assert rc == 0
+        out = capsys.readouterr().out.strip()
+        thash = out.rsplit(" ", 1)[-1]
+        reg = json.loads((Path("workspace") / "translations" / thash / "registered.json").read_text())
+        entry = reg["algorithms"][0]
+        assert entry["image_ref"] == image
+        assert entry["image_digest"] == "sha256:" + "d" * 64
+
+    def test_at_in_config_path_rejected(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        rc = sim2real.main([
+            "translation", "register",
+            "--algorithm", "foo=img:tag@path@with@ats/overlay.yaml",
+        ])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "overlay path cannot contain" in err
+
+    def test_config_path_with_equals_supported(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+        cfg = tmp_path / "weird=name.yaml"
+        cfg.write_text("scorers: []\n")
+        rc = sim2real.main([
+            "translation", "register",
+            "--algorithm", f"foo=img:v1@{cfg}",
+        ])
+        assert rc == 0
+
+    def test_duplicate_algorithm_names_rejected(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        c1 = self._cfg(tmp_path, "foo")
+        c2 = self._cfg(tmp_path, "foo2")
+        rc = sim2real.main([
+            "translation", "register",
+            "--algorithm", f"foo=img1@{c1}",
+            "--algorithm", f"foo=img2@{c2}",
+        ])
+        assert rc == 2
+        assert "duplicate algorithm name" in capsys.readouterr().err
+
+    def test_missing_config_errors(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        rc = sim2real.main([
+            "translation", "register",
+            "--algorithm", "foo=img:v1@does-not-exist.yaml",
+        ])
+        assert rc == 2
+        assert "not found" in capsys.readouterr().err
+
+    def test_malformed_config_errors_no_writes(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = tmp_path / "bad.yaml"
+        cfg.write_text("::not: yaml: [\n")
+        rc = sim2real.main([
+            "translation", "register",
+            "--algorithm", f"foo=img:v1@{cfg}",
+        ])
+        assert rc == 2
+        assert "not valid YAML" in capsys.readouterr().err
+        assert not (tmp_path / "workspace" / "translations").exists()
+
+    def test_registered_hash_mismatch_exits_2(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = self._cfg(tmp_path, "foo")
+        rc = sim2real.main([
+            "translation", "register",
+            "--algorithm", f"foo=img:v1@{cfg}",
+            "--registered-hash", "deadbeef",
+        ])
+        assert rc == 2
+        assert "--registered-hash mismatch" in capsys.readouterr().err
+
+    def test_idempotent_second_run_prints_warning(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = self._cfg(tmp_path, "foo")
+        sim2real.main([
+            "translation", "register",
+            "--algorithm", f"foo=img:v1@{cfg}",
+        ])
+        capsys.readouterr()  # reset
+        rc = sim2real.main([
+            "translation", "register",
+            "--algorithm", f"foo=img:v1@{cfg}",
+        ])
+        assert rc == 0
+        err = capsys.readouterr().err
+        assert "already registered" in err
+
+    def test_digest_ref_no_null_warning(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = self._cfg(tmp_path, "foo")
+        rc = sim2real.main([
+            "translation", "register",
+            "--algorithm", f"foo=reg/img@sha256:{'a'*64}@{cfg}",
+        ])
+        assert rc == 0
+        err = capsys.readouterr().err
+        assert "null" not in err
+
+    def test_deprecated_form_with_multiple_algorithms_rejected(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = self._cfg(tmp_path, "foo")
+        rc = sim2real.main([
+            "translation", "register",
+            "--algorithm", "foo",
+            "--algorithm", "bar",
+            "--image", "img:v1",
+            "--config", str(cfg),
+        ])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "deprecated form" in err or "single --algorithm" in err
+
+    def test_mixed_form_new_algo_plus_image_rejected(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cfg = self._cfg(tmp_path, "foo")
+        rc = sim2real.main([
+            "translation", "register",
+            "--algorithm", f"foo=img:v1@{cfg}",
+            "--image", "other:v1",
+        ])
+        assert rc == 2
 
     def test_oserror_from_register_returns_2_not_traceback(
         self, tmp_path, capsys, monkeypatch
     ):
-        # translation_output.json is now written via _atomic_write_json
-        # (tempfile + os.replace), not write_text. Patch the helper directly.
-        cfg = tmp_path / "treatment.yaml"
-        cfg.write_text("scorer: mine\n")
-
-        # Wrap: call the real impl for non-output.json paths.
-        original = sim2real._atomic_write_json
-
-        def patched(path, data):
-            if path.name == "translation_output.json":
-                raise OSError("simulated: disk full")
-            return original(path, data)
-
-        monkeypatch.setattr(sim2real, "_atomic_write_json", patched)
-
+        monkeypatch.chdir(tmp_path)
+        cfg = self._cfg(tmp_path, "foo")
+        # Simulate an OSError from _register_translation by making the workspace
+        # translations dir a file (blocks mkdir).
+        ws = tmp_path / "workspace" / "translations"
+        ws.parent.mkdir()
+        ws.write_text("")  # occupy the path with a regular file
         rc = sim2real.main([
-            "--experiment-root", str(tmp_path),
             "translation", "register",
-            "--algorithm", "softreflective",
-            "--image", "ghcr.io/foo:v1",
-            "--config", str(cfg),
+            "--algorithm", f"foo=img:v1@{cfg}",
         ])
         assert rc == 2
-        captured = capsys.readouterr()
-        assert "error:" in captured.err
-        assert "disk full" in captured.err
+        # Not a Python traceback.
+        assert "Traceback" not in capsys.readouterr().err
 
 
 class TestUseCommand:
@@ -770,9 +1030,7 @@ class TestAssembleCommand:
             b"    inferenceExtension:\n      pluginsConfigFile: sr.yaml\n"
         )
         thash, _ = sim2real._register_translation(
-            algorithm_name="sr",
-            image_ref="ghcr.io/foo/bar:v1",
-            config_path=cfg,
+            algorithms=[{"name": "sr", "image_ref": "ghcr.io/foo/bar:v1", "config_path": cfg}],
             baseline_config_path=None,
             registered_hash=None,
             now_iso="2026-07-01T14:00:00Z",
@@ -926,61 +1184,75 @@ class TestAssembleCommand:
 
 
 class TestAliasCollision:
-    def _seed_register(self, tmp_path, algo, image, config_yaml):
-        cfg = tmp_path / f"{algo}.yaml"
-        cfg.write_text(config_yaml)
-        thash, status = sim2real._register_translation(
-            algorithm_name=algo,
-            image_ref=image,
-            config_path=cfg,
+    """Alias collision is checked per-algorithm regardless of batch size."""
+
+    def _reg(self, tmp_path, name: str, image: str = "img:v1", config: str = None):
+        cfg = tmp_path / f"{name}_cfg.yaml"
+        cfg.write_text(config if config else f"scorers:\n  - name: {name}\n")
+        return sim2real._register_translation(
+            algorithms=[{"name": name, "image_ref": image, "config_path": cfg}],
             baseline_config_path=None,
             registered_hash=None,
-            now_iso="2026-07-02T14:00:00Z",
+            now_iso="2026-07-05T10:00:00Z",
         )
-        return thash
 
-    def test_same_alias_same_content_is_idempotent(self, tmp_path):
-        h1 = self._seed_register(tmp_path, "algo", "ghcr.io/x:v1", "a: 1\n")
-        h2 = self._seed_register(tmp_path, "algo", "ghcr.io/x:v1", "a: 1\n")
+    def test_same_alias_same_content_is_idempotent(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        h1, _ = self._reg(tmp_path, "foo")
+        h2, s2 = self._reg(tmp_path, "foo")
         assert h1 == h2
+        assert s2 == "idempotent"
 
-    def test_alias_collision_without_force_raises(self, tmp_path):
-        self._seed_register(tmp_path, "algo", "ghcr.io/x:v1", "a: 1\n")
-        cfg = tmp_path / "different.yaml"
-        cfg.write_text("a: 2\n")
+    def test_alias_collision_without_force_raises(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        self._reg(tmp_path, "foo", image="img:v1")
         with pytest.raises(RuntimeError, match="already assigned"):
-            sim2real._register_translation(
-                algorithm_name="algo",
-                image_ref="ghcr.io/x:v1",
-                config_path=cfg,
-                baseline_config_path=None,
-                registered_hash=None,
-                now_iso="2026-07-02T14:00:00Z",
-            )
+            self._reg(tmp_path, "foo", image="img:v2")
 
-    def test_force_reassigns_alias_and_clears_previous(self, tmp_path):
-        from pipeline.lib import translation_ref
-        h_old = self._seed_register(tmp_path, "algo", "ghcr.io/x:v1", "a: 1\n")
-        cfg = tmp_path / "different.yaml"
-        cfg.write_text("a: 2\n")
-        h_new, _status = sim2real._register_translation(
-            algorithm_name="algo",
-            image_ref="ghcr.io/x:v1",
-            config_path=cfg,
+    def test_force_reassigns_alias_and_clears_previous(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        h_old, _ = self._reg(tmp_path, "foo", image="img:v1")
+        # Re-register 'foo' with different content and --force.
+        cfg = tmp_path / "foo_v2.yaml"
+        cfg.write_text("scorers:\n  - name: foo_v2\n")
+        h_new, _ = sim2real._register_translation(
+            algorithms=[{"name": "foo", "image_ref": "img:v2", "config_path": cfg}],
             baseline_config_path=None,
             registered_hash=None,
-            now_iso="2026-07-02T14:00:00Z",
+            now_iso="2026-07-05T11:00:00Z",
             force=True,
         )
         assert h_new != h_old
-        # New translation carries the alias.
-        assert translation_ref.find_by_alias("algo") == h_new
-        # Old translation's alias is null; it's still reachable by hash.
-        old_data = translation_ref.read_translation_output(
-            layout.translation_output_path(h_old)
+        # Previous translation's alias cleared.
+        old_tout = json.loads(
+            (Path("workspace") / "translations" / h_old / "translation_output.json").read_text()
         )
-        assert old_data["alias"] is None
-        assert layout.translation_dir(h_old).exists()
+        assert old_tout["alias"] is None
+        # New translation owns the alias.
+        new_tout = json.loads(
+            (Path("workspace") / "translations" / h_new / "translation_output.json").read_text()
+        )
+        assert new_tout["alias"] == "foo"
+
+    def test_batched_alias_collision_on_one_of_N_algos(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        # Pre-existing single-algo translation with alias 'foo'.
+        self._reg(tmp_path, "foo", image="img:v1")
+        # Now try to register a BATCHED translation whose members include 'foo'.
+        c_foo = tmp_path / "foo_batched.yaml"
+        c_foo.write_text("scorers:\n  - name: foo_b\n")
+        c_bar = tmp_path / "bar.yaml"
+        c_bar.write_text("scorers:\n  - name: bar\n")
+        with pytest.raises(RuntimeError, match="already assigned"):
+            sim2real._register_translation(
+                algorithms=[
+                    {"name": "foo", "image_ref": "img:v3", "config_path": c_foo},
+                    {"name": "bar", "image_ref": "img:v4", "config_path": c_bar},
+                ],
+                baseline_config_path=None,
+                registered_hash=None,
+                now_iso="2026-07-05T11:00:00Z",
+            )
 
 
 class TestAssembleResolvesAlias:
@@ -991,9 +1263,7 @@ class TestAssembleResolvesAlias:
         cfg = tmp_path / "algo.yaml"
         cfg.write_text("scenario: []\n")
         thash, _ = sim2real._register_translation(
-            algorithm_name="my-algo",
-            image_ref="ghcr.io/x:v1",
-            config_path=cfg,
+            algorithms=[{"name": "my-algo", "image_ref": "ghcr.io/x:v1", "config_path": cfg}],
             baseline_config_path=None,
             registered_hash=None,
             now_iso="2026-07-02T14:00:00Z",

--- a/pipeline/tests/test_translate.py
+++ b/pipeline/tests/test_translate.py
@@ -561,3 +561,58 @@ class TestTranslateAliasCollision:
         # --resume → error "no translation to resume", NOT an alias error.
         rc = _run_translate(["--resume"])
         assert rc == 2  # nothing-to-resume is still an error; different cause.
+
+
+# ── BYO guard (issue #497) ────────────────────────────────────────────────
+
+
+class TestTranslateByoGuard:
+    """`sim2real translate` refuses to run on BYO algorithms — the BYO
+    path is `sim2real translation register`, not `translate`."""
+
+    def _write_byo_manifest(self, tmp_path):
+        exp = tmp_path
+        (exp / "algorithms").mkdir(exist_ok=True)
+        manifest = {
+            "kind": "sim2real-transfer",
+            "version": 3,
+            "scenario": "byo-scenario",
+            "baselines": [{"name": "base", "scenario": "baseline-scenario"}],
+            "algorithms": [
+                {"name": "byoalgo", "defaults": "base", "byo": True},
+            ],
+            "context": {"text": "", "files": []},
+        }
+        path = exp / "transfer.yaml"
+        path.write_text(yaml.safe_dump(manifest))
+        return path
+
+    def test_all_byo_manifest_errors(self, tmp_path, capsys):
+        self._write_byo_manifest(tmp_path)
+        assert _run_translate([]) == 2
+        err = capsys.readouterr().err
+        assert "cannot translate algorithm 'byoalgo'" in err
+        assert "sim2real translation register" in err
+
+    def test_mixed_manifest_errors_on_byo_algo(self, tmp_path, capsys):
+        """One BYO + one BLIS algorithm → still errors, naming the BYO one."""
+        exp = tmp_path
+        (exp / "algorithms").mkdir(exist_ok=True)
+        (exp / "algorithms" / "blisalgo.py").write_text("# stub\n")
+        manifest = {
+            "kind": "sim2real-transfer",
+            "version": 3,
+            "scenario": "mixed-scenario",
+            "baselines": [{"name": "base", "scenario": "baseline-scenario"}],
+            "algorithms": [
+                {"name": "byoalgo", "defaults": "base", "byo": True},
+                {"name": "blisalgo", "defaults": "base",
+                 "source": "algorithms/blisalgo.py"},
+            ],
+            "component": {"repo": "example.com/x/y", "kind": "scorer"},
+            "context": {"text": "", "files": []},
+        }
+        (exp / "transfer.yaml").write_text(yaml.safe_dump(manifest))
+        assert _run_translate([]) == 2
+        err = capsys.readouterr().err
+        assert "cannot translate algorithm 'byoalgo'" in err


### PR DESCRIPTION
Closes #496.

## Phase summary

Ports the `/sim2real-bootstrap` skill to the three-dimensional workspace layout and adds `--byo` mode for operators arriving with pre-built EPP images. Both flows (BLIS regression + BYO new) validated against the shipped fixtures at phase HEAD.

## Child PRs (all merged into `refactor/v2-step-4`)

| PR | Closes | Title |
|---|---|---|
| #501 | #497 | schema `byo: true` marker + validator + command-specific guards |
| #503 | #498 | `sim2real translation register` batched-algorithm mode |
| #504 | #500 | BLIS-mode `sim2real-bootstrap` SKILL.md refresh |
| #505 | #499 | `/sim2real-bootstrap --byo` mode |
| #508 | #507 | `transfer.yaml`: emit `# Available fragments` comment near `defaults.disable` (intra-phase enhancement) |
| #517 | #516 | fix: restore `_align_overlay_name` — kills phantom facebook/opt-125m deployment (intra-phase regression fix) |

## Demo evidence

Posted verbatim to the epic: https://github.com/inference-sim/sim2real/issues/496#issuecomment-4904714463

Highlights:
- Full CI-equivalent suite: **602 passed, 1 skipped**. Ruff `--select F` clean.
- Operator-run end-to-end: BLIS-mode bootstrap → `translate` → `register` → `assemble` produced correct scaffolding; `deploy.py run --workload code_generation_4` reached Running on healthy nodes. `deploy.py collect` intentionally not exercised in this demo (untouched by step-4; fixture coverage retained).
- Confirmed post-#517: exactly one `download-model-*` job per namespace slot — the phantom `download-model-facebook-*-opt-125m-*` regression is gone.
- Two cluster-side blockers observed but flagged as infrastructure-scope (Poughkeepsie site DNS SERVFAIL + cross-tenant GPU-memory contention on some pokprod nodes with the operator's `ClusterPolicy` in `notReady`). Neither is step-4 code.

## What follows

After this merges, `refactor/v2` picks up step-4's changes. The umbrella branch is NOT shipped to `main` as part of this merge — that's a separate, one-time action when the umbrella refactor is done. Next epic: step-5.

## Test plan

- [x] Full CI-equivalent suite locally at HEAD `8c78d3e` on `refactor/v2-step-4` → 602/1s passed, ruff clean.
- [x] Operator manual end-to-end (bootstrap → translate → register → assemble → deploy.py run, minus collect) → succeeded on the algorithm/namespace pair that landed on healthy GPUs; other pair blocked on infrastructure.
- [ ] After merge: `refactor/v2` fast-forwarded to include step-4; local base sync + submodule update per the close-epic skill flow.