### PR TITLE
feat(deploy): support fnmatch globs in --workload and --package (#518)

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -394,16 +394,18 @@ The parser accepts a legacy no-suffix form (`wl-<workload>|<package>`) and reads
 | Flag | Scope | Notes |
 |------|-------|-------|
 | `--only PAIR…` | Full pair keys (with or without `wl-` prefix) | Narrows both workload and package. Takes precedence over `--workload`. |
-| `--workload NAME…` | Workload dimension | Multiple values are OR'd within the flag. |
-| `--package NAME…` | Package dimension | Multiple values are OR'd within the flag. |
+| `--workload NAME…` | Workload dimension | Multiple values are OR'd within the flag. Glob patterns supported (see below). |
+| `--package NAME…` | Package dimension | Multiple values are OR'd within the flag. Glob patterns supported (see below). |
 | `--iteration SPEC` | Iteration dimension | Grammar below. |
 | `--status STATE` | Progress state (`pending` / `running` / `done` / `failed` / `timed-out` / `stalled`) | Not available on every subcommand — see per-subcommand tables. |
 
 Different flags compose as AND: `--workload X --package baseline --iteration 1,3` narrows to iterations 1 and 3 of workload X's baseline package.
 
+**Glob patterns in `--workload` and `--package`** (issue #518). Values containing `*`, `?`, or `[` are matched against the valid set with Python's `fnmatch` (standard shell-glob, no regex). Values without those metacharacters are literals (backwards-compatible). Examples: `--workload 'code_generation_*'`, `--workload 'code*'`, `--workload code_generation_4 'reasoning_0_*'` (literal + glob). A pattern matching zero valid names fails fatally with the same "unrecognized values" error as an unknown literal. For `collect --package`, the synthetic `experiment` value remains literal-only — a pattern like `exp*` will NOT match it (pass `experiment` verbatim to keep today's expand-to-all-known-phases behavior).
+
 **Iteration filter spec.** The `--iteration` value is a comma-separated list of tokens; each token is either a positive integer (`3`) or an inclusive range (`1-3`). Whitespace around commas and hyphens is tolerated. Rejected: `0`, negatives, reversed ranges (`5-1`), non-integer tokens (`abc`), leading zeros (`01`), empty spec, empty token. Malformed specs fail with `malformed iteration spec '<spec>': <reason>` before any pair discovery runs. Legacy pair keys (no `|iN` suffix) parse as iteration `1`, so `--iteration 1` matches them.
 
-**Collection phases** — `deploy.py collect` derives valid phases dynamically from progress data (packages with status `done`). Falls back to `[baseline, treatment]` when no progress exists. Use `--package` to filter, or `--package experiment` to collect all known phases.
+**Collection phases** — `deploy.py collect` derives valid phases dynamically from progress data (packages with status `done`). Falls back to `[baseline, treatment]` when no progress exists. Use `--package` (literals or globs) to filter, or `--package experiment` to collect all known phases. Note: globs (`base*`, `*`) never match the `experiment` magic token; pass it as a literal.
 
 **`--skip-build`** — skips the image build; use when resubmitting after a failed PipelineRun without changing the scorer.
 
@@ -426,8 +428,8 @@ python pipeline/deploy.py pairs   [flags]   # list available pair keys, workload
 |------|---------|-------------|
 | `--remote` | — | Submit orchestrator as in-cluster Job instead of running locally |
 | `--only PAIR…` | — | Scope execution to specific pair keys (comma or space-separated, `wl-` prefix optional) |
-| `--workload NAME…` | — | Scope execution to pairs matching these workloads (comma or space-separated) |
-| `--package NAME…` | — | Scope execution to pairs matching these packages (comma or space-separated) |
+| `--workload NAME…` | — | Scope execution to pairs matching these workloads (comma or space-separated; globs OK) |
+| `--package NAME…` | — | Scope execution to pairs matching these packages (comma or space-separated; globs OK) |
 | `--iteration SPEC` | — | Scope to iteration(s): `'2'`, `'1,3'`, `'1-3'`, `'1,3-5'` |
 | `--status STATE` | — | Scope execution to pairs with this status (e.g. `failed`, `timed-out`) |
 | `--skip-teardown` | — | Skip the Tekton teardown task, leaving namespace resources intact for debugging |
@@ -462,8 +464,8 @@ python pipeline/deploy.py pairs   [flags]   # list available pair keys, workload
 | Flag | Description |
 |------|-------------|
 | `--only PAIR…` | Scope to specific pair keys (comma or space-separated, `wl-` prefix optional) |
-| `--workload NAME…` | Filter by workload names (comma or space-separated) |
-| `--package NAME…` | Filter by package names (comma or space-separated) |
+| `--workload NAME…` | Filter by workload names (comma or space-separated; globs OK) |
+| `--package NAME…` | Filter by package names (comma or space-separated; globs OK) |
 | `--iteration SPEC` | Scope to iteration(s): `'2'`, `'1,3'`, `'1-3'`, `'1,3-5'` |
 | `--status STATE` | Filter by status (e.g. `running`, `done`, `failed`) |
 | `-s`, `--silent` | Suppress the per-pair table and banner; print only the summary line (machine-readable) |
@@ -475,8 +477,8 @@ Per phase, the resolved llm-d-benchmark plan YAMLs are also pulled into `workspa
 | Flag | Description |
 |------|-------------|
 | `--only PAIR…` | Scope to specific pair keys — narrows both workload and package (comma or space-separated, `wl-` prefix optional; takes precedence over `--workload`) |
-| `--workload NAME…` | Scope to pairs matching these workloads (comma or space-separated) |
-| `--package NAME…` | Scope to pairs matching these packages (comma or space-separated). Pass the synthetic value `experiment` to collect every package directory of the scoped pairs. |
+| `--workload NAME…` | Scope to pairs matching these workloads (comma or space-separated; globs OK) |
+| `--package NAME…` | Scope to pairs matching these packages (comma or space-separated; globs OK, but never against `experiment`). Pass the synthetic value `experiment` as a literal to collect every package directory of the scoped pairs. |
 | `--iteration SPEC` | Scope to iteration(s): `'2'`, `'1,3'`, `'1-3'`, `'1,3-5'` |
 | `--skip-logs` | Skip vLLM and EPP log files, collect only traces |
 
@@ -489,8 +491,8 @@ When `--only` or `--workload` is given, only matching workload subdirectories ar
 | Flag | Description |
 |------|-------------|
 | `--only PAIR…` | Scope reset to specific pair keys (comma or space-separated, `wl-` prefix optional) |
-| `--workload NAME…` | Scope reset to pairs matching these workloads (comma or space-separated) |
-| `--package NAME…` | Scope reset to pairs matching these packages (comma or space-separated) |
+| `--workload NAME…` | Scope reset to pairs matching these workloads (comma or space-separated; globs OK) |
+| `--package NAME…` | Scope reset to pairs matching these packages (comma or space-separated; globs OK) |
 | `--iteration SPEC` | Scope to iteration(s): `'2'`, `'1,3'`, `'1-3'`, `'1,3-5'` |
 | `--status STATE` | Scope reset to pairs with this status |
 | `--preserve-done-status` | Keep done pairs' status unchanged (cluster cleanup only) |
@@ -503,8 +505,8 @@ When `--only` or `--workload` is given, only matching workload subdirectories ar
 | Flag | Description |
 |------|-------------|
 | `--only PAIR…` | Scope wipe to specific pair keys (comma or space-separated, `wl-` prefix optional) |
-| `--workload NAME…` | Scope wipe to pairs matching these workloads (comma or space-separated) |
-| `--package NAME…` | Scope wipe to pairs matching these packages (comma or space-separated) |
+| `--workload NAME…` | Scope wipe to pairs matching these workloads (comma or space-separated; globs OK) |
+| `--package NAME…` | Scope wipe to pairs matching these packages (comma or space-separated; globs OK) |
 | `--iteration SPEC` | Narrows which pair keys are targeted, but the delete still removes the entire `results/<package>/<workload>/` workload tree — sibling iterations for the same workload are removed too. Tracked at #525. |
 | `--dry-run` | Print what would be wiped without acting |
 | `--yes` / `-y` | Skip confirmation prompt |

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -13,6 +13,7 @@ Subcommands:
 """
 
 import argparse
+import fnmatch
 import json
 import os
 import random
@@ -1678,12 +1679,13 @@ def _cmd_collect(args, run_dir: Path, cluster_config: dict):
             phases_to_collect: list[str] = []
         elif (pkg_filter := scope_package):
             valid = set(scoped_phases) | {"experiment"}
-            unknown = set(pkg_filter) - valid
+            expanded, unknown = _expand_glob_values(
+                pkg_filter, valid, exclude_from_pattern={"experiment"})
             if unknown:
                 err(f"Unknown packages: {sorted(unknown)}. Valid: {sorted(valid)}")
                 sys.exit(1)
             phases_to_collect = []
-            for p in pkg_filter:
+            for p in expanded:
                 if p == "experiment":
                     phases_to_collect.extend(scoped_phases)
                 else:
@@ -1825,12 +1827,13 @@ def _cmd_collect(args, run_dir: Path, cluster_config: dict):
         pkg_filter = _parse_list(args.package)
         if pkg_filter:
             valid = set(known_phases) | {"experiment"}
-            unknown = set(pkg_filter) - valid
+            expanded, unknown = _expand_glob_values(
+                pkg_filter, valid, exclude_from_pattern={"experiment"})
             if unknown:
                 err(f"Unknown packages: {sorted(unknown)}. Valid: {sorted(valid)}")
                 sys.exit(1)
             phases_to_collect = []
-            for p in pkg_filter:
+            for p in expanded:
                 if p == "experiment":
                     phases_to_collect.extend(known_phases)
                 else:
@@ -2268,6 +2271,55 @@ def _parse_list(value) -> "list[str] | None":
     return result if result else None
 
 
+# Any of these in a value makes it a shell-glob pattern; otherwise the value is a literal.
+_GLOB_METACHARS = ("*", "?", "[")
+
+
+def _is_glob(value: str) -> bool:
+    return any(c in value for c in _GLOB_METACHARS)
+
+
+def _expand_glob_values(
+    values,
+    valid,
+    *,
+    exclude_from_pattern=frozenset(),
+) -> "tuple[list[str], list[str]]":
+    """Expand a mixed list of literals and shell-glob patterns against *valid*.
+
+    A value containing ``*``, ``?``, or ``[`` is treated as an ``fnmatch`` pattern;
+    otherwise it must be a literal member of *valid*. Patterns match against
+    ``valid - exclude_from_pattern`` so magic tokens (e.g. ``experiment``) remain
+    literal-only and are never surfaced by a pattern like ``exp*``.
+
+    Returns ``(expanded, unknown)`` where *expanded* preserves the order of the
+    user's input (first occurrence wins) and *unknown* lists literals not in
+    *valid* plus patterns that matched zero names.
+    """
+    pattern_pool = sorted(set(valid) - set(exclude_from_pattern))
+    valid_set = set(valid)
+    expanded: list[str] = []
+    seen: set[str] = set()
+    unknown: list[str] = []
+    for v in values:
+        if _is_glob(v):
+            matches = [n for n in pattern_pool if fnmatch.fnmatchcase(n, v)]
+            if not matches:
+                unknown.append(v)
+                continue
+            for m in matches:
+                if m not in seen:
+                    seen.add(m)
+                    expanded.append(m)
+        elif v in valid_set:
+            if v not in seen:
+                seen.add(v)
+                expanded.append(v)
+        else:
+            unknown.append(v)
+    return expanded, unknown
+
+
 def _apply_run_filters(progress: dict, args) -> set:
     """Return the set of pair keys in scope for this invocation.
 
@@ -2318,7 +2370,7 @@ def _apply_run_filters(progress: dict, args) -> set:
 
     if workload:
         valid_workloads = {v.get("workload", "") for v in pair_entries.values()} - {""}
-        unknown = set(workload) - valid_workloads
+        workload, unknown = _expand_glob_values(workload, valid_workloads)
         if unknown:
             err(f"--workload: unrecognized values {sorted(unknown)}")
             print(f"  Valid --workload values: {', '.join(sorted(valid_workloads))}", file=sys.stderr)
@@ -2326,7 +2378,7 @@ def _apply_run_filters(progress: dict, args) -> set:
 
     if package:
         valid_packages = {v.get("package", "") for v in pair_entries.values()} - {""}
-        unknown = set(package) - valid_packages
+        package, unknown = _expand_glob_values(package, valid_packages)
         if unknown:
             err(f"--package: unrecognized values {sorted(unknown)}")
             print(f"  Valid --package values: {', '.join(sorted(valid_packages))}", file=sys.stderr)
@@ -2334,9 +2386,11 @@ def _apply_run_filters(progress: dict, args) -> set:
 
     candidates = set(pair_entries.keys())
     if workload:
-        candidates = {k for k in candidates if pair_entries[k].get("workload") in workload}
+        workload_set = set(workload)
+        candidates = {k for k in candidates if pair_entries[k].get("workload") in workload_set}
     if package:
-        candidates = {k for k in candidates if pair_entries[k].get("package") in package}
+        package_set = set(package)
+        candidates = {k for k in candidates if pair_entries[k].get("package") in package_set}
     if status_filter:
         candidates = {k for k in candidates if pair_entries[k].get("status") == status_filter}
     if iteration_set is not None:

--- a/pipeline/tests/test_deploy_collect.py
+++ b/pipeline/tests/test_deploy_collect.py
@@ -129,6 +129,191 @@ def test_collect_experiment_expands_to_all_progress_phases(tmp_path, monkeypatch
     assert collected_phases == ["baseline", "canary", "treatment"]
 
 
+# ── --package glob tests (issue #518) ───────────────────────────────────────
+
+
+def test_collect_package_glob_matches_family(tmp_path, monkeypatch):
+    """--package 'base*' expands via fnmatch to matching real packages
+    (unscoped path — no --only/--workload)."""
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    data = {
+        "wl-smoke-baseline":     {"workload": "wl-smoke", "package": "baseline",     "status": "done", "completed_namespace": "ns-0"},
+        "wl-smoke-baseline-alt": {"workload": "wl-smoke", "package": "baseline-alt", "status": "done", "completed_namespace": "ns-0"},
+        "wl-smoke-treatment":    {"workload": "wl-smoke", "package": "treatment",    "status": "done", "completed_namespace": "ns-0"},
+    }
+    _mock_cm(monkeypatch, data)
+
+    class Args:
+        package = ["base*"]
+        skip_logs = False
+
+    collected_phases = []
+
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
+        collected_phases.extend(phases)
+        return {p: None for p in phases}
+
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
+        deploy._cmd_collect(Args(), run_dir, {"namespaces": ["ns-0"]})
+
+    assert sorted(collected_phases) == ["baseline", "baseline-alt"]
+
+
+def test_collect_package_glob_does_not_match_experiment(tmp_path, monkeypatch):
+    """A pattern like '*' matches every real package but must NOT match the
+    synthetic 'experiment' magic token (which is literal-only)."""
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    data = {
+        "wl-smoke-baseline":  {"workload": "wl-smoke", "package": "baseline",  "status": "done", "completed_namespace": "ns-0"},
+        "wl-smoke-treatment": {"workload": "wl-smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
+    }
+    _mock_cm(monkeypatch, data)
+
+    class Args:
+        package = ["*"]
+        skip_logs = False
+
+    collected_phases = []
+
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
+        collected_phases.extend(phases)
+        return {p: None for p in phases}
+
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
+        deploy._cmd_collect(Args(), run_dir, {"namespaces": ["ns-0"]})
+
+    # Real packages only; the magic 'experiment' token does not appear.
+    assert sorted(collected_phases) == ["baseline", "treatment"]
+    assert "experiment" not in collected_phases
+
+
+def test_collect_package_glob_pattern_matching_only_experiment_fatals(tmp_path, monkeypatch):
+    """A pattern like 'exp*' does not match the 'experiment' magic literal — even
+    though 'experiment' is in the valid set for --package on collect, patterns
+    are excluded from matching it. With no real packages matching the pattern,
+    collect exits fatally."""
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    data = {
+        "wl-smoke-baseline":  {"workload": "wl-smoke", "package": "baseline",  "status": "done", "completed_namespace": "ns-0"},
+        "wl-smoke-treatment": {"workload": "wl-smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
+    }
+    _mock_cm(monkeypatch, data)
+
+    class Args:
+        package = ["exp*"]
+        skip_logs = False
+
+    with pytest.raises(SystemExit):
+        deploy._cmd_collect(Args(), run_dir, {"namespaces": ["ns-0"]})
+
+
+def test_collect_package_experiment_literal_still_expands(tmp_path, monkeypatch):
+    """Backwards compat: literal --package experiment continues to expand to
+    every known phase after glob support is added."""
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    data = {
+        "wl-smoke-baseline":  {"workload": "wl-smoke", "package": "baseline",  "status": "done", "completed_namespace": "ns-0"},
+        "wl-smoke-treatment": {"workload": "wl-smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
+        "wl-smoke-canary":    {"workload": "wl-smoke", "package": "canary",    "status": "done", "completed_namespace": "ns-0"},
+    }
+    _mock_cm(monkeypatch, data)
+
+    class Args:
+        package = ["experiment"]
+        skip_logs = False
+
+    collected_phases = []
+
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
+        collected_phases.extend(phases)
+        return {p: None for p in phases}
+
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
+        deploy._cmd_collect(Args(), run_dir, {"namespaces": ["ns-0"]})
+
+    assert sorted(collected_phases) == ["baseline", "canary", "treatment"]
+
+
+def test_collect_package_glob_scoped_path(tmp_path, monkeypatch):
+    """Glob expansion also applies in the scoped path (with --workload)."""
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    data = {
+        "wl-smoke-baseline":     {"workload": "smoke", "package": "baseline",     "status": "done", "completed_namespace": "ns-0"},
+        "wl-smoke-baseline-alt": {"workload": "smoke", "package": "baseline-alt", "status": "done", "completed_namespace": "ns-0"},
+        "wl-smoke-treatment":    {"workload": "smoke", "package": "treatment",    "status": "done", "completed_namespace": "ns-0"},
+        "wl-load-baseline":      {"workload": "load",  "package": "baseline",     "status": "done", "completed_namespace": "ns-0"},
+    }
+    _mock_cm(monkeypatch, data)
+
+    class Args:
+        only = None
+        workload = "smoke"
+        package = ["base*"]
+        skip_logs = False
+
+    extract_calls = []
+
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
+        extract_calls.append({"phases": sorted(phases), "allowed_workloads": allowed_workloads})
+        if on_workload_done and allowed_workloads:
+            for phase in phases:
+                for wl in allowed_workloads.get(phase, set()):
+                    on_workload_done(phase, wl, namespace, None)
+        return {p: None for p in phases}
+
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
+        deploy._cmd_collect(Args(), run_dir, {"namespaces": ["ns-0"]})
+
+    assert len(extract_calls) == 1
+    assert extract_calls[0]["phases"] == ["baseline", "baseline-alt"]
+    # smoke's pairs match; load-baseline is excluded because workload filter drops it
+    assert extract_calls[0]["allowed_workloads"] == {"baseline": {"smoke"}, "baseline-alt": {"smoke"}}
+
+
+def test_collect_package_literal_and_glob_mix(tmp_path, monkeypatch):
+    """Literal + glob in the same --package value list unions correctly."""
+    from pipeline import deploy
+
+    run_dir = tmp_path / "workspace" / "runs" / "test-run"
+    (run_dir / "cluster").mkdir(parents=True)
+    data = {
+        "wl-smoke-baseline":  {"workload": "wl-smoke", "package": "baseline",  "status": "done", "completed_namespace": "ns-0"},
+        "wl-smoke-treatment": {"workload": "wl-smoke", "package": "treatment", "status": "done", "completed_namespace": "ns-0"},
+        "wl-smoke-canary":    {"workload": "wl-smoke", "package": "canary",    "status": "done", "completed_namespace": "ns-0"},
+    }
+    _mock_cm(monkeypatch, data)
+
+    class Args:
+        package = ["canary", "treat*"]
+        skip_logs = False
+
+    collected_phases = []
+
+    def mock_extract(phases, run_name, namespace, run_dir_arg, *, skip_logs=False, workload=None, allowed_workloads=None, on_workload_done=None):
+        collected_phases.extend(phases)
+        return {p: None for p in phases}
+
+    with patch.object(deploy, "_extract_phases_from_pvc", mock_extract):
+        deploy._cmd_collect(Args(), run_dir, {"namespaces": ["ns-0"]})
+
+    assert sorted(collected_phases) == ["canary", "treatment"]
+
+
 def test_collect_unknown_package_exits(tmp_path, monkeypatch):
     """With --package foo (not in progress), collect exits with error."""
     from pipeline import deploy

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -849,6 +849,137 @@ def test_apply_run_filters_only_empty_string():
     assert result == set()
 
 
+# ── --workload / --package glob tests (issue #518) ───────────────────────
+
+
+def test_apply_run_filters_workload_glob_star():
+    """--workload 'wl-s*' expands to all workloads starting with wl-s."""
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = None; workload = ["wl-s*"]; package = None; status = None
+
+    result = _apply_run_filters(dict(_PROGRESS), _Args())
+    assert result == {"wl-smoke-baseline", "wl-smoke-treatment", "wl-stale-baseline"}
+
+
+def test_apply_run_filters_workload_glob_multi_union():
+    """Multiple globs in --workload compose as OR (union)."""
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = None
+        workload = ["wl-s*", "wl-l*"]
+        package = None
+        status = None
+
+    result = _apply_run_filters(dict(_PROGRESS), _Args())
+    assert result == {
+        "wl-smoke-baseline", "wl-smoke-treatment",
+        "wl-stale-baseline",
+        "wl-load-baseline", "wl-load-treatment",
+    }
+
+
+def test_apply_run_filters_workload_literal_and_glob_mix():
+    """Mixing a literal and a glob within --workload keeps both selections."""
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = None
+        workload = ["wl-heavy", "wl-l*"]
+        package = None
+        status = None
+
+    result = _apply_run_filters(dict(_PROGRESS), _Args())
+    assert result == {
+        "wl-heavy-baseline",
+        "wl-load-baseline", "wl-load-treatment",
+    }
+
+
+def test_apply_run_filters_workload_literal_backwards_compat():
+    """Existing literal --workload invocations still work verbatim."""
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = None
+        workload = ["wl-smoke"]
+        package = None
+        status = None
+
+    result = _apply_run_filters(dict(_PROGRESS), _Args())
+    assert result == {"wl-smoke-baseline", "wl-smoke-treatment"}
+
+
+def test_apply_run_filters_workload_glob_zero_match_exits(capsys):
+    """A pattern that matches nothing fatals with the same unrecognized-values error
+    as a literal-not-in-valid, and prints the valid list."""
+    import pytest as _pytest
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = None
+        workload = ["nonexistent_*"]
+        package = None
+        status = None
+
+    with _pytest.raises(SystemExit) as exc_info:
+        _apply_run_filters(dict(_PROGRESS), _Args())
+    assert exc_info.value.code == 1
+    stderr = capsys.readouterr().err
+    assert "--workload: unrecognized values ['nonexistent_*']" in stderr
+    # The valid-values line must include real workload names so the operator can correct.
+    assert "wl-smoke" in stderr
+
+
+def test_apply_run_filters_package_glob():
+    """Glob support applies to --package the same way as --workload."""
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = None
+        workload = None
+        package = ["base*"]
+        status = None
+
+    result = _apply_run_filters(dict(_PROGRESS), _Args())
+    assert result == {
+        "wl-smoke-baseline", "wl-load-baseline",
+        "wl-heavy-baseline", "wl-stale-baseline",
+    }
+
+
+def test_apply_run_filters_package_glob_zero_match_exits(capsys):
+    """--package pattern with zero matches exits with unrecognized-values error."""
+    import pytest as _pytest
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = None
+        workload = None
+        package = ["missing_*"]
+        status = None
+
+    with _pytest.raises(SystemExit):
+        _apply_run_filters(dict(_PROGRESS), _Args())
+    assert "--package: unrecognized values ['missing_*']" in capsys.readouterr().err
+
+
+def test_apply_run_filters_workload_glob_composes_with_status():
+    """Glob expansion for --workload composes with --status (AND)."""
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = None
+        workload = ["wl-*"]  # matches everything
+        package = None
+        status = "failed"
+
+    result = _apply_run_filters(dict(_PROGRESS), _Args())
+    assert result == {"wl-heavy-baseline"}
+
+
 # ── --iteration filter tests (issue #512) ────────────────────────────────
 
 _ITER_PROGRESS = {


### PR DESCRIPTION
Closes #518.

## Summary

`deploy.py` scoping flags `--workload` and `--package` now accept shell-glob patterns in addition to literal names. Values containing `*`, `?`, or `[` are matched against the valid set with Python's `fnmatch`; everything else is a literal (existing invocations unchanged). Applies to every filter-aware subcommand: `run`, `status`, `collect`, `reset`, `wipe`.

Per the vet, this extends the issue's original `--workload`-only scope to include `--package` as well, since the pattern generalizes cleanly.

```bash
python pipeline/deploy.py run --workload 'code_generation_*'
python pipeline/deploy.py run --workload 'code*'
python pipeline/deploy.py run --workload code_generation_4 'reasoning_0_*'
python pipeline/deploy.py collect --package 'baseline*'
```

## What changed

- `pipeline/deploy.py`
  - `_expand_glob_values` helper (near `_parse_list`) — expands a mixed literal/pattern list against a valid set, preserving user input order, with an optional `exclude_from_pattern` set for magic tokens.
  - `_apply_run_filters`: `--workload` and `--package` blocks now expand via the helper before the set-membership check. Same error text on unrecognized values.
  - `collect` scoped path (with `--only`/`--workload`) and unscoped path: both `--package` filter sites go through the helper with `exclude_from_pattern={"experiment"}` — patterns never match the `experiment` magic token; literal `experiment` continues to expand to every known phase.
- `pipeline/tests/test_deploy_run.py`: 8 new `_apply_run_filters` glob cases — workload glob single/multi/literal-mix/backwards-compat/zero-match-fatal, package glob + zero-match-fatal, glob-composes-with-status.
- `pipeline/tests/test_deploy_collect.py`: 6 new `_cmd_collect` glob cases covering both scoped and unscoped paths, `experiment` literal-only, glob-doesn't-match-magic behavior, and literal+glob mix.
- `pipeline/README.md`: master scoping-flags section adds a Glob patterns block and points every per-subcommand `--workload`/`--package` row to it (`; globs OK`). Collect's `--package` row explicitly notes the `experiment` carve-out.

## Design notes worth flagging

- **Magic token carve-out**: `collect --package` accepts a synthetic `experiment` value that expands to "all known phases." Making glob patterns never match this token keeps its semantics unambiguous — the operator must type it verbatim to trigger the expand. Verified in a dedicated test.
- **Error-text stability**: `_apply_run_filters` still fails with `--workload: unrecognized values [...]` (list) exactly as before. `test_deploy_remote.py:294` asserts on this text and continues to pass.
- **Order preservation**: `_expand_glob_values` returns the expanded list in user-input order (first occurrence wins). Matters for `collect`'s phase-selection stage, which iterates the expansion in order.

## Sweep for stale references

Grepped `docs/`, `.claude/skills/`, `pipeline/README.md`, and all `README*` for `--workload NAME`, `--package NAME`, `_apply_run_filters`, and the unknown-values error text. Historical planning docs under `docs/superpowers/plans/` and `docs/proposals/` mention `_apply_run_filters` as records-in-time; unchanged per project convention. `.claude/skills/sim2real-check/SKILL.md` mentions `--workload` in a note about a *removed* flag (unrelated to this change).

## Test plan

- [x] `python3 -m pytest pipeline/tests/test_deploy_run.py pipeline/tests/test_deploy_collect.py -v` — 14 new tests pass; existing filter tests unchanged.
- [x] `python3 -m pytest pipeline/ .claude/skills/sim2real-*/tests/ -q` — full CI test set: 1737 passed, 1 skipped, 2 xfailed.
- [x] `ruff check pipeline/ .claude/skills/ --select F` — clean.