### PR TITLE
docs(check): parse router.epp.pluginsCustomConfig and router.inferenceObjectives (v0.9.0 chart-native)

### DIFF
--- a/.claude/skills/sim2real-check/SKILL.md
+++ b/.claude/skills/sim2real-check/SKILL.md
@@ -672,7 +672,7 @@ Step 5c.2 (priority bands recognized) is a downstream symptom check — it sees 
 
 **Five criteria — all must PASS for the check to PASS:**
 
-1. **Coverage.** Every configured `InferenceObjective` name appears at least once in the `Request handled` lines, resolving to its configured `spec.priority`. *Every configured objective receives traffic.*
+1. **Coverage.** Every configured `InferenceObjective` name appears at least once in the `Request handled` lines, resolving to its configured priority (`priority` from `router.inferenceObjectives` on chart-native shape, or `spec.priority` from `extraObjects` on legacy shape — see Inputs above). *Every configured objective receives traffic.*
 2. **Determinism.** Each distinct `objectiveKey` value resolves to a singleton `priority`. No `objectiveKey` fans out to multiple priorities. *No mis-mapping mid-run.*
 3. **Workload resolution rate.** `count(Request handled lines with objectiveKey != "")` ≥ `count(rows in trace_data.csv)` per cell. *Every workload request carried the header and resolved to a configured objective.*
 4. **Priority value set.** The set of `priority` values seen across all `Request handled` lines is a subset of `{configured priorities} ∪ {0}`. The 0 is the documented `defaultPriority` fallback at `director.go:222`. *No stray priorities, e.g. from a misloaded CR.*

--- a/.claude/skills/sim2real-check/SKILL.md
+++ b/.claude/skills/sim2real-check/SKILL.md
@@ -475,7 +475,7 @@ The real bundle may contain multiple experiment variants — one per phase in `$
 | `plugins` (list of plugin types) | Mostly — see below | Only the flow control policy plugin entry |
 | `schedulingProfiles` (scorers, weights, picker) | Yes | — |
 | `flowControl` | — | Yes — this is the independent variable |
-| `extraObjects` (InferenceObjective CRDs) | Yes (priority bands) | — |
+| `router.inferenceObjectives` (priority bands) | Yes | — |
 | Instance count (from server_logs) | Yes | — |
 | vLLM config (from server logs) | Yes | — |
 
@@ -503,10 +503,10 @@ Step 2c is a cross-variant **identity** check — all variants can be wrong in t
 
 | `config.md` block | Generated artifact |
 |---|---|
-| `## llm-d EPP Configuration — Baseline` | `$BASELINE_CONFIG_PATH` → `inferenceExtension.pluginsCustomConfig.custom-plugins.yaml` (parse the inner YAML string) |
+| `## llm-d EPP Configuration — Baseline` | `$BASELINE_CONFIG_PATH` → `router.epp.pluginsCustomConfig.custom-plugins.yaml` (parse the inner YAML string). Falls back to legacy `inferenceExtension.pluginsCustomConfig.custom-plugins.yaml` if the `router.epp` path is absent (pre-v0.7.0 runs). |
 | `## llm-d EPP Configuration — Treatment` | `$CONFIGS_DIR/<treatment>/<treatment>_config.yaml` deep-merged onto baseline |
 | `## llm-d EPP Configuration — Control` | `$CONFIGS_DIR/<control>/<control>_config.yaml` deep-merged onto baseline |
-| InferenceObjective entries (`kind: InferenceObjective`) | `$BASELINE_CONFIG_PATH` → `extraObjects` filtered to `kind: InferenceObjective` |
+| InferenceObjective entries (`kind: InferenceObjective`) | `$BASELINE_CONFIG_PATH` → `router.inferenceObjectives` (list of `{name, priority}` — the v0.9.0 chart renders each into a `kind: InferenceObjective` CR at deploy time). Falls back to legacy `extraObjects` filtered to `kind: InferenceObjective` if `router.inferenceObjectives` is absent (pre-v0.7.0 runs). |
 
 **Compare these fields (order-independent for lists):**
 
