### PR TITLE
deploy: --iteration filter (list+range) on filter-aware subcommands (#512)

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -51,13 +51,31 @@ def _c(code: str, text: str) -> str:
 
 from pipeline.lib import build, cluster_ops, layout
 from pipeline.lib.log import info, ok, warn, err
-from pipeline.lib.pairkey import parse_pair_key
+from pipeline.lib.pairkey import parse_iteration_spec, parse_pair_key
 from pipeline.lib.redact import redact_yaml_file, redact_yaml_tree
 
 
 def _is_pair_key(key: str) -> bool:
     """Return True if key is a real pair entry (not metadata)."""
     return not key.startswith("_")
+
+
+def _key_iteration(key: str) -> int:
+    """Return the iteration number encoded in a pair key.
+
+    Canonical grammar (``wl-<workload>|<package>[|i<N>]``) yields the
+    parsed ``iteration``; keys without an ``|iN`` suffix parse as ``1``.
+    Legacy dash-shape keys that predate the step-5 grammar (e.g.
+    ``wl-smoke-baseline`` from a pre-PR-2 run) do not parse; they map to
+    ``1`` here to match the design's step-5 semantics — the
+    single-replica shape reads as implicit ``i1``. ``--iteration 1``
+    therefore includes legacy pairs and higher values exclude them,
+    which is what the design table specifies for the mid-rollout state.
+    """
+    try:
+        return parse_pair_key(key).iteration
+    except ValueError:
+        return 1
 
 
 def _format_capacity(effective: int, probed: int, reserved: int,
@@ -684,6 +702,7 @@ def _cmd_status(args, run_dir: Path,
             getattr(args, "workload", None) is not None,
             getattr(args, "package", None) is not None,
             getattr(args, "status", None) is not None,
+            getattr(args, "iteration", None) is not None,
         ])
         if filters_given:
             suffix += " — filters ignored"
@@ -1499,14 +1518,16 @@ def _cmd_collect(args, run_dir: Path, cluster_config: dict):
             "cluster.")
         sys.exit(1)
 
-    # ── Pair-level scoping (--only / --workload / --package) ─────────────
+    # ── Pair-level scoping (--only / --workload / --package / --iteration) ─
     scope_only = getattr(args, "only", None)
     scope_workload = getattr(args, "workload", None)
     scope_package = _parse_list(getattr(args, "package", None))
-    scoped = scope_only is not None or scope_workload is not None
+    scope_iteration = getattr(args, "iteration", None)
+    scoped = (scope_only is not None or scope_workload is not None
+              or scope_iteration is not None)
 
     if scoped and not progress:
-        err("--only/--workload require progress data to resolve pairs, but none was found.")
+        err("--only/--workload/--iteration require progress data to resolve pairs, but none was found.")
         sys.exit(1)
 
     if scoped and progress:
@@ -1524,6 +1545,7 @@ def _cmd_collect(args, run_dir: Path, cluster_config: dict):
             workload = scope_workload
             package = _pair_scope_pkg
             status = None
+            iteration = scope_iteration
 
         in_scope = _resolve_scope(progress, _ScopeArgs())
 
@@ -2140,12 +2162,22 @@ def _apply_run_filters(progress: dict, args) -> set:
     """Return the set of pair keys in scope for this invocation.
 
     With no flags: returns empty set (caller interprets as all pairs in scope).
-    With flags: returns only matching pairs.
+    With flags: returns only matching pairs. Filters compose via AND.
     """
     only = _parse_list(getattr(args, "only", None))
     workload = _parse_list(getattr(args, "workload", None))
     package = _parse_list(getattr(args, "package", None))
     status_filter = getattr(args, "status", None)
+    iteration_spec = getattr(args, "iteration", None)
+
+    # Parse --iteration up-front so malformed specs fail before any other work.
+    iteration_set: "set[int] | None" = None
+    if iteration_spec is not None:
+        try:
+            iteration_set = parse_iteration_spec(iteration_spec)
+        except ValueError as exc:
+            err(str(exc))
+            sys.exit(1)
 
     if only:
         result = set()
@@ -2165,9 +2197,11 @@ def _apply_run_filters(progress: dict, args) -> set:
             valid = sorted(k for k in progress.keys() if _is_pair_key(k))
             print(f"  Valid pair keys: {valid}", file=sys.stderr)
             sys.exit(1)
+        if iteration_set is not None:
+            result = {k for k in result if _key_iteration(k) in iteration_set}
         return result
 
