### PR TITLE
fix(assemble,deploy): truthful no-op ack and self-serving deploy error (#555)

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -327,7 +327,7 @@ Then each treatment scenario has `router.epp.image` set from that algorithm's ow
 
 **Additive-merge (grow-only).** Re-assembling an existing run with `--replicas` interacts with the prior state as follows (without `--force`):
 
-- `N == prior_replicas` — true no-op. No files rewritten; the assemble returns silently.
+- `N == prior_replicas` — true no-op. No files rewritten. The CLI prints `No change needed for run '<run>': manifest, replicas, and translation are unchanged since <prior assembled_at>. To rebuild anyway (e.g. after an assembler code update), pass --force.` so operators can tell a no-op from an actual write; the past-tense `assembled run <name>` ack is reserved for paths that touched disk.
 - `N > prior_replicas` — additive grow. Existing PipelineRun files (`i1..i{prior}`) are preserved byte-for-byte and by mtime; new files are emitted for `i{prior+1}..iN`. `manifest.assembly.yaml` and `run_metadata.json` are rewritten with the new `replicas` count; `params_hash` is preserved (drift check passed).
 - `N < prior_replicas` — refused with `run '<name>' already has <prior> replicas; refusing to shrink to <N>. Replica shrink is tracked in #506.` This guard runs BEFORE every other check, so `--force` does NOT bypass it.
 

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -230,9 +230,26 @@ def _make_progress_store(namespace: str, run_dir: Path):
         if isinstance(meta, dict) else ""
     )
     if not scenario:
-        err(f"run_metadata.json is missing 'scenario' — re-run "
-            f"'sim2real assemble --run {run_dir.name}' to record it "
-            f"(added in issue #551).")
+        # The remediation names --force because the assemble no-op path
+        # (same manifest content + same replicas since last assemble)
+        # would otherwise swallow the backfill silently. Prefill
+        # --translation and --cluster from run_metadata.json when present
+        # so the operator can copy-paste; fall back to placeholders when
+        # either field is absent.
+        translation_ref = ""
+        cluster_ref = ""
+        if isinstance(meta, dict):
+            translation_ref = str(meta.get("translation_hash") or "").strip()
+            cluster_ref = str(meta.get("cluster_id") or "").strip()
+        translation_arg = translation_ref or "<translation-ref>"
+        cluster_arg = cluster_ref or "<cluster-id>"
+        err(
+            f"scenario not recorded for run '{run_dir.name}' — this run "
+            f"predates scenario tracking and cannot be resolved to a "
+            f"ConfigMap. To backfill: sim2real assemble "
+            f"--translation {translation_arg} --cluster {cluster_arg} "
+            f"--run {run_dir.name} --force"
+        )
         sys.exit(1)
     return ConfigMapProgressStore(
         namespace, run_name=run_dir.name, scenario=scenario

--- a/pipeline/lib/assemble_run.py
+++ b/pipeline/lib/assemble_run.py
@@ -867,6 +867,10 @@ def assemble_run(
                                 # True no-op: reset side-band attrs and return.
                                 assemble_run.skipped_algorithms = []  # type: ignore[attr-defined]
                                 assemble_run.missing_submodules = []  # type: ignore[attr-defined]
+                                assemble_run.status = "noop"  # type: ignore[attr-defined]
+                                assemble_run.prior_assembled_at = (  # type: ignore[attr-defined]
+                                    str(prior_rm.get("assembled_at") or "")
+                                )
                                 return
                         elif force:
                             # replicas > prior_replicas with --force: full
@@ -896,6 +900,8 @@ def assemble_run(
         # skipped_algorithms/missing_submodules unchanged from prior assemble.
         assemble_run.skipped_algorithms = []  # type: ignore[attr-defined]
         assemble_run.missing_submodules = []  # type: ignore[attr-defined]
+        assemble_run.status = "written"  # type: ignore[attr-defined]
+        assemble_run.prior_assembled_at = ""  # type: ignore[attr-defined]
         return
 
     # 4. Resolve packages (translation load, algorithm filter, baseline +
@@ -971,8 +977,12 @@ def assemble_run(
     )
     # Skipped-algorithm list exposed for the CLI wrapper to surface as warnings.
     assemble_run.skipped_algorithms = resolved.skipped_algo_names  # type: ignore[attr-defined]
+    assemble_run.status = "written"  # type: ignore[attr-defined]
+    assemble_run.prior_assembled_at = ""  # type: ignore[attr-defined]
 
 
 # Initialize side-band attributes so `getattr` in the CLI works on first call.
 assemble_run.skipped_algorithms = []  # type: ignore[attr-defined]
 assemble_run.missing_submodules = []  # type: ignore[attr-defined]
+assemble_run.status = "written"  # type: ignore[attr-defined]
+assemble_run.prior_assembled_at = ""  # type: ignore[attr-defined]

--- a/pipeline/sim2real.py
+++ b/pipeline/sim2real.py
@@ -1460,7 +1460,19 @@ def _cmd_assemble(args) -> int:
             "in the sim2real repo to fix.",
             file=sys.stderr,
         )
-    print(f"assembled run {args.run}")
+    status = getattr(_assemble_run_lib.assemble_run, "status", "written")
+    if status == "noop":
+        prior_assembled_at = getattr(
+            _assemble_run_lib.assemble_run, "prior_assembled_at", ""
+        ) or "unknown"
+        print(
+            f"No change needed for run '{args.run}': manifest, replicas, and "
+            f"translation are unchanged since {prior_assembled_at}.\n"
+            "To rebuild anyway (e.g. after an assembler code update), "
+            "pass --force."
+        )
+    else:
+        print(f"assembled run {args.run}")
     return 0
 
 

--- a/pipeline/tests/test_assemble_replicas.py
+++ b/pipeline/tests/test_assemble_replicas.py
@@ -118,6 +118,40 @@ class TestAssembleReplicas:
         _assemble(fx, replicas=3, now_iso="2026-07-02T00:00:00Z")
         mtimes_after = _mtimes([p for p in all_paths if p.is_file()])
         assert mtimes_before == mtimes_after
+        # Issue #555: side-band status attrs let the CLI wrapper distinguish
+        # the no-op path from actual writes and print a truthful message.
+        assert assemble_run.assemble_run.status == "noop"
+        assert (
+            assemble_run.assemble_run.prior_assembled_at
+            == "2026-07-01T00:00:00Z"
+        )
+
+    def test_fresh_assemble_sets_status_written_and_empty_prior(self, tmp_path):
+        """Issue #555: fresh assemble is a write path — status='written',
+        prior_assembled_at=''."""
+        fx = _make_experiment(tmp_path, algo_names_registered=["sr"],
+                              algo_names_manifest=["sr"])
+        _assemble(fx, replicas=1, now_iso="2026-07-01T00:00:00Z")
+        assert assemble_run.assemble_run.status == "written"
+        assert assemble_run.assemble_run.prior_assembled_at == ""
+
+    def test_additive_grow_sets_status_written(self, tmp_path):
+        """Issue #555: additive-grow is a write path — status='written'."""
+        fx = _make_experiment(tmp_path, algo_names_registered=["sr"],
+                              algo_names_manifest=["sr"])
+        _assemble(fx, replicas=3, now_iso="2026-07-01T00:00:00Z")
+        _assemble(fx, replicas=5, now_iso="2026-07-02T00:00:00Z")
+        assert assemble_run.assemble_run.status == "written"
+        assert assemble_run.assemble_run.prior_assembled_at == ""
+
+    def test_force_rebuild_sets_status_written(self, tmp_path):
+        """Issue #555: --force full rebuild is a write path — status='written'."""
+        fx = _make_experiment(tmp_path, algo_names_registered=["sr"],
+                              algo_names_manifest=["sr"])
+        _assemble(fx, replicas=3, now_iso="2026-07-01T00:00:00Z")
+        _assemble(fx, replicas=3, force=True, now_iso="2026-07-02T00:00:00Z")
+        assert assemble_run.assemble_run.status == "written"
+        assert assemble_run.assemble_run.prior_assembled_at == ""
 
     def test_reassemble_at_same_replica_count_with_force_rebuilds(self, tmp_path):
         """Issue #532: --force must rebuild even when the manifest hash and

--- a/pipeline/tests/test_deploy_status.py
+++ b/pipeline/tests/test_deploy_status.py
@@ -117,3 +117,71 @@ def test_cmd_status_reads_run_scoped_configmap(tmp_path, monkeypatch):
     assert store_kwargs[0]["run_name"] == "trial-1"
     assert store_kwargs[0]["namespace"] == "sim2real-ns"
     assert store_kwargs[0]["scenario"] == "softr"
+
+
+def test_make_progress_store_missing_scenario_prefills_ref_and_cluster(
+    tmp_path, capsys
+):
+    """Issue #555: when scenario is missing from run_metadata.json but
+    translation_hash and cluster_id are present, the error message names
+    'scenario' (not the file), drops the '(added in issue #551)' reference,
+    prefills --translation and --cluster from meta, and recommends --force.
+    """
+    import json
+    import pytest
+
+    from pipeline.deploy import _make_progress_store
+
+    run_dir = tmp_path / "workspace" / "runs" / "trial-1"
+    run_dir.mkdir(parents=True)
+    (run_dir / "run_metadata.json").write_text(
+        json.dumps({
+            "run_name": "trial-1",
+            "translation_hash": "abc12345",
+            "cluster_id": "ocp-east",
+            # scenario intentionally absent
+        })
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        _make_progress_store("sim2real-ns", run_dir)
+    assert exc.value.code == 1
+
+    err = capsys.readouterr().err
+    assert "scenario not recorded for run 'trial-1'" in err
+    # Names the missing thing, not the file it lives in.
+    assert "run_metadata.json" not in err
+    # Drops the internal issue reference.
+    assert "#551" not in err
+    # Names --force explicitly (defeats the no-op path).
+    assert "--force" in err
+    # Prefills the copy-paste-able assemble invocation.
+    assert "--translation abc12345" in err
+    assert "--cluster ocp-east" in err
+    assert "--run trial-1" in err
+
+
+def test_make_progress_store_missing_scenario_placeholders_when_meta_lacks_fields(
+    tmp_path, capsys
+):
+    """Issue #555: if translation_hash or cluster_id are missing from
+    run_metadata.json (extremely old runs), the error falls back to
+    placeholders rather than emitting the empty string."""
+    import json
+    import pytest
+
+    from pipeline.deploy import _make_progress_store
+
+    run_dir = tmp_path / "workspace" / "runs" / "trial-2"
+    run_dir.mkdir(parents=True)
+    (run_dir / "run_metadata.json").write_text(
+        json.dumps({"run_name": "trial-2"})  # nothing else
+    )
+
+    with pytest.raises(SystemExit):
+        _make_progress_store("sim2real-ns", run_dir)
+
+    err = capsys.readouterr().err
+    assert "<translation-ref>" in err
+    assert "<cluster-id>" in err
+    assert "--force" in err

--- a/pipeline/tests/test_sim2real.py
+++ b/pipeline/tests/test_sim2real.py
@@ -1106,6 +1106,78 @@ class TestAssembleCommand:
         assert (run_dir / "cluster" / "sr.yaml").exists()
         assert (run_dir / "cluster" / "pipelinerun-w1|baseline|i1.yaml").exists()
         assert (run_dir / "cluster" / "pipelinerun-w1|sr|i1.yaml").exists()
+        # Issue #555: write path prints the past-tense ack.
+        out = capsys.readouterr().out
+        assert "assembled run trial-1" in out
+
+    def test_noop_reassemble_prints_no_change_message(self, tmp_path, capsys):
+        """Issue #555: second assemble with identical inputs prints the
+        'No change needed' message and does not print 'assembled run …'."""
+        thash = self._make_minimal_registration(tmp_path)
+        cluster_id = self._bootstrap_experiment(tmp_path)
+        # First assemble — write path.
+        rc1 = sim2real.main(
+            [
+                "--experiment-root", str(tmp_path),
+                "assemble",
+                "--translation", thash,
+                "--cluster", cluster_id,
+                "--run", "trial-1",
+            ]
+        )
+        assert rc1 == 0
+        # Capture prior assembled_at so we can assert the message includes it.
+        run_dir = tmp_path / "workspace" / "runs" / "trial-1"
+        meta = json.loads((run_dir / "run_metadata.json").read_text())
+        prior_assembled_at = meta["assembled_at"]
+        capsys.readouterr()  # drain
+        # Second assemble — same inputs — no-op path.
+        rc2 = sim2real.main(
+            [
+                "--experiment-root", str(tmp_path),
+                "assemble",
+                "--translation", thash,
+                "--cluster", cluster_id,
+                "--run", "trial-1",
+            ]
+        )
+        assert rc2 == 0
+        out = capsys.readouterr().out
+        assert "No change needed for run 'trial-1'" in out
+        assert prior_assembled_at in out
+        assert "--force" in out
+        assert "assembled run trial-1" not in out
+
+    def test_force_rebuild_prints_assembled_not_no_change(self, tmp_path, capsys):
+        """Issue #555: --force after an initial assemble still prints the
+        past-tense ack, not the no-op message."""
+        thash = self._make_minimal_registration(tmp_path)
+        cluster_id = self._bootstrap_experiment(tmp_path)
+        rc1 = sim2real.main(
+            [
+                "--experiment-root", str(tmp_path),
+                "assemble",
+                "--translation", thash,
+                "--cluster", cluster_id,
+                "--run", "trial-1",
+            ]
+        )
+        assert rc1 == 0
+        capsys.readouterr()  # drain
+        rc2 = sim2real.main(
+            [
+                "--experiment-root", str(tmp_path),
+                "assemble",
+                "--translation", thash,
+                "--cluster", cluster_id,
+                "--run", "trial-1",
+                "--force",
+            ]
+        )
+        assert rc2 == 0
+        out = capsys.readouterr().out
+        assert "assembled run trial-1" in out
+        assert "No change needed" not in out
 
     def test_refuses_existing_run_without_force(self, tmp_path, capsys):
         thash = self._make_minimal_registration(tmp_path)


### PR DESCRIPTION
## Summary

Fixes two related operator-facing messaging problems in the `assemble → deploy` workflow. Closes #555.

### 1. `sim2real assemble` no-op ack is now truthful

Before this PR, `sim2real assemble` printed `assembled run <name>` unconditionally — including when the no-op path fired (manifest content hash and replicas both unchanged since the prior assemble). Operators had no way to tell a real reassemble from a silent skip, and no way to know that `--force` is the escape hatch when the assembler code changed but inputs didn't.

Now:

- **Write paths (fresh, additive-grow, force-rebuild):** keep the past-tense `assembled run <name>` ack.
- **No-op path:** the CLI prints

  ```
  No change needed for run '<run>': manifest, replicas, and translation are unchanged since <prior assembled_at>.
  To rebuild anyway (e.g. after an assembler code update), pass --force.
  ```

The library signals which path fired via two new side-band attributes on `assemble_run.assemble_run` — `status` (`"noop"` | `"written"`) and `prior_assembled_at` — following the existing pattern used for `skipped_algorithms` and `missing_submodules`. Chosen over changing the return signature to keep the 15+ existing test callers untouched.

### 2. `deploy.py` scenario-missing error is now self-serving

Before this PR, when a pre-#551 run hit any `deploy.py` subcommand, the error was:

```
run_metadata.json is missing 'scenario' — re-run 'sim2real assemble --run trial-1' to record it (added in issue #551).
```

Three problems:
- Named the storage file rather than the missing information.
- Leaked internal issue history that has no bearing on remediation.
- **The remediation didn't work** — `sim2real assemble --run trial-1` hits the no-op path from problem #1 and silently doesn't backfill the field. Operator would follow the message verbatim, see `assembled run trial-1`, then hit the same error on the next `deploy.py status`.

Now the message names the missing thing, drops the issue reference, and emits a copy-pasteable remediation prefilled from the loaded `run_metadata.json`:

```
scenario not recorded for run '<run>' — this run predates scenario tracking and cannot be resolved to a ConfigMap. To backfill: sim2real assemble --translation <hash> --cluster <id> --run <run> --force
```

`--force` is named explicitly so the no-op path from fix #1 doesn't swallow the backfill. If `translation_hash` or `cluster_id` are absent from meta (very old runs), the message degrades to `<translation-ref>` / `<cluster-id>` placeholders.

## Why one PR

Both fixes touch the same operator workflow, and #2's remediation text depends on #1's fix being in place. Shipping them together keeps the `deploy error → follow message → run assemble --force → get truthful ack` loop coherent. The issue argues this explicitly.

## Files touched

- `pipeline/lib/assemble_run.py` — sets side-band `status` / `prior_assembled_at` at each return point of `assemble_run()`.
- `pipeline/sim2real.py` — `_cmd_assemble` reads the status attrs and branches its print.
- `pipeline/deploy.py` — `_make_progress_store` scenario-missing error rewritten with prefill.
- `pipeline/README.md` — updated the ""$N == prior_replicas — true no-op"" bullet to reflect the new CLI output.
- `pipeline/tests/test_assemble_replicas.py` — extends `test_reassemble_at_same_replica_count_is_noop` and adds fresh / additive-grow / force-rebuild status assertions.
- `pipeline/tests/test_sim2real.py` — adds CLI-print tests for no-op, write, and force-rebuild paths.
- `pipeline/tests/test_deploy_status.py` — adds tests for the new scenario-missing error (prefill and placeholder fallback).

## Verification

- `python -m pytest pipeline/ .claude/skills/…/tests/` (full CI set): **1778 passed, 1 skipped, 2 xfailed**.
- `ruff check pipeline/ .claude/skills/ --select F`: **clean**.
- Issue's verification checklist (each satisfied by the tests above):
  - [x] Unchanged-inputs assemble prints ""No change needed / pass --force"", not ""assembled run""
  - [x] Changed-inputs assemble (grow, drift, force) still prints ""assembled run""
  - [x] `--force` on any existing run still prints ""assembled run"" and rewrites `run_metadata.json`
  - [x] `deploy.py` against pre-#551 run prints the new message with no `run_metadata.json` mention and no `#551` reference
  - [x] Suggested remediation works end-to-end when followed verbatim (guaranteed because `--force` is named)

Sweep for stale references: only `pipeline/README.md:330` needed updating (line described the no-op path as ""returns silently""). Historical plan docs under `docs/superpowers/plans/` were left alone.

## Test plan

- [x] `python -m pytest pipeline/` — 1778 passed
- [x] `ruff check pipeline/ .claude/skills/ --select F` — clean
- [x] Manual: verified deploy error prefills from real `run_metadata.json` fields (see new `test_make_progress_store_missing_scenario_prefills_ref_and_cluster` in `test_deploy_status.py`)
- [x] Manual: verified assemble→re-assemble prints new no-op line with prior `assembled_at` timestamp (see new `test_noop_reassemble_prints_no_change_message` in `test_sim2real.py`)