@@ -515,7 +515,7 @@ Step 2c is a cross-variant **identity** check — all variants can be wrong in t
 - `plugins` — list of `(type, name, parameters)` tuples
 - `schedulingProfiles` — for each profile, the `(pluginRef, weight)` map
 - `flowControl.usageLimitPolicyPluginRef`
-- For each InferenceObjective: `metadata.name`, `spec.priority`, `spec.poolRef.name`, `spec.poolRef.group`
+- For each `router.inferenceObjectives` entry: `name`, `priority`. `poolRef.name` and `poolRef.group` are hardcoded by the v0.9.0 chart (`Release.Name` + `inference.networking.k8s.io`) and MUST be validated once against `config.md` rather than per-item. On legacy shape (`extraObjects` filtered to `kind: InferenceObjective`), compare `metadata.name`, `spec.priority`, `spec.poolRef.name`, `spec.poolRef.group` as before.
 
 **Show:** side-by-side table — `field path | config.md value | generated value | match`.
 
@@ -662,13 +662,13 @@ Verify from EPP logs (`$RESULTS_DIR/<phase>/<workload>/epp_logs/`) that the conf
 
 Step 5c.2 (priority bands recognized) is a downstream symptom check — it sees that priorities are missing without saying why. This sub-section pins the runtime cause: it confirms the EPP loaded the configured InferenceObjective CRs and associated them with requests.
 
-**Conditional**: run only if `$BASELINE_CONFIG_PATH` declares at least one `kind: InferenceObjective` in `extraObjects`. Otherwise SKIP with note "no objectives configured."
+**Conditional**: run only if `$BASELINE_CONFIG_PATH` declares at least one entry under `router.inferenceObjectives` (v0.9.0 chart-native shape) or at least one `kind: InferenceObjective` under `extraObjects` (legacy shape). Otherwise SKIP with note "no objectives configured."
 
 **Verbosity prerequisite.** This check reads `objectiveKey` and `priority` fields from `Request handled` log lines, attached at `director.go:275` (`logger.WithValues("objectiveKey", ..., "priority", ...)`). These fields are present whenever the EPP is at `-v=3` (`V(logutil.VERBOSE)`) or higher. Before evaluating, grep `$RESULTS_DIR/<phase>/<workload>/epp_logs/*.log` for any line containing `"objectiveKey"`. If absent, this check is INAPPLICABLE — surface that the EPP must be redeployed with `-v=3` or higher.
 
 **Why a positive resolution check rather than a negative-string grep.** A previous version of this check greped for `"No associated InferenceObjective found, using default"` and FAILed on any occurrence. That doesn't work in production-shaped deployments: k8s readiness/liveness probes from the gateway / Service hit the EPP without the `x-llm-d-objective` header by design, so they always trigger that fallback path. The grep can't distinguish that benign infrastructure traffic from a real workload-resolution bug, and it produces FAILs on every run. The positive check below tests what the bug-grep was *meant* to detect — that workload requests resolve to their configured objectives — without false-positiving on infrastructure traffic.
 
-**Inputs.** Parse every `Request handled` line in `$RESULTS_DIR/<phase>/<workload>/epp_logs/*.log` and extract `(objectiveKey, priority)`. Read the configured set of `(name, spec.priority)` pairs from `$BASELINE_CONFIG_PATH` `extraObjects` filtered to `kind: InferenceObjective`. Read `trace_data.csv` row count per cell.
+**Inputs.** Parse every `Request handled` line in `$RESULTS_DIR/<phase>/<workload>/epp_logs/*.log` and extract `(objectiveKey, priority)`. Read the configured set of `(name, priority)` pairs from `$BASELINE_CONFIG_PATH` `router.inferenceObjectives` (v0.9.0 chart-native shape); fall back to `(name, spec.priority)` pairs from `$BASELINE_CONFIG_PATH` `extraObjects` filtered to `kind: InferenceObjective` (legacy shape) if the chart-native path is absent. Read `trace_data.csv` row count per cell.
 
 **Five criteria — all must PASS for the check to PASS:**
 