-    if not any([workload, package, status_filter]):
+    if not any([workload, package, status_filter, iteration_set]):
         return set()
 
     pair_entries = {k: v for k, v in progress.items() if _is_pair_key(k)}
@@ -2195,6 +2229,8 @@ def _apply_run_filters(progress: dict, args) -> set:
         candidates = {k for k in candidates if pair_entries[k].get("package") in package}
     if status_filter:
         candidates = {k for k in candidates if pair_entries[k].get("status") == status_filter}
+    if iteration_set is not None:
+        candidates = {k for k in candidates if _key_iteration(k) in iteration_set}
     return candidates
 
 
@@ -2209,6 +2245,7 @@ def _resolve_scope(progress: dict, args) -> set:
         getattr(args, "workload", None) is not None,
         getattr(args, "package", None) is not None,
         getattr(args, "status", None) is not None,
+        getattr(args, "iteration", None) is not None,
     ])
     filtered = _apply_run_filters(progress, args)
     if filters_given and not filtered:
@@ -2223,6 +2260,7 @@ def _report_filter_mismatch(progress: dict, args) -> None:
     workload = _parse_list(getattr(args, "workload", None))
     package = _parse_list(getattr(args, "package", None))
     status_filter = getattr(args, "status", None)
+    iteration_spec = getattr(args, "iteration", None)
 
     parts = []
     if only is not None:
@@ -2233,6 +2271,8 @@ def _report_filter_mismatch(progress: dict, args) -> None:
         parts.append(f"--package '{','.join(package)}'")
     if status_filter is not None:
         parts.append(f"--status '{status_filter}'")
+    if iteration_spec is not None:
+        parts.append(f"--iteration '{iteration_spec}'")
 
     err(f"No pairs matched {', '.join(parts)}.\n")
 
@@ -2245,10 +2285,12 @@ def _report_filter_mismatch(progress: dict, args) -> None:
     valid_workloads = sorted({v.get("workload", "") for v in pair_values} - {""})
     valid_packages = sorted({v.get("package", "") for v in pair_values} - {""})
     valid_statuses = sorted({v.get("status", "") for v in pair_values} - {""})
+    valid_iterations = sorted({_key_iteration(k) for k in progress if _is_pair_key(k)})
 
-    print(f"\n  Valid --workload values: {', '.join(valid_workloads)}", file=sys.stderr)
-    print(f"  Valid --package values:  {', '.join(valid_packages)}", file=sys.stderr)
-    print(f"  Valid --status values:   {', '.join(valid_statuses)}", file=sys.stderr)
+    print(f"\n  Valid --workload values:   {', '.join(valid_workloads)}", file=sys.stderr)
+    print(f"  Valid --package values:    {', '.join(valid_packages)}", file=sys.stderr)
+    print(f"  Valid --status values:     {', '.join(valid_statuses)}", file=sys.stderr)
+    print(f"  Valid --iteration values:  {','.join(str(n) for n in valid_iterations)}", file=sys.stderr)
 
 
 def _check_slot_ready(namespace: str, hf_secret_name: str = "hf-secret") -> tuple[bool, list[str]]:
@@ -3438,6 +3480,8 @@ Examples:
                            help="Scope to pairs matching these workloads (comma or space-separated)")
     collect_p.add_argument("--package", nargs="+", metavar="NAME",
                            help="Collect only these packages (comma or space-separated)")
+    collect_p.add_argument("--iteration", metavar="SPEC", dest="iteration",
+                           help="Scope to iteration(s): '2', '1,3', '1-3', '1,3-5'")
     collect_p.add_argument("--skip-logs", action="store_true", dest="skip_logs",
                            help="Skip vLLM and EPP log files, collect only traces")
 
@@ -3446,6 +3490,8 @@ Examples:
     status_p.add_argument("--workload", nargs="+", metavar="NAME",  help="Scope to pairs matching these workloads (comma or space-separated)")
     status_p.add_argument("--package",  nargs="+", metavar="NAME",  help="Scope to pairs matching these packages (comma or space-separated)")
     status_p.add_argument("--status",   metavar="STATE", help="Scope to pairs with this status (e.g. running, done, failed)")
+    status_p.add_argument("--iteration", metavar="SPEC", dest="iteration",
+                          help="Scope to iteration(s): '2', '1,3', '1-3', '1,3-5'")
     status_p.add_argument("-s", "--silent", action="store_true",
                           help="Suppress the per-pair table; print only the summary line")
 
