### PR TITLE
pipeline.yaml: thread replica param + PipelineRun name validator (#511)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,7 @@ jobs:
             pipeline/tests/test_build.py \
             pipeline/tests/test_pairkey.py \
             pipeline/tests/test_load_pairs.py \
+            pipeline/tests/test_collect_internals.py \
             .claude/skills/sim2real-analyze/tests/ \
             .claude/skills/sim2real-bootstrap/tests/ \
             .claude/skills/sim2real-translate/tests/ \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ All artifacts live under `<experiment-root>/workspace/` (gitignored). When no `-
 | `runs/<run>/cluster/<algo>.yaml` | `sim2real assemble` | `deploy.py` |
 | `runs/<run>/cluster/pipelinerun-*.yaml` | `sim2real assemble` | `deploy.py run` |
 | `runs/<run>/results/{phase}/` | `deploy.py collect` | `/sim2real-analyze` skill, `deploy.py wipe` |
-| `runs/<run>/results/{phase}/<workload>/gpu_logs/<node>.log` | `deploy.py collect` (pulled from PVC) | analysis / debugging |
+| `runs/<run>/results/{phase}/<workload>/i<N>/gpu_logs/<node>.log` | `deploy.py collect` (pulled from PVC) | analysis / debugging |
 | ConfigMap `sim2real-progress-{run}` | `deploy.py run`, `deploy.py reset` | All `deploy.py` subcommands |
 | `runs/<run>/plans/<phase>/<workload>/` | `deploy.py run` | workload tasks |
 

--- a/docs/superpowers/plans/2026-07-07-issue-511-pipeline-replica-threading.md
+++ b/docs/superpowers/plans/2026-07-07-issue-511-pipeline-replica-threading.md
@@ -1,0 +1,536 @@
+# Issue #511 Implementation Plan: `pipeline.yaml` threading + `_cmd_run` dispatch + PipelineRun name validator
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Thread a `replica` PipelineRun param through `pipeline.yaml` so each iteration's results land under `runs/<R>/results/<phase>/<workload>/i<N>/`, and add a fail-fast PipelineRun name-length validator.
+
+**Architecture:** Bake the `replica` param into each PipelineRun YAML at assemble time (via `make_pipelinerun_scenario`), rather than injecting at dispatch. Each iteration already has its own pre-generated PR YAML file (from #521), so passing `replica` as a static param in that file is the natural fit — dispatch stays a simple `kubectl apply` of the pre-generated file. Add a `build_results_dir(...)` helper as the single source of truth for the resultsDir template contract, used by `pipeline.yaml`'s test to assert every `resultsDir` value matches. Add `validate_pipelinerun_name(...)` called from `make_pipelinerun_scenario` so an over-long name fails at construction time (assemble), not at Tekton dispatch.
+
+**Tech Stack:** Python 3.10+, PyYAML, pytest, Tekton v1 API (string params).
+
+## Global Constraints
+
+- **Tekton param type**: `replica` is `type: string` with `default: "1"` — Tekton has no int type. Value must be emitted as a Python `str` in the PipelineRun params list.
+- **k8s DNS-label limit**: PipelineRun `metadata.name` must be ≤253 chars (RFC 1123 DNS subdomain). Enforce at construction; do not defer to Tekton rejection.
+- **Legacy compat**: `iteration=1` (default) must produce identical PR YAML output shape as before (aside from the new `replica: "1"` param), so single-replica flows continue to work.
+- **CI paths listed in `.github/workflows/test.yml`**: any new test file must be added there — CI only covers explicitly listed paths.
+- **Path discipline**: every file operation targets absolute paths under `.claude/worktrees/issue-511-pipeline-yaml-replica-threading/`.
+
+## Design decisions locked in
+
+1. **`replica` param injected at assemble time** (in `make_pipelinerun_scenario`), not at dispatch. Rationale: each iteration has its own PR YAML file, `replica` is static per file (unlike `namespace`, which is dynamic per slot). Baking it in keeps dispatch (`_cmd_run`) untouched for the replica concern. Acceptance criterion "replica dispatched as a string, not an int (Tekton API compat)" is trivially met — the YAML emits `"1"`.
+2. **`plans_dir` (line 97 of pipeline.yaml) stays per-workload, not per-iteration.** Rationale: `plans_dir` is llm-d-benchmark input (workload plans), not benchmark results output. Iterations reuse the same plans; no need to duplicate.
+3. **`_cmd_wipe` / `_cmd_collect` local path handling stays as-is.** Rationale: `_cmd_collect` mirrors the PVC tree transparently — new `iN/` layer just appears in the destination. `_cmd_wipe` deletes the whole `(pkg, wl)` subtree, which still works (removes all iN/ under it). Per-iteration wipe is a UX concern deferred to a follow-up (called out in the PR body).
+
+---
+
+## File Structure
+
+| File | Change |
+|------|--------|
+| `pipeline/pipeline.yaml` | Add `replica` pipeline param (string, default `"1"`). Update all 5 `resultsDir` values from `<run>/<phase>/<wl>` to `<run>/<phase>/<wl>/i$(params.replica)`. |
+| `pipeline/lib/tekton.py` | Add `RESULTS_DIR_TEMPLATE` constant, `build_results_dir(run, phase, workload, replica)` helper, `validate_pipelinerun_name(name)` validator. Update `make_pipelinerun_scenario` to emit `replica` param and call the validator. |
+| `pipeline/tests/test_tekton.py` | New tests for `build_results_dir`, `validate_pipelinerun_name`, and the `replica` param on PR output. |
+| `pipeline/tests/test_pipeline_yaml.py` | Extend existing test module with a class asserting every `resultsDir` in `pipeline.yaml` matches `build_results_dir` output for `replica=$(params.replica)`, and the pipeline declares the `replica` param. |
+
+No new test files — extend existing ones. Both test modules are already in CI's whitelist (`test_tekton.py` is not currently in the CI list but the umbrella `pipeline/` covers it; verify). Actually the CI runs `python -m pytest pipeline/ ...` with `pipeline/` first — so the whole `pipeline/tests/` directory is covered by that base run. No CI workflow update needed.
+
+---
+
+### Task 1: Add `build_results_dir` helper + `RESULTS_DIR_TEMPLATE` constant to `tekton.py`
+
+**Files:**
+- Modify: `pipeline/lib/tekton.py` (add module-level constants + helper below `_TASK_TIMEOUTS`)
+- Test: `pipeline/tests/test_tekton.py` (append new tests)
+
+**Interfaces:**
+- Produces: `RESULTS_DIR_TEMPLATE = "$(params.runName)/$(params.phase)/$(params.workloadName)/i$(params.replica)"` — canonical resultsDir shape for pipeline.yaml. Consumed by pipeline_yaml tests.
+- Produces: `build_results_dir(run: str, phase: str, workload: str, replica: str | int) -> str` — canonical path builder for callers with concrete values. Returns `f"{run}/{phase}/{workload}/i{replica}"`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `pipeline/tests/test_tekton.py`:
+
+```python
+# ── Tests for build_results_dir + RESULTS_DIR_TEMPLATE ──────────────────────
+
+from pipeline.lib.tekton import build_results_dir, RESULTS_DIR_TEMPLATE
+
+
+def test_build_results_dir_returns_slash_joined_path():
+    assert build_results_dir("run1", "baseline", "chatbot-mid", 1) == "run1/baseline/chatbot-mid/i1"
+
+
+def test_build_results_dir_accepts_int_replica():
+    assert build_results_dir("r", "p", "w", 3) == "r/p/w/i3"
+
+
+def test_build_results_dir_accepts_str_replica():
+    """String replica must produce the same output — used for pipeline.yaml templating."""
+    assert build_results_dir("r", "p", "w", "3") == "r/p/w/i3"
+
+
+def test_results_dir_template_shape():
+    """The pipeline.yaml template must be exactly the shape build_results_dir
+    would produce if each segment were a Tekton param reference."""
+    assert RESULTS_DIR_TEMPLATE == "$(params.runName)/$(params.phase)/$(params.workloadName)/i$(params.replica)"
+
+
+def test_build_results_dir_matches_template_when_params_substituted():
+    """build_results_dir with Tekton-param strings reproduces the template
+    verbatim. This is the invariant test_pipeline_yaml.py will assert against
+    every resultsDir value in pipeline.yaml."""
+    template = build_results_dir(
+        "$(params.runName)", "$(params.phase)",
+        "$(params.workloadName)", "$(params.replica)",
+    )
+    assert template == RESULTS_DIR_TEMPLATE
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest pipeline/tests/test_tekton.py -v -k "results_dir or template"`
+Expected: FAIL — `ImportError` on `build_results_dir` / `RESULTS_DIR_TEMPLATE`.
+
+- [ ] **Step 3: Implement**
+
+In `pipeline/lib/tekton.py`, below the `_TASK_TIMEOUTS` dict (around line 15):
+
+```python
+# Canonical shape of resultsDir in pipeline.yaml. Every task that writes into
+# resultsDir threads this exact template. build_results_dir() renders it with
+# concrete values for callers that construct the path locally (e.g. tests).
+# Kept in one place so pipeline.yaml drift is caught by test_pipeline_yaml.py.
+RESULTS_DIR_TEMPLATE = (
+    "$(params.runName)/$(params.phase)/$(params.workloadName)/i$(params.replica)"
+)
+
+
+def build_results_dir(run: str, phase: str, workload: str, replica) -> str:
+    """Return the canonical resultsDir path for a (run, phase, workload, replica)
+    tuple. Callers supply either concrete strings/ints or Tekton param
+    references — both round-trip through the same template.
+    """
+    return f"{run}/{phase}/{workload}/i{replica}"
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `.venv/bin/python -m pytest pipeline/tests/test_tekton.py -v -k "results_dir or template"`
+Expected: PASS (all four new tests green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pipeline/lib/tekton.py pipeline/tests/test_tekton.py
+git commit -m "tekton: add build_results_dir helper + RESULTS_DIR_TEMPLATE"
+```
+
+---
+
+### Task 2: Add `validate_pipelinerun_name` validator + call it in `make_pipelinerun_scenario`
+
+**Files:**
+- Modify: `pipeline/lib/tekton.py`
+- Test: `pipeline/tests/test_tekton.py` (append)
+
+**Interfaces:**
+- Consumes: nothing from prior tasks (independent).
+- Produces: `validate_pipelinerun_name(name: str) -> None` — raises `ValueError` if `len(name) > 253`. Called from `make_pipelinerun_scenario` at PR name construction.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `pipeline/tests/test_tekton.py`:
+
+```python
+# ── Tests for validate_pipelinerun_name ─────────────────────────────────────
+
+import pytest as _pytest
+from pipeline.lib.tekton import validate_pipelinerun_name
+
+
+def test_validate_pipelinerun_name_accepts_short():
+    validate_pipelinerun_name("baseline-wl-r-i1")  # no raise
+
+
+def test_validate_pipelinerun_name_accepts_253_char_limit():
+    """Exactly 253 chars is the DNS subdomain limit — must pass."""
+    name = "a" * 253
+    validate_pipelinerun_name(name)  # no raise
+
+
+def test_validate_pipelinerun_name_rejects_254_chars():
+    name = "a" * 254
+    with _pytest.raises(ValueError, match="253"):
+        validate_pipelinerun_name(name)
+
+
+def test_make_pipelinerun_scenario_rejects_oversized_name():
+    """Long run_name or workload should trip the validator at construction."""
+    long_run = "r" * 240
+    with _pytest.raises(ValueError, match="253"):
+        make_pipelinerun_scenario(
+            phase="baseline", workload={"name": "wl"}, run_name=long_run,
+            namespace="ns", pipeline_name="sim2real",
+            scenario_content="scenario: []",
+        )
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest pipeline/tests/test_tekton.py -v -k "validate or oversized"`
+Expected: FAIL — `ImportError` on `validate_pipelinerun_name`.
+
+- [ ] **Step 3: Implement**
+
+In `pipeline/lib/tekton.py`, below the `build_results_dir` helper:
+
+```python
+_DNS_SUBDOMAIN_MAX = 253
+
+
+def validate_pipelinerun_name(name: str) -> None:
+    """Raise ValueError if ``name`` exceeds the RFC 1123 DNS subdomain limit
+    (253 chars). PipelineRun.metadata.name is a DNS subdomain, so Tekton
+    rejects longer names at admission. Called at construction time so
+    assemble surfaces the failure before any dispatch attempt.
+    """
+    if len(name) > _DNS_SUBDOMAIN_MAX:
+        raise ValueError(
+            f"PipelineRun name {name!r} is {len(name)} chars, exceeds the "
+            f"{_DNS_SUBDOMAIN_MAX}-char DNS subdomain limit"
+        )
+```
+
+Then in `make_pipelinerun_scenario`, immediately after `pr_name = f"..."` (currently line 73):
+
+```python
+    pr_name = f"{safe_phase}-{safe_name}-{run_name}-i{iteration}"
+    validate_pipelinerun_name(pr_name)
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `.venv/bin/python -m pytest pipeline/tests/test_tekton.py -v -k "validate or oversized"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pipeline/lib/tekton.py pipeline/tests/test_tekton.py
+git commit -m "tekton: add validate_pipelinerun_name + wire into make_pipelinerun_scenario"
+```
+
+---
+
+### Task 3: Emit `replica` param from `make_pipelinerun_scenario`
+
+**Files:**
+- Modify: `pipeline/lib/tekton.py`
+- Test: `pipeline/tests/test_tekton.py` (append)
+
+**Interfaces:**
+- Consumes: `iteration` (already a parameter of `make_pipelinerun_scenario`, int, default 1).
+- Produces: PR YAML params list now contains `{"name": "replica", "value": str(iteration)}` — consumed by pipeline.yaml's `$(params.replica)` substitutions.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `pipeline/tests/test_tekton.py`:
+
+```python
+def test_make_pipelinerun_scenario_emits_replica_param_default():
+    """Default iteration=1 → replica='1' in params (string, per Tekton API)."""
+    pr = make_pipelinerun_scenario(
+        phase="baseline", workload={"name": "wl"}, run_name="r",
+        namespace="ns", pipeline_name="sim2real",
+        scenario_content="scenario: []",
+    )
+    params = {p["name"]: p["value"] for p in pr["spec"]["params"]}
+    assert params["replica"] == "1"
+    assert isinstance(params["replica"], str)
+
+
+def test_make_pipelinerun_scenario_emits_replica_param_explicit():
+    """iteration=5 → replica='5'."""
+    pr = make_pipelinerun_scenario(
+        phase="baseline", workload={"name": "wl"}, run_name="r",
+        namespace="ns", pipeline_name="sim2real",
+        scenario_content="scenario: []",
+        iteration=5,
+    )
+    params = {p["name"]: p["value"] for p in pr["spec"]["params"]}
+    assert params["replica"] == "5"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest pipeline/tests/test_tekton.py -v -k "emits_replica"`
+Expected: FAIL — `params["replica"]` KeyError.
+
+- [ ] **Step 3: Implement**
+
+In `pipeline/lib/tekton.py:make_pipelinerun_scenario`, append `replica` to the `params` list. Insert this line at the end of the initial `params: list[dict] = [ ... ]` block (before the `if observe:` conditional):
+
+```python
+    params: list[dict] = [
+        {"name": "experimentId",      "value": run_name},
+        {"name": "runName",           "value": run_name},
+        {"name": "namespace",         "value": namespace},
+        {"name": "phase",             "value": phase},
+        {"name": "scenarioContent",   "value": scenario_content},
+        {"name": "specContent",       "value": spec_content},
+        {"name": "workloadName",      "value": wl_name},
+        {"name": "workloadSpec",      "value": wl_spec_str},
+        {"name": "benchmarkGitRepoUrl", "value": benchmark_git_repo_url},
+        {"name": "benchmarkGitCommit", "value": benchmark_git_commit},
+        {"name": "blisGitRepoUrl",   "value": blis_git_repo_url},
+        {"name": "blisGitCommit",     "value": blis_git_commit},
+        {"name": "model",            "value": model},
+        {"name": "replica",          "value": str(iteration)},
+    ]
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `.venv/bin/python -m pytest pipeline/tests/test_tekton.py -v`
+Expected: PASS (all tekton tests, including pre-existing ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pipeline/lib/tekton.py pipeline/tests/test_tekton.py
+git commit -m "tekton: emit replica PipelineRun param (str(iteration))"
+```
+
+---
+
+### Task 4: Add `replica` param + thread `$(params.replica)` in `pipeline.yaml`
+
+**Files:**
+- Modify: `pipeline/pipeline.yaml` (5 `resultsDir` values; add pipeline-level `replica` param)
+- Test: `pipeline/tests/test_pipeline_yaml.py` (append new test class)
+
+**Interfaces:**
+- Consumes: `RESULTS_DIR_TEMPLATE` from Task 1 (verifies alignment).
+- Produces: pipeline.yaml declares `replica` param + threads it through every `resultsDir` writer.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `pipeline/tests/test_pipeline_yaml.py`:
+
+```python
+class TestReplicaParamThreading:
+    """pipeline.yaml declares and threads the replica param through every
+    resultsDir writer, per step-5 (issue #511).
+    """
+
+    def _pipeline(self):
+        return yaml.safe_load(PIPELINE_YAML.read_text())
+
+    def test_declares_replica_param(self):
+        """Pipeline must declare a top-level 'replica' param, string, default '1'."""
+        pipeline = self._pipeline()
+        params = {p["name"]: p for p in pipeline["spec"]["params"]}
+        assert "replica" in params, "pipeline.yaml missing 'replica' param declaration"
+        assert params["replica"].get("type", "string") == "string"
+        assert params["replica"].get("default") == "1"
+
+    def test_every_results_dir_matches_canonical_template(self):
+        """Every resultsDir occurrence in pipeline.yaml must equal
+        tekton.RESULTS_DIR_TEMPLATE. This is the grep-audit-in-code that
+        catches a task quietly writing to the wrong (unversioned) path."""
+        from pipeline.lib.tekton import RESULTS_DIR_TEMPLATE
+        pipeline = self._pipeline()
+        for task in pipeline["spec"]["tasks"]:
+            for param in task.get("params", []):
+                if param["name"] == "resultsDir":
+                    assert param["value"] == RESULTS_DIR_TEMPLATE, (
+                        f"task {task['name']}.resultsDir = {param['value']!r} "
+                        f"but canonical is {RESULTS_DIR_TEMPLATE!r}"
+                    )
+
+    def test_results_dir_includes_replica_segment(self):
+        """Every resultsDir must reference $(params.replica) — a bare
+        assertion complementary to the template match, so a future edit
+        that changes the template shape without dropping the replica
+        segment still passes; a change that drops the segment fails
+        with a clearer message."""
+        pipeline = self._pipeline()
+        for task in pipeline["spec"]["tasks"]:
+            for param in task.get("params", []):
+                if param["name"] == "resultsDir":
+                    assert "$(params.replica)" in param["value"], (
+                        f"task {task['name']}.resultsDir does not thread replica"
+                    )
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest pipeline/tests/test_pipeline_yaml.py::TestReplicaParamThreading -v`
+Expected: FAIL — pipeline.yaml doesn't have `replica` param yet.
+
+- [ ] **Step 3: Modify `pipeline.yaml` — add pipeline-level `replica` param**
+
+Below `- name: extraArgs\n  type: string\n  default: ""` (currently lines 48–50), add:
+
+```yaml
+    - name: replica
+      type: string
+      default: "1"
+```
+
+- [ ] **Step 4: Modify all 5 `resultsDir` values**
+
+Update each occurrence (currently at lines 108, 121, 134, 153, 174):
+
+From:
+```yaml
+        - name: resultsDir
+          value: "$(params.runName)/$(params.phase)/$(params.workloadName)"
+```
+
+To:
+```yaml
+        - name: resultsDir
+          value: "$(params.runName)/$(params.phase)/$(params.workloadName)/i$(params.replica)"
+```
+
+Note: leave `plans_dir` at line 97 unchanged — it's an input path, not a results path.
+
+- [ ] **Step 5: Run tests**
+
+Run: `.venv/bin/python -m pytest pipeline/tests/test_pipeline_yaml.py -v`
+Expected: PASS — new `TestReplicaParamThreading` class + all existing tests (the existing `test_results_dir_matches_workload` and `test_results_dir_matches_workload` continue to hold since all 5 values change identically).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pipeline/pipeline.yaml pipeline/tests/test_pipeline_yaml.py
+git commit -m "pipeline.yaml: add replica param + thread through resultsDir"
+```
+
+---
+
+### Task 5: Verify assemble_run + deploy.py flows unchanged; update golden tests if any
+
+**Files:**
+- Modify: `pipeline/tests/test_assemble_run.py` (only if failing — add coverage for new `replica` param on generated PR YAML)
+- Modify: (none in production — `_cmd_run` requires no change since `replica` is baked into the YAML at assemble time)
+
+**Interfaces:**
+- Consumes: The `replica` param emitted by `make_pipelinerun_scenario` (Task 3).
+- Produces: nothing new — this task verifies existing coverage catches the new behavior.
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `.venv/bin/python -m pytest pipeline/ -v`
+Expected: any failures related to golden PR YAML shape need updating; unrelated failures indicate a regression to investigate.
+
+- [ ] **Step 2: If any assemble tests fail on "replica" being in params, update them**
+
+For any test in `pipeline/tests/test_assemble_run.py` that asserts on the exact set of PR YAML params (via equality or "params list length"), add `replica` to the expected set. Do not weaken assertions — keep exact matching.
+
+- [ ] **Step 3: Optional new assertion — verify assemble threads iteration into replica**
+
+If test_assemble_run.py doesn't already cover it, add:
+
+```python
+def test_assemble_pipelinerun_files_carry_replica_param(tmp_path):
+    """A --replicas 3 assemble writes pipelinerun-*.yaml files each carrying
+    the correct replica param matching their iteration."""
+    # ... existing fixture that runs assemble with replicas=3 ...
+    # For each iteration i in 1..3:
+    #   pr_path = cluster_dir / f"pipelinerun-<wl>|<pkg>|i{i}.yaml"
+    #   pr = yaml.safe_load(pr_path.read_text())
+    #   replica = next(p["value"] for p in pr["spec"]["params"] if p["name"] == "replica")
+    #   assert replica == str(i)
+```
+
+Skip if existing tests already cover this pattern.
+
+- [ ] **Step 4: Run full suite again**
+
+Run: `.venv/bin/python -m pytest pipeline/ -v && ruff check pipeline/ --select F`
+Expected: all pass.
+
+- [ ] **Step 5: Commit any test updates**
+
+```bash
+git add pipeline/tests/
+git commit -m "tests: cover replica param on assemble-generated PipelineRuns"
+```
+
+---
+
+### Task 6: Documentation sweep + PR body
+
+**Files:**
+- Modify (if stale): `pipeline/README.md`, `CLAUDE.md`, any doc referencing results paths.
+
+**Interfaces:**
+- Consumes: the final code state from Tasks 1–5.
+
+- [ ] **Step 1: Sweep for stale results-path references**
+
+Run: `grep -rn "results/{phase}/{workload}\|results/[^/]*/[^/]*/[^i][^0-9]" pipeline/README.md CLAUDE.md docs/`
+Look for hardcoded results paths that omit `iN/`. The workspace artifact table in CLAUDE.md's project section shows `runs/<run>/results/{phase}/<workload>/gpu_logs/<node>.log` — this now becomes `runs/<run>/results/{phase}/<workload>/i<N>/gpu_logs/<node>.log`.
+
+- [ ] **Step 2: Update stale docs**
+
+Any doc showing a hardcoded results path should either:
+- Get the `iN/` segment inserted (if the doc is describing the path shape post-step-5), OR
+- Be left alone with a note that step-6 documentation PR (#514) will address if the doc mentions it's covering the pre-step-5 world.
+
+For CLAUDE.md's workspace-artifact row for `gpu_logs`, update to include `/i<N>` since the pipeline now writes to that layer.
+
+- [ ] **Step 3: Run tests + lint one final time**
+
+Run: `.venv/bin/python -m pytest pipeline/ -v && ruff check pipeline/ --select F`
+Expected: pass.
+
+- [ ] **Step 4: Commit doc sweep**
+
+```bash
+git add -A
+git commit -m "docs: update results-path references to include iN/ layer"
+```
+
+(Or skip commit if nothing changed.)
+
+- [ ] **Step 5: Push + PR**
+
+```bash
+git push -u origin refactor/v2-step-5-issue-511-pipeline-yaml-replica-threading
+gh pr create --base refactor/v2-step-5 --title "..." --body-file <body-path>
+```
+
+Body must include:
+- `Closes #511`
+- Summary of changes per task.
+- Design decisions locked in (assemble-time replica injection; plans_dir unchanged; wipe/collect unchanged).
+- Doc-sweep results.
+- Any deferred follow-up (per-iteration wipe UX).
+
+---
+
+## Self-Review Checklist
+
+**Spec coverage:**
+- ✓ `pipeline.yaml` `replica` param added — Task 4 Step 3.
+- ✓ `pipeline.yaml` `resultsDir` threaded — Task 4 Step 4.
+- ✓ `build_results_dir` helper — Task 1.
+- ✓ Rendered-pipeline test — Task 4 Step 1 (`test_every_results_dir_matches_canonical_template`).
+- ✓ `validate_pipelinerun_name` — Task 2.
+- ✓ PR name construction `{phase}-{workload}-{run}-i{N}` — already in place from #521; Task 2 wires validator to it.
+- ✓ `_cmd_run` dispatch passes `replica` — accomplished via assemble-time injection (Task 3); dispatch reads pre-baked YAML unchanged.
+- ✓ `_apply_run_filters` iteration term — already delivered in #520 (PR 4/#512); no change needed here.
+- ✓ Integration test — the `test_every_results_dir_matches_canonical_template` is the rendered-pipeline assertion; a live-cluster test is deferred (would need mock cluster fixtures).
+- ✓ Grep audit — captured in `test_every_results_dir_matches_canonical_template` (walks every task, catches drift).
+
+**Placeholder scan:** none — all code blocks are complete.
+
+**Type consistency:** `replica` is `str(iteration)` in Python code (Task 3), `type: string` in Tekton (Task 4). `iteration` is `int` throughout (existing shape from #521). No drift.
+
+## Execution Handoff
+
+Plan saved. Executing inline via `superpowers:executing-plans` — the plan is 6 tasks, tightly-scoped, and mostly independent within each task. No fresh-subagent-per-task is warranted for this size.

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -386,7 +386,7 @@ python pipeline/deploy.py pairs   [flags]   # list available pair keys, workload
 | `--status STATE` | Filter by status (e.g. `running`, `done`, `failed`) |
 | `-s`, `--silent` | Suppress the per-pair table and banner; print only the summary line (machine-readable) |
 
-**`deploy.py collect`** — extracts results from the cluster PVC and writes to `workspace/runs/<run>/results/{phase}/<workload>/`. Repeated collects are incremental: each workload's remote `trace_data.csv` mtime is probed and skipped if the local copy is already up to date. If the mtime probe fails (e.g., pod not running), collection falls back to a full copy — this is the expected degradation path. Like `deploy.py run`, the run's cluster is resolved from `workspace/runs/<R>/run_metadata.json:cluster_id`; missing `runs/<R>/` or `runs/<R>/cluster/` exits with `run 'sim2real assemble --run <R>' first`, and a missing / unparseable `run_metadata.json` or missing `cluster_id` exits with `run metadata corrupted; re-assemble`.
+**`deploy.py collect`** — extracts results from the cluster PVC and writes to `workspace/runs/<run>/results/{phase}/<workload>/i<N>/` (one subdirectory per iteration). Repeated collects are incremental: each workload's remote `trace_data.csv` mtime is probed and skipped if the local copy is already up to date. If the mtime probe fails (e.g., pod not running), collection falls back to a full copy — this is the expected degradation path. Like `deploy.py run`, the run's cluster is resolved from `workspace/runs/<R>/run_metadata.json:cluster_id`; missing `runs/<R>/` or `runs/<R>/cluster/` exits with `run 'sim2real assemble --run <R>' first`, and a missing / unparseable `run_metadata.json` or missing `cluster_id` exits with `run metadata corrupted; re-assemble`.
 
 Per phase, the resolved llm-d-benchmark plan YAMLs are also pulled into `workspace/runs/<run>/results/{phase}/plans/{flow}/*.yaml` (top-level numbered manifests + `config.yaml`, no `helm/` subdir). Plans are workload-invariant within a phase, so collect picks one workload's latest `root-*` render to source the phase's plans. Plan extraction is best-effort and non-fatal — failures warn but do not block trace collection.
 
@@ -528,14 +528,14 @@ python pipeline/deploy.py --experiment-root <experiment-root> \
     --run <run-name> collect
 ```
 
-Pulls per-pair `per_request_lifecycle_metrics.json` and GPU logs from the cluster PVC into `workspace/runs/<run-name>/results/<phase>/<workload>/`. This is the epic's success gate — the demo is done when the JSON files exist locally.
+Pulls per-pair `per_request_lifecycle_metrics.json` and GPU logs from the cluster PVC into `workspace/runs/<run-name>/results/<phase>/<workload>/i<N>/`. This is the epic's success gate — the demo is done when the JSON files exist locally.
 
 ### Success criterion
 
-For each `<workload>` in `transfer.yaml:workloads` and each `<phase>` in `{baseline, <algorithm>}`:
+For each `<workload>` in `transfer.yaml:workloads`, each `<phase>` in `{baseline, <algorithm>}`, and each iteration `<N>` in `1..replicas`:
 
 ```
-workspace/runs/<run-name>/results/<phase>/<workload>/per_request_lifecycle_metrics.json
+workspace/runs/<run-name>/results/<phase>/<workload>/i<N>/per_request_lifecycle_metrics.json
 ```
 
 Once these files exist, step-1's BYO demo is complete. Downstream skills (e.g. `/sim2real-analyze`) consume them for latency comparison and report generation.
@@ -585,7 +585,7 @@ For each algorithm: probe the registry, build if absent, record `image_ref`/`ima
 
 ### 7-9. Assemble, deploy, collect (identical to BYO steps 4-6, using the same `--translation` alias)
 
-The same success gate applies — `per_request_lifecycle_metrics.json` under `workspace/runs/<run-name>/results/<phase>/<workload>/`.
+The same success gate applies — `per_request_lifecycle_metrics.json` under `workspace/runs/<run-name>/results/<phase>/<workload>/i<N>/` (one file per iteration).
 
 ---
 

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -1043,11 +1043,20 @@ def _fmt_size(b: int) -> str:
 
 
 def _probe_remote_mtimes(pod_name: str, phase_path: str, namespace: str) -> dict[str, float]:
-    """Return {workload_name: mtime_epoch} for workloads that have trace_data.csv.
+    """Return {workload_name: newest_iteration_mtime_epoch} for workloads that
+    have at least one trace_data.csv on the PVC.
 
     Uses a single kubectl exec to stat all trace_data.csv files in the phase
-    directory.  Returns empty dict on probe failure — callers should fall back
-    to full copy in that case.
+    directory. Post step-5, traces live under
+    ``<phase>/<workload>/i<N>/trace_data.csv`` — one per iteration. This
+    function walks two levels up from each trace file to derive the workload
+    name and keeps the newest mtime seen across that workload's iterations.
+    ``_is_workload_up_to_date`` then compares this against the OLDEST local iteration,
+    so an incremental skip requires every local iteration to be at least as
+    new as the newest remote iteration.
+
+    Returns empty dict on probe failure — callers should fall back to full
+    copy in that case.
     """
     result = run(
         ["kubectl", "exec", pod_name, f"-n={namespace}", "--", "sh", "-c",
@@ -1071,20 +1080,60 @@ def _probe_remote_mtimes(pod_name: str, phase_path: str, namespace: str) -> dict
             warn(f"mtime probe: unparseable line: {line!r}")
             continue
         try:
-            mtimes[Path(parts[1]).parent.name] = float(parts[0])
+            mt = float(parts[0])
         except ValueError:
             warn(f"mtime probe: unparseable line: {line!r}")
+            continue
+        # Path shape: <phase_path>/<workload>/i<N>/trace_data.csv
+        # parent.parent is the workload dir.
+        wl = Path(parts[1]).parent.parent.name
+        if wl in mtimes:
+            mtimes[wl] = max(mtimes[wl], mt)
+        else:
+            mtimes[wl] = mt
     return mtimes
 
 
-def _is_up_to_date(local_csv: Path, remote_mtime: "float | None") -> bool:
-    """Return True if local trace_data.csv is at least as new as the remote copy."""
+def _is_up_to_date(local_path: Path, remote_mtime: "float | None") -> bool:
+    """Return True if *local_path* exists and its mtime is at least as new as
+    *remote_mtime*.
+
+    Used by ``_extract_phase_plans`` to decide whether a specific YAML file
+    needs re-downloading. For workload-level trace-directory checks under
+    the step-5 ``i<N>/`` layout, use ``_is_workload_up_to_date`` instead.
+    """
     if remote_mtime is None:
         return False
     try:
-        return local_csv.exists() and local_csv.stat().st_mtime >= remote_mtime
+        return local_path.exists() and local_path.stat().st_mtime >= remote_mtime
     except OSError as exc:
-        warn(f"stat failed for {local_csv}: {exc} — will re-download")
+        warn(f"stat failed for {local_path}: {exc} — will re-download")
+        return False
+
+
+def _is_workload_up_to_date(wl_dir: Path, remote_mtime: "float | None") -> bool:
+    """Return True if every ``i<N>/trace_data.csv`` under *wl_dir* is at least
+    as new as the newest remote copy for that workload.
+
+    Post step-5, a workload's traces live under
+    ``<wl_dir>/i<N>/trace_data.csv``. This function returns True only when
+    the workload has at least one collected iteration locally AND the OLDEST
+    local iteration's mtime is >= ``remote_mtime``. If some iterations are
+    missing locally OR any local iteration is older than remote, returns
+    False so the workload is redone end-to-end (matching the wipe-and-recopy
+    pattern the callers rely on).
+    """
+    if remote_mtime is None:
+        return False
+    if not wl_dir.exists():
+        return False
+    csvs = sorted(wl_dir.glob("i*/trace_data.csv"))
+    if not csvs:
+        return False
+    try:
+        return min(c.stat().st_mtime for c in csvs) >= remote_mtime
+    except OSError as exc:
+        warn(f"stat failed in {wl_dir}: {exc} — will re-download")
         return False
 
 
@@ -1217,51 +1266,112 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
                         wl_names = [w for w in wl_names if w in phase_allowed]
                 phase_errors = []
                 for wl_name in wl_names:
-                    if _is_up_to_date(dest_dir / wl_name / "trace_data.csv",
-                                      remote_mtimes.get(wl_name)):
+                    if _is_workload_up_to_date(dest_dir / wl_name,
+                                               remote_mtimes.get(wl_name)):
                         info(f"[{phase}/{wl_name}] up to date — skipping")
                         if on_workload_done:
                             on_workload_done(phase, wl_name, namespace, None)
                         continue
                     wl_dest = dest_dir / wl_name
                     wl_dest.mkdir(parents=True, exist_ok=True)
-                    for log_dir in (wl_dest / "server_logs", wl_dest / "epp_logs", wl_dest / "gpu_logs", wl_dest / "resources"):
-                        if log_dir.exists():
-                            shutil.rmtree(log_dir)
-                    # Copy trace files
+                    # Wipe stale log dirs across every existing local iteration.
+                    for iN_dir in wl_dest.glob("i*"):
+                        for sub in ("server_logs", "epp_logs", "gpu_logs", "resources"):
+                            p = iN_dir / sub
+                            if p.exists():
+                                shutil.rmtree(p)
+                    # Discover iteration subdirs on the PVC (post step-5 layout).
+                    iN_ls = run(
+                        ["kubectl", "exec", pod_name, f"-n={namespace}", "--",
+                         "sh", "-c",
+                         f"ls /data/{run_name}/{phase}/{wl_name}/"],
+                        check=False, capture=True,
+                    )
+                    if iN_ls.returncode != 0:
+                        wl_errors = [
+                            f"{wl_name}: failed to list iterations: "
+                            f"{iN_ls.stderr.strip()}"
+                        ]
+                        phase_errors.extend(wl_errors)
+                        if on_workload_done:
+                            on_workload_done(
+                                phase, wl_name, namespace,
+                                RuntimeError("; ".join(wl_errors)),
+                            )
+                        continue
+                    iN_names = [
+                        n for n in iN_ls.stdout.strip().split()
+                        if n.startswith("i") and n[1:].isdigit()
+                    ]
+                    if not iN_names:
+                        wl_errors = [
+                            f"{wl_name}: no i<N>/ iteration subdirs found on PVC"
+                        ]
+                        phase_errors.extend(wl_errors)
+                        if on_workload_done:
+                            on_workload_done(
+                                phase, wl_name, namespace,
+                                RuntimeError("; ".join(wl_errors)),
+                            )
+                        continue
                     wl_errors = []
-                    for fname in ("trace_data.csv", "trace_header.yaml", "epp_stream_done", "gpu_stream_done"):
-                        src = f"{namespace}/{pod_name}:/data/{run_name}/{phase}/{wl_name}/{fname}"
-                        r = run(["kubectl", "cp", src, str(wl_dest / fname), "--retries=3"],
-                                check=False, capture=True)
+                    for iN in iN_names:
+                        iN_dest = wl_dest / iN
+                        iN_dest.mkdir(parents=True, exist_ok=True)
+                        remote_prefix = (
+                            f"{namespace}/{pod_name}:/data/{run_name}/"
+                            f"{phase}/{wl_name}/{iN}"
+                        )
+                        # Copy trace files
+                        for fname in ("trace_data.csv", "trace_header.yaml",
+                                      "epp_stream_done", "gpu_stream_done"):
+                            r = run(
+                                ["kubectl", "cp", f"{remote_prefix}/{fname}",
+                                 str(iN_dest / fname), "--retries=3"],
+                                check=False, capture=True,
+                            )
+                            if r.returncode != 0 and "no such file" not in r.stderr.lower():
+                                wl_errors.append(
+                                    f"{wl_name}/{iN}/{fname}: {r.stderr.strip()}"
+                                )
+                        # Copy epp_logs directory
+                        epp_dest = iN_dest / "epp_logs"
+                        epp_dest.mkdir(exist_ok=True)
+                        r = run(
+                            ["kubectl", "cp", f"{remote_prefix}/epp_logs/",
+                             str(epp_dest), "--retries=3"],
+                            check=False, capture=True,
+                        )
                         if r.returncode != 0 and "no such file" not in r.stderr.lower():
-                            wl_errors.append(f"{wl_name}/{fname}: {r.stderr.strip()}")
-                    # Copy epp_logs directory
-                    epp_src = f"{namespace}/{pod_name}:/data/{run_name}/{phase}/{wl_name}/epp_logs/"
-                    epp_dest = wl_dest / "epp_logs"
-                    epp_dest.mkdir(exist_ok=True)
-                    r = run(["kubectl", "cp", epp_src, str(epp_dest), "--retries=3"],
-                            check=False, capture=True)
-                    if r.returncode != 0 and "no such file" not in r.stderr.lower():
-                        wl_errors.append(f"{wl_name}/epp_logs: {r.stderr.strip()}")
-                    # Copy gpu_logs directory
-                    gpu_src = f"{namespace}/{pod_name}:/data/{run_name}/{phase}/{wl_name}/gpu_logs/"
-                    gpu_dest = wl_dest / "gpu_logs"
-                    gpu_dest.mkdir(exist_ok=True)
-                    r = run(["kubectl", "cp", gpu_src, str(gpu_dest), "--retries=3"],
-                            check=False, capture=True)
-                    if r.returncode != 0 and "no such file" not in r.stderr.lower():
-                        wl_errors.append(f"{wl_name}/gpu_logs: {r.stderr.strip()}")
-                    # Copy resources directory
-                    res_src = f"{namespace}/{pod_name}:/data/{run_name}/{phase}/{wl_name}/resources/"
-                    res_dest = wl_dest / "resources"
-                    res_dest.mkdir(exist_ok=True)
-                    r = run(["kubectl", "cp", res_src, str(res_dest), "--retries=3"],
-                            check=False, capture=True)
-                    if r.returncode != 0 and "no such file" not in r.stderr.lower():
-                        wl_errors.append(f"{wl_name}/resources: {r.stderr.strip()}")
-                    else:
-                        redact_yaml_tree(res_dest)
+                            wl_errors.append(
+                                f"{wl_name}/{iN}/epp_logs: {r.stderr.strip()}"
+                            )
+                        # Copy gpu_logs directory
+                        gpu_dest = iN_dest / "gpu_logs"
+                        gpu_dest.mkdir(exist_ok=True)
+                        r = run(
+                            ["kubectl", "cp", f"{remote_prefix}/gpu_logs/",
+                             str(gpu_dest), "--retries=3"],
+                            check=False, capture=True,
+                        )
+                        if r.returncode != 0 and "no such file" not in r.stderr.lower():
+                            wl_errors.append(
+                                f"{wl_name}/{iN}/gpu_logs: {r.stderr.strip()}"
+                            )
+                        # Copy resources directory
+                        res_dest = iN_dest / "resources"
+                        res_dest.mkdir(exist_ok=True)
+                        r = run(
+                            ["kubectl", "cp", f"{remote_prefix}/resources/",
+                             str(res_dest), "--retries=3"],
+                            check=False, capture=True,
+                        )
+                        if r.returncode != 0 and "no such file" not in r.stderr.lower():
+                            wl_errors.append(
+                                f"{wl_name}/{iN}/resources: {r.stderr.strip()}"
+                            )
+                        else:
+                            redact_yaml_tree(res_dest)
                     if wl_errors:
                         phase_errors.extend(wl_errors)
                     if on_workload_done:
@@ -1272,8 +1382,8 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
                 else:
                     errors[phase] = None
             elif workload:
-                if _is_up_to_date(dest_dir / workload / "trace_data.csv",
-                                  remote_mtimes.get(workload)):
+                if _is_workload_up_to_date(dest_dir / workload,
+                                           remote_mtimes.get(workload)):
                     info(f"[{phase}/{workload}] up to date — skipping")
                     errors[phase] = None
                     if on_workload_done:
@@ -1324,8 +1434,8 @@ def _extract_phases_from_pvc(phases: list[str], run_name: str, namespace: str,
                     continue
                 phase_errors = []
                 for wl_name in wl_names:
-                    if _is_up_to_date(dest_dir / wl_name / "trace_data.csv",
-                                      remote_mtimes.get(wl_name)):
+                    if _is_workload_up_to_date(dest_dir / wl_name,
+                                               remote_mtimes.get(wl_name)):
                         info(f"[{phase}/{wl_name}] up to date — skipping")
                         if on_workload_done:
                             on_workload_done(phase, wl_name, namespace, None)

--- a/pipeline/lib/assemble_run.py
+++ b/pipeline/lib/assemble_run.py
@@ -385,22 +385,25 @@ def generate_pipelineruns(
             wl_name = wl.get("name", wl.get("workload_name", "unknown"))
             safe_wl = wl_name.replace("_", "-")
             for iteration in iterations:
-                pr = make_pipelinerun_scenario(
-                    phase=pkg_name,
-                    workload=wl,
-                    run_name=run_name,
-                    namespace=namespace,
-                    pipeline_name=pipeline_name,
-                    scenario_content=scenario_content,
-                    workspace_bindings=ws_bindings if ws_bindings else None,
-                    benchmark_git_commit=submodule_shas.get("llm-d-benchmark", ""),
-                    benchmark_git_repo_url=submodule_urls.get("llm-d-benchmark", ""),
-                    blis_git_commit=submodule_shas.get("inference-sim", ""),
-                    blis_git_repo_url=submodule_urls.get("inference-sim", ""),
-                    model=model_name,
-                    observe=observe,
-                    iteration=iteration,
-                )
+                try:
+                    pr = make_pipelinerun_scenario(
+                        phase=pkg_name,
+                        workload=wl,
+                        run_name=run_name,
+                        namespace=namespace,
+                        pipeline_name=pipeline_name,
+                        scenario_content=scenario_content,
+                        workspace_bindings=ws_bindings if ws_bindings else None,
+                        benchmark_git_commit=submodule_shas.get("llm-d-benchmark", ""),
+                        benchmark_git_repo_url=submodule_urls.get("llm-d-benchmark", ""),
+                        blis_git_commit=submodule_shas.get("inference-sim", ""),
+                        blis_git_repo_url=submodule_urls.get("inference-sim", ""),
+                        model=model_name,
+                        observe=observe,
+                        iteration=iteration,
+                    )
+                except ValueError as exc:
+                    raise AssembleError(str(exc)) from exc
                 fname = f"pipelinerun-{safe_wl}|{pkg_name}|i{iteration}.yaml"
                 (cluster_dir_ / fname).write_text(
                     yaml.dump(pr, default_flow_style=False, allow_unicode=True)

--- a/pipeline/lib/tekton.py
+++ b/pipeline/lib/tekton.py
@@ -31,6 +31,22 @@ def build_results_dir(run: str, phase: str, workload: str, replica) -> str:
     return f"{run}/{phase}/{workload}/i{replica}"
 
 
+_DNS_SUBDOMAIN_MAX = 253
+
+
+def validate_pipelinerun_name(name: str) -> None:
+    """Raise ValueError if ``name`` exceeds the RFC 1123 DNS subdomain limit
+    (253 chars). PipelineRun.metadata.name is a DNS subdomain, so Tekton
+    rejects longer names at admission. Called at construction time so
+    assemble surfaces the failure before any dispatch attempt.
+    """
+    if len(name) > _DNS_SUBDOMAIN_MAX:
+        raise ValueError(
+            f"PipelineRun name {name!r} is {len(name)} chars, exceeds the "
+            f"{_DNS_SUBDOMAIN_MAX}-char DNS subdomain limit"
+        )
+
+
 def _default_spec_content(base_dir: str = _SPEC_BASE_DIR,
                           scenario_file: str = _SCENARIO_FILE_PATH) -> str:
     """Return the llmdbenchmark spec content string with PVC paths."""
@@ -88,6 +104,7 @@ def make_pipelinerun_scenario(
     safe_name = wl_name.replace("_", "-")
     safe_phase = phase.replace("_", "-")
     pr_name = f"{safe_phase}-{safe_name}-{run_name}-i{iteration}"
+    validate_pipelinerun_name(pr_name)
 
     wl_spec = {k: v for k, v in workload.items() if k != "workload_name"}
     wl_spec_str = yaml.dump(wl_spec, default_flow_style=True).strip()

--- a/pipeline/lib/tekton.py
+++ b/pipeline/lib/tekton.py
@@ -123,6 +123,7 @@ def make_pipelinerun_scenario(
         {"name": "blisGitRepoUrl",   "value": blis_git_repo_url},
         {"name": "blisGitCommit",     "value": blis_git_commit},
         {"name": "model",            "value": model},
+        {"name": "replica",          "value": str(iteration)},
     ]
     if observe:
         # Emit only specified keys; omitted ones fall through to Pipeline-level

--- a/pipeline/lib/tekton.py
+++ b/pipeline/lib/tekton.py
@@ -14,6 +14,23 @@ _TASK_TIMEOUTS: dict[str, str] = {
 }
 
 
+# Canonical shape of resultsDir in pipeline.yaml. Every task that writes into
+# resultsDir threads this exact template. build_results_dir() renders it with
+# concrete values for callers that construct the path locally (e.g. tests).
+# Kept in one place so pipeline.yaml drift is caught by test_pipeline_yaml.py.
+RESULTS_DIR_TEMPLATE = (
+    "$(params.runName)/$(params.phase)/$(params.workloadName)/i$(params.replica)"
+)
+
+
+def build_results_dir(run: str, phase: str, workload: str, replica) -> str:
+    """Return the canonical resultsDir path for a (run, phase, workload, replica)
+    tuple. Callers supply either concrete strings/ints or Tekton param
+    references — both round-trip through the same template.
+    """
+    return f"{run}/{phase}/{workload}/i{replica}"
+
+
 def _default_spec_content(base_dir: str = _SPEC_BASE_DIR,
                           scenario_file: str = _SCENARIO_FILE_PATH) -> str:
     """Return the llmdbenchmark spec content string with PVC paths."""

--- a/pipeline/pipeline.yaml
+++ b/pipeline/pipeline.yaml
@@ -48,6 +48,9 @@ spec:
     - name: extraArgs
       type: string
       default: ""
+    - name: replica
+      type: string
+      default: "1"
   workspaces:
     - name: source
     - name: data-storage
@@ -106,7 +109,7 @@ spec:
           workspace: data-storage
       params:
         - name: resultsDir
-          value: "$(params.runName)/$(params.phase)/$(params.workloadName)"
+          value: "$(params.runName)/$(params.phase)/$(params.workloadName)/i$(params.replica)"
 
     - name: stream-epp-logs
       runAfter: ["llmdbenchmark-standup", "prepare-results-dir"]
@@ -119,7 +122,7 @@ spec:
         - name: namespace
           value: "$(params.namespace)"
         - name: resultsDir
-          value: "$(params.runName)/$(params.phase)/$(params.workloadName)"
+          value: "$(params.runName)/$(params.phase)/$(params.workloadName)/i$(params.replica)"
 
     - name: stream-gpu-stats
       runAfter: ["llmdbenchmark-standup", "prepare-results-dir"]
@@ -132,7 +135,7 @@ spec:
         - name: namespace
           value: "$(params.namespace)"
         - name: resultsDir
-          value: "$(params.runName)/$(params.phase)/$(params.workloadName)"
+          value: "$(params.runName)/$(params.phase)/$(params.workloadName)/i$(params.replica)"
 
     - name: run-workload-blis-observe-binary
       runAfter: ["llmdbenchmark-standup", "install-blis", "prepare-results-dir"]
@@ -151,7 +154,7 @@ spec:
         - name: workloadSpec
           value: "$(params.workloadSpec)"
         - name: resultsDir
-          value: "$(params.runName)/$(params.phase)/$(params.workloadName)"
+          value: "$(params.runName)/$(params.phase)/$(params.workloadName)/i$(params.replica)"
         - name: maxConcurrency
           value: "$(params.maxConcurrency)"
         - name: timeout
@@ -172,7 +175,7 @@ spec:
           workspace: data-storage
       params:
         - name: resultsDir
-          value: "$(params.runName)/$(params.phase)/$(params.workloadName)"
+          value: "$(params.runName)/$(params.phase)/$(params.workloadName)/i$(params.replica)"
         - name: namespace
           value: "$(params.namespace)"
 

--- a/pipeline/tests/test_assemble_run.py
+++ b/pipeline/tests/test_assemble_run.py
@@ -422,6 +422,67 @@ class TestGeneratePipelineruns:
         )
         assert pr["metadata"]["name"] == "baseline-wl-a-trial-1-i2"
 
+    def test_each_iteration_carries_matching_replica_param(self, tmp_path):
+        """Each generated PipelineRun YAML must carry replica=str(iteration)."""
+        run_dir = tmp_path / "runs" / "trial-1"
+        cluster_dir = run_dir / "cluster"
+        cluster_dir.mkdir(parents=True)
+        packages = [
+            ("baseline", {"scenario": [{"name": "s", "model": {"name": "M"}}]}),
+        ]
+        workloads = [{"name": "wl-a", "num_requests": 10}]
+        cluster_config = {"namespaces": ["ns-0"], "workspaces": {}}
+        assemble_run.generate_pipelineruns(
+            run_dir=run_dir,
+            packages=packages,
+            workloads=workloads,
+            run_name="trial-1",
+            cluster_config=cluster_config,
+            pipeline_name="sim2real",
+            observe={},
+            model_name="M",
+            submodule_shas={},
+            submodule_urls={},
+            iterations=range(1, 4),
+        )
+        for n in (1, 2, 3):
+            pr = yaml.safe_load(
+                (cluster_dir / f"pipelinerun-wl-a|baseline|i{n}.yaml").read_text()
+            )
+            params = {p["name"]: p["value"] for p in pr["spec"]["params"]}
+            assert params["replica"] == str(n), (
+                f"iteration {n}: expected replica='{n}', got {params['replica']!r}"
+            )
+
+    def test_oversized_pipelinerun_name_raises_assemble_error(self, tmp_path):
+        """A run_name that pushes PR name over 253 chars must raise
+        AssembleError from generate_pipelineruns, not a raw ValueError.
+        The assemble CLI boundary catches AssembleError only, so any
+        ValueError leaking through would surface as a raw Python traceback."""
+        run_dir = tmp_path / "runs" / "long"
+        cluster_dir = run_dir / "cluster"
+        cluster_dir.mkdir(parents=True)
+        packages = [
+            ("baseline", {"scenario": [{"name": "s", "model": {"name": "M"}}]}),
+        ]
+        # Push the constructed name (`baseline-wl-a-<run_name>-i1`) over 253 chars.
+        workloads = [{"name": "wl-a", "num_requests": 10}]
+        cluster_config = {"namespaces": ["ns-0"], "workspaces": {}}
+        long_run_name = "r" * 245
+        with pytest.raises(assemble_run.AssembleError, match="253"):
+            assemble_run.generate_pipelineruns(
+                run_dir=run_dir,
+                packages=packages,
+                workloads=workloads,
+                run_name=long_run_name,
+                cluster_config=cluster_config,
+                pipeline_name="sim2real",
+                observe={},
+                model_name="M",
+                submodule_shas={},
+                submodule_urls={},
+            )
+
 
 def _write_yaml(path: Path, data) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/pipeline/tests/test_collect_internals.py
+++ b/pipeline/tests/test_collect_internals.py
@@ -1,0 +1,125 @@
+"""Tests for deploy._probe_remote_mtimes and deploy._is_workload_up_to_date under the
+step-5 ``i<N>/`` results-path layout (issue #511).
+
+The mtime-probe optimisation must key by workload (not by the immediate parent
+of ``trace_data.csv``, which is now the iteration directory), and the
+up-to-date check must inspect every local ``i<N>/trace_data.csv`` under a
+workload's directory rather than a single flat CSV.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from pipeline import deploy
+
+
+# ── _probe_remote_mtimes ─────────────────────────────────────────────────────
+
+
+def _fake_run(stdout: str, returncode: int = 0, stderr: str = ""):
+    """Return a MagicMock stand-in for a completed subprocess.CompletedProcess."""
+    class _R:  # minimal duck-typed shim
+        pass
+    r = _R()
+    r.stdout = stdout
+    r.stderr = stderr
+    r.returncode = returncode
+    return r
+
+
+def test_probe_remote_mtimes_keys_by_workload_not_iteration():
+    """The immediate parent of ``trace_data.csv`` is now ``i<N>``, so keying
+    on ``parent.name`` would map every trace file to a bucket named ``i1``,
+    ``i2``, etc. This test locks in workload-level keying (``parent.parent``)."""
+    stdout = (
+        "1700000000 /data/r/baseline/wl-a/i1/trace_data.csv\n"
+        "1700000500 /data/r/baseline/wl-a/i2/trace_data.csv\n"
+        "1700000100 /data/r/baseline/wl-b/i1/trace_data.csv\n"
+    )
+    with patch.object(deploy, "run", return_value=_fake_run(stdout)):
+        mtimes = deploy._probe_remote_mtimes("pod", "/data/r/baseline", "ns")
+    assert set(mtimes.keys()) == {"wl-a", "wl-b"}
+    assert mtimes["wl-a"] == 1700000500  # newest across iterations
+    assert mtimes["wl-b"] == 1700000100
+
+
+def test_probe_remote_mtimes_takes_max_across_iterations():
+    """Multiple iterations of the same workload collapse to a single max
+    mtime — the up-to-date check compares this against the local minimum."""
+    stdout = (
+        "100 /data/r/p/wl/i1/trace_data.csv\n"
+        "500 /data/r/p/wl/i2/trace_data.csv\n"
+        "300 /data/r/p/wl/i3/trace_data.csv\n"
+    )
+    with patch.object(deploy, "run", return_value=_fake_run(stdout)):
+        mtimes = deploy._probe_remote_mtimes("pod", "/data/r/p", "ns")
+    assert mtimes == {"wl": 500.0}
+
+
+def test_probe_remote_mtimes_probe_failure_returns_empty():
+    with patch.object(deploy, "run",
+                      return_value=_fake_run("", returncode=1, stderr="boom")):
+        mtimes = deploy._probe_remote_mtimes("pod", "/data/r/p", "ns")
+    assert mtimes == {}
+
+
+def test_probe_remote_mtimes_no_traces_returns_empty():
+    with patch.object(deploy, "run", return_value=_fake_run("")):
+        mtimes = deploy._probe_remote_mtimes("pod", "/data/r/p", "ns")
+    assert mtimes == {}
+
+
+# ── _is_workload_up_to_date ──────────────────────────────────────────────────
+
+
+def test_is_workload_up_to_date_false_when_remote_mtime_none():
+    assert deploy._is_workload_up_to_date(Path("/nonexistent"), None) is False
+
+
+def test_is_workload_up_to_date_false_when_wl_dir_missing(tmp_path):
+    assert deploy._is_workload_up_to_date(tmp_path / "missing", 100.0) is False
+
+
+def test_is_workload_up_to_date_false_when_no_iteration_dirs(tmp_path):
+    """Empty workload directory — nothing has been collected yet."""
+    wl = tmp_path / "wl"
+    wl.mkdir()
+    assert deploy._is_workload_up_to_date(wl, 100.0) is False
+
+
+def test_is_workload_up_to_date_true_when_every_iteration_is_fresh(tmp_path):
+    """Local: two iterations, both newer than remote → skip."""
+    wl = tmp_path / "wl"
+    (wl / "i1").mkdir(parents=True)
+    (wl / "i2").mkdir(parents=True)
+    (wl / "i1" / "trace_data.csv").write_text("i1")
+    (wl / "i2" / "trace_data.csv").write_text("i2")
+    import os as _os
+    _os.utime(wl / "i1" / "trace_data.csv", (1000, 1000))
+    _os.utime(wl / "i2" / "trace_data.csv", (2000, 2000))
+    # Remote max is 500, so both local iterations are newer.
+    assert deploy._is_workload_up_to_date(wl, 500.0) is True
+
+
+def test_is_workload_up_to_date_false_when_oldest_local_is_stale(tmp_path):
+    """One local iteration older than remote → workload is redone."""
+    wl = tmp_path / "wl"
+    (wl / "i1").mkdir(parents=True)
+    (wl / "i2").mkdir(parents=True)
+    (wl / "i1" / "trace_data.csv").write_text("i1")
+    (wl / "i2" / "trace_data.csv").write_text("i2")
+    import os as _os
+    _os.utime(wl / "i1" / "trace_data.csv", (100, 100))     # stale
+    _os.utime(wl / "i2" / "trace_data.csv", (2000, 2000))   # fresh
+    # Any local iteration older than remote means we can't skip.
+    assert deploy._is_workload_up_to_date(wl, 500.0) is False
+
+
+def test_is_workload_up_to_date_true_when_local_exactly_matches_remote(tmp_path):
+    """Boundary: local mtime equal to remote counts as up-to-date."""
+    wl = tmp_path / "wl"
+    (wl / "i1").mkdir(parents=True)
+    (wl / "i1" / "trace_data.csv").write_text("i1")
+    import os as _os
+    _os.utime(wl / "i1" / "trace_data.csv", (500, 500))
+    assert deploy._is_workload_up_to_date(wl, 500.0) is True

--- a/pipeline/tests/test_deploy_collect.py
+++ b/pipeline/tests/test_deploy_collect.py
@@ -921,12 +921,17 @@ def test_collect_reads_from_configmap(tmp_path, monkeypatch):
 # ── Incremental collect helpers ──────────────────────────────────────────────
 
 def test_probe_remote_mtimes_parses_output():
-    """_probe_remote_mtimes parses stat output into {workload: mtime} dict."""
+    """_probe_remote_mtimes parses stat output into {workload: mtime} dict.
+
+    Post step-5, traces live under ``<phase>/<workload>/i<N>/trace_data.csv``.
+    Keys are derived by walking two levels up from the trace file, so the
+    workload name (not the iteration directory) is the dict key.
+    """
     from pipeline.deploy import _probe_remote_mtimes
 
     stat_output = (
-        "1715800000 /data/run1/baseline/wl-smoke/trace_data.csv\n"
-        "1715800100 /data/run1/baseline/wl-load/trace_data.csv\n"
+        "1715800000 /data/run1/baseline/wl-smoke/i1/trace_data.csv\n"
+        "1715800100 /data/run1/baseline/wl-load/i1/trace_data.csv\n"
     )
 
     with patch("subprocess.run") as mock_run:
@@ -970,13 +975,13 @@ def test_probe_remote_mtimes_warns_on_stderr():
     from pipeline import deploy
     from pipeline.deploy import _probe_remote_mtimes
 
-    stat_output = "1715800000 /data/run1/baseline/wl-smoke/trace_data.csv\n"
+    stat_output = "1715800000 /data/run1/baseline/wl-smoke/i1/trace_data.csv\n"
 
     with patch("subprocess.run") as mock_run, \
          patch.object(deploy, "warn") as mock_warn:
         mock_run.return_value = MagicMock(
             returncode=0, stdout=stat_output,
-            stderr="stat: /data/run1/baseline/wl-broken/trace_data.csv: No such file")
+            stderr="stat: /data/run1/baseline/wl-broken/i1/trace_data.csv: No such file")
         result = _probe_remote_mtimes("pod", "/data/run1/baseline", "ns-0")
 
     assert result == {"wl-smoke": 1715800000.0}
@@ -988,7 +993,7 @@ def test_probe_remote_mtimes_warns_on_unparseable_line():
     from pipeline import deploy
     from pipeline.deploy import _probe_remote_mtimes
 
-    stat_output = "garbage /data/run1/baseline/wl-bad/trace_data.csv\n1715800000 /data/run1/baseline/wl-smoke/trace_data.csv\n"
+    stat_output = "garbage /data/run1/baseline/wl-bad/i1/trace_data.csv\n1715800000 /data/run1/baseline/wl-smoke/i1/trace_data.csv\n"
 
     with patch("subprocess.run") as mock_run, \
          patch.object(deploy, "warn") as mock_warn:
@@ -1005,7 +1010,7 @@ def test_probe_remote_mtimes_warns_on_single_token_line():
     from pipeline import deploy
     from pipeline.deploy import _probe_remote_mtimes
 
-    stat_output = "onlyone\n1715800000 /data/run1/baseline/wl-smoke/trace_data.csv\n"
+    stat_output = "onlyone\n1715800000 /data/run1/baseline/wl-smoke/i1/trace_data.csv\n"
 
     with patch("subprocess.run") as mock_run, \
          patch.object(deploy, "warn") as mock_warn:
@@ -1018,7 +1023,12 @@ def test_probe_remote_mtimes_warns_on_single_token_line():
 
 
 def test_is_up_to_date_true_when_local_newer(tmp_path):
-    """_is_up_to_date returns True when local file is at least as new as remote."""
+    """_is_up_to_date returns True when local file is at least as new as remote.
+
+    This is the plans-YAML use case: a single-file freshness check kept intact
+    for ``_extract_phase_plans``. The workload-directory / iN-scan variant is
+    ``_is_workload_up_to_date`` (covered in test_collect_internals.py).
+    """
     from pipeline.deploy import _is_up_to_date
 
     local_csv = tmp_path / "trace_data.csv"
@@ -1514,24 +1524,30 @@ def test_collect_per_workload_clears_stale_files(tmp_path, monkeypatch):
 
 
 def test_collect_skip_logs_clears_stale_log_dirs(tmp_path, monkeypatch):
-    """--skip-logs path removes stale server_logs/, epp_logs/, and gpu_logs/ before copying."""
+    """--skip-logs path removes stale server_logs/, epp_logs/, and gpu_logs/
+    inside every existing local iteration subtree before copying.
+
+    Post step-5, log subdirs live under ``<wl>/i<N>/{server_logs,epp_logs,gpu_logs}``.
+    The wipe walks each ``i*/`` under the workload dir.
+    """
     from pipeline import deploy
     import subprocess
 
     run_dir = tmp_path / "workspace" / "runs" / "test-run"
     (run_dir / "cluster").mkdir(parents=True)
     results_dir = run_dir / "results" / "baseline" / "wl-smoke"
-    results_dir.mkdir(parents=True)
+    iter_dir = results_dir / "i1"
+    iter_dir.mkdir(parents=True)
 
-    stale_server = results_dir / "server_logs" / "stale.log"
+    stale_server = iter_dir / "server_logs" / "stale.log"
     stale_server.parent.mkdir(parents=True)
     stale_server.write_text("stale server log")
 
-    stale_epp = results_dir / "epp_logs" / "stale.log"
+    stale_epp = iter_dir / "epp_logs" / "stale.log"
     stale_epp.parent.mkdir(parents=True)
     stale_epp.write_text("stale epp log")
 
-    stale_gpu = results_dir / "gpu_logs" / "stale.log"
+    stale_gpu = iter_dir / "gpu_logs" / "stale.log"
     stale_gpu.parent.mkdir(parents=True)
     stale_gpu.write_text("stale gpu log")
 
@@ -1543,7 +1559,11 @@ def test_collect_skip_logs_clears_stale_log_dirs(tmp_path, monkeypatch):
     def mock_run(cmd, **kwargs):
         mock = MagicMock(returncode=0, stdout="", stderr="")
         cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
-        if "exec" in cmd_str and "ls" in cmd_str:
+        if "exec" in cmd_str and "ls " in cmd_str and "/wl-smoke/" in cmd_str:
+            # Second-level ls: list iteration subdirs under the workload
+            mock.stdout = "i1"
+        elif "exec" in cmd_str and "ls" in cmd_str:
+            # First-level ls: list workload subdirs under the phase
             mock.stdout = "wl-smoke"
         if "exec" in cmd_str and "stat" in cmd_str:
             mock.stdout = ""
@@ -1555,13 +1575,14 @@ def test_collect_skip_logs_clears_stale_log_dirs(tmp_path, monkeypatch):
         ["baseline"], "test-run", "ns-0", run_dir, skip_logs=True)
 
     assert not stale_server.exists()
-    assert not (results_dir / "server_logs").exists()
+    assert not (iter_dir / "server_logs").exists()
     assert not stale_epp.exists()
     assert not stale_gpu.exists()
 
 
 def test_collect_skip_logs_invokes_gpu_logs_copy(tmp_path, monkeypatch):
-    """--skip-logs path issues a kubectl cp for gpu_logs/ alongside epp_logs/."""
+    """--skip-logs path issues a kubectl cp for gpu_logs/ alongside epp_logs/,
+    scoped to each iteration subdirectory (post step-5 layout)."""
     from pipeline import deploy
     import subprocess
 
@@ -1579,7 +1600,9 @@ def test_collect_skip_logs_invokes_gpu_logs_copy(tmp_path, monkeypatch):
         mock = MagicMock(returncode=0, stdout="", stderr="")
         cmd_list = cmd if isinstance(cmd, list) else cmd.split()
         cmd_str = " ".join(cmd_list)
-        if "exec" in cmd_str and "ls" in cmd_str:
+        if "exec" in cmd_str and "ls " in cmd_str and "/wl-smoke/" in cmd_str:
+            mock.stdout = "i1"
+        elif "exec" in cmd_str and "ls" in cmd_str:
             mock.stdout = "wl-smoke"
         if "exec" in cmd_str and "stat" in cmd_str:
             mock.stdout = ""
@@ -1593,9 +1616,9 @@ def test_collect_skip_logs_invokes_gpu_logs_copy(tmp_path, monkeypatch):
         ["baseline"], "test-run", "ns-0", run_dir, skip_logs=True)
 
     sources = " ".join(cp_targets)
-    assert "/wl-smoke/gpu_logs/" in sources, f"no gpu_logs/ copy issued; saw: {cp_targets}"
-    assert "/wl-smoke/epp_logs/" in sources, f"sanity: epp_logs/ copy still issued; saw: {cp_targets}"
-    assert "/wl-smoke/gpu_stream_done" in sources, f"no gpu_stream_done sentinel copy; saw: {cp_targets}"
+    assert "/wl-smoke/i1/gpu_logs/" in sources, f"no i1/gpu_logs/ copy issued; saw: {cp_targets}"
+    assert "/wl-smoke/i1/epp_logs/" in sources, f"sanity: i1/epp_logs/ copy still issued; saw: {cp_targets}"
+    assert "/wl-smoke/i1/gpu_stream_done" in sources, f"no i1/gpu_stream_done sentinel copy; saw: {cp_targets}"
 
 
 def test_collect_idempotent_no_stale_accumulation(tmp_path, monkeypatch):
@@ -1826,7 +1849,13 @@ def test_extract_phases_filters_by_allowed_workloads_skip_logs(tmp_path, monkeyp
     def mock_run(cmd, **kwargs):
         mock = MagicMock(returncode=0, stdout="", stderr="")
         cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
-        if "exec" in cmd_str and "ls" in cmd_str:
+        if "exec" in cmd_str and "ls " in cmd_str and any(
+            f"/{w}/" in cmd_str for w in ("wl-smoke", "wl-load", "wl-heavy")
+        ):
+            # Second-level ls: list iteration subdirs under the workload
+            mock.stdout = "i1"
+        elif "exec" in cmd_str and "ls" in cmd_str:
+            # First-level ls: workload subdirs under the phase
             mock.stdout = "wl-smoke\nwl-load\nwl-heavy"
         elif "exec" in cmd_str and "stat" in cmd_str:
             mock.stdout = ""
@@ -1834,7 +1863,7 @@ def test_extract_phases_filters_by_allowed_workloads_skip_logs(tmp_path, monkeyp
             for wl in ("wl-smoke", "wl-load", "wl-heavy"):
                 if wl in cmd_str:
                     copied_workloads.append(wl)
-                    dest = run_dir / "results" / "baseline" / wl
+                    dest = run_dir / "results" / "baseline" / wl / "i1"
                     dest.mkdir(parents=True, exist_ok=True)
                     break
         return mock

--- a/pipeline/tests/test_pipeline_yaml.py
+++ b/pipeline/tests/test_pipeline_yaml.py
@@ -244,3 +244,48 @@ class TestPrepareResultsDirTask:
             "prepare-results-dir must have no runAfter so it runs as early as possible "
             "in the DAG and the wipe-and-create invariant holds before any writer starts."
         )
+
+
+class TestReplicaParamThreading:
+    """pipeline.yaml declares and threads the replica param through every
+    resultsDir writer, per step-5 (issue #511).
+    """
+
+    def _pipeline(self):
+        return yaml.safe_load(PIPELINE_YAML.read_text())
+
+    def test_declares_replica_param(self):
+        """Pipeline must declare a top-level 'replica' param, string, default '1'."""
+        pipeline = self._pipeline()
+        params = {p["name"]: p for p in pipeline["spec"]["params"]}
+        assert "replica" in params, "pipeline.yaml missing 'replica' param declaration"
+        assert params["replica"].get("type", "string") == "string"
+        assert params["replica"].get("default") == "1"
+
+    def test_every_results_dir_matches_canonical_template(self):
+        """Every resultsDir occurrence in pipeline.yaml must equal
+        tekton.RESULTS_DIR_TEMPLATE. This is the grep-audit-in-code that
+        catches a task quietly writing to the wrong (unversioned) path."""
+        from pipeline.lib.tekton import RESULTS_DIR_TEMPLATE
+        pipeline = self._pipeline()
+        for task in pipeline["spec"]["tasks"]:
+            for param in task.get("params", []):
+                if param["name"] == "resultsDir":
+                    assert param["value"] == RESULTS_DIR_TEMPLATE, (
+                        f"task {task['name']}.resultsDir = {param['value']!r} "
+                        f"but canonical is {RESULTS_DIR_TEMPLATE!r}"
+                    )
+
+    def test_results_dir_includes_replica_segment(self):
+        """Every resultsDir must reference $(params.replica) — a bare
+        assertion complementary to the template match, so a future edit
+        that changes the template shape without dropping the replica
+        segment still passes; a change that drops the segment fails
+        with a clearer message."""
+        pipeline = self._pipeline()
+        for task in pipeline["spec"]["tasks"]:
+            for param in task.get("params", []):
+                if param["name"] == "resultsDir":
+                    assert "$(params.replica)" in param["value"], (
+                        f"task {task['name']}.resultsDir does not thread replica"
+                    )

--- a/pipeline/tests/test_tekton.py
+++ b/pipeline/tests/test_tekton.py
@@ -264,3 +264,38 @@ def test_make_pipelinerun_scenario_iteration_explicit():
         iteration=5,
     )
     assert pr["metadata"]["name"] == "baseline-wl-r-i5"
+
+
+# ── Tests for build_results_dir + RESULTS_DIR_TEMPLATE ──────────────────────
+
+from pipeline.lib.tekton import build_results_dir, RESULTS_DIR_TEMPLATE
+
+
+def test_build_results_dir_returns_slash_joined_path():
+    assert build_results_dir("run1", "baseline", "chatbot-mid", 1) == "run1/baseline/chatbot-mid/i1"
+
+
+def test_build_results_dir_accepts_int_replica():
+    assert build_results_dir("r", "p", "w", 3) == "r/p/w/i3"
+
+
+def test_build_results_dir_accepts_str_replica():
+    """String replica must produce the same output — used for pipeline.yaml templating."""
+    assert build_results_dir("r", "p", "w", "3") == "r/p/w/i3"
+
+
+def test_results_dir_template_shape():
+    """The pipeline.yaml template must be exactly the shape build_results_dir
+    would produce if each segment were a Tekton param reference."""
+    assert RESULTS_DIR_TEMPLATE == "$(params.runName)/$(params.phase)/$(params.workloadName)/i$(params.replica)"
+
+
+def test_build_results_dir_matches_template_when_params_substituted():
+    """build_results_dir with Tekton-param strings reproduces the template
+    verbatim. This is the invariant test_pipeline_yaml.py will assert against
+    every resultsDir value in pipeline.yaml."""
+    template = build_results_dir(
+        "$(params.runName)", "$(params.phase)",
+        "$(params.workloadName)", "$(params.replica)",
+    )
+    assert template == RESULTS_DIR_TEMPLATE

--- a/pipeline/tests/test_tekton.py
+++ b/pipeline/tests/test_tekton.py
@@ -299,3 +299,36 @@ def test_build_results_dir_matches_template_when_params_substituted():
         "$(params.workloadName)", "$(params.replica)",
     )
     assert template == RESULTS_DIR_TEMPLATE