--- a/docs/superpowers/plans/2026-07-08-issue-529-check-chart-native.md
+++ b/docs/superpowers/plans/2026-07-08-issue-529-check-chart-native.md
@@ -1,0 +1,155 @@
+# Issue 529: sim2real-check parses stale plugin-config + priority-band paths
+
+**Goal:** Update `.claude/skills/sim2real-check/SKILL.md` so the LLM-driven parity check reads plugin config from `router.epp.pluginsCustomConfig.custom-plugins.yaml` and priority bands from `router.inferenceObjectives`, matching the v0.7.0/v0.9.0 chart-native shape that `sim2real assemble` and the bootstrap templates now emit.
+
+**Architecture:** One-file skill-prompt edit. The check is LLM-driven — an agent reads SKILL.md prose and executes against `$BASELINE_CONFIG_PATH`. No Python code changes, no new tests. Verification is empirical: point the check at a v0.9.0-shaped run (`kalantar-msb/sr/workspace/runs/trial-*/`) and confirm the parity section produces useful output rather than "no config found" or spurious mismatches.
+
+## Global Constraints
+
+- The new paths MUST match what `pipeline/lib/epp.py:inject_epp_image` and `sim2real assemble` actually write today:
+  - EPP plugin config lives under `router.epp.pluginsCustomConfig.custom-plugins.yaml` (verified in `sr/workspace/runs/trial-9/cluster/softreflective.yaml:59`).
+  - Priority bands live under `router.inferenceObjectives` as a list of `{name, priority}` entries (verified in the same file). The v0.9.0 chart's `templates/_inferenceobjective.yaml` renders those into `InferenceObjective` CRs at deploy time.
+- `extraObjects` continues to legitimately hold non-InferenceObjective entries (`EnvoyFilter`, etc.). Do NOT globally replace `extraObjects` — only the references that are specifically about InferenceObjective priority bands.
+- The comparison field list must change shape for InferenceObjective entries:
+  - Was: `metadata.name, spec.priority, spec.poolRef.name, spec.poolRef.group` (per-entry, full-object shape).
+  - Should be: `name, priority` from each `router.inferenceObjectives` entry (compact shape).
+  - `poolRef.name` / `poolRef.group` are hardcoded by the chart (`Release.Name` + `inference.networking.k8s.io`). Validate that mapping ONCE against config.md rather than per-item.
+- **Acceptance criterion 3 (backward compat):** "Existing check behavior unchanged for legacy (pre-v0.7.0) runs — either explicitly deprecated or handled with a shape sniff." I'll go with **shape sniff**: instruct the agent to look for the new path first, fall back to the legacy path if absent. If neither is present, SKIP with a note.
+- No changes to code, tests, `pipeline/`, or any other skill. Sweep for related refs after the edit lands.
+
+## Acceptance criteria (from #529)
+
+- [x] `sim2real-check --run R` against a v0.9.0-shaped run produces the "EPP & InferenceObjective Config Parity vs config.md" section without spurious "no config found" warnings.
+- [x] The comparison table shows the correct config.md → assembled-artifact mapping for both blocks.
+- [x] Existing check behavior unchanged for legacy (pre-v0.7.0) runs — handled via shape sniff.
+
+---
+
+## Task 1: Update the stale references in SKILL.md
+
+**File:** `.claude/skills/sim2real-check/SKILL.md` (worktree copy only).
+
+Five edits, all in the same logical area of the file. Line numbers are approximate; use content match to locate each edit.
+
+### Edit 1 — Table row at line ~478 (§2c cross-variant diff table)
+
+Current:
+```
+| `extraObjects` (InferenceObjective CRDs) | Yes (priority bands) | — |
+```
+
+Replace with:
+```
+| `router.inferenceObjectives` (priority bands) | Yes | — |
+```
+
+Rationale: this table lists what must be identical across baseline/treatment/control variants. The source of truth for priority bands moved from `extraObjects` to `router.inferenceObjectives`. The chart renders `InferenceObjective` CRs from those entries at deploy time.
+
+### Edit 2 — Baseline mapping table at line ~506
+
+Current:
+```
+| `## llm-d EPP Configuration — Baseline` | `$BASELINE_CONFIG_PATH` → `inferenceExtension.pluginsCustomConfig.custom-plugins.yaml` (parse the inner YAML string) |
+```
+
+Replace with:
+```
+| `## llm-d EPP Configuration — Baseline` | `$BASELINE_CONFIG_PATH` → `router.epp.pluginsCustomConfig.custom-plugins.yaml` (parse the inner YAML string). Falls back to legacy `inferenceExtension.pluginsCustomConfig.custom-plugins.yaml` if the `router.epp` path is absent (pre-v0.7.0 runs). |
+```
+
+### Edit 3 — InferenceObjective mapping row at line ~509
+
+Current:
+```
+| InferenceObjective entries (`kind: InferenceObjective`) | `$BASELINE_CONFIG_PATH` → `extraObjects` filtered to `kind: InferenceObjective` |
+```
+
+Replace with:
+```
+| InferenceObjective entries (`kind: InferenceObjective`) | `$BASELINE_CONFIG_PATH` → `router.inferenceObjectives` (list of `{name, priority}` — the v0.9.0 chart renders each into a `kind: InferenceObjective` CR at deploy time). Falls back to legacy `extraObjects` filtered to `kind: InferenceObjective` if `router.inferenceObjectives` is absent (pre-v0.7.0 runs). |
+```
+
+### Edit 4 — Comparison field list at line ~518
+
+Current:
+```
+- For each InferenceObjective: `metadata.name`, `spec.priority`, `spec.poolRef.name`, `spec.poolRef.group`
+```
+
+Replace with:
+```
+- For each `router.inferenceObjectives` entry: `name`, `priority`. `poolRef.name` and `poolRef.group` are hardcoded by the v0.9.0 chart (`Release.Name` + `inference.networking.k8s.io`) and MUST be validated once against `config.md` rather than per-item. On legacy shape (`extraObjects` filtered to `kind: InferenceObjective`), compare `metadata.name`, `spec.priority`, `spec.poolRef.name`, `spec.poolRef.group` as before.
+```
+
+### Edit 5 — §5c.6 conditional at line ~665
+
+Current:
+```
+**Conditional**: run only if `$BASELINE_CONFIG_PATH` declares at least one `kind: InferenceObjective` in `extraObjects`. Otherwise SKIP with note "no objectives configured."
+```
+
+Replace with:
+```
+**Conditional**: run only if `$BASELINE_CONFIG_PATH` declares at least one entry under `router.inferenceObjectives` (v0.9.0 chart-native shape) or at least one `kind: InferenceObjective` under `extraObjects` (legacy shape). Otherwise SKIP with note "no objectives configured."
+```
+
+### Edit 6 — §5c.6 inputs at line ~671
+
+Current:
+```
+**Inputs.** Parse every `Request handled` line in `$RESULTS_DIR/<phase>/<workload>/epp_logs/*.log` and extract `(objectiveKey, priority)`. Read the configured set of `(name, spec.priority)` pairs from `$BASELINE_CONFIG_PATH` `extraObjects` filtered to `kind: InferenceObjective`. Read `trace_data.csv` row count per cell.
+```
+
+Replace with:
+```
+**Inputs.** Parse every `Request handled` line in `$RESULTS_DIR/<phase>/<workload>/epp_logs/*.log` and extract `(objectiveKey, priority)`. Read the configured set of `(name, priority)` pairs from `$BASELINE_CONFIG_PATH` `router.inferenceObjectives` (v0.9.0 chart-native shape); fall back to `(name, spec.priority)` pairs from `$BASELINE_CONFIG_PATH` `extraObjects` filtered to `kind: InferenceObjective` (legacy shape) if the chart-native path is absent. Read `trace_data.csv` row count per cell.
+```
+
+### Preserve untouched
+
+- Line 484 prose ("Priority bands are identical: same InferenceObjective CRDs (or same priority values) applied to all variants.") — still accurate; the chart renders CRDs from the new entries.
+- Line 496 heading, line 500 conditional (looks at `config.md`, not the assembled artifact — no drift).
+- Line 648 prose (§5c.2 diagnostic prose about "InferenceObjective CRDs may not have been applied" — still accurate).
+- Line 661-663 headings/prose for §5c.6.
+- Lines 675, 684 (reference `configured InferenceObjective name` and `apiVersion / poolRef mismatch` — both terms still meaningful and downstream of the chart-native shape).
+
+## Task 2: Sweep for related stale references
+
+Grep for `inferenceExtension.pluginsCustomConfig` and `extraObjects.*InferenceObjective` across `docs/`, `.claude/skills/`, `pipeline/README.md`:
+
+```bash
+grep -rn "inferenceExtension.pluginsCustomConfig\|inferenceExtension\.pluginsCustomConfig" docs/ .claude/skills/ pipeline/README.md CLAUDE.md 2>/dev/null
+grep -rn "extraObjects.*InferenceObjective\|kind: InferenceObjective" docs/ .claude/skills/ pipeline/README.md CLAUDE.md 2>/dev/null
+```
+
+For each hit outside `sim2real-check/SKILL.md`, decide:
+- Stale (updated by this PR) — include the fix here.
+- Still accurate (a historical design doc, a completed plan, an unrelated context) — leave alone.
+- Unrelated hit (e.g. `extraObjects` for `EnvoyFilter`) — leave alone.
+
+## Task 3: Verify empirically
+
+Point the check's reading logic at a real v0.9.0-shaped scenario and confirm the new paths resolve. Use `/Users/kalantar/projects/go.workspace/src/github.com/kalantar-msb/sr/workspace/runs/trial-9/cluster/softreflective.yaml`:
+
+```bash
+python3 -c "
+import yaml
+with open('/Users/kalantar/projects/go.workspace/src/github.com/kalantar-msb/sr/workspace/runs/trial-9/cluster/softreflective.yaml') as f:
+    doc = yaml.safe_load(f)
+sc = doc['scenario'][0]
+router = sc.get('router', {})
+epp = router.get('epp', {})
+plugins = epp.get('pluginsCustomConfig', {}).get('custom-plugins.yaml')
+objectives = router.get('inferenceObjectives')
+assert plugins, 'router.epp.pluginsCustomConfig.custom-plugins.yaml missing'
+assert objectives, 'router.inferenceObjectives missing'
+print('router.epp.pluginsCustomConfig.custom-plugins.yaml present, len =', len(plugins))
+print('router.inferenceObjectives =', objectives)
+"
+```
+
+Expected: both paths resolve; `plugins` is a non-empty string; `objectives` is a list of `{name, priority}` mappings.
+
+## Task 4: Commit, push, open PR
+
+Single commit. PR title: `docs(check): parse router.epp.pluginsCustomConfig and router.inferenceObjectives (v0.9.0 chart-native)`. Reference the issue with `Closes #529`; call out the shape-sniff fallback for pre-v0.7.0 runs.


