### PR TITLE
fix(remote): encode pipe-shape pipelinerun filenames in run-inputs ConfigMap keys (#557)

### DIFF
--- a/pipeline/lib/remote.py
+++ b/pipeline/lib/remote.py
@@ -1,5 +1,6 @@
 """Remote run support — Kubernetes resource generation for --remote mode."""
 
+import re
 from pathlib import Path
 
 CONFIGMAP_NAME = "sim2real-run-inputs"
@@ -12,6 +13,46 @@ MOUNT_BASE = "/data"
 # ``clusters/<cluster_id>/cluster_config.json``. Distinct from ``cluster--``,
 # which is reserved for per-run cluster/*.yaml files.
 _CLUSTER_CONFIG_KEY_PREFIX = "cluster_config--"
+
+# Kubernetes ConfigMap data keys must match this regex. See
+# https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
+# and the validator's error message ("regex used for validation is
+# '[-._a-zA-Z0-9]+'"). Anything outside this set must be encoded before use
+# as a data key and decoded when reconstructing the source filename.
+_CM_KEY_ALLOWED_RE = re.compile(r"^[-._a-zA-Z0-9]+$")
+
+# In-scope characters to encode. Today only ``|`` appears in cluster/*.yaml
+# filenames (produced by the pipe-shape pair-key grammar in lib/pairkey.py).
+# Encoding follows URL-percent-encoding shape but uses ``.`` as the escape
+# introducer since ``%`` is not in the CM-key allowed set. Round-trip is
+# ``|`` <-> ``.7C``; extend ``_CM_KEY_ESCAPES`` if new disallowed chars
+# appear in filenames.
+_CM_KEY_ESCAPES = {"|": ".7C"}
+
+
+def _encode_filename_for_cm(name: str) -> str:
+    """Return ``name`` transformed into a ConfigMap-key-legal string.
+
+    Only characters listed in ``_CM_KEY_ESCAPES`` are transformed. All other
+    characters pass through — in particular ``.`` (extension separator) and
+    ``-`` (identifier separator) are already legal. Callers should verify the
+    result is legal before use; see ``_CM_KEY_ALLOWED_RE``.
+    """
+    for src, esc in _CM_KEY_ESCAPES.items():
+        name = name.replace(src, esc)
+    return name
+
+
+def _decode_filename_from_cm(key_suffix: str) -> str:
+    """Inverse of ``_encode_filename_for_cm``.
+
+    ``key_suffix`` is the part of the CM key after the ``cluster--`` prefix has
+    been stripped. Returns the original filename with disallowed characters
+    restored so it can be used as an on-disk path.
+    """
+    for src, esc in _CM_KEY_ESCAPES.items():
+        key_suffix = key_suffix.replace(esc, src)
+    return key_suffix
 
 
 def _discover_cluster_id(workspace_dir: Path) -> str:
@@ -76,7 +117,7 @@ def build_run_inputs_configmap(
             f"No cluster YAML files in {cluster_dir} — re-assemble the run"
         )
     for yaml_file in yaml_files:
-        data[f"cluster--{yaml_file.name}"] = yaml_file.read_text()
+        data[f"cluster--{_encode_filename_for_cm(yaml_file.name)}"] = yaml_file.read_text()
 
     return {
         "apiVersion": "v1",
@@ -103,7 +144,7 @@ def _configmap_items(data: dict, run_name: str) -> list[dict]:
                 "path": f"clusters/{cluster_id}/cluster_config.json",
             })
         elif key.startswith("cluster--"):
