### PR TITLE
feat(sim2real-check): detect llm-d-router and BLIS via SIM2REAL

### DIFF
--- a/.claude/skills/sim2real-check/SKILL.md
+++ b/.claude/skills/sim2real-check/SKILL.md
@@ -154,9 +154,11 @@ fi
 Regardless of which mode-dispatch branch ran, the checks below need four additional variables — `SIM` (the simulation bundle), `BLIS` (the simulator codebase), `GAIE` (the gateway-api-inference-extension codebase), and `LLMD` (the llm-d-router codebase). The mode-dispatch block does not populate them. Run this detection *after* the mode dispatch completes, in every mode, using the same predicates as the pre-refactor skill:
 
 - **Sim bundle** (`SIM`): if `--sim` was passed, use it verbatim. Otherwise scan `$EXPERIMENT_ROOT/experiments/*/` for directories containing `README.md` + `algorithm/` + `workloads/`. First match wins. Common patterns: `sim2real_bundle*`, `sim2real_*bundle*`. Leave unset if no candidate is found.
-- **BLIS codebase** (`BLIS`): first try `$SIM2REAL_ROOT/inference-sim` — the framework repo's own BLIS submodule (`.gitmodules`) — if `$SIM2REAL_ROOT` is set and that directory contains `sim/` + `go.mod`. Fall back to the current working directory if it contains `sim/` + `go.mod`, otherwise search `../` and `tmp/` for a directory with the same shape.
-- **GAIE codebase** (`GAIE`): look for `gateway-api-inference-extension` under `tmp/`, `../`, or nearby. If not found and `LLMD` (below) resolves to an `llm-d-router` checkout, set `GAIE` to that same path — `gateway-api-inference-extension` has been merged into `llm-d-router`, so the router codebase serves both roles.
+- **BLIS codebase** (`BLIS`): first derive `$SIM2REAL_ROOT` inline via the same discovery Step 0.5 uses (`python -c 'from pipeline.lib import layout; import pathlib; print(pathlib.Path(layout.__file__).resolve().parents[2])'`); then try `$SIM2REAL_ROOT/inference-sim` — the framework repo's own BLIS submodule (`.gitmodules`) — if that directory contains `sim/` + `go.mod`. Fall back to the current working directory if it contains `sim/` + `go.mod`, otherwise search `../` and `tmp/` for a directory with the same shape.
+- **GAIE codebase** (`GAIE`): look for `gateway-api-inference-extension` under `tmp/`, `../`, or nearby.
 - **llm-d router** (`LLMD`): look for `llm-d-router` under `tmp/`, `../`, or nearby. (Legacy `llm-d-inference-scheduler` checkouts are no longer detected — that project has been sunset in favor of `llm-d-router`.)
+
+After all four variables have been resolved, apply this GAIE alias: **if `GAIE` is unset and `LLMD` points at an `llm-d-router` checkout, set `GAIE=$LLMD`**. `gateway-api-inference-extension` has been merged into `llm-d-router`, so the router codebase serves both roles when no standalone `gateway-api-inference-extension` checkout is on disk.
 
 **Required vs. optional at check time:**
 

--- a/.claude/skills/sim2real-check/SKILL.md
+++ b/.claude/skills/sim2real-check/SKILL.md
@@ -151,12 +151,12 @@ fi
 
 ### Auxiliary detection (all modes)
 
-Regardless of which mode-dispatch branch ran, the checks below need four additional variables — `SIM` (the simulation bundle), `BLIS` (the simulator codebase), `GAIE` (the gateway-api-inference-extension codebase), and `LLMD` (the llm-d-inference-scheduler codebase). The mode-dispatch block does not populate them. Run this detection *after* the mode dispatch completes, in every mode, using the same predicates as the pre-refactor skill:
+Regardless of which mode-dispatch branch ran, the checks below need four additional variables — `SIM` (the simulation bundle), `BLIS` (the simulator codebase), `GAIE` (the gateway-api-inference-extension codebase), and `LLMD` (the llm-d-router codebase). The mode-dispatch block does not populate them. Run this detection *after* the mode dispatch completes, in every mode, using the same predicates as the pre-refactor skill:
 
 - **Sim bundle** (`SIM`): if `--sim` was passed, use it verbatim. Otherwise scan `$EXPERIMENT_ROOT/experiments/*/` for directories containing `README.md` + `algorithm/` + `workloads/`. First match wins. Common patterns: `sim2real_bundle*`, `sim2real_*bundle*`. Leave unset if no candidate is found.