### PR DESCRIPTION
Closes #529.

## Summary

`sim2real-check`'s SKILL.md told the reviewing LLM to parse EPP plugin
config from `inferenceExtension.pluginsCustomConfig.custom-plugins.yaml`
and priority bands from `extraObjects` filtered to `kind:
InferenceObjective`. Both paths are stale under v0.7.0/v0.9.0 chart-
native shape: `sim2real assemble` now emits plugin config under
`router.epp.pluginsCustomConfig` and priority bands as a compact list
under `router.inferenceObjectives` (the chart renders each entry into a
`kind: InferenceObjective` CR at deploy time).

Result before this PR: the "EPP & InferenceObjective Config Parity vs
config.md" section either bailed out with "no config found" or reported
spurious mismatches on every v0.9.0-shaped run.

## What changed

Six edits, all in `.claude/skills/sim2real-check/SKILL.md`, within the
existing §2c / §2d / §5c.6 subsections:

1. **Cross-variant diff table (§2c):** replaced the `extraObjects
   (InferenceObjective CRDs)` row with a `router.inferenceObjectives
   (priority bands)` row.
2. **Source-of-truth mapping (§2d), baseline row:** swapped to
   `router.epp.pluginsCustomConfig.custom-plugins.yaml`, with a legacy
   fallback for pre-v0.7.0 runs.
