### PR TITLE
fix(sim2real-translate): update skill to current harness team/session API

### DIFF
--- a/.claude/skills/sim2real-translate/SKILL.md
+++ b/.claude/skills/sim2real-translate/SKILL.md
@@ -13,12 +13,11 @@ argument-hint: "[--experiment-root PATH] [--rounds N]"
 user-invocable: true
 allowed-tools:
   - Agent
-  - TeamCreate
-  - TeamDelete
   - SendMessage
   - TaskCreate
   - TaskUpdate
   - TaskList
+  - TaskStop
   - Bash(python3 *)
   - Bash(.venv/bin/python *)
   - Bash(cd * && *)
@@ -310,25 +309,19 @@ variable:
 - `{CONTEXT_TEXT}` → `$CONTEXT_TEXT`
 - `{CONTEXT_FILE_PATHS}` → `$CONTEXT_FILE_PATHS` (newline-separated absolute paths — one path per line)
 - `{EXPERT_AGENT_NAME}` → `"expert"`
-- `{MAIN_SESSION_NAME}` → `"main-session"`
-
-Create the team:
-```
-TeamCreate(team_name="translate-${TRANSLATION_HASH:0:12}-$ALGO_NAME",
-           description="sim2real expert+writer+reviewer for $ALGO_NAME")
-```
+- `{MAIN_SESSION_NAME}` → `"main"`
 
 **Spawn all three agents in a single tool-call message** so they start in
 parallel. Issue three Agent tool calls at once — do not wait between them:
 
-1. Agent(name="expert", team_name="translate-<prefix>-<algo>",
+1. Agent(name="expert",
          run_in_background=true, subagent_type=general-purpose, model="opus",
          prompt=<substituted agent-expert.md>)
-2. Agent(name="reviewer", team_name="translate-<prefix>-<algo>",
+2. Agent(name="reviewer",
          run_in_background=true, subagent_type=general-purpose, model="opus",
          prompt=<substituted agent-reviewer.md>)
-3. Agent(name="writer", team_name="translate-<prefix>-<algo>",
-         subagent_type=general-purpose, model="opus",
+3. Agent(name="writer",
+         run_in_background=true, subagent_type=general-purpose, model="opus",
          prompt=<substituted agent-writer.md>)
 
 All three start simultaneously. Expert and Reviewer initialize in the
@@ -416,16 +409,18 @@ Options:
   [q] Quit and investigate — reply with: quit
 ```
 
-- If `continue N`: bump `REVIEW_ROUNDS=$((REVIEW_ROUNDS + N))`, then spawn a
-  NEW writer agent with the updated value substituted. The reviewer is still
-  idle — it does not need to be restarted.
+- If `continue N`: bump `REVIEW_ROUNDS=$((REVIEW_ROUNDS + N))`, then stop the
+  current writer with `TaskStop(task_id="writer")` before spawning a NEW
+  writer agent with the updated value substituted (the harness silently
+  renames a second live `writer` to `writer-2`, and the reviewer would then
+  message the wrong one). The reviewer is still idle — it does not need to
+  be restarted.
 - If `accept`: proceed to Step 4 with `consensus='accepted_without_consensus'`.
 - If `quit`:
   ```
-  SendMessage("writer", "shutdown")
-  SendMessage("reviewer", "shutdown")
-  SendMessage("expert", "shutdown")
-  TeamDelete()
+  TaskStop(task_id="writer")
+  TaskStop(task_id="reviewer")
+  TaskStop(task_id="expert")
   ```
   Skip to the next algorithm in the loop (or exit if none remain).
 
@@ -481,12 +476,12 @@ print(f"Verified {algo}: plugin_type={o['plugin_type']}, "
 PY
 ```
 
-Shut down the team:
+Shut down the team so the agent names are freed before the next algorithm's
+spawn:
 ```
-SendMessage("writer", "shutdown")
-SendMessage("reviewer", "shutdown")
-SendMessage("expert", "shutdown")
-TeamDelete()
+TaskStop(task_id="writer")
+TaskStop(task_id="reviewer")
+TaskStop(task_id="expert")
 ```
 
 Loop to the next algorithm in `$INCOMPLETE_ALGOS`.


### PR DESCRIPTION
## Summary

Update `sim2real-translate` skill to the current Claude Code harness API. Four fixes from the issue plus one additional agent-name-collision fix caught during implementation, all in a single file. Closes #482.

## Changes (all in `.claude/skills/sim2real-translate/SKILL.md`)

1. **Drop deprecated team API.** Remove `TeamCreate` / `TeamDelete` from allowed-tools; drop the `TeamCreate(...)` call and the `team_name=...` arg on all three `Agent()` spawns. The harness now says: *"team_name — Deprecated; ignored. The session has a single implicit team."*

2. **Fix parent-session address.** `{MAIN_SESSION_NAME}` substitution changed from `"main-session"` (invalid recipient) to `"main"` per current `SendMessage` docs.

3. **Free agent names between algorithms.** Replace the two shutdown blocks (`SendMessage("*", "shutdown")` x3 + `TeamDelete()`) with `TaskStop(task_id="writer"/"reviewer"/"expert")`. The `SendMessage("*", "shutdown")` calls were dead code — no prompt file listens for that message. `TaskStop` is the actual stopping mechanism.

4. **Also fix name collision inside a single algorithm's "continue N more rounds" branch.** Previously spawned a new writer without stopping the old one, so the second would be silently renamed `writer-2` and the reviewer's outgoing messages to `writer` would land in the wrong inbox. Added `TaskStop(task_id="writer")` before the respawn.

5. **Make writer's background execution explicit.** Writer's `Agent()` call now has `run_in_background=true` (previously omitted; worked only because the harness default is now background).

## Reviewer attention

- **Prompt files intentionally unchanged.** The only `{*_AGENT_NAME}` placeholder used anywhere is `{EXPERT_AGENT_NAME}` (writer and reviewer both send queries to the expert). No `{REVIEWER_AGENT_NAME}` or `{WRITER_AGENT_NAME}` placeholder exists in any prompt. Issue's option A (`TaskStop` between algos → names freed → next spawn gets clean `writer`/`reviewer`/`expert` names) is sufficient without adding new substitutions.
- **`SendMessage("*", "shutdown")` calls removed alongside `TeamDelete()`.** Grep confirmed no prompt file references `"shutdown"` as a signal to handle — the messages were being sent into a void. If future prompts want a shutdown signal, adding it back is one line.
- **`team_name=...` removal on `Agent()` calls.** Coherent with the team-API deletion. The arg still parses (harness ignores it silently), but keeping stale-but-tolerated arguments invites the same drift confusion this PR is fixing.

## Sweep for stale references

Grep across `.claude/`, `pipeline/`, `docs/`, `CLAUDE.md`, `README.md` for `TeamCreate`, `TeamDelete`, `main-session`: zero hits outside this PR. Prompt files (`prompts/agent-*.md`) reference only `{EXPERT_AGENT_NAME}` and no team API.

## Test plan

- [x] `python -m pytest .claude/skills/sim2real-translate/tests/ -v` — 37 passed.
- [x] `ruff check pipeline/ .claude/skills/ --select F` — clean.
- [ ] Field verification: run `/sim2real-translate` against a multi-algorithm experiment; confirm no orphan agents remain after the skill completes; confirm agent names don't drift to `writer-2` / `expert-2` across algorithms.

Closes #482
