### PR TITLE
feat(sim2real-analyze): standard analyses catalog

### DIFF
--- a/.claude/skills/sim2real-analyze/SKILL.md
+++ b/.claude/skills/sim2real-analyze/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: sim2real-analyze
 description: |
-  Analyze sim2real pipeline run results. Shows per-workload latency comparison tables
-  (TTFT/TPOT/E2E baseline vs treatment) and handles any user analysis request: charts,
-  distributions, HTML reports, cross-run comparisons.
+  Analyze sim2real pipeline run results. Offers a catalog of standard analyses
+  (per-workload latency comparison, per-request scatter) plus a free-form loop
+  for custom charts, distributions, HTML reports, and cross-run comparisons.
 argument-hint: "[--run NAME]"
 user-invocable: true
 allowed-tools:
@@ -58,8 +58,10 @@ If the user describes a specific analysis → skip to Step 4 with that request.
 
 ## Step 3 — Compute and print comparison table
 
+Run the default catalog entry (`latency-table`):
+
 ```bash
-python .claude/skills/sim2real-analyze/scripts/compute_table.py --run <name>
+python .claude/skills/sim2real-analyze/analyses/latency_table.py --run <name>
 ```
 
 Print the full output to the user. If the script exits with code 1, surface the error and stop.
@@ -73,56 +75,88 @@ Then go to Step 4.
 
 ## Step 4 — Interactive analysis loop
 
-Ask:
+Enumerate the catalog of standard analyses:
+
+```bash
+python .claude/skills/sim2real-analyze/scripts/list_analyses.py
 ```
-What would you like to analyze next? (or 'done' to exit)
+
+Parse the resulting JSON. Each entry has `name`, `title`, `when-to-use`,
+`inputs`, `output`, `runner`, `path`, and (for `runner: script`) `script`.
+
+Present the catalog as a numbered menu, excluding the `latency-table` entry
+(already run in Step 3):
+
+```
+Analyses available for run '<name>':
+  1. <title> — <when-to-use>
+  2. <title> — <when-to-use>
+  ...
+
+Choose a number, an analysis name, describe what you'd like, or 'done' to exit.
 ```
 
 For each user request:
 
-1. Before the first user analysis request, check if pandas and matplotlib are importable:
-   ```bash
-   python -c "import pandas, matplotlib" 2>/dev/null
-   ```
-   If exit code ≠ 0, print once:
-   ```
-   Some analysis features require pandas and matplotlib. Install with:
-     pip install pandas matplotlib seaborn
-   ```
-   and fall back to stdlib-only analysis (tables and statistics, no charts). Do not attempt to write chart scripts for requests that require matplotlib.
+1. **Numbered / named catalog entry.** Look up the matching entry and invoke it by `runner`:
+   - `runner: script` — invoke:
+     ```bash
+     python .claude/skills/sim2real-analyze/analyses/<script> --run <name>
+     ```
+     Print the output. Ask the user for any additional parameters the script requires.
+   - `runner: prompt` — read the entry's file at `path` and follow the prompt block in its body as instructions. The prompt itself specifies required parameters, defaults, and the output path convention.
 
-2. Create `workspace/runs/<name>/results_charts/` if it doesn't exist:
-   ```bash
-   mkdir -p workspace/runs/<name>/results_charts/
-   ```
-   If this fails, tell the user and continue the loop.
+2. **Free-text.** Match the user's phrasing against each entry's `when-to-use`.
+   - Exactly one strong match → confirm briefly ("Sounds like `<name>` — run it?") and invoke.
+   - Multiple plausible matches → list the candidates and ask.
+   - No match → fall back to the one-off-script flow (step 3 below).
 
-3. Write a self-contained Python script to a temp file. Generate the filename with:
-   ```python
-   import os; name = f"/tmp/sim2real_analyze_{os.urandom(4).hex()}.py"
-   ```
-   The script must:
-   - Import pandas, matplotlib, seaborn as needed
-   - Load CSVs from `workspace/runs/<name>/results/baseline/{workload}/trace_data.csv` and `results/treatment/`
-   - All timestamps are in **microseconds** — divide by 1000 for milliseconds
-   - Filter to `status == "ok"` rows before computing any metrics
-   - Save charts to `workspace/runs/<name>/results_charts/<descriptive-name>.png` or `.html`
-   - Print any tabular results to stdout
+3. **One-off-script fallback.** For requests with no catalog match:
 
-4. Execute the script:
-   ```bash
-   python /tmp/sim2real_analyze_<hex>.py
-   ```
+   a. Before the first fallback in this session, check pandas and matplotlib are importable:
+      ```bash
+      python -c "import pandas, matplotlib" 2>/dev/null
+      ```
+      If exit code ≠ 0, print once:
+      ```
+      Some analyses require pandas and matplotlib. Install with:
+        pip install pandas matplotlib seaborn
+      ```
+      and fall back to stdlib-only analysis (tables and statistics, no charts).
 