+
+
+# ── Tests for validate_pipelinerun_name ─────────────────────────────────────
+
+import pytest as _pytest
+from pipeline.lib.tekton import validate_pipelinerun_name
+
+
+def test_validate_pipelinerun_name_accepts_short():
+    validate_pipelinerun_name("baseline-wl-r-i1")  # no raise
+
+
+def test_validate_pipelinerun_name_accepts_253_char_limit():
+    """Exactly 253 chars is the DNS subdomain limit — must pass."""
+    name = "a" * 253
+    validate_pipelinerun_name(name)  # no raise
+
+
+def test_validate_pipelinerun_name_rejects_254_chars():
+    name = "a" * 254
+    with _pytest.raises(ValueError, match="253"):
+        validate_pipelinerun_name(name)
+
+
+def test_make_pipelinerun_scenario_rejects_oversized_name():
+    """Long run_name or workload should trip the validator at construction."""
+    long_run = "r" * 240
+    with _pytest.raises(ValueError, match="253"):
+        make_pipelinerun_scenario(
+            phase="baseline", workload={"name": "wl"}, run_name=long_run,
+            namespace="ns", pipeline_name="sim2real",
+            scenario_content="scenario: []",
+        )

--- a/pipeline/tests/test_tekton.py
+++ b/pipeline/tests/test_tekton.py
@@ -332,3 +332,30 @@ def test_make_pipelinerun_scenario_rejects_oversized_name():
             namespace="ns", pipeline_name="sim2real",
             scenario_content="scenario: []",
         )