@@ -3462,6 +3508,8 @@ Examples:
     run_p.add_argument("--workload",     nargs="+", metavar="NAME",  help="Scope execution to pairs matching these workloads (comma or space-separated)")
     run_p.add_argument("--package",      nargs="+", metavar="NAME",  help="Scope execution to pairs matching these packages (comma or space-separated)")
     run_p.add_argument("--status",       metavar="STATE", help="Scope execution to pairs with this status (e.g. failed, timed-out)")
+    run_p.add_argument("--iteration",    metavar="SPEC", dest="iteration",
+                       help="Scope execution to iteration(s): '2', '1,3', '1-3', '1,3-5'")
     run_p.add_argument("--force",        action="store_true",
                        help="Reset non-pending pairs to pending, cleaning cluster resources for pairs with assigned namespaces")
     run_p.add_argument("--skip-teardown", action="store_true", dest="skip_teardown",
@@ -3492,6 +3540,8 @@ Examples:
     reset_p.add_argument("--workload", nargs="+", metavar="NAME",  help="Scope to pairs matching these workloads (comma or space-separated)")
     reset_p.add_argument("--package",  nargs="+", metavar="NAME",  help="Scope to pairs matching these packages (comma or space-separated)")
     reset_p.add_argument("--status",   metavar="STATE", help="Scope to pairs with this status")
+    reset_p.add_argument("--iteration", metavar="SPEC", dest="iteration",
+                         help="Scope to iteration(s): '2', '1,3', '1-3', '1,3-5'")
     reset_p.add_argument("--preserve-done-status", action="store_true", dest="preserve_done_status",
                          help="Keep done pairs' status unchanged (cluster cleanup only)")
     reset_p.add_argument("--dry-run",  action="store_true", dest="dry_run",
@@ -3501,6 +3551,8 @@ Examples:
     wipe_p.add_argument("--only",     nargs="+", metavar="PAIR",  help="Scope to specific pair keys (comma or space-separated, wl- prefix optional)")
     wipe_p.add_argument("--workload", nargs="+", metavar="NAME",  help="Scope to pairs matching these workloads (comma or space-separated)")
     wipe_p.add_argument("--package",  nargs="+", metavar="NAME",  help="Scope to pairs matching these packages (comma or space-separated)")
+    wipe_p.add_argument("--iteration", metavar="SPEC", dest="iteration",
+                        help="Scope to iteration(s): '2', '1,3', '1-3', '1,3-5'")
     wipe_p.add_argument("--dry-run",  action="store_true", dest="dry_run",
                          help="Print what would be wiped without doing it")
     wipe_p.add_argument("--yes", "-y", action="store_true",

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -2290,7 +2290,7 @@ def _report_filter_mismatch(progress: dict, args) -> None:
     print(f"\n  Valid --workload values:   {', '.join(valid_workloads)}", file=sys.stderr)
     print(f"  Valid --package values:    {', '.join(valid_packages)}", file=sys.stderr)
     print(f"  Valid --status values:     {', '.join(valid_statuses)}", file=sys.stderr)
-    print(f"  Valid --iteration values:  {','.join(str(n) for n in valid_iterations)}", file=sys.stderr)
+    print(f"  Valid --iteration values:  {', '.join(str(n) for n in valid_iterations)}", file=sys.stderr)
 
 
 def _check_slot_ready(namespace: str, hf_secret_name: str = "hf-secret") -> tuple[bool, list[str]]:
@@ -3162,8 +3162,8 @@ _FAIL_FAST_REASONS = {
 def _collect_run_flags(args) -> list[str]:
     """Collect run subcommand flags to forward to the in-cluster Job."""
     flags: list[str] = []
-    for name in ("only", "workload", "package", "status"):
-        val = getattr(args, name)
+    for name in ("only", "workload", "package", "status", "iteration"):
+        val = getattr(args, name, None)
         if val is not None:
             if isinstance(val, list):
                 flags.extend([f"--{name}"] + val)

--- a/pipeline/tests/test_deploy_collect.py
+++ b/pipeline/tests/test_deploy_collect.py
@@ -2236,3 +2236,100 @@ def test_cmd_collect_empty_namespaces_exits(tmp_path, capsys, monkeypatch):
     with pytest.raises(SystemExit):
         deploy._cmd_collect(Args(), run_dir, {})
     assert "No namespace configured." in capsys.readouterr().err
+
+
+# ── --iteration filter (issue #512) ─────────────────────────────────────────
+
+
+def test_collect_iteration_filter_narrows_scope(tmp_path, monkeypatch):
+    """--iteration 1-3 restricts collect to the matching iteration subset.
+
+    Integration test named in the issue: pairs exist at i1..i5 for the same
+    (workload, package); ``deploy.py collect --iteration 1-3`` must consider
+    only i1..i3. We surface the effect by placing i4 and i5 in a separate
+    completed_namespace and asserting no extract call is made against that
+    namespace when the filter is applied.
+    """
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    data = {
+        "wl-chat-mid|sim2real-ac|i1": {"workload": "chat-mid", "package": "sim2real-ac", "status": "done", "completed_namespace": "ns-a"},
+        "wl-chat-mid|sim2real-ac|i2": {"workload": "chat-mid", "package": "sim2real-ac", "status": "done", "completed_namespace": "ns-a"},
+        "wl-chat-mid|sim2real-ac|i3": {"workload": "chat-mid", "package": "sim2real-ac", "status": "done", "completed_namespace": "ns-a"},
+        "wl-chat-mid|sim2real-ac|i4": {"workload": "chat-mid", "package": "sim2real-ac", "status": "done", "completed_namespace": "ns-b"},
+        "wl-chat-mid|sim2real-ac|i5": {"workload": "chat-mid", "package": "sim2real-ac", "status": "done", "completed_namespace": "ns-b"},
+    }
+    _mock_cm(monkeypatch, data)
+
+    class Args:
+        only = None
+        workload = None
+        package = None
+        iteration = "1-3"
+        skip_logs = False
+
+    extract_calls = []
+
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
+        extract_calls.append({"namespace": namespace, "phases": sorted(phases)})
+        return {p: None for p in phases}
+
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
+        deploy._cmd_collect(Args(), run_dir, {"namespaces": ["ns-a"]})
+
+    dispatched_ns = {c["namespace"] for c in extract_calls}
+    assert "ns-a" in dispatched_ns, "expected extract against ns-a (holds i1..i3)"
+    assert "ns-b" not in dispatched_ns, (
+        "ns-b holds only i4..i5 — must be excluded by --iteration 1-3")
+
+
+def test_collect_iteration_filter_no_match_aborts(tmp_path, capsys, monkeypatch):
+    """--iteration with no matching iteration aborts via _report_filter_mismatch."""
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    data = {
+        "wl-chat-mid|sim2real-ac|i1": {"workload": "chat-mid", "package": "sim2real-ac", "status": "done", "completed_namespace": "ns-a"},
+        "wl-chat-mid|sim2real-ac|i2": {"workload": "chat-mid", "package": "sim2real-ac", "status": "done", "completed_namespace": "ns-a"},
+    }
+    _mock_cm(monkeypatch, data)
+
+    class Args:
+        only = None
+        workload = None
+        package = None
+        iteration = "9"
+        skip_logs = False
+
+    with pytest.raises(SystemExit) as exc_info:
+        deploy._cmd_collect(Args(), run_dir, {"namespaces": ["ns-a"]})
+    assert exc_info.value.code == 1
+    assert "--iteration '9'" in capsys.readouterr().err
+
+
+def test_collect_iteration_malformed_exits(tmp_path, capsys, monkeypatch):
+    """--iteration abc surfaces parse_iteration_spec's error before doing work."""
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    data = {
+        "wl-chat-mid|sim2real-ac|i1": {"workload": "chat-mid", "package": "sim2real-ac", "status": "done", "completed_namespace": "ns-a"},
+    }
+    _mock_cm(monkeypatch, data)
+
+    class Args:
+        only = None
+        workload = None
+        package = None
+        iteration = "abc"
+        skip_logs = False
+
+    with pytest.raises(SystemExit) as exc_info:
+        deploy._cmd_collect(Args(), run_dir, {"namespaces": ["ns-a"]})
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "iteration" in (captured.out + captured.err).lower()

--- a/pipeline/tests/test_deploy_remote.py
+++ b/pipeline/tests/test_deploy_remote.py
@@ -10,7 +10,7 @@ import pipeline.deploy as mod
 
 
 def _make_run_args(*, remote=False, workload=None, only=None, package=None,
-                   status=None, force=False, skip_build=False,
+                   status=None, iteration=None, force=False, skip_build=False,
                    skip_teardown=False,
                    max_retries=2, poll_interval=30, gpu_resource_type=None,
                    default_gpu_cost=1, pending_threshold=600,
@@ -18,7 +18,7 @@ def _make_run_args(*, remote=False, workload=None, only=None, package=None,
                    shadow_ttl=120):
     return argparse.Namespace(
         remote=remote, workload=workload, only=only, package=package,
-        status=status, force=force, skip_build=skip_build,
+        status=status, iteration=iteration, force=force, skip_build=skip_build,
         skip_teardown=skip_teardown,
         max_retries=max_retries, poll_interval=poll_interval,
         gpu_resource_type=gpu_resource_type, default_gpu_cost=default_gpu_cost,
@@ -83,6 +83,29 @@ def test_collect_run_flags_default_shadow_ttl_not_forwarded():
     args = _make_run_args(shadow_ttl=120)
     flags = mod._collect_run_flags(args)
     assert "--shadow-ttl" not in flags
+
+
+def test_collect_run_flags_iteration_forwarded():
+    """--iteration must reach the in-cluster Job (regression for PR #520 review)."""
+    args = _make_run_args(iteration="2")
+    flags = mod._collect_run_flags(args)
+    assert "--iteration" in flags
+    idx = flags.index("--iteration")
+    assert flags[idx + 1] == "2"
+
+
+def test_collect_run_flags_iteration_range_forwarded():
+    """--iteration '1-3' is forwarded verbatim (parser lives in-cluster too)."""
+    args = _make_run_args(iteration="1-3")
+    flags = mod._collect_run_flags(args)
+    assert "--iteration" in flags
+    idx = flags.index("--iteration")
+    assert flags[idx + 1] == "1-3"
+
+
+def test_collect_run_flags_iteration_absent_by_default():
+    args = _make_run_args()
+    assert "--iteration" not in mod._collect_run_flags(args)
 
 
 # ── skip-teardown parser tests ─────────────────────────────────────────────

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -115,6 +115,104 @@ def test_status_filter_by_workload(tmp_path, capsys, monkeypatch):
     assert "wl-load-baseline" not in out
 
 
+def test_status_filter_by_iteration_list(tmp_path, capsys, monkeypatch):
+    """--iteration 2,3 shows only i2 and i3 rows (issue #512).
+
+    Integration test named in the issue: on a 3-replica run,
+    ``deploy.py status --iteration 2,3`` returns only i2 and i3 rows.
+    """
+    from pipeline.deploy import _cmd_status
+    _mock_cm(monkeypatch, _ITER_PROGRESS)
+
+    class _Args:
+        only = None
+        workload = None
+        package = None
+        status = None
+        iteration = "2,3"
+        silent = False
+        live = False
+
+    _cmd_status(_Args(), tmp_path, cluster_config={"namespaces": ["sim2real-ns"]})
+    out = capsys.readouterr().out
+    # i2 and i3 rows must appear.
+    assert "wl-chat-mid|sim2real-ac|i2" in out
+    assert "wl-chat-mid|sim2real-ac|i3" in out
+    assert "wl-chat-mid|sim2real-routing|i2" in out
+    assert "wl-heavy|sim2real-ac|i2" in out
+    # i1 rows must not.
+    assert "wl-chat-mid|sim2real-ac|i1" not in out
+    assert "wl-chat-mid|sim2real-routing|i1" not in out
+    assert "wl-heavy|sim2real-ac|i1" not in out
+
+
+def test_status_filter_by_iteration_range(tmp_path, capsys, monkeypatch):
+    """--iteration 1-3 shows every replica row (all iterations present)."""
+    from pipeline.deploy import _cmd_status
+    _mock_cm(monkeypatch, _ITER_PROGRESS)
+
+    class _Args:
+        only = None
+        workload = None
+        package = None
+        status = None
+        iteration = "1-3"
+        silent = False
+        live = False
+
+    _cmd_status(_Args(), tmp_path, cluster_config={"namespaces": ["sim2real-ns"]})
+    out = capsys.readouterr().out
+    for k in _ITER_PROGRESS:
+        if k.startswith("_"):
+            continue
+        assert k in out, f"expected {k} in status output"
+
+
+def test_status_filter_by_iteration_composes_with_workload(tmp_path, capsys, monkeypatch):
+    """--iteration composes with --workload (AND semantics)."""
+    from pipeline.deploy import _cmd_status
+    _mock_cm(monkeypatch, _ITER_PROGRESS)
+
+    class _Args:
+        only = None
+        workload = "chat-mid"
+        package = None
+        status = None
+        iteration = "1"
+        silent = False
+        live = False
+
+    _cmd_status(_Args(), tmp_path, cluster_config={"namespaces": ["sim2real-ns"]})
+    out = capsys.readouterr().out
+    assert "wl-chat-mid|sim2real-ac|i1" in out
+    assert "wl-chat-mid|sim2real-routing|i1" in out
+    assert "wl-heavy|sim2real-ac|i1" not in out    # excluded by --workload
+    assert "wl-chat-mid|sim2real-ac|i2" not in out  # excluded by --iteration
+
+
+def test_status_filter_by_iteration_no_match_aborts(tmp_path, capsys, monkeypatch):
+    """--iteration with no matching pair aborts via _report_filter_mismatch."""
+    import pytest
+    from pipeline.deploy import _cmd_status
+    _mock_cm(monkeypatch, _ITER_PROGRESS)
+
+    class _Args:
+        only = None
+        workload = None
+        package = None
+        status = None
+        iteration = "9"
+        silent = False
+        live = False
+
+    with pytest.raises(SystemExit) as exc_info:
+        _cmd_status(_Args(), tmp_path, cluster_config={"namespaces": ["sim2real-ns"]})
+    assert exc_info.value.code == 1
+    stderr = capsys.readouterr().err
+    assert "--iteration '9'" in stderr
+    assert "Valid --iteration values" in stderr
+
+
 def test_status_filter_by_package(tmp_path, capsys, monkeypatch):
     from pipeline.deploy import _cmd_status
     _mock_cm(monkeypatch, _PROGRESS)
@@ -749,6 +847,208 @@ def test_apply_run_filters_only_empty_string():
 
     result = _apply_run_filters(dict(_PROGRESS), _Args())
     assert result == set()
+
+
+# ── --iteration filter tests (issue #512) ────────────────────────────────
+
+_ITER_PROGRESS = {
+    "wl-chat-mid|sim2real-ac|i1":       {"workload": "chat-mid", "package": "sim2real-ac", "status": "pending"},
+    "wl-chat-mid|sim2real-ac|i2":       {"workload": "chat-mid", "package": "sim2real-ac", "status": "running"},
+    "wl-chat-mid|sim2real-ac|i3":       {"workload": "chat-mid", "package": "sim2real-ac", "status": "done"},
+    "wl-chat-mid|sim2real-routing|i1":  {"workload": "chat-mid", "package": "sim2real-routing", "status": "pending"},
+    "wl-chat-mid|sim2real-routing|i2":  {"workload": "chat-mid", "package": "sim2real-routing", "status": "failed"},
+    "wl-heavy|sim2real-ac|i1":          {"workload": "heavy", "package": "sim2real-ac", "status": "done"},
+    "wl-heavy|sim2real-ac|i2":          {"workload": "heavy", "package": "sim2real-ac", "status": "done"},
+    "_orchestrator":                    {"state": "normal"},
+}
+
+
+def test_apply_run_filters_iteration_single():
+    """--iteration 2 selects only iN=2 pair keys."""
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = None; workload = None; package = None; status = None; iteration = "2"
+
+    result = _apply_run_filters(dict(_ITER_PROGRESS), _Args())
+    assert result == {
+        "wl-chat-mid|sim2real-ac|i2",
+        "wl-chat-mid|sim2real-routing|i2",
+        "wl-heavy|sim2real-ac|i2",
+    }
+
+
+def test_apply_run_filters_iteration_list():
+    """--iteration 1,3 selects a discontiguous set."""
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = None; workload = None; package = None; status = None; iteration = "1,3"
+
+    result = _apply_run_filters(dict(_ITER_PROGRESS), _Args())
+    assert result == {
+        "wl-chat-mid|sim2real-ac|i1",
+        "wl-chat-mid|sim2real-ac|i3",
+        "wl-chat-mid|sim2real-routing|i1",
+        "wl-heavy|sim2real-ac|i1",
+    }
+
+
+def test_apply_run_filters_iteration_range():
+    """--iteration 1-3 selects the closed range."""
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = None; workload = None; package = None; status = None; iteration = "1-3"
+
+    result = _apply_run_filters(dict(_ITER_PROGRESS), _Args())
+    assert result == {
+        "wl-chat-mid|sim2real-ac|i1",
+        "wl-chat-mid|sim2real-ac|i2",
+        "wl-chat-mid|sim2real-ac|i3",
+        "wl-chat-mid|sim2real-routing|i1",
+        "wl-chat-mid|sim2real-routing|i2",
+        "wl-heavy|sim2real-ac|i1",
+        "wl-heavy|sim2real-ac|i2",
+    }
+
+
+def test_apply_run_filters_iteration_mixed():
+    """--iteration 1,3-5 mixes list and range."""
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = None; workload = None; package = None; status = None; iteration = "1,3-5"
+
+    # Only i1 and i3 exist in fixture; i4/i5 don't exist so they're just absent.
+    result = _apply_run_filters(dict(_ITER_PROGRESS), _Args())
+    assert result == {
+        "wl-chat-mid|sim2real-ac|i1",
+        "wl-chat-mid|sim2real-ac|i3",
+        "wl-chat-mid|sim2real-routing|i1",
+        "wl-heavy|sim2real-ac|i1",
+    }
+
+
+def test_apply_run_filters_iteration_composes_with_workload():
+    """--iteration composes with --workload (AND semantics)."""
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = None; workload = "heavy"; package = None; status = None; iteration = "1,2"
+
+    result = _apply_run_filters(dict(_ITER_PROGRESS), _Args())
+    assert result == {
+        "wl-heavy|sim2real-ac|i1",
+        "wl-heavy|sim2real-ac|i2",
+    }
+
+
+def test_apply_run_filters_iteration_composes_with_package_and_status():
+    """--iteration composes with --package and --status (AND semantics)."""
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = None; workload = None; package = "sim2real-ac"; status = "done"; iteration = "2,3"
+
+    result = _apply_run_filters(dict(_ITER_PROGRESS), _Args())
+    assert result == {
+        "wl-chat-mid|sim2real-ac|i3",
+        "wl-heavy|sim2real-ac|i2",
+    }
+
+
+def test_apply_run_filters_iteration_composes_with_only():
+    """--iteration further narrows the --only selection."""
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = ["wl-chat-mid|sim2real-ac|i1", "wl-chat-mid|sim2real-ac|i2",
+                "wl-chat-mid|sim2real-ac|i3"]
+        workload = None; package = None; status = None; iteration = "1-2"
+
+    result = _apply_run_filters(dict(_ITER_PROGRESS), _Args())
+    assert result == {
+        "wl-chat-mid|sim2real-ac|i1",
+        "wl-chat-mid|sim2real-ac|i2",
+    }
+
+
+def test_apply_run_filters_iteration_malformed_zero_exits(capsys):
+    """--iteration 0 exits with a clear message from parse_iteration_spec."""
+    import pytest
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = None; workload = None; package = None; status = None; iteration = "0"
+
+    with pytest.raises(SystemExit) as exc_info:
+        _apply_run_filters(dict(_ITER_PROGRESS), _Args())
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "iteration" in (captured.out + captured.err).lower()
+
+
+def test_apply_run_filters_iteration_malformed_reversed_range_exits():
+    """--iteration 5-1 exits (reversed range rejected by parser)."""
+    import pytest
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = None; workload = None; package = None; status = None; iteration = "5-1"
+
+    with pytest.raises(SystemExit) as exc_info:
+        _apply_run_filters(dict(_ITER_PROGRESS), _Args())
+    assert exc_info.value.code == 1
+
+
+def test_apply_run_filters_iteration_malformed_nonint_exits():
+    """--iteration abc exits (non-integer rejected by parser)."""
+    import pytest
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = None; workload = None; package = None; status = None; iteration = "abc"
+
+    with pytest.raises(SystemExit) as exc_info:
+        _apply_run_filters(dict(_ITER_PROGRESS), _Args())
+    assert exc_info.value.code == 1
+
+
+def test_apply_run_filters_iteration_alone_no_match_returns_empty():
+    """--iteration alone with no matching pair returns empty set (caller reports)."""
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = None; workload = None; package = None; status = None; iteration = "9"
+
+    result = _apply_run_filters(dict(_ITER_PROGRESS), _Args())
+    assert result == set()
+
+
+def test_apply_run_filters_iteration_legacy_dash_shape_treated_as_i1():
+    """Legacy dash-shape pair keys are treated as iteration 1 by the filter.
+
+    This preserves --iteration semantics for the mid-rollout state where PR 2
+    (assemble filename reshape) has not yet landed and legacy dash-shape keys
+    still coexist with canonical grammar keys.
+    """
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = None; workload = None; package = None; status = None; iteration = "1"
+
+    result = _apply_run_filters(dict(_PROGRESS), _Args())
+    # _PROGRESS keys are legacy dash-shape (wl-smoke-baseline etc.); all
+    # non-metadata pair keys collapse to iteration=1 via _key_iteration.
+    expected = {k for k in _PROGRESS if not k.startswith("_")}
+    assert result == expected
+
+    class _ArgsI2:
+        only = None; workload = None; package = None; status = None; iteration = "2"
+
+    result_i2 = _apply_run_filters(dict(_PROGRESS), _ArgsI2())
+    assert result_i2 == set()
 
 
 # ── Multi-value flag tests (issue #212) ────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds `--iteration` argparse entries to `run`, `status`, `collect`, `reset`, and `wipe`, wired through `_apply_run_filters` using `parse_iteration_spec` from `pipeline/lib/pairkey.py` (landed in #509 via #515). Composes with existing `--workload` / `--package` / `--status` / `--only` under AND semantics.

Closes #512. Part of epic #502.

## What changed

- **`pipeline/deploy.py`**:
  - Import `parse_iteration_spec` alongside `parse_pair_key`.
  - New module-level helper `_key_iteration(key)` — parses key iteration; legacy dash-shape keys collapse to iteration=1 (matches the step-5 design table row for the mid-rollout state where PR 2's canonical filename layout hasn't landed).
  - `_apply_run_filters`: parses `--iteration` up-front; malformed input aborts with a clear error before other filter work. Applies as an intersection filter in both the `--only` branch and the general branch; included in the "no filters → empty set" gate.
  - `_resolve_scope`: includes `iteration` in `filters_given`.
  - `_report_filter_mismatch`: surfaces `--iteration '<spec>'` in the mismatched-parts list and prints a `Valid --iteration values` line.
  - `_cmd_status`'s empty-progress path: includes iteration in its `filters_given` diagnostic.
  - `_cmd_collect`: `--iteration` alone now triggers the scoped path; threaded through `_ScopeArgs`.
  - `--iteration SPEC` added to the five subparsers.

- **Tests**:
  - `pipeline/tests/test_deploy_run.py`: 12 new unit tests on `_apply_run_filters` — single/list/range/mixed syntax, composition with `--workload` / `--package` / `--status` / `--only`, malformed input (`0`, `5-1`, `abc`), and legacy dash-shape → i1 semantics. Plus 4 integration tests on `_cmd_status` including the one named in the issue (`status --iteration 2,3`).
  - `pipeline/tests/test_deploy_collect.py`: 3 integration tests on `_cmd_collect` including the one named in the issue (`collect --iteration 1-3` narrows the extract target set) plus a no-match abort and a malformed-input abort.

## Notes for reviewers

- **Legacy dash-shape keys** (e.g. `wl-smoke-baseline`, produced by pre-PR-2 assemble) do not parse under the new grammar. The design's step-5 table row specifies these should be treated as implicit i1 for filter purposes. `_key_iteration` implements that: catches `ValueError` and returns 1. Once PR 2 lands and runs re-assemble, this fallback becomes a no-op.
- **`--only` composition**: the issue calls out AND semantics with `--only`. Implemented by applying the iteration filter as a secondary narrowing step on the `--only`-resolved set. Existing `--only` behavior (short-circuits `--workload`/`--package`/`--status`) is preserved for those three; only `--iteration` now further narrows an `--only` selection.
- **Docs sweep**: `pipeline/README.md`'s flag tables list `--workload` / `--package` / `--status` but not `--iteration` yet. The epic (#502) puts docs in PR 6 (#514), which lands last across all step-5 code. Not updated here.
- No changes to `pipeline.yaml`, `assemble`, or the `iN/` result-path model — those are PR 2 (#510) and PR 3 (#511).

## Base

`refactor/v2-step-5`. Dependency #509 satisfied by PR #515 already merged into this base.

## Test plan

- [x] `python -m pytest pipeline/ -v` — 1438 passed
- [x] CI-shape run (`pipeline/` + selected skill tests) — 1527 passed
- [x] `ruff check pipeline/ .claude/skills/ --select F` — all checks passed
- [x] Named integration tests exercise `status --iteration 2,3` and `collect --iteration 1-3`
- [x] Malformed input (`--iteration 0`, `5-1`, `abc`) exits with code 1 and a clear message