-5. Delete the temp file after execution:
-   ```bash
-   rm /tmp/sim2real_analyze_<hex>.py
-   ```
+   b. Ensure the charts directory exists:
+      ```bash
+      mkdir -p workspace/runs/<name>/results_charts/
+      ```
 
-6. Report results:
-   - For PNG outputs: `Saved: workspace/runs/<name>/results_charts/<name>.png`
-   - For HTML outputs: report path and open it: `open workspace/runs/<name>/results_charts/<name>.html`
-   - For stdout tables: print them directly
+   c. Write a self-contained Python script to a temp file:
+      ```python
+      import os; name = f"/tmp/sim2real_analyze_{os.urandom(4).hex()}.py"
+      ```
+      The script must:
+      - Import pandas, matplotlib, seaborn as needed
+      - Load CSVs from `workspace/runs/<name>/results/baseline/{workload}/trace_data.csv` and `results/treatment/`
+      - All timestamps are in **microseconds** — divide by 1000 for milliseconds
+      - Filter to `status == "ok"` rows before computing any metrics
+      - Save charts to `workspace/runs/<name>/results_charts/<descriptive-name>.png` or `.html`
+      - Print any tabular results to stdout
+
+   d. Execute the script:
+      ```bash
+      python /tmp/sim2real_analyze_<hex>.py
+      ```
+
+   e. Delete the temp file:
+      ```bash
+      rm /tmp/sim2real_analyze_<hex>.py
+      ```
+
+   f. Report results:
+      - PNG outputs: `Saved: workspace/runs/<name>/results_charts/<name>.png`
+      - HTML outputs: report the path and open it: `open workspace/runs/<name>/results_charts/<name>.html`
+      - Stdout tables: print them directly
+
+   Recurring one-off analyses are candidates for the standard catalog — note them for follow-up ("this pattern would be worth adding to `analyses/` as a `runner: prompt` entry").
 
 **Session memory:** Remember what has been generated so far. "Show me that last chart again" → re-run or re-open the chart at its saved path.
 
@@ -149,9 +183,40 @@ workspace/runs/<name>/
       workload_<name>/
         trace_data.csv
         trace_header.yaml
