### PR TITLE
docs: refresh transfer.yaml v3 fields block to component: shape (fixes #402)

### DIFF
--- a/docs/superpowers/plans/2026-07-08-issue-402-readme-transfer-schema.md
+++ b/docs/superpowers/plans/2026-07-08-issue-402-readme-transfer-schema.md
@@ -1,0 +1,79 @@
+# Issue 402: Refresh stale transfer.yaml schema block in pipeline/README.md
+
+**Goal:** Replace the stale `target:` / `config:` / `build:` / `epp_image:` block in `pipeline/README.md` (currently lines 756-771) with the `component:` shape the loader (`pipeline/lib/manifest.py:171-233`) has actually required since PR #109 landed on 2026-05-12.
+
+**Architecture:** One-file docs change. No code, no tests to add — the validation is that a `transfer.yaml` copy-authored from the fixed schema block loads cleanly through `pipeline/lib/manifest.py:load_manifest` with `algorithms:` populated.
+
+## Global Constraints
+
+- The schema block MUST reflect what `pipeline/lib/manifest.py:171-233` actually accepts:
+  - `component.repo`: required, string.
+  - `component.kind`: required, string.
+  - `component.path`: optional, string; defaults to the last segment of `repo` when absent.
+  - `component.ref`: optional, non-empty string.
+  - `component.base_image`: optional, mapping requiring `hub` and `name` — NO `tag` field (image tags now come from `translation_output.json:algorithms[i].image_ref`, per #403).
+  - `component.build`: optional, mapping; `commands` list; `build.image` optional mapping with `hub` required (defaults from `base_image.hub` if present).
+- `component:` itself is REQUIRED when at least one algorithm entry omits `byo: true`; optional for all-BYO manifests. This nuance is stated in prose at README:37 and README:48 and must be reflected in the schema block's inline comment.
+- Preserve the `pipeline:` block (README:772-774) and the `blis_observe:` block (README:776-781) that follow — both are current and correct.
+- Do NOT restructure the rest of the schema example (kind, version, scenario, baselines, algorithms, workloads, context, defaults) — those parts are still accurate.
+- No changes to code, tests, or other docs unless the sweep in Step 3 uncovers a stale reference tied to the four removed top-level keys (`target`, `config`, `build`, `epp_image`).
+
+## Acceptance criteria (from #402)
+
+- [x] The "v3 fields" block in `pipeline/README.md` describes `component:` (and its sub-fields) instead of `target:` / `config:` / `epp_image:`.
+- [x] A `transfer.yaml` authored against the README, with `algorithms:` populated, loads cleanly through `pipeline/lib/manifest.py:load_manifest` (no `Missing required field` errors, no silently-ignored fields).
+
+---
+
+## Task 1: Replace the stale block
+
+**File:** `pipeline/README.md` (worktree copy only)
+
+Replace lines 756-771 (the `# v3 fields (required unless noted)` header plus the four stale sub-blocks) with the following, in the same commenting/indentation style as the neighboring `baselines:` and `algorithms:` blocks:
+
+```
+# v3 fields (required unless noted)
+component:                    # required when algorithms[] contains any non-BYO entry;
+                              # optional if every algorithm carries `byo: true`.
+  repo: <name>                # component repo name (matches submodule directory in the sim2real repo)
+  kind: <string>              # component kind (e.g. "EndpointPickerConfig")
+  path: <string>              # optional — defaults to the last segment of `repo`
+  ref: <string>               # optional — tag, branch, or commit SHA identifying the expected component version
+  base_image:                 # optional — base image the built EPP layers on top of
+    hub: <registry>           # e.g. ghcr.io/llm-d
+    name: <repo>              # e.g. llm-d-inference-scheduler
+  build:                      # optional — build overrides
+    commands: []              # component build commands (list of argv-style commands)
+    image:                    # optional — override coords for the built EPP image
+      hub: <registry>         # defaults to base_image.hub when set
+      name: <repo>            # defaults to base_image.name when set
+```
+
+Do NOT touch the surrounding lines. Specifically preserve:
+- The empty line separating the schema block from the `defaults:` block above.
+- The `pipeline:` block (currently at 772-774).
+- The `blis_observe:` block (currently at 776-781).
+- The closing ``` fence and the prose after it (currently at 784+), including the sentence at line 786 ("`component.ref` (optional): tag, branch, or commit SHA ...") — that sentence is now redundant with the schema comment but leaving it alone avoids scope creep.
+
+## Task 2: Verify the acceptance criterion
+
+Write a minimal `transfer.yaml` matching the fixed schema block (with all required fields present) to `/tmp` and load it through `pipeline/lib/manifest.py:load_manifest`. Assert no exception is raised and that `component.repo`, `component.kind`, and every algorithm are present in the loaded dict.
+
+## Task 3: Sweep for stale references
+
+Grep for the four removed top-level keys across `**/*.md` and `docs/`:
+
+```bash
+grep -rn "^target:" docs/ *.md **/*.md 2>/dev/null
+grep -rn "^epp_image:" docs/ *.md **/*.md 2>/dev/null
+grep -rn "epp_image\|target:\s*$\|config:\s*$" pipeline/README.md CLAUDE.md docs/ .claude/skills/ 2>/dev/null
+```
+
+For each hit, decide: stale (update in this PR), still accurate (leave), unrelated (leave). Bare `config:` / `build:` hits are noise (they collide with many YAML keys); look at context before flagging. Note in the PR body what was swept and what changed.
+
+## Task 4: Commit, push, open PR
+
+Single commit. Message body: reference #402, note that #109 introduced the drift and this brings the README back in sync.
+
+PR title: `docs: refresh transfer.yaml v3 fields block to component: shape (fixes #402)`.
+PR body: reference #402 with `Closes #402`, summarize the swap, note the sweep result, and — if anything besides `pipeline/README.md` changed — call it out.

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -754,21 +754,20 @@ defaults:                   # optional — controls framework defaults overlay
                             # docs/troubleshooting.md#framework-defaults-overlay.
 
 # v3 fields (required unless noted)
-target:
-  repo: <path>              # llm-d-inference-scheduler repo path
-config:
-  kind: <string>            # config kind (e.g. "gaie")
-build:                      # optional — defaults applied if absent
-  commands: []              # EPP build commands
-epp_image:                  # optional
-  upstream:
-    hub: <registry>
-    name: <repo>
-    tag: <tag>
-  build:                    # override for built EPP image coordinates
-    hub: <registry>
-    name: <repo>
-    tag: <tag>
+component:                    # required when algorithms[] contains any non-BYO entry;
+                              # optional if every algorithm carries `byo: true`.
+  repo: <name>                # component repo name (matches submodule directory in the sim2real repo)
+  kind: <string>              # component kind (e.g. "EndpointPickerConfig")
+  path: <string>              # optional — defaults to the last segment of `repo`
+  ref: <string>               # optional — tag, branch, or commit SHA identifying the expected component version
+  base_image:                 # optional — base image the built EPP layers on top of
+    hub: <registry>           # e.g. ghcr.io/llm-d
+    name: <repo>              # e.g. llm-d-inference-scheduler
+  build:                      # optional — build overrides
+    commands: []              # component build commands (list of argv-style commands)
+    image:                    # optional — override coords for the built EPP image
+      hub: <registry>         # defaults to base_image.hub when set
+      name: <repo>            # defaults to base_image.name when set
 pipeline:                   # optional — defaults applied if absent
   name: sim2real            # Pipeline resource name referenced in PipelineRuns (default: "sim2real")
   yaml: pipeline/pipeline.yaml  # path relative to repo root (default: "pipeline/pipeline.yaml")


### PR DESCRIPTION
Closes #402.

## Summary

`pipeline/README.md`'s "v3 fields" schema block still documented the four
top-level sections (`target:` / `config:` / `build:` / `epp_image:`) that
PR #109 (2026-05-12, `9a50df2`) consolidated into `component:`. The loader
`pipeline/lib/manifest.py:171-233` was updated at the time; the README was
not, and has been touched 42 times since without anyone catching the drift.

This PR replaces the stale block with the `component:` shape the loader
actually accepts today.

## What changed

`pipeline/README.md:756-770` — swapped in the `component:` block, matching
the fields validated by `pipeline/lib/manifest.py`:

- `component.repo` (required)
- `component.kind` (required)
- `component.path` (optional, defaults from last segment of `repo`)
- `component.ref` (optional; tag, branch, or commit SHA)
- `component.base_image` (optional; `hub` + `name`)
- `component.build` (optional; `commands` list + optional `build.image`)

The `pipeline:` and `blis_observe:` blocks that immediately follow were
preserved verbatim — both are current.

## Verification

Authored a minimal `transfer.yaml` from the fixed schema block (with
`algorithms:` populated) and loaded it through
`pipeline/lib/manifest.py:load_manifest`. No `Missing required field`
errors, no silently-ignored fields; `component.path` auto-defaulted from
`component.repo` as designed. This satisfies both acceptance criteria on
#402.

## Stale-doc sweep

Swept `docs/`, `.claude/skills/`, `CLAUDE.md`, and `pipeline/README.md`
for `target:` / `epp_image` / `config:` / `build:` at line-start and
inside prose:

- `docs/epics/step-2/design.md` — 5 references to
  `transfer.yaml:epp_image.build.{hub,name}`. Already flagged as
  aspirational-and-superseded in
  `docs/superpowers/plans/2026-07-02-issue-469-sim2real-build.md:17`;
  design doc is a historical record. Left alone — updating retroactively
  would rewrite history and is out of scope for this fix.
- Historical `docs/superpowers/plans/2026-06-04-issue-191*.md`,
  `2026-06-21-issue-365*.md`, `2026-06-30-issue-424*.md` — all reference
  `run_metadata.json:epp_image` (a **different** field, later renamed to
  `component_image` in PR #109). Historical plan records; out of scope.
- `CLAUDE.md:92`, `pipeline/README.md:694` — references to
  `inject_epp_image`, the Python helper in `pipeline/lib/epp.py`.
  Function name, unrelated to schema. Left alone.

Only `pipeline/README.md` needed updating.

## Notes

- Plan doc for this change checked in at
  `docs/superpowers/plans/2026-07-08-issue-402-readme-transfer-schema.md`.
- Meta-observation from the issue (a CI check that would prevent this
  class of doc-code drift) remains out of scope. The 2026-05-12 CLAUDE.md
  rule requiring README updates alongside `pipeline/` changes existed
  when #109 landed and would have caught this, had it been enforced.

## Test plan

- [x] Manifest loader accepts a `transfer.yaml` authored against the new
      schema (verified inline; see Verification above).
- [x] No code changes; existing test suite unaffected.