### PR TITLE
fix(assemble): --force rebuilds run_dir on every existing-run branch (#532)

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -325,11 +325,13 @@ Then each treatment scenario has `router.epp.image` set from that algorithm's ow
 
 **Replicas.** `--replicas N` (default 1) is the number of iterations per (workload, package) pair. Each iteration gets its own PipelineRun (`{phase}-{workload}-{run}-iN`, with `_` → `-` normalization) and its own results subdirectory (`results/<phase>/<workload>/iN/`). `manifest.assembly.yaml` carries a top-level `replicas: N`, and `run_metadata.json` carries the same value as a schema field. Both are set on every assemble.
 
-**Additive-merge (grow-only).** Re-assembling an existing run with `--replicas` interacts with the prior state as follows:
+**Additive-merge (grow-only).** Re-assembling an existing run with `--replicas` interacts with the prior state as follows (without `--force`):
 
 - `N == prior_replicas` — true no-op. No files rewritten; the assemble returns silently.
 - `N > prior_replicas` — additive grow. Existing PipelineRun files (`i1..i{prior}`) are preserved byte-for-byte and by mtime; new files are emitted for `i{prior+1}..iN`. `manifest.assembly.yaml` and `run_metadata.json` are rewritten with the new `replicas` count; `params_hash` is preserved (drift check passed).
-- `N < prior_replicas` — refused with `run '<name>' already has <prior> replicas; refusing to shrink to <N>. Replica shrink is tracked in #506.` This guard runs BEFORE the drift check, so `--force` does NOT bypass it.
+- `N < prior_replicas` — refused with `run '<name>' already has <prior> replicas; refusing to shrink to <N>. Replica shrink is tracked in #506.` This guard runs BEFORE every other check, so `--force` does NOT bypass it.
+
+**`--force` behavior.** With `--force`, the run directory is rebuilt from scratch (`shutil.rmtree` followed by a fresh assemble) in every branch of the decision tree above except shrink. Specifically, `--force` bypasses the no-op path (`N == prior_replicas`) AND the additive-grow path (`N > prior_replicas`) — both do a full rebuild. Use `--force` when the assembler code itself has changed and the on-disk yamls need to be regenerated even though `transfer.yaml` and `--replicas` are unchanged. Shrink is still refused (tracked in #506).
 
 Two invariants shape the grow-only path:
 

--- a/pipeline/lib/assemble_run.py
+++ b/pipeline/lib/assemble_run.py
@@ -848,12 +848,27 @@ def assemble_run(
                         shutil.rmtree(run_dir)
                     else:
                         if replicas == prior_replicas:
-                            # True no-op: reset side-band attrs and return.
-                            assemble_run.skipped_algorithms = []  # type: ignore[attr-defined]
-                            assemble_run.missing_submodules = []  # type: ignore[attr-defined]
-                            return
-                        # replicas > prior_replicas: additive grow.
-                        additive_grow_from = prior_replicas
+                            if force:
+                                # --force overrides the true-no-op path so
+                                # operators can rebuild when the assembler
+                                # code has changed even though inputs did not.
+                                shutil.rmtree(run_dir)
+                            else:
+                                # True no-op: reset side-band attrs and return.
+                                assemble_run.skipped_algorithms = []  # type: ignore[attr-defined]
+                                assemble_run.missing_submodules = []  # type: ignore[attr-defined]
+                                return
+                        elif force:
+                            # replicas > prior_replicas with --force: full
+                            # rebuild rather than additive-grow. --force is
+                            # the "nuke and start over" escape hatch and
+                            # applies uniformly to every branch inside the
+                            # existing-run decision tree except shrink,
+                            # which is guarded above.
+                            shutil.rmtree(run_dir)
+                        else:
+                            # replicas > prior_replicas: additive grow.
+                            additive_grow_from = prior_replicas
 
     if additive_grow_from is not None:
         _additive_grow(

--- a/pipeline/tests/test_assemble_replicas.py
+++ b/pipeline/tests/test_assemble_replicas.py
@@ -119,6 +119,60 @@ class TestAssembleReplicas:
         mtimes_after = _mtimes([p for p in all_paths if p.is_file()])
         assert mtimes_before == mtimes_after
 
+    def test_reassemble_at_same_replica_count_with_force_rebuilds(self, tmp_path):
+        """Issue #532: --force must rebuild even when the manifest hash and
+        --replicas match the prior assemble. Counterpart to
+        test_reassemble_at_same_replica_count_is_noop — same setup, +force,
+        opposite mtime expectation."""
+        fx = _make_experiment(tmp_path, algo_names_registered=["sr"],
+                              algo_names_manifest=["sr"])
+        _assemble(fx, replicas=3, now_iso="2026-07-01T00:00:00Z")
+        run_dir = _run_dir_of(fx)
+        # Seed a sentinel to prove rmtree happened (bytes are byte-identical
+        # across the two calls when inputs match, so mtime is the only other
+        # signal we can rely on).
+        (run_dir / "sentinel").write_text("leftover")
+        time.sleep(0.01)
+        _assemble(fx, replicas=3, force=True,
+                  now_iso="2026-07-02T00:00:00Z")
+        assert not (run_dir / "sentinel").exists()
+        # Cluster/pipelinerun files present after rebuild.
+        names = _pipelinerun_files(_cluster_dir_of(fx))
+        assert "pipelinerun-wl-a|baseline|i3.yaml" in names
+        assert "pipelinerun-wl-a|sr|i3.yaml" in names
+        # manifest.assembly.yaml still records replicas=3.
+        ma = yaml.safe_load(
+            (run_dir / "manifest.assembly.yaml").read_text()
+        )
+        assert ma["replicas"] == 3
+
+    def test_grow_with_force_rebuilds_instead_of_additive_grow(self, tmp_path):
+        """Issue #532: --force with replicas > prior_replicas should do a
+        full rebuild, NOT additive-grow. Counterpart to
+        test_grow_from_3_to_5_preserves_i1_i3_and_adds_i4_i5 — same setup,
+        +force, opposite expectation for the pre-existing iterations."""
+        fx = _make_experiment(tmp_path, algo_names_registered=["sr"],
+                              algo_names_manifest=["sr"])
+        _assemble(fx, replicas=3, now_iso="2026-07-01T00:00:00Z")
+        run_dir = _run_dir_of(fx)
+        # Seed a sentinel to prove full rebuild (rmtree) rather than
+        # additive-grow (which would leave the sentinel in place).
+        (run_dir / "sentinel").write_text("leftover")
+        time.sleep(0.01)
+        _assemble(fx, replicas=5, force=True,
+                  now_iso="2026-07-02T00:00:00Z")
+        assert not (run_dir / "sentinel").exists()
+        # All five iterations present.
+        names = _pipelinerun_files(_cluster_dir_of(fx))
+        for i in (1, 2, 3, 4, 5):
+            assert f"pipelinerun-wl-a|baseline|i{i}.yaml" in names
+            assert f"pipelinerun-wl-a|sr|i{i}.yaml" in names
+        # manifest.assembly.yaml records new replicas.
+        ma = yaml.safe_load(
+            (run_dir / "manifest.assembly.yaml").read_text()
+        )
+        assert ma["replicas"] == 5
+
     def test_legacy_run_with_replicas_gt_1_refuses(self, tmp_path):
         """Existing run with no `replicas` field in manifest.assembly.yaml."""
         fx = _make_experiment(tmp_path, algo_names_registered=["sr"],


### PR DESCRIPTION
## Summary

Closes #532. Base: `refactor/v2`.

`sim2real assemble --force` silently no-op'd in two branches of the existing-run decision tree — same-hash + same-replicas (true no-op) and same-hash + grow-replicas (additive-grow). This PR makes `--force` uniformly rebuild the run directory (`shutil.rmtree` + fresh assemble) in every branch inside `if run_dir.exists():`. Only shrink is preserved; the shrink guard runs first and `--force` cannot bypass it (tracked in #506).

## Change surface

- `pipeline/lib/assemble_run.py` — inside `assemble_run()`, added `if force: shutil.rmtree(run_dir)` inside the equal-replicas branch (previously true-no-op return) and `elif force: shutil.rmtree(run_dir)` for the grow branch (previously always additive-grow). Existing behavior when `force=False` unchanged.
- `pipeline/tests/test_assemble_replicas.py` — two new tests:
  - `test_reassemble_at_same_replica_count_with_force_rebuilds` — counterpart to the existing `test_reassemble_at_same_replica_count_is_noop`, asserts sentinel file seeded between calls is deleted (proves `rmtree`) and iN files still present.
  - `test_grow_with_force_rebuilds_instead_of_additive_grow` — counterpart to `test_grow_from_3_to_5_preserves_i1_i3_and_adds_i4_i5`, uses the same sentinel technique to prove full rebuild vs additive-grow.
- `pipeline/README.md` — new "**`--force` behavior**" paragraph clarifying that `--force` bypasses no-op and additive-grow but not shrink. The pre-existing drift and legacy-run notes already covered `--force` for those two branches.

## Why this is a bug (not a feature request)

The pre-existing code already treated `--force` as "rmtree + rebuild" in the drift, corrupt-metadata, legacy-shape, and missing-metadata branches (see `pipeline/lib/assemble_run.py` around lines 796–848). The equal-replicas and additive-grow branches were the only ones that silently discarded `--force`. The README's line 351 already documented `--force` as "recursively deletes workspace/runs/<run>/ before re-materializing it" — the pre-fix code contradicted this. This PR aligns code with documented intent and closes the discovery gap.

## Reviewer attention

- The shrink guard at line 829 still runs before every other check, unconditionally. `test_shrink_with_force_and_drift_still_refuses` (pre-existing) covers this; no regression risk.
- The `if force: shutil.rmtree(run_dir)` inserted here duplicates a pattern that appears three other times in this function. A future cleanup could hoist the `--force` check to the top of `if run_dir.exists():` (after the shrink guard), collapsing five duplicated `rmtree` calls into one. Chose not to do that here to keep this fix surgical.
- Additive-grow-with-`--force` is now interpreted as "full rebuild", not "grow-with-side-effects". Per issue-scope comment: `--force` is the "I know what I'm doing, nuke it" escape hatch; silently routing to grow when the operator asked to rebuild is the same class of confusion as the equal-replicas no-op.

## Stale-reference sweep

Grepped for "true no-op", "no-op idempotence", "additive-grow", "--force" across `pipeline/`, `docs/`, `README.md`, and `.claude/skills/`:

- `pipeline/README.md:330` — updated. Added `--force` behavior paragraph and reframed the three-way listing as "without `--force`".
- `docs/epics/step-5/design.md:78,107,201` — accurate as historical design records; describes without-`--force` behavior which is unchanged. Not modified.
- `pipeline/lib/assemble_run.py:857` — my own edit. Comment "True no-op" is now inside the `else: force=False` branch, still accurate.
- `pipeline/tests/test_assemble_replicas.py:4` — module docstring says "no-op idempotence" among tested behaviors. Still true — the no-op path with `force=False` is unchanged and the new tests exercise the counterpart behavior.

## Test plan

- [x] `python -m pytest pipeline/tests/test_assemble_replicas.py -v` — 20 pass (2 new + 18 pre-existing).
- [x] `python -m pytest pipeline/` — 1555 pass, 2 xfailed, no regressions.
- [x] `ruff check pipeline/ --select F` — clean.