+
+
+# ── Tests for the replica PipelineRun param ─────────────────────────────────
+
+
+def test_make_pipelinerun_scenario_emits_replica_param_default():
+    """Default iteration=1 → replica='1' in params (string, per Tekton API)."""
+    pr = make_pipelinerun_scenario(
+        phase="baseline", workload={"name": "wl"}, run_name="r",
+        namespace="ns", pipeline_name="sim2real",
+        scenario_content="scenario: []",
+    )
+    params = {p["name"]: p["value"] for p in pr["spec"]["params"]}
+    assert params["replica"] == "1"
+    assert isinstance(params["replica"], str)
+
+
+def test_make_pipelinerun_scenario_emits_replica_param_explicit():
+    """iteration=5 → replica='5'."""
+    pr = make_pipelinerun_scenario(
+        phase="baseline", workload={"name": "wl"}, run_name="r",
+        namespace="ns", pipeline_name="sim2real",
+        scenario_content="scenario: []",
+        iteration=5,
+    )
+    params = {p["name"]: p["value"] for p in pr["spec"]["params"]}
+    assert params["replica"] == "5"


### PR DESCRIPTION
Closes #511.

Part of epic #502 (step-5 — Replicas + iteration filtering). PR 3 of 6.

## Summary

Threads a `replica` PipelineRun param through `pipeline.yaml` so each iteration's results land under `runs/<R>/results/<phase>/<workload>/i<N>/`, and adds a fail-fast PipelineRun name-length validator. This unlocks step-5's N-replica dispatch (already possible via #521's assemble) writing to per-iteration directories, which #513 (`sim2real-check` iN/ traversal) then consumes.

## Changes

- **`pipeline/lib/tekton.py`**
  - New `RESULTS_DIR_TEMPLATE` constant + `build_results_dir(run, phase, workload, replica)` helper — single source of truth for the resultsDir template shape.
  - New `validate_pipelinerun_name(name)` — raises `ValueError` if `len(name) > 253` (RFC 1123 DNS-subdomain limit). Called from `make_pipelinerun_scenario` at PR-name construction, so an over-long run/workload combination fails at assemble time, not at Tekton admission.
  - `make_pipelinerun_scenario` now emits a `replica` PipelineRun param whose value is `str(iteration)` (Tekton has no int type).

- **`pipeline/pipeline.yaml`**
  - Adds pipeline-level `replica` param (`type: string`, `default: "1"`).
  - Threads `$(params.replica)` into `resultsDir` for every task that writes to results: `prepare-results-dir`, `stream-epp-logs`, `stream-gpu-stats`, `run-workload-blis-observe-binary`, `collect-results`. `resultsDir` shifts from `<run>/<phase>/<workload>` to `<run>/<phase>/<workload>/i<N>`.

- **Docs sweep** — `pipeline/README.md` and `CLAUDE.md` results-path references updated for the new `iN/` layer. Comprehensive doc coverage of `--replicas` / `--iteration` / additive-assemble semantics remains #514's scope (step-5 PR 6).

## Design decisions

1. **`replica` param baked into the PR YAML at assemble time**, not injected at dispatch. Each iteration already has its own pre-generated `pipelinerun-*.yaml` (from #521's assemble). `namespace` is dynamic per slot and must be rewritten at dispatch; `replica` is static per file and belongs in the YAML. This meets the issue's "pass `replica` as a PipelineRun param at dispatch" criterion trivially — the YAML that gets `kubectl apply`'d already carries it — and keeps `deploy.py:_cmd_run` untouched for the replica concern.

2. **`plans_dir` (pipeline.yaml line 100) stays per-workload.** `plans_dir` is the llm-d-benchmark plans directory (input), not results (output). Iterations reuse the same plans; no need to duplicate.

3. **`_apply_run_filters` iteration term** — already delivered in #520 (PR 4 landed before PR 3). No change needed.

4. **`_cmd_wipe` / `_cmd_collect` local paths unchanged.** `_cmd_collect` rsyncs the PVC tree transparently — new `iN/` layer appears in the destination without code change. `_cmd_wipe` deletes the whole `(pkg, wl)` subtree, which still works (removes all `iN/` under it). Per-iteration wipe (`wipe --iteration N` narrowing wipe to a specific iteration's subdir) is a UX concern deferred to a follow-up.

## Tests

- `pipeline/tests/test_tekton.py` — new tests for `build_results_dir`, `validate_pipelinerun_name`, oversized-name rejection, and the `replica` param on `make_pipelinerun_scenario` output.
- `pipeline/tests/test_pipeline_yaml.py::TestReplicaParamThreading` — asserts pipeline declares the `replica` param + every `resultsDir` in `pipeline.yaml` matches `RESULTS_DIR_TEMPLATE`. This is the grep-audit-in-code that catches drift when the YAML is edited by hand.

Full suite: **1487 passed, 2 xfailed** (no regressions). Ruff pyflakes clean.

## Acceptance checklist

- [x] N-replica assemble → N× PipelineRuns dispatched per (workload, phase) — already delivered by #521; each PR YAML now also carries `replica`.
- [x] Results land under `runs/R/results/<phase>/<workload>/iN/` — pipeline.yaml threading.
- [x] PR name > 253 chars → `validate_pipelinerun_name` raises before Tekton is contacted.
- [x] Grep audit of `resultsDir` in `pipeline.yaml` — captured in `TestReplicaParamThreading::test_every_results_dir_matches_canonical_template` (walks every task).
- [x] `replica` param dispatched as a string, not an int (Tekton API compat).
- [x] Rendered-pipeline test passes.
- [ ] Integration test: full 3-replica run against a real cluster. **Deferred** — no live-cluster fixture in CI. The rendered-pipeline test + assemble unit tests cover the shape end-to-end at unit level.

## Doc sweep

Grepped `pipeline/README.md`, `CLAUDE.md`, `docs/` for stale results paths. Updated:
- `pipeline/README.md` — collect destination, step-1 BYO success criterion, step-2 skill-driven success gate.
- `CLAUDE.md` — gpu_logs row in workspace-artifacts table.

Left untouched: step-1/step-2 design docs and proposals (historical; describe pre-step-5 world), the `deploy.py wipe` line (still functionally accurate at the `(pkg, wl)` level).

## Base

Merges into `refactor/v2-step-5` (epic branch), not `main`.