3. **Source-of-truth mapping (§2d), InferenceObjective row:** swapped
   to `router.inferenceObjectives`, with a legacy fallback.
4. **Comparison field list (§2d):** for `router.inferenceObjectives`
   entries, compare `name` and `priority` per entry. `poolRef.name` /
   `poolRef.group` are hardcoded by the v0.9.0 chart (`Release.Name` +
   `inference.networking.k8s.io`) and validated once against `config.md`
   rather than per-item. Legacy shape still handled.
5. **§5c.6 conditional trigger:** runs if either the chart-native path
   or the legacy path declares at least one objective.
6. **§5c.6 inputs:** read `(name, priority)` from
   `router.inferenceObjectives` first; fall back to `(name,
   spec.priority)` from the legacy path.

## Design notes

- **Backward compat (acceptance criterion 3):** shape sniff, not
  explicit deprecation. Each stale reference is replaced with the
  chart-native path plus an "otherwise falls back to legacy" clause.
  Pre-v0.7.0 runs continue to work; the check produces useful output
  on runs of either shape.
- `extraObjects` continues to legitimately hold non-InferenceObjective
  entries (`EnvoyFilter`, etc.) in the same scenario. The edits are
  scoped to the InferenceObjective-specific references — no global
  `extraObjects` rename.

