### PR TITLE
feat(translate): surface alias alongside hash in stdout messages

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -211,7 +211,7 @@ Two-phase state machine — the operator picks the lane explicitly (plain vs `--
 |---|---|---|---|
 | Absent | Create dir, write `skill_input.json` + `translation_output.json` with `image_ref: null`. Print checkpoint. Exit 0. | Error: `no translation to resume`. Exit 2. | Same as plain. |
 | Partial (checkpoint files present, some `generated/<algo>/<algo>_output.json` missing) | Error: `translation incomplete — run '/sim2real-translate' then 'translate --resume'`. Exit 2. Never mutates. | Reports missing algorithms by name. Exit 2. Never mutates. | Delete + recreate as if absent. |
-| Complete (all `<algo>_output.json` present) | Print `translation already complete — run 'sim2real build' next` and exit 0. | Same. | Delete + recreate; operator re-runs the skill. |
+| Complete (all `<algo>_output.json` present) | Print `translation <hash> (alias: <alias>) already complete — run 'sim2real build --translation <alias>' next` and exit 0. | Print `translation <hash> (alias: <alias>) complete — run 'sim2real build --translation <alias>' next` and exit 0. | Delete + recreate; operator re-runs the skill. |
 
 The translation hash is derived from `transfer.yaml`'s translation slice (scenario, component, context, per-algorithm sources) plus the SHA-256 of each `algorithms[i].source` file's bytes (see `pipeline/lib/slicer.py:translation_hash_with_sources`). Two runs of `translate` with the same `transfer.yaml` and the same source files produce the same hash and reuse the same `translations/<hash>/` directory.
 

--- a/pipeline/sim2real.py
+++ b/pipeline/sim2real.py
@@ -919,7 +919,10 @@ def _cmd_translate(args) -> int:
                 file=sys.stderr,
             )
             return 2
-        print(f"translation {thash} already complete — run 'sim2real build' next")
+        print(
+            f"translation {thash} (alias: {scenario}) complete — "
+            f"run 'sim2real build --translation {scenario}' next"
+        )
         return 0
 
     if args.force:
@@ -940,7 +943,10 @@ def _cmd_translate(args) -> int:
         )
         return 2
     if state == "complete":
-        print(f"translation {thash} already complete — run 'sim2real build' next")
+        print(
+            f"translation {thash} (alias: {scenario}) already complete — "
+            f"run 'sim2real build --translation {scenario}' next"
+        )
         return 0
     return _translate_write_checkpoint(
         thash=thash,
@@ -1040,7 +1046,7 @@ def _translate_write_checkpoint(
     _atomic_write_json(tdir / "skill_input.json", skin)
 
     print(
-        f"translation {thash} checkpoint written — "
+        f"translation {thash} (alias: {scenario}) checkpoint written — "
         f"run '/sim2real-translate' then 'sim2real translate --resume'"
     )
     return 0

--- a/pipeline/tests/test_translate.py
+++ b/pipeline/tests/test_translate.py
@@ -379,6 +379,9 @@ class TestTranslateEmpty:
         _run_translate([])
         out = capsys.readouterr().out
         assert "/sim2real-translate" in out
+        assert "(alias: softreflective-v1)" in out
+        assert "checkpoint written" in out
+        assert "sim2real translate --resume" in out
 
     def test_force_behaves_like_plain(self, tmp_path):
         _write_manifest(tmp_path)
@@ -460,13 +463,20 @@ class TestTranslateComplete:
         assert _run_translate([]) == 0
         out = capsys.readouterr().out
         assert "already complete" in out
+        assert "(alias: softreflective-v1)" in out
+        assert "sim2real build --translation softreflective-v1" in out
 
     def test_resume_prints_already_complete(self, tmp_path, capsys):
         self._setup_complete(tmp_path)
         capsys.readouterr()
         assert _run_translate(["--resume"]) == 0
         out = capsys.readouterr().out
-        assert "already complete" in out
+        # Resume-on-complete uses "complete" (validation passed) rather than
+        # "already complete" (which is the plain-on-complete idempotent case);
+        # see issue #483 for the deliberate wording split.
+        assert "complete" in out
+        assert "(alias: softreflective-v1)" in out
+        assert "sim2real build --translation softreflective-v1" in out
 
     def test_force_recreates_and_clears_algo_outputs(self, tmp_path):
         thash = self._setup_complete(tmp_path)

--- a/pipeline/tests/test_translate.py
+++ b/pipeline/tests/test_translate.py
@@ -473,8 +473,11 @@ class TestTranslateComplete:
         out = capsys.readouterr().out
         # Resume-on-complete uses "complete" (validation passed) rather than
         # "already complete" (which is the plain-on-complete idempotent case);
-        # see issue #483 for the deliberate wording split.
+        # see issue #483 for the deliberate wording split. The negative
+        # assertion guards against a silent regression to "already complete"
+        # that the substring-only `"complete" in out` check would miss.
         assert "complete" in out
+        assert "already complete" not in out
         assert "(alias: softreflective-v1)" in out
         assert "sim2real build --translation softreflective-v1" in out
 


### PR DESCRIPTION
## Summary

Update `sim2real translate` stdout to surface the alias (== `transfer.yaml:scenario`) alongside the hash in all three state messages, and change the "next command" hint to use `sim2real build --translation <alias>` so it's copy-pasteable rather than just a status report. Closes #483.

## Changes

- **`pipeline/sim2real.py`** — three print sites updated:
  - **Checkpoint written** (initial `translate`): `translation <hash> (alias: <scenario>) checkpoint written — run '/sim2real-translate' then 'sim2real translate --resume'`
  - **`--resume` on complete state**: `translation <hash> (alias: <scenario>) complete — run 'sim2real build --translation <scenario>' next`
  - **Plain on complete state (idempotent)**: `translation <hash> (alias: <scenario>) already complete — run 'sim2real build --translation <scenario>' next`
- **`pipeline/tests/test_translate.py`** — three named tests updated to assert the alias appears in stdout and the "next command" hint uses `--translation <alias>`:
  - `test_plain_prints_checkpoint_message`
  - `test_plain_prints_already_complete`
  - `test_resume_prints_already_complete`
- **`pipeline/README.md`** — Complete-state row of the translate state table shows the per-column messages verbatim with alias placeholder.

## Reviewer attention

- **Wording split between plain and `--resume` on complete state is deliberate** per the issue spec: plain says "already complete" (idempotent no-op); `--resume` says "complete" (validation passed). The `test_resume_prints_already_complete` test name refers to the *state* being validated (state was already complete when `--resume` ran), not the message text — kept as-is; the test now asserts `"complete"` rather than `"already complete"` with a comment explaining the deliberate difference.
- **Alias == scenario**: `_cmd_translate` reads `scenario = manifest.get("scenario")` at line 831 and passes it to `_translate_write_checkpoint`. It's in scope at all three print sites. Alias validation and cross-hash uniqueness (`translation_ref.find_by_alias`) already run earlier in the flow, so the value printed matches what is stored in `translation_output.json:alias`.
- **`--translation <alias>` hint is valid**: `sim2real build`'s `--translation` flag accepts alias / hash-prefix / full hash via `translation_ref.resolve_translation_ref`. The hint text isn't a docs-only claim.
- **No schema or on-disk changes**: `translation_output.json` is unchanged; the alias is only surfaced in stdout.

## Sweep for stale references

Grepped `pipeline/`, `.claude/`, `docs/`, `README.md`, `CLAUDE.md` for `already complete`, `checkpoint written — run`, and `complete — run 'sim2real build'`:

- `.claude/skills/sim2real-translate/SKILL.md:232, 245` — different code path (skill-side idempotency check with its own message advising `sim2real translate --resume` after the skill run). Left unchanged.
- `docs/epics/step-2/design.md:268, 293` — historical design record describing pre-#483 spec. Left unchanged (matches step-5 design.md precedent from prior PRs — historical design records are not living source of truth).
- `docs/superpowers/plans/2026-07-02-issue-467-sim2real-translate.md:18` — historical implementation plan. Left unchanged.

## Test plan

- [x] `python -m pytest pipeline/tests/test_translate.py -v` — 33 passed.
- [x] `python -m pytest pipeline/` — 1555 passed, 2 xfailed (baseline).
- [x] `ruff check pipeline/ .claude/skills/ --select F` — clean.

Closes #483