-- **BLIS codebase** (`BLIS`): current working directory if it contains `sim/` + `go.mod`; otherwise search `../` and `tmp/` for a directory with the same shape.
-- **GAIE codebase** (`GAIE`): look for `gateway-api-inference-extension` under `tmp/`, `../`, or nearby.
-- **llm-d scheduler** (`LLMD`): look for `llm-d-inference-scheduler` under `tmp/`, `../`, or nearby.
+- **BLIS codebase** (`BLIS`): first try `$SIM2REAL_ROOT/inference-sim` — the framework repo's own BLIS submodule (`.gitmodules`) — if `$SIM2REAL_ROOT` is set and that directory contains `sim/` + `go.mod`. Fall back to the current working directory if it contains `sim/` + `go.mod`, otherwise search `../` and `tmp/` for a directory with the same shape.
+- **GAIE codebase** (`GAIE`): look for `gateway-api-inference-extension` under `tmp/`, `../`, or nearby. If not found and `LLMD` (below) resolves to an `llm-d-router` checkout, set `GAIE` to that same path — `gateway-api-inference-extension` has been merged into `llm-d-router`, so the router codebase serves both roles.
+- **llm-d router** (`LLMD`): look for `llm-d-router` under `tmp/`, `../`, or nearby. (Legacy `llm-d-inference-scheduler` checkouts are no longer detected — that project has been sunset in favor of `llm-d-router`.)
 
 **Required vs. optional at check time:**
 
@@ -212,7 +212,7 @@ Manifest assembly path:          <path or "(legacy mode)">
 Cluster config path:             <path or "(legacy mode)">
 BLIS codebase:                   <path or "(not found)">
 GAIE codebase:                   <path or "(not found)">