-            filename = key[len("cluster--"):]
+            filename = _decode_filename_from_cm(key[len("cluster--"):])
             items.append({"key": key, "path": f"runs/{run_name}/cluster/{filename}"})
         else:
             raise ValueError(

--- a/pipeline/tests/test_remote.py
+++ b/pipeline/tests/test_remote.py
@@ -7,6 +7,9 @@ import pytest
 from pipeline.lib.remote import (
     CONFIGMAP_NAME,
     JOB_NAME,
+    _CM_KEY_ALLOWED_RE,
+    _decode_filename_from_cm,
+    _encode_filename_for_cm,
     build_orchestrator_job,
     build_run_inputs_configmap,
     _configmap_items,
@@ -351,3 +354,137 @@ def test_configmap_items_defaults_at_root():
     data = {"defaults.yaml": "content", "setup_config.json": "{}"}
     items = _configmap_items(data, "run1")
     assert {"key": "defaults.yaml", "path": "defaults.yaml"} in items
+
+
+# --- pipe-shape filename encoding (issue #557) ---
+
+
+def test_encode_pipe_to_dot7c():
+    """`|` is encoded as `.7C` in CM keys."""
+    assert (
+        _encode_filename_for_cm("pipelinerun-wl-a|baseline|i1.yaml")
+        == "pipelinerun-wl-a.7Cbaseline.7Ci1.yaml"
+    )
+
+
+def test_encode_no_pipe_unchanged():
+    """Filenames without `|` pass through unchanged."""
+    assert _encode_filename_for_cm("baseline.yaml") == "baseline.yaml"
+    assert _encode_filename_for_cm("pipelinerun-smoke-baseline.yaml") == (
+        "pipelinerun-smoke-baseline.yaml"
+    )
+
+
+def test_decode_dot7c_to_pipe():
+    """`.7C` in an encoded key decodes back to `|`."""
+    assert (
+        _decode_filename_from_cm("pipelinerun-wl-a.7Cbaseline.7Ci1.yaml")
+        == "pipelinerun-wl-a|baseline|i1.yaml"
+    )
+
+
+@pytest.mark.parametrize("original", [
+    "pipelinerun-code-generation-10|constantceiling|i2.yaml",
+    "pipelinerun-interactive-chat-80|softreflective|i1.yaml",
+    "pipelinerun-reasoning-0-2|baseline|i2.yaml",
+    "baseline.yaml",
+    "constantceiling.yaml",
+    "pipelinerun-smoke-baseline.yaml",  # legacy dash-shape, no pipes
+])
+def test_encode_decode_roundtrip(original):
+    """Encoding then decoding yields the original filename byte-for-byte."""
+    encoded = _encode_filename_for_cm(original)
+    assert _CM_KEY_ALLOWED_RE.match(encoded), (
+        f"encoded name {encoded!r} contains chars outside "
+        f"the ConfigMap key allowed set"
+    )
+    assert _decode_filename_from_cm(encoded) == original
+
+
+def test_pipe_shape_filenames_produce_legal_cm_keys(workspace):
+    """Pipe-shape pipelinerun filenames yield ConfigMap keys that pass k8s validation.
+
+    Regression for the bug in issue #557: kubectl apply rejected the CM with
+    `data[cluster--pipelinerun-code-generation-10|constantceiling|i2.yaml]:
+    Invalid value ... regex used for validation is '[-._a-zA-Z0-9]+'` because
+    the pair-key grammar (lib/pairkey.py) produces `|`-containing filenames
+    that were used verbatim as CM data keys.
+    """
+    workspace_dir, run_dir = workspace
+    _write_defaults(workspace_dir, run_dir)
+    # Mix of pipe-shape (post-PR-2) and no-pipe (treatment overlay) files as
+    # in a real cluster/ directory.
+    (run_dir / "cluster" / "baseline.yaml").write_text("t: 1\n")
+    (run_dir / "cluster" / "pipelinerun-wl-a|baseline|i1.yaml").write_text("p: 1\n")
+    (run_dir / "cluster" / "pipelinerun-wl-a|baseline|i2.yaml").write_text("p: 2\n")
+    cm = build_run_inputs_configmap(
+        run_dir=run_dir, workspace_dir=workspace_dir,
+        namespace="ns", run_name="test-run",
+    )
+    illegal = [k for k in cm["data"] if not _CM_KEY_ALLOWED_RE.match(k)]
+    assert illegal == [], (
+        f"kubectl would reject these CM data keys: {illegal}"
+    )
+    # And no `|` leaked through despite the source filenames containing `|`.
+    assert not any("|" in k for k in cm["data"])
+
+
+def test_pipe_shape_roundtrip_via_configmap_items(workspace):
+    """End-to-end: CM key encodes `|`, projected volume `path:` restores `|`.
+
+    This is what the remote orchestrator Job relies on — the projected file
+    inside the pod must have the same name as the source on the operator's
+    disk so pair-key parsing and workload lookup work identically in-cluster.
+    """
+    workspace_dir, run_dir = workspace
+    _write_defaults(workspace_dir, run_dir)
+    # _write_defaults seeds `pipelinerun-smoke-baseline.yaml`; include it in
+    # the expected set so the assertion matches the full cluster/ contents.
+    extra_filenames = {
+        "pipelinerun-code-generation-10|constantceiling|i2.yaml",
+        "pipelinerun-interactive-chat-80|softreflective|i1.yaml",
+        "baseline.yaml",
+    }
+    for name in extra_filenames:
+        (run_dir / "cluster" / name).write_text(f"# {name}\n")
+    source_filenames = extra_filenames | {"pipelinerun-smoke-baseline.yaml"}
+    cm = build_run_inputs_configmap(
+        run_dir=run_dir, workspace_dir=workspace_dir,
+        namespace="ns", run_name="test-run",
+    )
+    items = _configmap_items(cm["data"], "test-run")
+    reconstructed = {
+        i["path"].removeprefix("runs/test-run/cluster/")
+        for i in items
+        if i["path"].startswith("runs/test-run/cluster/")
+    }
+    assert reconstructed == source_filenames
+
+
+def test_configmap_items_decodes_pipe_shape_cluster_yaml():
+    """`_configmap_items` decodes `.7C` back to `|` when constructing paths."""
+    data = {"cluster--pipelinerun-wl-a.7Cbaseline.7Ci1.yaml": "p"}
+    items = _configmap_items(data, "run-x")
+    assert items == [{
+        "key": "cluster--pipelinerun-wl-a.7Cbaseline.7Ci1.yaml",
+        "path": "runs/run-x/cluster/pipelinerun-wl-a|baseline|i1.yaml",
+    }]
+
+
+def test_cm_key_allowed_re_matches_k8s_validator():
+    """Guard against divergence from Kubernetes' CM-key validation regex.
+
+    The Kubernetes validator's error message quotes the regex as
+    ``[-._a-zA-Z0-9]+``. If that ever changes upstream (unlikely), this test
+    surfaces the drift.
+    """
+    # Legal.
+    assert _CM_KEY_ALLOWED_RE.match("simple.name")
+    assert _CM_KEY_ALLOWED_RE.match("KEY_NAME")
+    assert _CM_KEY_ALLOWED_RE.match("key-name")
+    assert _CM_KEY_ALLOWED_RE.match("pipelinerun-wl-a.7Cbaseline.7Ci1.yaml")
+    # Illegal — anything with `|`.
+    assert not _CM_KEY_ALLOWED_RE.match("pipelinerun-wl-a|baseline|i1.yaml")
+    # Illegal — spaces, slashes, other punctuation.
+    assert not _CM_KEY_ALLOWED_RE.match("with space")
+    assert not _CM_KEY_ALLOWED_RE.match("with/slash")


### PR DESCRIPTION
Closes #557.

## What changed

`deploy.py run --remote` was failing at "Applying run-inputs ConfigMap" with the error `data[cluster--pipelinerun-<w>|<p>|iN.yaml]: Invalid value ... regex used for validation is '[-._a-zA-Z0-9]+'`. Kubernetes' ConfigMap-data-key validator rejects `|`, which the pipe-shape pair-key grammar (`lib/pairkey.py`) puts into every pipelinerun filename on disk.

Fix is a round-trip encoding at the two matching sites in `pipeline/lib/remote.py`:

- **Write side** (`build_run_inputs_configmap`, previously line 79): filename → CM key via `_encode_filename_for_cm`, which currently replaces `|` with `.7C` (URL-hex style; `.` is legal in CM keys, `%` is not).
- **Read side** (`_configmap_items`, previously lines 105–107): CM key → filename via `_decode_filename_from_cm`, so the projected volume `path:` still points at `runs/<R>/cluster/pipelinerun-<w>|<p>|iN.yaml` inside the pod. Round-trip is byte-exact.

Helpers use an `_CM_KEY_ESCAPES` dict so if another disallowed character ever shows up in cluster/ filenames, it's a one-line addition — no changes to the call sites. Only `|` is in scope today.

## Tests

Added to `pipeline/tests/test_remote.py`:

- Direct helper tests: `_encode_filename_for_cm` maps `|` → `.7C`; no-pipe input passes through; `_decode_filename_from_cm` is the exact inverse.
- Parametrized round-trip over pipe-shape and no-pipe fixtures — asserts encoded output matches `_CM_KEY_ALLOWED_RE` and decoding recovers the original.
- Integration: `build_run_inputs_configmap` fed a `cluster/` dir with pipe-shape filenames produces zero keys containing `|`, and every key matches the k8s allowed regex.
- End-to-end round-trip: `build_run_inputs_configmap` → `_configmap_items` reconstructs the original pipe-shape filename in the volume `path:`.
- A regex-drift guard test on `_CM_KEY_ALLOWED_RE` so a future upstream change would surface loudly.

Full pipeline test suite: 1602 passed, 2 xfailed (unchanged from `main`). Ruff clean.

## Reviewer attention

- **Encoding choice.** `.7C` was picked over `__pipe__` for compactness and URL-percent-encoding parity. Could equally be `__pipe__` — it's isolated in `_CM_KEY_ESCAPES` so easy to swap. Argument for `.7C`: standard convention, terse; against: `.` interleaves with filename dots. If reviewers prefer `__pipe__` (or another sentinel), the change is one dict entry plus a test string update.
- **Test fixture caveat.** `_write_defaults` seeds `pipelinerun-smoke-baseline.yaml` in the `cluster/` dir; the new round-trip integration test explicitly includes that entry in its expected set (see comment inline). Not a real footgun; called out for future readers.
- **Non-goal.** This PR does not rename pipelinerun filenames on disk to avoid `|` — that would require reversing the pair-key grammar migration and is much larger. Encoding-in-CM-only is the smaller surface.

## Stale-reference sweep

Grepped `**/*.md` and `pipeline/*.py` for `cluster--`, `run-inputs`, `sim2real-run-inputs`. One hit outside `remote.py` — `pipeline/deploy.py:3622` code comment `"cluster--*.yaml entries"` — still accurate since the `cluster--` prefix survives; only the suffix's `|` is now encoded. No doc, skill, or plan-file references to the CM-key format itself. Nothing to update.