-  deploy_comparison_table.txt  # written by compute_table.py
+  deploy_comparison_table.txt  # written by analyses/latency_table.py
   results_charts/              # your analysis outputs go here
 ```
+
+## Standard analyses catalog
+
+The skill ships a curated catalog under `analyses/`, discovered at runtime
+via `scripts/list_analyses.py`. Each entry is a `.md` file with YAML
+front-matter:
+
+```yaml
+---
+name: <slug>
+title: <human title>
+when-to-use: <one-line trigger>
+inputs: run
+output: html | png | table
+runner: script | prompt
+script: <filename>   # required when runner == script
+---
+```
+
+The skill enumerates the catalog on entry to the interactive loop and
+offers each entry as a menu choice. Free-text is matched against each
+entry's `when-to-use`; on a strong match the skill invokes the entry, on
+no match it falls back to the one-off-script flow.
+
+To add a standard analysis:
+
+- Create a new `.md` file under `analyses/` with valid front-matter.
+- For `runner: script`, add the co-located script alongside — the skill
+  invokes `python .claude/skills/sim2real-analyze/analyses/<script> --run <name>`.
+- For `runner: prompt`, put the prompt in the `.md` body — the skill
+  follows the prompt block verbatim when the entry is selected.
 
 All timestamps are **microseconds**. Metrics:
 - TTFT = (first_chunk_time_us - send_time_us) / 1000 ms

--- a/.claude/skills/sim2real-analyze/analyses/latency-table.md
+++ b/.claude/skills/sim2real-analyze/analyses/latency-table.md
@@ -1,0 +1,36 @@
+---
+name: latency-table
+title: Per-workload latency comparison table
+when-to-use: default first-look at a run — TTFT/TPOT/E2E mean/p50/p99 for baseline vs treatment, side-by-side per workload
+inputs: run
+output: table
+runner: script
+script: latency_table.py
+---
+
+# Per-workload latency comparison table
+
+The default analysis for a sim2real run. Loads `trace_data.csv` from both
+`results/baseline/<workload>/` and `results/treatment/<workload>/`, filters
+to `status == "ok"`, and prints one section per workload with:
+
+- **TTFT** mean / p50 / p99 (ms)
+- **TPOT** mean / p50 / p99 (ms) — only when the workload has requests
+  with `output_tokens > 1`
+- **E2E** mean / p50 / p99 (ms)
+
+Each row shows baseline, treatment, absolute delta, and a percentage
+change with a `(better)` / `(worse)` / `(no change)` verdict.
+
+The full table is also written to `<run>/deploy_comparison_table.txt` so
+future runs of this analysis are diff-able.
+
+## Invocation
+
+The skill invokes this analysis by running its `script` field:
+
+```bash
+python .claude/skills/sim2real-analyze/analyses/latency_table.py --run <name>
+```
+
+`--run` defaults to `current_run` from `workspace/setup_config.json`.

--- a/.claude/skills/sim2real-analyze/analyses/latency_table.py
+++ b/.claude/skills/sim2real-analyze/analyses/latency_table.py
@@ -2,7 +2,7 @@
 """Compute per-workload comparison table from sim2real trace CSVs.
 
 Invocation:
-    python .claude/skills/sim2real-analyze/scripts/compute_table.py --run <name>
+    python .claude/skills/sim2real-analyze/analyses/latency_table.py --run <name>
     # --run defaults to current_run from workspace/setup_config.json if omitted
 """
 import argparse
@@ -12,7 +12,7 @@ import statistics
 import sys
 from pathlib import Path
 
-# Repo root: script is at {repo}/.claude/skills/sim2real-analyze/scripts/compute_table.py
+# Repo root: script is at {repo}/.claude/skills/sim2real-analyze/analyses/latency_table.py
 REPO_ROOT = Path(__file__).resolve().parents[4]
 WORKSPACE_DIR = REPO_ROOT / "workspace"
 

--- a/.claude/skills/sim2real-analyze/analyses/per-request-scatter.md
+++ b/.claude/skills/sim2real-analyze/analyses/per-request-scatter.md
@@ -1,0 +1,133 @@
+---
+name: per-request-scatter
+title: Per-request latency scatter (latency vs send time, phases as rows, workloads as columns)
+when-to-use: see per-request behavior over time — makes queue admission / priority / flow-control engagement visible by eye without reading numbers
+inputs: run
+output: png
+runner: prompt
+---
+
+# Per-request scatter plot
+
+Ported from `kalantar-msb/soft-reflective:workspace/prompts/per-request-scatter.md`
+and adapted for sim2real's single-run, two-phase layout.
+
+The chart's purpose: when a flow-control / admission / priority algorithm
+engages, its per-request behavior should be visible by eye — e.g.,
+"treatment holds the floor while baseline climbs under load," or "both
+phases scatter identically under light load."
+
+## Prompt
+
+```
+Build a single PNG that, for a sim2real run's collected results, plots
+per-request latency vs send time as a scatter, with phases as rows and
+workloads as columns. One color per phase.
+
+INPUT DATA
+- Run directory: workspace/runs/<run>/
+- Trace CSVs at:
+    workspace/runs/<run>/results/<phase>/<workload>/trace_data.csv
+  where <phase> is one of {baseline, treatment} and <workload> is a
+  per-workload subdirectory (e.g. workload_fm8_short_output_highrate).
+- trace_data.csv is per-request, one row per request. Required columns:
+    send_time_us         request egress timestamp (microseconds)
+    first_chunk_time_us  first response chunk arrival (microseconds)
+    last_chunk_time_us   last response chunk arrival (microseconds)
+    output_tokens        token count (only needed for TPOT)
+    status               row-level status; filter to "ok"
+- Optional column: slo_class. If present, override the default
+  per-phase coloring with per-class coloring (see COLORS below).
+
+WHAT TO COMPUTE
+- Discover workloads: intersection of subdirectory names under
+  results/baseline/ and results/treatment/. Skip any that lack a
+  trace_data.csv.
+- For each (phase, workload) cell:
+    Filter to status == "ok".
+    Compute the chosen latency metric in milliseconds (default TTFT):
+       TTFT = (first_chunk_time_us - send_time_us) / 1000
+       E2E  = (last_chunk_time_us - send_time_us)  / 1000
+       TPOT = (last_chunk_time_us - first_chunk_time_us) / max(output_tokens-1, 1) / 1000
+              (only valid when output_tokens > 1)
+    Compute send time relative to first request, in seconds:
+       t_s = (send_time_us - cell_min_send_time) / 1e6
+
+OUTPUT
+- One matplotlib PNG saved to <output_path> at >= 130 dpi. Default
+  output path:
+    workspace/runs/<run>/results_charts/per_request_<metric>.png
+- Grid: rows = phases in order [baseline, treatment], cols = workloads
+  in sorted order.
+- Each panel: scatter of (t_s, latency_ms) for status=='ok' rows.
+- Markers: small circles, size ~6 pt^2, alpha ~0.45 to show density.
+- Each panel has its own y-axis range (metric range varies orders of
+  magnitude across workloads; a shared y-axis would wash out low-load
+  panels). If the caller wants shared-y-per-row to compare phases at
+  the same workload, support that as an option.
+- Column titles on the top row: the workload name with the
+  "workload_" prefix stripped and underscores replaced with hyphens.
+- Row labels on the left of each row's first panel: phase name in bold.
+- Both x-axis (send time, seconds) and y-axis (metric, ms) labels on
+  every panel.
+- Y-axis tick formatter: "Nk" for values >= 1000, "N.NN" for < 10,
+  plain integer otherwise.
+
+COLORS
+- Default (no slo_class column): one color per phase.
+    baseline  → "#1f77b4" (blue)
+    treatment → "#d62728" (red)
+- If slo_class column is present: color by slo_class instead. Defaults:
+    critical  → "#d62728" (red)
+    sheddable → "#1f77b4" (blue)
+    other classes → cycle through tab10
+- Legend on the top-left panel only, showing one entry per color group
+  with count "n=…" for density context.
+
+LAYOUT AND STYLING
+- Single .png file. No HTML, no JS.
+- Light background, gray dotted gridlines at alpha 0.4.
+- Title: "<run> — per-request <metric> vs send time / Each dot = one
+  request".
+- tight_layout with bbox_inches='tight' on save.
+- Figure size: ~5 inches per workload column, ~3.5 inches per phase row.
+
+PARAMETERS THE CALLER MAY SUPPLY
+- run (default: current_run from workspace/setup_config.json)
+- metric (one of "TTFT" / "E2E" / "TPOT"; default "TTFT")
+- shared_y_per_row (default False — independent per panel)
+- output_path (default: workspace/runs/<run>/results_charts/per_request_<metric>.png)
+
+If a parameter is missing, fall back to the default. Do not guess paths.
+
+DELIVERABLE
+- One PNG written to output_path.
+- Print a short summary: number of panels rendered, the (phase, workload)
+  of the panel with the most data points, and whether coloring is by
+  phase (default) or slo_class.
+```
+
+## Visual decisions this prompt bakes in
+
+- **Per-panel y-axis (not shared).** Metric range varies orders of
+  magnitude across workloads; a shared axis would hide the algorithm
+  effect at low load.
+- **Small markers + alpha.** At tens of thousands of requests per cell,
+  full-opacity scatter becomes a solid band.
+- **Per-phase color when slo_class is absent.** Sim2real trace CSVs
+  currently don't emit `slo_class`; the per-class coloring is retained
+  as a fallback for future compatibility.
+- **TTFT default.** A queue-admission algorithm's effect is sharpest
+  in TTFT. E2E mixes queue wait with decode and is noisier.
+
+## Notes for the caller
+
+- **One run, both phases.** Unlike the multi-replicate soft-reflective
+  version, this analysis operates on a single sim2real run with two
+  phases (baseline and treatment) side-by-side.
+- **Cold-start tail is part of what you see.** The chart deliberately
+  shows the early seconds where TTFT can be inflated by CUDA-graph
+  capture, prefix-cache fill, and saturation-signal stabilization. If
+  that's distracting, add a `t_min` parameter to clip the x-axis from
+  below — but you'd also lose visibility into how the algorithm
+  responds to startup transients.

--- a/.claude/skills/sim2real-analyze/scripts/list_analyses.py
+++ b/.claude/skills/sim2real-analyze/scripts/list_analyses.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""List analyses in the sim2real-analyze catalog.
+
+Discovers .md files under `.claude/skills/sim2real-analyze/analyses/`,
+parses YAML front-matter, and prints a JSON array of entries to stdout.
+Malformed entries are reported to stderr and skipped so the catalog
+remains usable when a single entry is broken.
+
+Front-matter schema:
+    name: <slug>          # required
+    title: <str>          # required
+    when-to-use: <str>    # required
+    inputs: <str>         # required (currently only "run")
+    output: <str>         # required ("html" | "png" | "table")
+    runner: <str>         # required ("script" | "prompt")
+    script: <filename>    # required when runner == "script";
+                          # path is relative to the analyses/ directory
+
+Usage:
+    python .claude/skills/sim2real-analyze/scripts/list_analyses.py \
+        [--analyses-dir PATH]
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print(
+        "Error: PyYAML required — install with `pip install PyYAML`",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+REQUIRED_FIELDS = ("name", "title", "when-to-use", "inputs", "output", "runner")
+VALID_RUNNERS = {"script", "prompt"}
+VALID_OUTPUTS = {"html", "png", "table"}
+
+
+def warn(msg: str) -> None:
+    print(f"Warning: {msg}", file=sys.stderr)
+
+
+def _default_analyses_dir() -> Path:
+    """analyses/ directory as a sibling of scripts/ (this script's location)."""
+    return Path(__file__).resolve().parent.parent / "analyses"
+
+
+def _parse_front_matter(text: str) -> dict | None:
+    """Extract the YAML block delimited by leading `---` / `---`.
+
+    Returns the parsed dict, or None when the file lacks a front-matter block
+    or the block fails to parse. Errors are reported by the caller with the
+    file path for context.
+    """
+    if not text.startswith("---\n") and not text.startswith("---\r\n"):
+        return None
+    body = text.split("\n", 1)[1] if text.startswith("---\n") else text.split("\r\n", 1)[1]
+    end = body.find("\n---")
+    if end == -1:
+        return None
+    yaml_block = body[:end]
+    try:
+        data = yaml.safe_load(yaml_block)
+    except yaml.YAMLError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+def _validate(entry: dict, entry_path: Path, analyses_dir: Path) -> str | None:
+    """Return None if the entry is valid, else a reason string for the caller."""
+    missing = [f for f in REQUIRED_FIELDS if f not in entry or entry[f] in (None, "")]
+    if missing:
+        return f"missing required field(s): {', '.join(missing)}"
+
+    runner = entry["runner"]
+    if runner not in VALID_RUNNERS:
+        return f"invalid runner {runner!r} — expected one of {sorted(VALID_RUNNERS)}"
+
+    output = entry["output"]
+    if output not in VALID_OUTPUTS:
+        return f"invalid output {output!r} — expected one of {sorted(VALID_OUTPUTS)}"
+
+    if runner == "script":
+        script = entry.get("script")
+        if not script:
+            return "runner is 'script' but the 'script' field is missing"
+        script_path = analyses_dir / script
+        if not script_path.exists():
+            return f"script {script!r} does not exist at {script_path}"
+
+    return None
+
+
+def load_catalog(analyses_dir: Path) -> list[dict]:
+    """Discover and parse every .md entry under `analyses_dir`.
+
+    Malformed entries are logged to stderr and skipped. The returned list is
+    sorted by `name` for stable output.
+    """
+    entries: list[dict] = []
+    for md in sorted(analyses_dir.glob("*.md")):
+        try:
+            text = md.read_text()
+        except OSError as e:
+            warn(f"{md}: could not read ({e})")
+            continue
+        fm = _parse_front_matter(text)
+        if fm is None:
+            warn(f"{md}: missing or malformed YAML front-matter — skipped")
+            continue
+        reason = _validate(fm, md, analyses_dir)
+        if reason:
+            warn(f"{md}: {reason} — skipped")
+            continue
+        fm["path"] = str(md.relative_to(analyses_dir.parent))
+        entries.append(fm)
+    entries.sort(key=lambda e: e["name"])
+    return entries
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="List analyses in the sim2real-analyze catalog"
+    )
+    parser.add_argument(
+        "--analyses-dir",
+        type=Path,
+        default=None,
+        help="Path to the analyses/ directory (default: alongside this script)",
+    )
+    args = parser.parse_args()
+
+    analyses_dir = args.analyses_dir or _default_analyses_dir()
+    if not analyses_dir.is_dir():
+        print(f"Error: analyses directory not found: {analyses_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    entries = load_catalog(analyses_dir)
+    print(json.dumps(entries, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/sim2real-analyze/tests/test_latency_table.py
+++ b/.claude/skills/sim2real-analyze/tests/test_latency_table.py
@@ -1,4 +1,4 @@
-"""Tests for compute_table.py — sim2real-analyze comparison table script."""
+"""Tests for latency_table.py — sim2real-analyze comparison table analysis."""
 import csv
 import json
 import sys
@@ -6,9 +6,8 @@ from pathlib import Path
 
 import pytest
 
-# Add scripts dir to path so we can import compute_table
-sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
-import compute_table
+sys.path.insert(0, str(Path(__file__).parent.parent / "analyses"))
+import latency_table as compute_table
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────

--- a/.claude/skills/sim2real-analyze/tests/test_list_analyses.py
+++ b/.claude/skills/sim2real-analyze/tests/test_list_analyses.py
@@ -1,0 +1,259 @@
+"""Tests for list_analyses.py — catalog discovery + front-matter parsing."""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+import list_analyses
+
+
+REAL_ANALYSES_DIR = Path(__file__).resolve().parent.parent / "analyses"
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / "scripts" / "list_analyses.py"
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def write_entry(dir_path: Path, name: str, front_matter: str, body: str = "") -> Path:
+    """Write a .md file with `front_matter` (YAML content between --- delimiters) and body."""
+    dir_path.mkdir(parents=True, exist_ok=True)
+    path = dir_path / f"{name}.md"
+    content = f"---\n{front_matter}---\n{body}"
+    path.write_text(content)
+    return path
+
+
+def write_script(dir_path: Path, script_name: str) -> Path:
+    """Create an empty script stub so `runner: script` validation passes."""
+    script_path = dir_path / script_name
+    script_path.write_text("# stub\n")
+    return script_path
+
+
+# ── Real-catalog smoke test ──────────────────────────────────────────────────
+
+def test_real_catalog_has_two_entries():
+    """The shipped catalog resolves without warnings and contains both exemplars."""
+    entries = list_analyses.load_catalog(REAL_ANALYSES_DIR)
+    names = {e["name"] for e in entries}
+    assert names == {"latency-table", "per-request-scatter"}
+
+
+def test_real_catalog_entries_have_all_required_fields():
+    entries = list_analyses.load_catalog(REAL_ANALYSES_DIR)
+    for e in entries:
+        for field in list_analyses.REQUIRED_FIELDS:
+            assert e.get(field), f"entry {e.get('name')!r} missing {field!r}"
+
+
+def test_real_catalog_script_entry_points_at_existing_file():
+    entries = {e["name"]: e for e in list_analyses.load_catalog(REAL_ANALYSES_DIR)}
+    lt = entries["latency-table"]
+    assert lt["runner"] == "script"
+    assert (REAL_ANALYSES_DIR / lt["script"]).exists()
+
+
+# ── Isolated-catalog tests ────────────────────────────────────────────────────
+
+def test_valid_prompt_entry_is_returned(tmp_path):
+    write_entry(tmp_path, "foo", (
+        "name: foo\n"
+        "title: Foo\n"
+        "when-to-use: exemplar\n"
+        "inputs: run\n"
+        "output: png\n"
+        "runner: prompt\n"
+    ))
+    entries = list_analyses.load_catalog(tmp_path)
+    assert len(entries) == 1
+    assert entries[0]["name"] == "foo"
+    assert entries[0]["runner"] == "prompt"
+
+
+def test_valid_script_entry_is_returned(tmp_path):
+    write_script(tmp_path, "foo.py")
+    write_entry(tmp_path, "foo", (
+        "name: foo\n"
+        "title: Foo\n"
+        "when-to-use: exemplar\n"
+        "inputs: run\n"
+        "output: table\n"
+        "runner: script\n"
+        "script: foo.py\n"
+    ))
+    entries = list_analyses.load_catalog(tmp_path)
+    assert len(entries) == 1
+    assert entries[0]["script"] == "foo.py"
+
+
+def test_missing_required_field_is_skipped(tmp_path, capsys):
+    write_entry(tmp_path, "bad", (
+        "name: bad\n"
+        "title: Bad\n"
+        # missing when-to-use, inputs, output, runner
+    ))
+    entries = list_analyses.load_catalog(tmp_path)
+    assert entries == []
+    assert "missing required field" in capsys.readouterr().err
+
+
+def test_malformed_yaml_is_skipped(tmp_path, capsys):
+    # Unbalanced brackets → PyYAML raises
+    write_entry(tmp_path, "bad", "name: bad\ntitle: [unclosed\n")
+    entries = list_analyses.load_catalog(tmp_path)
+    assert entries == []
+    assert "malformed YAML" in capsys.readouterr().err
+
+
+def test_missing_front_matter_is_skipped(tmp_path, capsys):
+    """File without the leading `---` delimiter is not a catalog entry."""
+    (tmp_path / "plain.md").write_text("just prose, no front-matter\n")
+    entries = list_analyses.load_catalog(tmp_path)
+    assert entries == []
+    assert "malformed YAML front-matter" in capsys.readouterr().err
+
+
+def test_unterminated_front_matter_is_skipped(tmp_path, capsys):
+    """Front-matter with an opening --- but no closing --- is malformed."""
+    (tmp_path / "bad.md").write_text("---\nname: bad\ntitle: Bad\n(no closing delim)\n")
+    entries = list_analyses.load_catalog(tmp_path)
+    assert entries == []
+    assert "malformed YAML front-matter" in capsys.readouterr().err
+
+
+def test_invalid_runner_is_skipped(tmp_path, capsys):
+    write_entry(tmp_path, "bad", (
+        "name: bad\n"
+        "title: Bad\n"
+        "when-to-use: exemplar\n"
+        "inputs: run\n"
+        "output: png\n"
+        "runner: banana\n"
+    ))
+    entries = list_analyses.load_catalog(tmp_path)
+    assert entries == []
+    assert "invalid runner" in capsys.readouterr().err
+
+
+def test_invalid_output_is_skipped(tmp_path, capsys):
+    write_entry(tmp_path, "bad", (
+        "name: bad\n"
+        "title: Bad\n"
+        "when-to-use: exemplar\n"
+        "inputs: run\n"
+        "output: gif\n"
+        "runner: prompt\n"
+    ))
+    entries = list_analyses.load_catalog(tmp_path)
+    assert entries == []
+    assert "invalid output" in capsys.readouterr().err
+
+
+def test_script_runner_missing_script_field_is_skipped(tmp_path, capsys):
+    write_entry(tmp_path, "bad", (
+        "name: bad\n"
+        "title: Bad\n"
+        "when-to-use: exemplar\n"
+        "inputs: run\n"
+        "output: table\n"
+        "runner: script\n"
+        # no script: field
+    ))
+    entries = list_analyses.load_catalog(tmp_path)
+    assert entries == []
+    assert "'script' field is missing" in capsys.readouterr().err
+
+
+def test_script_runner_missing_script_file_is_skipped(tmp_path, capsys):
+    write_entry(tmp_path, "bad", (
+        "name: bad\n"
+        "title: Bad\n"
+        "when-to-use: exemplar\n"
+        "inputs: run\n"
+        "output: table\n"
+        "runner: script\n"
+        "script: nonexistent.py\n"
+    ))
+    entries = list_analyses.load_catalog(tmp_path)
+    assert entries == []
+    assert "does not exist" in capsys.readouterr().err
+
+
+def test_empty_catalog_returns_empty_list(tmp_path):
+    entries = list_analyses.load_catalog(tmp_path)
+    assert entries == []
+
+
+def test_entries_are_sorted_by_name(tmp_path):
+    for name in ("zebra", "apple", "middle"):
+        write_entry(tmp_path, name, (
+            f"name: {name}\n"
+            f"title: {name.title()}\n"
+            "when-to-use: exemplar\n"
+            "inputs: run\n"
+            "output: png\n"
+            "runner: prompt\n"
+        ))
+    entries = list_analyses.load_catalog(tmp_path)
+    assert [e["name"] for e in entries] == ["apple", "middle", "zebra"]
+
+
+def test_mixed_valid_and_invalid_returns_only_valid(tmp_path, capsys):
+    write_entry(tmp_path, "good", (
+        "name: good\n"
+        "title: Good\n"
+        "when-to-use: exemplar\n"
+        "inputs: run\n"
+        "output: png\n"
+        "runner: prompt\n"
+    ))
+    write_entry(tmp_path, "bad", "name: bad\n")  # missing required fields
+    entries = list_analyses.load_catalog(tmp_path)
+    assert [e["name"] for e in entries] == ["good"]
+    assert "missing required field" in capsys.readouterr().err
+
+
+def test_unknown_extra_fields_are_preserved(tmp_path):
+    """Forward-compat: unknown keys in front-matter are kept, not dropped."""
+    write_entry(tmp_path, "foo", (
+        "name: foo\n"
+        "title: Foo\n"
+        "when-to-use: exemplar\n"
+        "inputs: run\n"
+        "output: png\n"
+        "runner: prompt\n"
+        "future_field: some_value\n"
+    ))
+    entries = list_analyses.load_catalog(tmp_path)
+    assert entries[0]["future_field"] == "some_value"
+
+
+# ── CLI-level tests ───────────────────────────────────────────────────────────
+
+def test_cli_emits_json_array():
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH)],
+        capture_output=True, text=True, check=True,
+    )
+    parsed = json.loads(result.stdout)
+    assert isinstance(parsed, list)
+    names = {e["name"] for e in parsed}
+    assert "latency-table" in names
+
+
+def test_cli_missing_dir_exits_nonzero(tmp_path):
+    nonexistent = tmp_path / "nope"
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--analyses-dir", str(nonexistent)],
+        capture_output=True, text=True,
+    )
+    assert result.returncode != 0
+    assert "not found" in result.stderr
+
+
+def test_cli_empty_dir_emits_empty_array(tmp_path):
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--analyses-dir", str(tmp_path)],
+        capture_output=True, text=True, check=True,
+    )
+    assert json.loads(result.stdout) == []


### PR DESCRIPTION
## Summary

Introduces a standard analyses catalog under `.claude/skills/sim2real-analyze/analyses/` so the interactive loop can offer a curated menu instead of the generic "what would you like to analyze next?" prompt. Addresses analysis-format drift across team members running ad-hoc analyses on the same run.

Closes #536.

## What's in the catalog

Two entries, one per runner type — proves the pattern works for both:

- `latency-table` — `runner: script`, `output: table`. Migrated from `scripts/compute_table.py`; behavior unchanged. This is the default that runs on skill entry.
- `per-request-scatter` — `runner: prompt`, `output: png`. Ported from `kalantar-msb/soft-reflective:workspace/prompts/per-request-scatter.md` and adapted for sim2real's single-run, `{baseline, treatment}` layout. The `slo_class` column doesn't exist in current sim2real trace CSVs (confirmed by grep), so coloring defaults to per-phase; the prompt keeps SLO-class coloring as a fallback for future compatibility.

## Front-matter schema

```yaml
---
name: <slug>
title: <human title>
when-to-use: <one-line trigger>
inputs: run
output: html | png | table
runner: script | prompt
script: <filename>   # required when runner == script
---
```

`scripts/list_analyses.py` discovers `analyses/*.md`, parses front-matter with PyYAML (already in requirements), validates required fields, and emits JSON. Malformed entries are logged to stderr and skipped so a single broken entry doesn't take the catalog down.

## SKILL.md changes

- Step 3 now invokes `analyses/latency_table.py` (behavior identical to the previous `scripts/compute_table.py`).
- Step 4 enumerates the catalog on entry and offers a numbered menu. Free-text is matched against each entry's `when-to-use`; on a strong match the skill invokes the entry, otherwise it falls back to the existing one-off-script flow.
- New "Standard analyses catalog" section documents how to add an entry.

## What warrants reviewer attention

1. **`compute_table.py` → `analyses/latency_table.py` rename.** The `REPO_ROOT = Path(__file__).resolve().parents[4]` math is preserved (same depth from repo root: `.claude/skills/sim2real-analyze/analyses/latency_table.py`). The test file uses `import latency_table as compute_table` to keep the existing 60+ test references working without a mechanical rename — reviewer's call on whether to also rename the local binding.
2. **Per-request-scatter port adaptation.** The soft-reflective source assumes `<bundle>/<run>/<phase>/<workload>/` with `<run>` as a replicate label; the sim2real port assumes `workspace/runs/<name>/results/<phase>/<workload>/` and `phase ∈ {baseline, treatment}`. The prompt body diverged from the source in that dimension — reviewer should verify the port's `INPUT DATA` block matches sim2real's actual layout.
3. **Free-text matching lives in the LLM, not a scorer.** `when-to-use` is prose that the skill's LLM reads at catalog-enumeration time and matches against user input. No mechanical matcher, no unit-testable ranking. This trades unit-testability for zero infrastructure. The alternative (a keyword scorer or embedding matcher) can be added later without changing the catalog format.

## Sweep for stale references

Grepped `**/*.md`, `**/*.py`, `**/*.yml`, `**/*.yaml` for `compute_table`, `scripts/compute_table`, `test_compute_table`. Findings:

- `test_latency_table.py` — 60+ hits are the local `compute_table` binding after `import latency_table as compute_table`. Intentional; not stale.
- `docs/proposals/incremental-implementation-plan-addendum.md:325,328` and `docs/proposals/incremental-implementation-plan.md:157` — the deferred design docs that motivated this issue. They describe step-7 as a future refactor and reference `compute_table.py` as "today's baked-in table." Both statements are now partially superseded by this PR (which delivers the catalog + scaffolding half of step-7 with dynamic-phase / `sim2real resolve` deferred). Left unchanged in this PR — reviewer's call whether the docs should be updated to say "partially delivered by #<this PR>" here or in a follow-up when the deferred rest-of-step-7 lands.
- `.github/workflows/test.yml` and `CLAUDE.md` — both already enumerate `.claude/skills/sim2real-analyze/tests/` at directory level, so the new `test_list_analyses.py` is picked up automatically. No CI change needed.

## Test plan

- [x] `python3 -m pytest pipeline/ .claude/skills/*/tests/` — 1758 passed, 1 skipped, 2 xfailed (identical to main baseline)
- [x] `ruff check pipeline/ .claude/skills/ --select F` — clean
- [x] `python3 .claude/skills/sim2real-analyze/scripts/list_analyses.py` on the real catalog — emits both entries with all required fields
- [x] `python3 .claude/skills/sim2real-analyze/analyses/latency_table.py --run <name>` — smoke-tested via the migrated test suite (all 33 pre-existing tests pass)
- [ ] Manual smoke of `/sim2real-analyze` interactive loop against a real run — not yet exercised in this session (no local run available), reviewer or follow-up

## Deferred (not in this PR)

Per the reshaped issue body, the following remain deferred with the larger workspace refactor and are explicit non-goals for this issue:

- Dynamic phase enumeration beyond `{baseline, treatment}`
- `sim2real resolve --run R` integration
- Multi-replicate bundle analyses (soft-reflective's `latency-pairwise-*`, `claim-verification-report`, heatmaps)
- The CDF trio, throughput-over-time, and error-rate analyses (trivial per-file follow-ups once the scaffolding lands)