-llm-d scheduler (LLMD):          <path or "(not found)">
+llm-d-router (LLMD):             <path or "(not found)">
 Workload filter (WORKLOAD):      <name or "(all)">
 ```
 
@@ -359,7 +359,7 @@ For numerical checks, always show a comparison table. For code/config checks, sh
 
 - **Simulation codebase** (`BLIS`): confirmed by user
 - **GAIE codebase** (`GAIE`): confirmed by user
-- **llm-d scheduler** (`LLMD`): confirmed by user
+- **llm-d router** (`LLMD`): confirmed by user
 - **Sim bundle** (`SIM`): `$SIM/README.md`, `$SIM/config.md`, `$SIM/algorithm/`, `$SIM/workloads/`, `$SIM/results/`
 - **Configs directory** (`CONFIGS_DIR`): Go plugins + YAML configs. In resolve-mode this is the translation's `generated/` dir under `workspace/translations/<hash>/`; in legacy-mode it's `$REAL/generated/`.
 - **Results directory** (`RESULTS_DIR`): per-phase workload data. **Do not iterate `$PHASES` × `${WORKLOADS_BY_PHASE[$phase]}` directly** — iterate the `PRESENT` rows in `$ENUM_JSON` (see Step 0.5) and use each row's `results_dir` field as the working path. In replica-shape runs (`SHAPE=replica`) `results_dir` is `$RESULTS_DIR/<phase>/<workload>/i<N>/`; in legacy-shape runs (`SHAPE=legacy`) it is `$RESULTS_DIR/<phase>/<workload>/`. Each `results_dir` contains `trace_header.yaml`, `trace_data.csv`, `server_logs/`, `epp_logs/`, `gpu_logs/`, `epp_stream_done`.


### PR DESCRIPTION
## Summary

Update `sim2real-check`'s auxiliary-detection step to match the current deployment reality — `llm-d-inference-scheduler` has been sunset in favor of `llm-d-router` (which has absorbed `gateway-api-inference-extension`), and this framework repo carries its own BLIS via the `inference-sim` submodule. Closes #494.

## Changes (single file: `.claude/skills/sim2real-check/SKILL.md`)

1. **`LLMD` auto-detect** (line 159): search `llm-d-router` only. Legacy `llm-d-inference-scheduler` fallback removed.
2. **`GAIE` auto-detect** (line 158): still tries standalone `gateway-api-inference-extension` first, but when that's absent and `LLMD` resolves, `GAIE` is set to the same router path. `gateway-api-inference-extension` has been merged into `llm-d-router`, so the router codebase serves both roles when consolidated.
3. **`BLIS` auto-detect** (line 157): new first choice `$SIM2REAL_ROOT/inference-sim` — the framework repo's own BLIS submodule (see `.gitmodules`). Existing predicates (cwd with `sim/` + `go.mod`, then `../`, then `tmp/`) become fallbacks.
4. **Labels** (lines 154, 215, 362): "llm-d scheduler" → "llm-d router" / "llm-d-router" in the variable description, confirmation prompt row, and reference-paths section.

## Reviewer attention

- **Amendment from user overrides the issue's original fallback design.** The issue as filed proposed adding `llm-d-router` as a fallback to `llm-d-inference-scheduler` in the LLMD predicate. The user's direction on this fix is stronger: scheduler is gone entirely, so it's not a fallback but a replacement.
- **`$GAIE` and `$LLMD` may resolve to the same directory.** In the consolidated case (router present, standalone gateway-api-inference-extension absent), both point at the same path. §3/§4 code-proof greps that reference `$GAIE` and `$LLMD` separately will then execute against the same tree — this is harmless (grep twice, get the same match twice) and preserves the skill's ability to work in the non-consolidated case (separate `gateway-api-inference-extension` checkout still exists). No prose change to §3/§4 needed.
- **`$SIM2REAL_ROOT` discovery** is already set later in the skill (Step 0.5, line 234) via `python -c 'from pipeline.lib import layout; ...'`. The BLIS predicate at line 157 references `$SIM2REAL_ROOT` and gracefully falls back if it's unset at auxiliary-detection time.
- **No test changes.** The skill is a prompt template. `tests/test_enumerate_iterations.py` covers the `scripts/enumerate_iterations.py` python helper, not the SKILL.md prose — unaffected by this diff (12 tests still pass).

## Sweep for stale references

Grepped `.claude/skills/`, `pipeline/`, `docs/`, `README.md`, `CLAUDE.md` for `llm-d-inference-scheduler`:

- Inside `.claude/skills/sim2real-check/SKILL.md:159` — one occurrence remains, inside my new prose *explaining* that scheduler has been sunset. Intentional.
- `.claude/skills/sim2real-translate/SKILL.md:5` — description text mentions scheduler as example target component. **Out of scope for this issue** (per issue's `sim2real-check`-only scoping); flagged for follow-up.
- `.claude/skills/sim2real-translate/scripts/copy_generated.py:27` — docstring similarly names scheduler as example. **Out of scope**; flagged for follow-up.
- `pipeline/deploy.py`, `pipeline/setup.py`, `pipeline/README.md`, `pipeline/tests/test_*.py`, `pipeline/scripts/build-epp.sh`, `CLAUDE.md:6` — multiple references to `llm-d-inference-scheduler` in code, tests, and root docs. **Out of scope for this issue** per its explicit "Skill-only change; no code changes to `pipeline/`" scoping and the user's amendment which focused on the skill. Recommend a follow-up issue if the broader rename is desired.

## Test plan

- [x] `python -m pytest .claude/skills/sim2real-check/tests/ -v` — 12 pass (unchanged).
- [x] `ruff check pipeline/ .claude/skills/ --select F` — clean.
- [ ] Field verification: run `/sim2real-check --run <name>` in an environment where `llm-d-router` is cloned; confirm the confirmation prompt shows `llm-d-router (LLMD): <path>` and the §3/§4 code-proof checks run against that path.
- [ ] Field verification: run in an environment where the framework's `inference-sim/` submodule is initialized but no `sim/`+`go.mod` exists elsewhere; confirm `BLIS` is picked up from `$SIM2REAL_ROOT/inference-sim`.

Closes #494