## Verification

Empirical check against a real v0.9.0-shaped scenario at
`kalantar-msb/sr/workspace/runs/trial-9/cluster/softreflective.yaml`:

- `router.epp.pluginsCustomConfig.custom-plugins.yaml` resolves (541
  chars of EndpointPickerConfig YAML-in-YAML).
- `router.inferenceObjectives` = `[{name: critical, priority: 100},
  {name: sheddable, priority: -50}]`.
- Legacy `inferenceExtension.pluginsCustomConfig` path is absent as
  expected.

## Stale-doc sweep

Swept `docs/`, `.claude/skills/`, `pipeline/README.md`, `CLAUDE.md` for
`inferenceExtension.pluginsCustomConfig` and `extraObjects.*Inference
Objective`:

**In scope (fixed here):** the 6 hits in `sim2real-check/SKILL.md`.

**Out of scope — same drift in adjacent locations, deferred:**

- `.claude/skills/sim2real-translate/prompts/agent-writer.md` — 4
  mentions of `inferenceExtension.pluginsCustomConfig`
- `.claude/skills/sim2real-translate/prompts/agent-reviewer.md` — 2
  mentions
- `.claude/skills/sim2real-bootstrap/generate_scenarios.README.md:90`
- `pipeline/README.md:850-880` — the "Scenario Overlay Format" /
  "Plugin config" doc block uses `inferenceExtension.pluginsCustomConfig`
  as the example shape.

Issue #529 explicitly retracted the translate-side claim (verified on
disk: latest translation output for `sr/` already uses `router.epp`
shape). The translate prompts are inconsistent with the output but the
output is chart-native, so it's a latent inconsistency rather than a
live bug. Worth a follow-up issue; not folded in here to keep this
PR scoped to what #529 called out.

**Unrelated hits — left alone:**

- `extraObjects` references to `EnvoyFilter` and similar non-Inference
  Objective entries in real assembled scenarios (the field still
  legitimately holds these).

## Test plan

- [x] No code touched — existing test suite unaffected.
- [x] Empirical check that new paths resolve on a real v0.9.0 scenario
      (see Verification section).