### PR TITLE
feat(sim2real-analyze): add five deferred single-run catalog entries

### DIFF
--- a/.claude/skills/sim2real-analyze/SKILL.md
+++ b/.claude/skills/sim2real-analyze/SKILL.md
@@ -235,7 +235,7 @@ histogram at a different bin size or a workload subset.
 For the standard CDF view use `ttft-cdf` from the catalog. Reach for a
 per-workload histogram when you need to see bin density directly (e.g.,
 "is the TTFT distribution bimodal at 50ms increments?") rather than
-the smoothed cumulative view.
+the empirical step-function CDF the catalog entry produces.
 
 ```python
 import pandas as pd

--- a/.claude/skills/sim2real-analyze/SKILL.md
+++ b/.claude/skills/sim2real-analyze/SKILL.md
@@ -223,9 +223,19 @@ All timestamps are **microseconds**. Metrics:
 - TPOT = (last_chunk_time_us - first_chunk_time_us) / (output_tokens - 1) / 1000 ms (output_tokens > 1 only)
 - E2E  = (last_chunk_time_us - send_time_us) / 1000 ms
 
-## Example analysis scripts
+## Example one-off analysis script
 
-### TTFT distribution histogram
+Common analyses live in the catalog (see previous section). This
+example shows the shape of a one-off script for the fallback flow when
+you need something the catalog doesn't cover — for instance, a
+histogram at a different bin size or a workload subset.
+
+### TTFT distribution histogram (one-off example)
+
+For the standard CDF view use `ttft-cdf` from the catalog. Reach for a
+per-workload histogram when you need to see bin density directly (e.g.,
+"is the TTFT distribution bimodal at 50ms increments?") rather than
+the smoothed cumulative view.
 
 ```python
 import pandas as pd
@@ -251,34 +261,6 @@ for ax, wl in zip(axes, workloads):
 
 plt.tight_layout()
 out = f"workspace/runs/{run}/results_charts/ttft_distribution.png"
-plt.savefig(out)
-print(f"Saved: {out}")
-```
-
-### Throughput over time
-
-```python
-import pandas as pd
-import matplotlib.pyplot as plt
-
-run = "<name>"
-wl = "workload_fm8_short_output_highrate"
-
-fig, ax = plt.subplots(figsize=(12, 4))
-for phase in ["baseline", "treatment"]:
-    df = pd.read_csv(f"workspace/runs/{run}/results/{phase}/{wl}/trace_data.csv")
-    df = df[df["status"] == "ok"]  # only compute metrics for successful requests
-    t0 = df["arrival_time_us"].min()
-    df["t_sec"] = (df["arrival_time_us"] - t0) / 1e6
-    counts = df.groupby(df["t_sec"].astype(int)).size()
-    ax.plot(counts.index, counts.values, label=phase)
-
-ax.set_xlabel("Time (s)")
-ax.set_ylabel("Requests/s")
-ax.set_title(f"Throughput over time — {wl.replace('workload_','').replace('_','-')}")
-ax.legend()
-plt.tight_layout()
-out = f"workspace/runs/{run}/results_charts/throughput_over_time.png"
 plt.savefig(out)
 print(f"Saved: {out}")
 ```

--- a/.claude/skills/sim2real-analyze/analyses/_cdf.py
+++ b/.claude/skills/sim2real-analyze/analyses/_cdf.py
@@ -1,0 +1,106 @@
+"""Shared CDF plotting for `ttft_cdf.py` / `tpot_cdf.py` / `e2e_cdf.py`.
+
+Each per-metric script is a thin wrapper that calls `cdf_main(metric=...)`.
+Kept out of `_common.py` because plotting pulls in matplotlib, and only the
+chart scripts (not `error_rate.py`) need it.
+"""
+import argparse
+import sys
+
+from _common import (
+    PHASE_COLORS,
+    PHASES,
+    charts_dir,
+    discover_workloads,
+    display_name,
+    latency_values,
+    load_csv,
+    phase_log_dirs,
+    require_matplotlib,
+    resolve_run,
+    warn,
+)
+
+
+VALID_METRICS = ("TTFT", "TPOT", "E2E")
+
+
+def _empirical_cdf(values, np):
+    """Return (sorted_values, cumulative_fraction) with 1/n step points.
+
+    Matches the standard textbook empirical CDF where y = k/n at the k-th
+    ordered sample.
+    """
+    if not values:
+        return np.array([]), np.array([])
+    v = np.sort(np.asarray(values, dtype=float))
+    n = len(v)
+    y = np.arange(1, n + 1, dtype=float) / n
+    return v, y
+
+
+def cdf_main(metric: str) -> None:
+    if metric not in VALID_METRICS:
+        raise ValueError(f"unknown metric {metric!r} — expected one of {VALID_METRICS}")
+
+    parser = argparse.ArgumentParser(
+        description=f"Plot empirical CDF of {metric} per workload, baseline vs treatment"
+    )
+    parser.add_argument("--run", metavar="NAME",
+                        help="Run name (default: current_run from setup_config.json)")
+    args = parser.parse_args()
+
+    run = resolve_run(args.run)
+    plt, np = require_matplotlib()
+    baseline_log, treatment_log = phase_log_dirs(run)
+    workloads = discover_workloads(baseline_log, treatment_log)
+
+    ncols = min(3, len(workloads))
+    nrows = (len(workloads) + ncols - 1) // ncols
+    fig, axes = plt.subplots(
+        nrows, ncols,
+        figsize=(5 * ncols, 3.5 * nrows),
+        squeeze=False,
+    )
+
+    rendered_panels = 0
+    for idx, wl in enumerate(workloads):
+        ax = axes[idx // ncols][idx % ncols]
+        panel_has_data = False
+        for phase, log_dir in zip(PHASES, (baseline_log, treatment_log)):
+            rows = load_csv(log_dir / wl / "trace_data.csv")
+            ok = [r for r in rows if r["status"] == "ok"]
+            values = latency_values(ok, metric)
+            if not values:
+                warn(f"skipping {metric} for workload '{wl}' phase '{phase}' — no valid rows")
+                continue
+            x, y = _empirical_cdf(values, np)
+            ax.plot(x, y, label=f"{phase} (n={len(values)})",
+                    color=PHASE_COLORS[phase], linewidth=1.5)
+            panel_has_data = True
+
+        if panel_has_data:
+            rendered_panels += 1
+            ax.set_title(display_name(wl))
+            ax.set_xlabel(f"{metric} (ms)")
+            ax.set_ylabel("CDF")
+            ax.set_ylim(0.0, 1.0)
+            ax.grid(True, alpha=0.4, linestyle=":")
+            ax.legend(loc="lower right", fontsize=8)
+        else:
+            ax.axis("off")
+
+    for empty_idx in range(len(workloads), nrows * ncols):
+        axes[empty_idx // ncols][empty_idx % ncols].axis("off")
+
+    if rendered_panels == 0:
+        print(f"Error: no {metric} data to plot in any workload", file=sys.stderr)
+        sys.exit(1)
+
+    fig.suptitle(f"{run} — {metric} empirical CDF (baseline vs treatment)", fontsize=12)
+    plt.tight_layout(rect=(0, 0, 1, 0.97))
+
+    out_path = charts_dir(run) / f"{metric.lower()}_cdf.png"
+    plt.savefig(out_path, dpi=130, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Saved: {out_path}")

--- a/.claude/skills/sim2real-analyze/analyses/_common.py
+++ b/.claude/skills/sim2real-analyze/analyses/_common.py
@@ -1,0 +1,178 @@
+"""Shared helpers for sim2real-analyze catalog scripts.
+
+Keeps every runner-script analysis operating on the same run-resolution,
+CSV-load, and workload-discovery contract so per-script bodies stay
+focused on the metric. Modeled after `latency_table.py` — anything that
+would otherwise be duplicated across `ttft_cdf.py`, `tpot_cdf.py`,
+`e2e_cdf.py`, `throughput_over_time.py`, and `error_rate.py` lives here.
+
+Underscore-prefixed filename so `list_analyses.py` treats it as a
+helper, not a catalog entry (only `.md` files are enumerated anyway,
+but the prefix documents intent).
+"""
+import csv
+import json
+import sys
+from pathlib import Path
+
+# Script location: {repo}/.claude/skills/sim2real-analyze/analyses/_common.py
+REPO_ROOT = Path(__file__).resolve().parents[4]
+WORKSPACE_DIR = REPO_ROOT / "workspace"
+
+REQUIRED_COLS = {
+    "send_time_us",
+    "first_chunk_time_us",
+    "last_chunk_time_us",
+    "output_tokens",
+    "status",
+}
+
+PHASES = ("baseline", "treatment")
+PHASE_COLORS = {"baseline": "#1f77b4", "treatment": "#d62728"}
+
+
+def err(msg: str) -> None:
+    print(f"Error: {msg}", file=sys.stderr)
+
+
+def warn(msg: str) -> None:
+    print(f"Warning: {msg}", file=sys.stderr)
+
+
+def resolve_run(run_arg: str | None) -> str:
+    """Return run name from argument or `current_run` in setup_config.json."""
+    if run_arg:
+        return run_arg
+    cfg_path = WORKSPACE_DIR / "setup_config.json"
+    try:
+        cfg = json.loads(cfg_path.read_text())
+        run = cfg.get("current_run", "")
+        if run:
+            return run
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        pass
+    err("no run specified — use --run NAME or set current_run in workspace/setup_config.json")
+    sys.exit(1)
+
+
+def display_name(dir_name: str) -> str:
+    """workload_fm8_short_output_highrate → fm8-short-output-highrate."""
+    name = dir_name[len("workload_"):] if dir_name.startswith("workload_") else dir_name
+    return name.replace("_", "-")
+
+
+def load_csv(csv_path: Path, *, require_metric_cols: bool = True) -> list[dict]:
+    """Load a trace CSV. Exits 1 on failure.
+
+    `require_metric_cols=False` skips the strict metric-column check —
+    used by `error_rate.py`, which only needs the `status` column.
+    """
+    try:
+        text = csv_path.read_text()
+    except OSError:
+        err(f"{csv_path}: failed to parse CSV")
+        sys.exit(1)
+
+    if not text.strip():
+        err(f"{csv_path}: empty or invalid CSV file")
+        sys.exit(1)
+
+    try:
+        reader = csv.DictReader(text.splitlines())
+        rows = list(reader)
+        fieldnames = reader.fieldnames or []
+    except Exception:
+        err(f"{csv_path}: failed to parse CSV")
+        sys.exit(1)
+
+    if not fieldnames:
+        err(f"{csv_path}: empty or invalid CSV file")
+        sys.exit(1)
+
+    required = REQUIRED_COLS if require_metric_cols else {"status"}
+    missing = sorted(required - set(fieldnames))
+    if missing:
+        err(f"{csv_path}: missing required columns: {', '.join(missing)}")
+        sys.exit(1)
+
+    return rows
+
+
+def run_dir(run_name: str) -> Path:
+    return WORKSPACE_DIR / "runs" / run_name
+
+
+def phase_log_dirs(run_name: str) -> tuple[Path, Path]:
+    """(baseline_log, treatment_log). Exits 1 if either is missing."""
+    rd = run_dir(run_name)
+    baseline = rd / "results" / "baseline"
+    treatment = rd / "results" / "treatment"
+    if not baseline.exists() or not treatment.exists():
+        err("need both results/baseline/ and results/treatment/ — run 'pipeline/deploy.py collect' first")
+        sys.exit(1)
+    return baseline, treatment
+
+
+def discover_workloads(baseline_log: Path, treatment_log: Path) -> list[str]:
+    """Return sorted workload dir names present in both phases. Warns on solos.
+
+    Exits 1 if the intersection is empty.
+    """
+    baseline_wl = {
+        d.name for d in baseline_log.iterdir()
+        if d.is_dir() and (d / "trace_data.csv").exists()
+    }
+    treatment_wl = {
+        d.name for d in treatment_log.iterdir()
+        if d.is_dir() and (d / "trace_data.csv").exists()
+    }
+    for wl in sorted(baseline_wl - treatment_wl):
+        warn(f"skipping workload '{wl}' — not present in both phases")
+    for wl in sorted(treatment_wl - baseline_wl):
+        warn(f"skipping workload '{wl}' — not present in both phases")
+    common = sorted(baseline_wl & treatment_wl)
+    if not common:
+        err("no workloads found in both baseline and treatment logs")
+        sys.exit(1)
+    return common
+
+
+def charts_dir(run_name: str) -> Path:
+    """Ensure and return results_charts/ for the run."""
+    d = run_dir(run_name) / "results_charts"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def latency_values(rows: list[dict], metric: str) -> list[float]:
+    """Compute a latency vector in ms from ok-status rows.
+
+    metric ∈ {"TTFT", "TPOT", "E2E"}. TPOT filters to rows with
+    output_tokens > 1 (the only rows for which per-output-token latency
+    is defined). Callers pass rows already filtered to status == "ok".
+    """
+    if metric == "TTFT":
+        return [(int(r["first_chunk_time_us"]) - int(r["send_time_us"])) / 1000 for r in rows]
+    if metric == "E2E":
+        return [(int(r["last_chunk_time_us"]) - int(r["send_time_us"])) / 1000 for r in rows]
+    if metric == "TPOT":
+        return [
+            (int(r["last_chunk_time_us"]) - int(r["first_chunk_time_us"]))
+            / (int(r["output_tokens"]) - 1)
+            / 1000
+            for r in rows if int(r["output_tokens"]) > 1
+        ]
+    raise ValueError(f"unknown metric {metric!r}")
+
+
+def require_matplotlib():
+    """Import and return (plt, np) or exit 1 with a helpful message."""
+    try:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+        import numpy as np
+    except ImportError:
+        err("matplotlib and numpy required — install with `pip install matplotlib numpy`")
+        sys.exit(1)
+    return plt, np

--- a/.claude/skills/sim2real-analyze/analyses/e2e-cdf.md
+++ b/.claude/skills/sim2real-analyze/analyses/e2e-cdf.md
@@ -1,0 +1,43 @@
+---
+name: e2e-cdf
+title: E2E empirical CDF per workload (baseline vs treatment)
+when-to-use: see end-to-end latency distribution — the composite view that combines queue, prefill, and decode
+inputs: run
+output: png
+runner: script
+script: e2e_cdf.py
+---
+
+# E2E empirical CDF
+
+One panel per workload, arranged in a grid capped at three columns
+wide. Each panel plots the empirical CDF of end-to-end latency (ms)
+for both phases: baseline in blue, treatment in red. Legend shows
+sample count per phase.
+
+E2E is `(last_chunk_time_us - send_time_us) / 1000`, computed over
+rows with `status == "ok"`.
+
+## Invocation
+
+The skill invokes this analysis by running its `script` field:
+
+```bash
+python .claude/skills/sim2real-analyze/analyses/e2e_cdf.py --run <name>
+```
+
+`--run` defaults to `current_run` from `workspace/setup_config.json`.
+
+## Output
+
+- `workspace/runs/<run>/results_charts/e2e_cdf.png`
+- Standalone PNG at 130 dpi.
+
+## E2E vs TTFT + TPOT
+
+The comparison table (`latency-table`) reports E2E, TTFT, and TPOT
+mean/p50/p99 side by side; E2E on its own is a composite that mixes
+queue wait, prefill, and decode. When the E2E CDF diverges between
+phases but neither TTFT nor TPOT does, the divergence is usually in
+the output-length distribution — check the request mix rather than
+blaming the algorithm.

--- a/.claude/skills/sim2real-analyze/analyses/e2e_cdf.py
+++ b/.claude/skills/sim2real-analyze/analyses/e2e_cdf.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+"""E2E empirical CDF, baseline vs treatment, one panel per workload.
+
+Invocation:
+    python .claude/skills/sim2real-analyze/analyses/e2e_cdf.py --run <name>
+    # --run defaults to current_run from workspace/setup_config.json
+"""
+from _cdf import cdf_main
+
+
+if __name__ == "__main__":
+    cdf_main("E2E")

--- a/.claude/skills/sim2real-analyze/analyses/error-rate.md
+++ b/.claude/skills/sim2real-analyze/analyses/error-rate.md
@@ -1,0 +1,55 @@
+---
+name: error-rate
+title: Per-workload error count and rate (baseline vs treatment)
+when-to-use: check whether a latency win is actually an error-rate loss — algorithms that shed load look faster in the ok-status view
+inputs: run
+output: table
+runner: script
+script: error_rate.py
+---
+
+# Error-rate table
+
+One section per workload, each with baseline + treatment rows showing:
+
+- **Total** — all rows in `trace_data.csv`, no `status` filter
+- **Errors** — rows where `status != "ok"`
+- **Rate** — errors / total, as a percent
+- **Top statuses (non-ok)** — the three most common non-ok status
+  values with counts, so a status_code:503 wave is visible without
+  opening the CSV
+
+Unlike every other catalog entry, this script does **not** filter to
+`status == "ok"` before counting — error rows are the metric.
+
+## Invocation
+
+The skill invokes this analysis by running its `script` field:
+
+```bash
+python .claude/skills/sim2real-analyze/analyses/error_rate.py --run <name>
+```
+
+`--run` defaults to `current_run` from `workspace/setup_config.json`.
+
+## Output
+
+- Table printed to stdout, one section per workload
+- `workspace/runs/<run>/error_rate.txt` for diffability, mirroring
+  `latency-table`'s `deploy_comparison_table.txt`
+
+## Why this matters after a latency-win
+
+The comparison table filters `status == "ok"` before computing TTFT,
+TPOT, and E2E — deliberately, because a per-token latency of a failed
+half-request is meaningless. But that filter hides the trade-off:
+
+- If treatment sheds 20% more load than baseline, treatment's remaining
+  requests will be faster on average because the slow / retrying tail
+  is what got shed. The latency table shows a win; the error-rate
+  table shows the cost.
+- If baseline and treatment have the same error rate, latency wins are
+  genuine.
+
+Always run this after `latency-table` on any run where the delta is
+suspiciously large.

--- a/.claude/skills/sim2real-analyze/analyses/error_rate.py
+++ b/.claude/skills/sim2real-analyze/analyses/error_rate.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Per-workload error-rate table, baseline vs treatment.
+
+Invocation:
+    python .claude/skills/sim2real-analyze/analyses/error_rate.py --run <name>
+    # --run defaults to current_run from workspace/setup_config.json
+
+Unlike the latency analyses, this script does NOT filter to status=="ok"
+— error rows are the metric.
+"""
+import argparse
+import sys
+from collections import Counter
+from pathlib import Path
+
+from _common import (
+    discover_workloads,
+    display_name,
+    load_csv,
+    phase_log_dirs,
+    resolve_run,
+    run_dir,
+    warn,
+)
+
+SEP = "  " + "─" * 78
+
+
+def _phase_stats(csv_path: Path) -> tuple[int, int, Counter]:
+    """Return (total, errors, status_counts) for one CSV."""
+    rows = load_csv(csv_path, require_metric_cols=False)
+    total = len(rows)
+    counts = Counter(r["status"] for r in rows)
+    errors = total - counts.get("ok", 0)
+    return total, errors, counts
+
+
+def _format_pct(part: int, whole: int) -> str:
+    if whole == 0:
+        return "N/A"
+    return f"{part / whole * 100:.2f}%"
+
+
+def _format_row(label: str, total: int, errors: int, statuses: Counter) -> str:
+    """Fixed-width row: label, total, errors, %, top non-ok statuses."""
+    non_ok = sorted(
+        ((k, v) for k, v in statuses.items() if k != "ok"),
+        key=lambda kv: (-kv[1], kv[0]),
+    )
+    top_str = ", ".join(f"{k}={v}" for k, v in non_ok[:3]) if non_ok else "—"
+    return (
+        f"  {label:<12}"
+        f"{total:>10}"
+        f"{errors:>10}"
+        f"{_format_pct(errors, total):>10}"
+        f"    {top_str}"
+    )
+
+
+def _section(wl_dir_name: str, baseline_log: Path, treatment_log: Path) -> list[str]:
+    b_total, b_err, b_counts = _phase_stats(baseline_log / wl_dir_name / "trace_data.csv")
+    t_total, t_err, t_counts = _phase_stats(treatment_log / wl_dir_name / "trace_data.csv")
+
+    if b_total == 0 and t_total == 0:
+        warn(f"skipping workload '{wl_dir_name}' — no rows in either phase")
+        return []
+
+    lines = [
+        f"=== Workload: {display_name(wl_dir_name)} ===",
+        "  Phase          Total    Errors     Rate    Top statuses (non-ok)",
+        SEP,
+        _format_row("baseline", b_total, b_err, b_counts),
+        _format_row("treatment", t_total, t_err, t_counts),
+    ]
+    return lines
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Report per-workload error rate for baseline vs treatment"
+    )
+    parser.add_argument("--run", metavar="NAME",
+                        help="Run name (default: current_run from setup_config.json)")
+    args = parser.parse_args()
+
+    run = resolve_run(args.run)
+    baseline_log, treatment_log = phase_log_dirs(run)
+    workloads = discover_workloads(baseline_log, treatment_log)
+
+    sections = [s for wl in workloads if (s := _section(wl, baseline_log, treatment_log))]
+    if not sections:
+        print("Error: no workloads had any rows to report", file=sys.stderr)
+        sys.exit(1)
+
+    output = "\n\n".join("\n".join(s) for s in sections)
+    print(output)
+
+    out_file = run_dir(run) / "error_rate.txt"
+    out_file.write_text(output + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/sim2real-analyze/analyses/throughput-over-time.md
+++ b/.claude/skills/sim2real-analyze/analyses/throughput-over-time.md
@@ -1,0 +1,54 @@
+---
+name: throughput-over-time
+title: Requests-per-second timeline per workload (baseline vs treatment)
+when-to-use: see load-vs-time shape — makes ramp-up, sustained-rate, and burst behavior visible so latency changes can be attributed to load, not the algorithm
+inputs: run
+output: png
+runner: script
+script: throughput_over_time.py
+---
+
+# Throughput over time
+
+One panel per workload arranged in a grid capped at three columns
+wide. Each panel plots sends-per-second (bucketed by integer second
+of `send_time_us`) for both phases: baseline in blue, treatment in
+red. Legend shows total ok-status count per phase.
+
+Time origin is the first send in the (phase, workload) cell — so the
+two curves in a panel share an x-axis that starts at each phase's own
+t=0. This makes ramp-up shape directly comparable across phases even
+when they were launched at different wall-clock times.
+
+## Invocation
+
+The skill invokes this analysis by running its `script` field:
+
+```bash
+python .claude/skills/sim2real-analyze/analyses/throughput_over_time.py --run <name>
+```
+
+`--run` defaults to `current_run` from `workspace/setup_config.json`.
+
+## Output
+
+- `workspace/runs/<run>/results_charts/throughput_over_time.png`
+- Standalone PNG at 130 dpi.
+
+## Reading the chart
+
+- **Both curves overlap.** Load-gen produced identical send timelines —
+  any latency delta between phases is genuinely the algorithm, not a
+  load mismatch.
+- **Curves diverge at rate ceilings.** One phase is queuing sends while
+  the other processes freely — check the latency table for the ceiling
+  phase's TTFT rise.
+- **Bursty flats.** Regular flat-then-spike shape suggests a rate
+  limiter (client or server) rather than natural request arrival.
+
+## Why sends, not completions
+
+`send_time_us` measures load *offered* to the server. Completion-time
+buckets (using `last_chunk_time_us`) would measure processing rate,
+which is the algorithm's *response* to that load — informative but
+easily confused with cause vs effect. Sends is the cleaner baseline.

--- a/.claude/skills/sim2real-analyze/analyses/throughput-over-time.md
+++ b/.claude/skills/sim2real-analyze/analyses/throughput-over-time.md
@@ -13,7 +13,15 @@ script: throughput_over_time.py
 One panel per workload arranged in a grid capped at three columns
 wide. Each panel plots sends-per-second (bucketed by integer second
 of `send_time_us`) for both phases: baseline in blue, treatment in
-red. Legend shows total ok-status count per phase.
+red. Legend shows total send count per phase.
+
+**This chart measures offered load, not successful throughput.** No
+`status` filter is applied — every row in `trace_data.csv` is counted
+as one send at its `send_time_us`. A request that later failed with
+`status == "500"` was still injected and still shows up on the
+timeline. If baseline and treatment have materially different error
+rates, cross-check with the `error-rate` catalog entry before
+interpreting shape differences as algorithmic.
 
 Time origin is the first send in the (phase, workload) cell — so the
 two curves in a panel share an x-axis that starts at each phase's own
@@ -48,7 +56,9 @@ python .claude/skills/sim2real-analyze/analyses/throughput_over_time.py --run <n
 
 ## Why sends, not completions
 
-`send_time_us` measures load *offered* to the server. Completion-time
-buckets (using `last_chunk_time_us`) would measure processing rate,
-which is the algorithm's *response* to that load — informative but
-easily confused with cause vs effect. Sends is the cleaner baseline.
+`send_time_us` — with no status filter — measures load *offered* to
+the server. Completion-time buckets (using `last_chunk_time_us`)
+would measure processing rate, which is the algorithm's *response*
+to that load — informative but easily confused with cause vs effect.
+Sends is the cleaner baseline. See `error-rate` for the ok-vs-error
+split that this chart deliberately does not surface.

--- a/.claude/skills/sim2real-analyze/analyses/throughput_over_time.py
+++ b/.claude/skills/sim2real-analyze/analyses/throughput_over_time.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Requests-per-second timeline per workload, baseline vs treatment.
+
+Invocation:
+    python .claude/skills/sim2real-analyze/analyses/throughput_over_time.py --run <name>
+    # --run defaults to current_run from workspace/setup_config.json
+"""
+import argparse
+import sys
+from pathlib import Path
+
+from _common import (
+    PHASE_COLORS,
+    PHASES,
+    charts_dir,
+    discover_workloads,
+    display_name,
+    load_csv,
+    phase_log_dirs,
+    require_matplotlib,
+    resolve_run,
+    warn,
+)
+
+
+def _rate_series(rows: list[dict]) -> tuple[list[int], list[int]]:
+    """Return (t_sec, requests_per_sec) bucketed by integer send-time second."""
+    if not rows:
+        return [], []
+    times_us = [int(r["send_time_us"]) for r in rows]
+    t0 = min(times_us)
+    buckets: dict[int, int] = {}
+    for t in times_us:
+        sec = (t - t0) // 1_000_000
+        buckets[sec] = buckets.get(sec, 0) + 1
+    if not buckets:
+        return [], []
+    max_sec = max(buckets)
+    xs = list(range(max_sec + 1))
+    ys = [buckets.get(s, 0) for s in xs]
+    return xs, ys
+
+
+def _plot(run: str, workloads: list[str], baseline_log: Path, treatment_log: Path) -> Path:
+    plt, _ = require_matplotlib()
+
+    ncols = min(3, len(workloads))
+    nrows = (len(workloads) + ncols - 1) // ncols
+    fig, axes = plt.subplots(
+        nrows, ncols,
+        figsize=(5.5 * ncols, 3.5 * nrows),
+        squeeze=False,
+    )
+
+    rendered = 0
+    for idx, wl in enumerate(workloads):
+        ax = axes[idx // ncols][idx % ncols]
+        panel_has_data = False
+        for phase, log_dir in zip(PHASES, (baseline_log, treatment_log)):
+            rows = load_csv(log_dir / wl / "trace_data.csv")
+            ok = [r for r in rows if r["status"] == "ok"]
+            if not ok:
+                warn(f"skipping throughput for workload '{wl}' phase '{phase}' — no ok rows")
+                continue
+            xs, ys = _rate_series(ok)
+            if not xs:
+                continue
+            ax.plot(xs, ys, label=f"{phase} (n={len(ok)})",
+                    color=PHASE_COLORS[phase], linewidth=1.4)
+            panel_has_data = True
+
+        if panel_has_data:
+            rendered += 1
+            ax.set_title(display_name(wl))
+            ax.set_xlabel("Time since first send (s)")
+            ax.set_ylabel("Requests / s")
+            ax.grid(True, alpha=0.4, linestyle=":")
+            ax.legend(loc="best", fontsize=8)
+        else:
+            ax.axis("off")
+
+    for empty in range(len(workloads), nrows * ncols):
+        axes[empty // ncols][empty % ncols].axis("off")
+
+    if rendered == 0:
+        print("Error: no throughput data to plot in any workload", file=sys.stderr)
+        sys.exit(1)
+
+    fig.suptitle(f"{run} — throughput over time (sends per second)", fontsize=12)
+    plt.tight_layout(rect=(0, 0, 1, 0.97))
+
+    out = charts_dir(run) / "throughput_over_time.png"
+    plt.savefig(out, dpi=130, bbox_inches="tight")
+    plt.close(fig)
+    return out
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Plot requests/sec over time per workload, baseline vs treatment"
+    )
+    parser.add_argument("--run", metavar="NAME",
+                        help="Run name (default: current_run from setup_config.json)")
+    args = parser.parse_args()
+
+    run = resolve_run(args.run)
+    baseline_log, treatment_log = phase_log_dirs(run)
+    workloads = discover_workloads(baseline_log, treatment_log)
+    out = _plot(run, workloads, baseline_log, treatment_log)
+    print(f"Saved: {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/sim2real-analyze/analyses/throughput_over_time.py
+++ b/.claude/skills/sim2real-analyze/analyses/throughput_over_time.py
@@ -58,14 +58,16 @@ def _plot(run: str, workloads: list[str], baseline_log: Path, treatment_log: Pat
         panel_has_data = False
         for phase, log_dir in zip(PHASES, (baseline_log, treatment_log)):
             rows = load_csv(log_dir / wl / "trace_data.csv")
-            ok = [r for r in rows if r["status"] == "ok"]
-            if not ok:
-                warn(f"skipping throughput for workload '{wl}' phase '{phase}' — no ok rows")
+            # No status filter: this chart measures OFFERED load. A failed
+            # request was still sent, and its send_time_us is still a valid
+            # datapoint on the injection timeline.
+            if not rows:
+                warn(f"skipping throughput for workload '{wl}' phase '{phase}' — no rows")
                 continue
-            xs, ys = _rate_series(ok)
+            xs, ys = _rate_series(rows)
             if not xs:
                 continue
-            ax.plot(xs, ys, label=f"{phase} (n={len(ok)})",
+            ax.plot(xs, ys, label=f"{phase} (n={len(rows)})",
                     color=PHASE_COLORS[phase], linewidth=1.4)
             panel_has_data = True
 

--- a/.claude/skills/sim2real-analyze/analyses/tpot-cdf.md
+++ b/.claude/skills/sim2real-analyze/analyses/tpot-cdf.md
@@ -1,0 +1,41 @@
+---
+name: tpot-cdf
+title: TPOT empirical CDF per workload (baseline vs treatment)
+when-to-use: see decode-time-per-token distribution — reveals steady-state throughput regressions the mean would average out
+inputs: run
+output: png
+runner: script
+script: tpot_cdf.py
+---
+
+# TPOT empirical CDF
+
+One panel per workload, arranged in a grid capped at three columns
+wide. Each panel plots the empirical CDF of TPOT (ms) for both phases:
+baseline in blue, treatment in red. Legend shows sample count per phase.
+
+TPOT is `(last_chunk_time_us - first_chunk_time_us) / (output_tokens - 1) / 1000`,
+computed over rows with `status == "ok"` **and** `output_tokens > 1`.
+A panel with no valid rows in either phase is hidden with a warning.
+
+## Invocation
+
+The skill invokes this analysis by running its `script` field:
+
+```bash
+python .claude/skills/sim2real-analyze/analyses/tpot_cdf.py --run <name>
+```
+
+`--run` defaults to `current_run` from `workspace/setup_config.json`.
+
+## Output
+
+- `workspace/runs/<run>/results_charts/tpot_cdf.png`
+- Standalone PNG at 130 dpi.
+
+## Why the `output_tokens > 1` filter
+
+TPOT is a per-decode-token quantity — undefined for one-token
+completions where there was no second chunk to time against.
+Workloads with all-single-token outputs (rare, but possible with
+`max_tokens=1` benchmarks) will produce an empty panel.

--- a/.claude/skills/sim2real-analyze/analyses/tpot_cdf.py
+++ b/.claude/skills/sim2real-analyze/analyses/tpot_cdf.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""TPOT empirical CDF, baseline vs treatment, one panel per workload.
+
+Invocation:
+    python .claude/skills/sim2real-analyze/analyses/tpot_cdf.py --run <name>
+    # --run defaults to current_run from workspace/setup_config.json
+
+TPOT is only defined for requests with output_tokens > 1; rows below that
+threshold are excluded per-phase before the CDF is computed.
+"""
+from _cdf import cdf_main
+
+
+if __name__ == "__main__":
+    cdf_main("TPOT")

--- a/.claude/skills/sim2real-analyze/analyses/ttft-cdf.md
+++ b/.claude/skills/sim2real-analyze/analyses/ttft-cdf.md
@@ -1,0 +1,45 @@
+---
+name: ttft-cdf
+title: TTFT empirical CDF per workload (baseline vs treatment)
+when-to-use: see full-distribution shape of time-to-first-token — reveals bimodality and tail behavior that mean/p50/p99 collapses away
+inputs: run
+output: png
+runner: script
+script: ttft_cdf.py
+---
+
+# TTFT empirical CDF
+
+One panel per workload, arranged in a grid capped at three columns
+wide. Each panel plots the empirical CDF of TTFT (ms) for both phases:
+baseline in blue, treatment in red. Legend shows sample count per phase.
+
+TTFT is `(first_chunk_time_us - send_time_us) / 1000`, computed over
+rows with `status == "ok"`. A panel with no ok-status rows in either
+phase is hidden.
+
+## Invocation
+
+The skill invokes this analysis by running its `script` field:
+
+```bash
+python .claude/skills/sim2real-analyze/analyses/ttft_cdf.py --run <name>
+```
+
+`--run` defaults to `current_run` from `workspace/setup_config.json`.
+
+## Output
+
+- `workspace/runs/<run>/results_charts/ttft_cdf.png`
+- Standalone PNG at 130 dpi; laid out with `tight_layout` and cropped
+  with `bbox_inches="tight"` so no whitespace slack in reports.
+
+## When mean/p50/p99 hides what the CDF shows
+
+- **Bimodality.** Two request populations with different queue behavior
+  produce two visible steps in the CDF; the summary table's percentiles
+  interpolate through them.
+- **Long-tail spread.** A p99 number treats the tail as a scalar. The
+  CDF shows how quickly the tail rises from p95 to p99 to p999.
+- **Cold-start transient.** If early requests are 10× slower than
+  steady-state, the CDF has a shelf that the mean smears out.

--- a/.claude/skills/sim2real-analyze/analyses/ttft_cdf.py
+++ b/.claude/skills/sim2real-analyze/analyses/ttft_cdf.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+"""TTFT empirical CDF, baseline vs treatment, one panel per workload.
+
+Invocation:
+    python .claude/skills/sim2real-analyze/analyses/ttft_cdf.py --run <name>
+    # --run defaults to current_run from workspace/setup_config.json
+"""
+from _cdf import cdf_main
+
+
+if __name__ == "__main__":
+    cdf_main("TTFT")

--- a/.claude/skills/sim2real-analyze/tests/conftest.py
+++ b/.claude/skills/sim2real-analyze/tests/conftest.py
@@ -1,0 +1,86 @@
+"""Shared test fixtures for sim2real-analyze catalog scripts.
+
+Adds the `analyses/` directory to `sys.path` once per session so
+`import ttft_cdf`, `import _common`, etc. resolve inside test modules
+without every file having to prepend it locally.
+"""
+import csv
+import sys
+from pathlib import Path
+
+import pytest
+
+ANALYSES_DIR = Path(__file__).resolve().parent.parent / "analyses"
+sys.path.insert(0, str(ANALYSES_DIR))
+
+
+def _write_csv(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not rows:
+        path.write_text("")
+        return
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _row(send: int = 0, first: int = 1_000_000, last: int = 6_000_000,
+         tokens: int = 10, status: str = "ok") -> dict:
+    return {
+        "send_time_us": str(send),
+        "first_chunk_time_us": str(first),
+        "last_chunk_time_us": str(last),
+        "output_tokens": str(tokens),
+        "status": status,
+    }
+
+
+@pytest.fixture
+def make_row():
+    """Factory returning a trace row with sensible defaults; override any field."""
+    return _row
+
+
+@pytest.fixture
+def make_csv():
+    """Factory writing a CSV from a list of row dicts."""
+    return _write_csv
+
+
+@pytest.fixture
+def workspace(tmp_path, make_row, make_csv):
+    """Create a workspace with baseline+treatment CSVs for a single workload.
+
+    Returns a namespace-like dict with:
+        `ws`        — the workspace/ dir
+        `baseline`  — path to baseline log dir
+        `treatment` — path to treatment log dir
+        `run`       — the run name ("testrun")
+        `workload`  — the sole workload dir name
+
+    Individual tests can add more CSVs or workloads via the fixtures.
+    """
+    run = "testrun"
+    wl = "workload_alpha"
+    ws_dir = tmp_path / "workspace"
+    run_root = ws_dir / "runs" / run
+    baseline_log = run_root / "results" / "baseline"
+    treatment_log = run_root / "results" / "treatment"
+
+    base_rows = [make_row(send=i * 100_000, first=(i * 100_000) + 500_000,
+                          last=(i * 100_000) + 1_500_000, tokens=10)
+                 for i in range(20)]
+    treat_rows = [make_row(send=i * 100_000, first=(i * 100_000) + 400_000,
+                           last=(i * 100_000) + 1_300_000, tokens=10)
+                  for i in range(20)]
+    make_csv(baseline_log / wl / "trace_data.csv", base_rows)
+    make_csv(treatment_log / wl / "trace_data.csv", treat_rows)
+
+    return {
+        "ws": ws_dir,
+        "baseline": baseline_log,
+        "treatment": treatment_log,
+        "run": run,
+        "workload": wl,
+    }

--- a/.claude/skills/sim2real-analyze/tests/test_cdf.py
+++ b/.claude/skills/sim2real-analyze/tests/test_cdf.py
@@ -1,0 +1,115 @@
+"""Tests for the CDF analyses (_cdf.py + ttft_cdf/tpot_cdf/e2e_cdf wrappers)."""
+import sys
+
+import pytest
+
+import _cdf
+import _common
+import e2e_cdf
+import ttft_cdf
+import tpot_cdf
+
+
+def _patch_workspace(monkeypatch, ws):
+    """Point the WORKSPACE_DIR module-globals used by _common at the fixture."""
+    monkeypatch.setattr(_common, "WORKSPACE_DIR", ws)
+
+
+# ── Unit: _empirical_cdf ──────────────────────────────────────────────────────
+
+def test_empirical_cdf_empty():
+    import numpy as np
+    x, y = _cdf._empirical_cdf([], np)
+    assert len(x) == 0 and len(y) == 0
+
+
+def test_empirical_cdf_sorted_and_stepped():
+    import numpy as np
+    values = [3.0, 1.0, 2.0, 4.0]
+    x, y = _cdf._empirical_cdf(values, np)
+    assert list(x) == [1.0, 2.0, 3.0, 4.0]
+    assert list(y) == [0.25, 0.5, 0.75, 1.0]
+
+
+def test_empirical_cdf_reaches_one_at_max():
+    import numpy as np
+    x, y = _cdf._empirical_cdf([5.0, 10.0, 15.0], np)
+    assert y[-1] == pytest.approx(1.0)
+
+
+# ── Integration: happy paths across the three metric wrappers ─────────────────
+
+@pytest.mark.parametrize("metric,out_stem", [
+    ("TTFT", "ttft_cdf"),
+    ("TPOT", "tpot_cdf"),
+    ("E2E",  "e2e_cdf"),
+])
+def test_cdf_produces_png_for_each_metric(workspace, monkeypatch, capsys, metric, out_stem):
+    _patch_workspace(monkeypatch, workspace["ws"])
+    monkeypatch.setattr(sys, "argv", [f"{out_stem}.py", "--run", workspace["run"]])
+    _cdf.cdf_main(metric)
+    out = capsys.readouterr().out
+    assert "Saved:" in out
+    png = workspace["ws"] / "runs" / workspace["run"] / "results_charts" / f"{out_stem}.png"
+    assert png.exists()
+    assert png.stat().st_size > 0
+
+
+def test_metric_wrapper_modules_re_export_cdf_main():
+    """Wrappers must expose the shared entry point so the skill sees a stable API."""
+    for m in (ttft_cdf, tpot_cdf, e2e_cdf):
+        assert getattr(m, "cdf_main", None) is _cdf.cdf_main, (
+            f"{m.__name__} is missing the cdf_main re-export"
+        )
+
+
+# ── Integration: TPOT single-token exclusion produces empty panels ────────────
+
+def test_tpot_all_single_token_exits_nonzero(workspace, monkeypatch, capsys, make_row, make_csv):
+    """When output_tokens <= 1 in every row, TPOT has no valid values."""
+    _patch_workspace(monkeypatch, workspace["ws"])
+    # Overwrite fixtures with single-token rows
+    rows = [make_row(send=i * 100_000, first=(i * 100_000) + 500_000,
+                     last=(i * 100_000) + 1_500_000, tokens=1)
+            for i in range(10)]
+    make_csv(workspace["baseline"] / workspace["workload"] / "trace_data.csv", rows)
+    make_csv(workspace["treatment"] / workspace["workload"] / "trace_data.csv", rows)
+    monkeypatch.setattr(sys, "argv", ["tpot_cdf.py", "--run", workspace["run"]])
+    with pytest.raises(SystemExit) as exc:
+        _cdf.cdf_main("TPOT")
+    assert exc.value.code == 1
+    assert "no TPOT data to plot" in capsys.readouterr().err
+
+
+# ── Integration: no ok rows → wrapper exits with a clear error ────────────────
+
+def test_all_error_rows_exits_nonzero(workspace, monkeypatch, capsys, make_row, make_csv):
+    _patch_workspace(monkeypatch, workspace["ws"])
+    bad = [make_row(status="error") for _ in range(10)]
+    make_csv(workspace["baseline"] / workspace["workload"] / "trace_data.csv", bad)
+    make_csv(workspace["treatment"] / workspace["workload"] / "trace_data.csv", bad)
+    monkeypatch.setattr(sys, "argv", ["ttft_cdf.py", "--run", workspace["run"]])
+    with pytest.raises(SystemExit) as exc:
+        _cdf.cdf_main("TTFT")
+    assert exc.value.code == 1
+
+
+# ── Guard: unknown metric raises before argument parsing ──────────────────────
+
+def test_unknown_metric_raises():
+    with pytest.raises(ValueError, match="unknown metric"):
+        _cdf.cdf_main("BOGUS")
+
+
+# ── Guard: run resolution defers to setup_config.json when --run omitted ──────
+
+def test_cdf_reads_current_run_from_config(workspace, monkeypatch, capsys):
+    import json
+    (workspace["ws"]).mkdir(parents=True, exist_ok=True)
+    (workspace["ws"] / "setup_config.json").write_text(
+        json.dumps({"current_run": workspace["run"]})
+    )
+    _patch_workspace(monkeypatch, workspace["ws"])
+    monkeypatch.setattr(sys, "argv", ["ttft_cdf.py"])  # no --run
+    _cdf.cdf_main("TTFT")
+    assert "Saved:" in capsys.readouterr().out

--- a/.claude/skills/sim2real-analyze/tests/test_error_rate.py
+++ b/.claude/skills/sim2real-analyze/tests/test_error_rate.py
@@ -93,10 +93,9 @@ def test_main_all_errors_reports_hundred_percent(workspace, monkeypatch, capsys,
     assert "100.00%" in out
 
 
-def test_main_empty_csv_is_skipped(workspace, monkeypatch, capsys, make_csv):
-    """Workloads with empty rows in both phases are skipped, not fatal."""
+def test_main_reports_multiple_workloads(workspace, monkeypatch, capsys, make_csv):
+    """Both alpha (from fixture) and beta (added here) appear in the output."""
     _patch_workspace(monkeypatch, workspace["ws"])
-    # Add a second workload with a single ok row in each phase.
     make_csv(workspace["baseline"] / "workload_beta" / "trace_data.csv",
              [{"send_time_us": "0", "first_chunk_time_us": "0",
                "last_chunk_time_us": "0", "output_tokens": "0", "status": "ok"}])
@@ -106,6 +105,5 @@ def test_main_empty_csv_is_skipped(workspace, monkeypatch, capsys, make_csv):
     monkeypatch.setattr(sys, "argv", ["error_rate.py", "--run", workspace["run"]])
     error_rate.main()
     out = capsys.readouterr().out
-    # Both workloads should be reported
     assert "alpha" in out
     assert "beta" in out

--- a/.claude/skills/sim2real-analyze/tests/test_error_rate.py
+++ b/.claude/skills/sim2real-analyze/tests/test_error_rate.py
@@ -1,0 +1,111 @@
+"""Tests for error_rate.py."""
+import sys
+from collections import Counter
+
+import _common
+import error_rate
+
+
+def _patch_workspace(monkeypatch, ws):
+    monkeypatch.setattr(_common, "WORKSPACE_DIR", ws)
+
+
+# ── Unit: _format_pct ────────────────────────────────────────────────────────
+
+def test_format_pct_zero_whole_returns_na():
+    assert error_rate._format_pct(0, 0) == "N/A"
+
+
+def test_format_pct_normal():
+    assert error_rate._format_pct(1, 4) == "25.00%"
+
+
+def test_format_pct_no_errors():
+    assert error_rate._format_pct(0, 100) == "0.00%"
+
+
+# ── Unit: _format_row ─────────────────────────────────────────────────────────
+
+def test_format_row_reports_top_status():
+    counts = Counter({"ok": 90, "timeout": 6, "500": 3, "429": 1})
+    row = error_rate._format_row("baseline", 100, 10, counts)
+    assert "baseline" in row
+    assert "100" in row
+    assert "10" in row
+    assert "10.00%" in row
+    assert "timeout=6" in row
+    assert "500=3" in row
+
+
+def test_format_row_no_errors_dash_status():
+    row = error_rate._format_row("baseline", 100, 0, Counter({"ok": 100}))
+    assert "—" in row
+
+
+# ── Integration: main happy path ──────────────────────────────────────────────
+
+def test_main_happy_path(workspace, monkeypatch, capsys, make_row, make_csv):
+    """Mix of ok and error rows across phases."""
+    _patch_workspace(monkeypatch, workspace["ws"])
+    baseline_rows = [make_row(status="ok") for _ in range(90)] + [make_row(status="timeout") for _ in range(10)]
+    treatment_rows = [make_row(status="ok") for _ in range(80)] + [make_row(status="500") for _ in range(20)]
+    make_csv(workspace["baseline"] / workspace["workload"] / "trace_data.csv", baseline_rows)
+    make_csv(workspace["treatment"] / workspace["workload"] / "trace_data.csv", treatment_rows)
+    monkeypatch.setattr(sys, "argv", ["error_rate.py", "--run", workspace["run"]])
+    error_rate.main()
+    out = capsys.readouterr().out
+    assert "alpha" in out
+    assert "baseline" in out and "treatment" in out
+    assert "10.00%" in out  # baseline error rate
+    assert "20.00%" in out  # treatment error rate
+    assert "timeout=10" in out
+    assert "500=20" in out
+
+
+def test_main_writes_txt_file(workspace, monkeypatch):
+    _patch_workspace(monkeypatch, workspace["ws"])
+    monkeypatch.setattr(sys, "argv", ["error_rate.py", "--run", workspace["run"]])
+    error_rate.main()
+    out_file = workspace["ws"] / "runs" / workspace["run"] / "error_rate.txt"
+    assert out_file.exists()
+    content = out_file.read_text()
+    assert "alpha" in content
+    assert content.endswith("\n")
+
+
+def test_main_zero_errors_reports_zero(workspace, monkeypatch, capsys):
+    """workspace fixture is all-ok — rate should be 0.00%."""
+    _patch_workspace(monkeypatch, workspace["ws"])
+    monkeypatch.setattr(sys, "argv", ["error_rate.py", "--run", workspace["run"]])
+    error_rate.main()
+    out = capsys.readouterr().out
+    assert "0.00%" in out
+
+
+def test_main_all_errors_reports_hundred_percent(workspace, monkeypatch, capsys, make_row, make_csv):
+    _patch_workspace(monkeypatch, workspace["ws"])
+    bad = [make_row(status="error") for _ in range(10)]
+    make_csv(workspace["baseline"] / workspace["workload"] / "trace_data.csv", bad)
+    make_csv(workspace["treatment"] / workspace["workload"] / "trace_data.csv", bad)
+    monkeypatch.setattr(sys, "argv", ["error_rate.py", "--run", workspace["run"]])
+    error_rate.main()
+    out = capsys.readouterr().out
+    assert "100.00%" in out
+
+
+def test_main_empty_csv_is_skipped(workspace, monkeypatch, capsys, make_csv):
+    """Workloads with empty rows in both phases are skipped, not fatal."""
+    _patch_workspace(monkeypatch, workspace["ws"])
+    # Add a second workload with a single ok row in each phase.
+    make_csv(workspace["baseline"] / "workload_beta" / "trace_data.csv",
+             [{"send_time_us": "0", "first_chunk_time_us": "0",
+               "last_chunk_time_us": "0", "output_tokens": "0", "status": "ok"}])
+    make_csv(workspace["treatment"] / "workload_beta" / "trace_data.csv",
+             [{"send_time_us": "0", "first_chunk_time_us": "0",
+               "last_chunk_time_us": "0", "output_tokens": "0", "status": "ok"}])
+    monkeypatch.setattr(sys, "argv", ["error_rate.py", "--run", workspace["run"]])
+    error_rate.main()
+    out = capsys.readouterr().out
+    # Both workloads should be reported
+    assert "alpha" in out
+    assert "beta" in out

--- a/.claude/skills/sim2real-analyze/tests/test_list_analyses.py
+++ b/.claude/skills/sim2real-analyze/tests/test_list_analyses.py
@@ -32,11 +32,26 @@ def write_script(dir_path: Path, script_name: str) -> Path:
 
 # ── Real-catalog smoke test ──────────────────────────────────────────────────
 
-def test_real_catalog_has_two_entries():
-    """The shipped catalog resolves without warnings and contains both exemplars."""
+def test_real_catalog_contains_expected_entries():
+    """The shipped catalog resolves without warnings and contains every expected entry.
+
+    Uses subset comparison so the assertion tolerates future additions without
+    another test-file edit — each new entry only has to appear here and in the
+    catalog itself. If an entry is REMOVED, the intersection fails loudly.
+    """
     entries = list_analyses.load_catalog(REAL_ANALYSES_DIR)
     names = {e["name"] for e in entries}
-    assert names == {"latency-table", "per-request-scatter"}
+    expected = {
+        "latency-table",
+        "per-request-scatter",
+        "ttft-cdf",
+        "tpot-cdf",
+        "e2e-cdf",
+        "throughput-over-time",
+        "error-rate",
+    }
+    missing = expected - names
+    assert not missing, f"catalog missing entries: {sorted(missing)}"
 
 
 def test_real_catalog_entries_have_all_required_fields():
@@ -46,11 +61,15 @@ def test_real_catalog_entries_have_all_required_fields():
             assert e.get(field), f"entry {e.get('name')!r} missing {field!r}"
 
 
-def test_real_catalog_script_entry_points_at_existing_file():
-    entries = {e["name"]: e for e in list_analyses.load_catalog(REAL_ANALYSES_DIR)}
-    lt = entries["latency-table"]
-    assert lt["runner"] == "script"
-    assert (REAL_ANALYSES_DIR / lt["script"]).exists()
+def test_real_catalog_script_entries_point_at_existing_files():
+    """Every runner:script entry in the shipped catalog references an existing .py."""
+    entries = list_analyses.load_catalog(REAL_ANALYSES_DIR)
+    script_entries = [e for e in entries if e["runner"] == "script"]
+    assert script_entries, "expected at least one script-runner entry"
+    for e in script_entries:
+        assert (REAL_ANALYSES_DIR / e["script"]).exists(), (
+            f"entry {e['name']!r} points at missing script {e['script']!r}"
+        )
 
 
 # ── Isolated-catalog tests ────────────────────────────────────────────────────

--- a/.claude/skills/sim2real-analyze/tests/test_throughput_over_time.py
+++ b/.claude/skills/sim2real-analyze/tests/test_throughput_over_time.py
@@ -1,8 +1,6 @@
 """Tests for throughput_over_time.py."""
 import sys
 
-import pytest
-
 import _common
 import throughput_over_time as tot
 
@@ -57,13 +55,16 @@ def test_main_produces_png(workspace, monkeypatch, capsys):
     assert png.stat().st_size > 0
 
 
-def test_main_no_ok_rows_exits_nonzero(workspace, monkeypatch, capsys, make_row, make_csv):
+def test_main_all_error_rows_still_plots(workspace, monkeypatch, capsys, make_row, make_csv):
+    """Offered-load semantics: an error row is still a send. Chart renders."""
     _patch_workspace(monkeypatch, workspace["ws"])
-    bad = [make_row(status="error") for _ in range(10)]
+    bad = [make_row(send=i * 100_000, status="error") for i in range(10)]
     make_csv(workspace["baseline"] / workspace["workload"] / "trace_data.csv", bad)
     make_csv(workspace["treatment"] / workspace["workload"] / "trace_data.csv", bad)
     monkeypatch.setattr(sys, "argv", ["throughput_over_time.py", "--run", workspace["run"]])
-    with pytest.raises(SystemExit) as exc:
-        tot.main()
-    assert exc.value.code == 1
-    assert "no throughput data" in capsys.readouterr().err
+    tot.main()
+    out = capsys.readouterr().out
+    assert "Saved:" in out
+    png = workspace["ws"] / "runs" / workspace["run"] / "results_charts" / "throughput_over_time.png"
+    assert png.exists()
+    assert png.stat().st_size > 0

--- a/.claude/skills/sim2real-analyze/tests/test_throughput_over_time.py
+++ b/.claude/skills/sim2real-analyze/tests/test_throughput_over_time.py
@@ -1,0 +1,69 @@
+"""Tests for throughput_over_time.py."""
+import sys
+
+import pytest
+
+import _common
+import throughput_over_time as tot
+
+
+def _patch_workspace(monkeypatch, ws):
+    monkeypatch.setattr(_common, "WORKSPACE_DIR", ws)
+
+
+# ── Unit: _rate_series ────────────────────────────────────────────────────────
+
+def test_rate_series_empty():
+    xs, ys = tot._rate_series([])
+    assert xs == []
+    assert ys == []
+
+
+def test_rate_series_buckets_by_second():
+    # Three rows in sec 0, two in sec 2 → gap at sec 1 filled with 0.
+    rows = [
+        {"send_time_us": "0"},
+        {"send_time_us": "500000"},
+        {"send_time_us": "900000"},
+        {"send_time_us": "2000000"},
+        {"send_time_us": "2500000"},
+    ]
+    xs, ys = tot._rate_series(rows)
+    assert xs == [0, 1, 2]
+    assert ys == [3, 0, 2]
+
+
+def test_rate_series_normalizes_to_first_send():
+    """Time origin should be the earliest send, not epoch."""
+    rows = [
+        {"send_time_us": "1_000_000_000"},   # sec 1000 absolute
+        {"send_time_us": "1_500_000_000"},   # sec 1500 absolute
+    ]
+    xs, ys = tot._rate_series(rows)
+    assert xs[0] == 0
+    assert xs[-1] == 500
+
+
+# ── Integration: main happy path ──────────────────────────────────────────────
+
+def test_main_produces_png(workspace, monkeypatch, capsys):
+    _patch_workspace(monkeypatch, workspace["ws"])
+    monkeypatch.setattr(sys, "argv", ["throughput_over_time.py", "--run", workspace["run"]])
+    tot.main()
+    out = capsys.readouterr().out
+    assert "Saved:" in out
+    png = workspace["ws"] / "runs" / workspace["run"] / "results_charts" / "throughput_over_time.png"
+    assert png.exists()
+    assert png.stat().st_size > 0
+
+
+def test_main_no_ok_rows_exits_nonzero(workspace, monkeypatch, capsys, make_row, make_csv):
+    _patch_workspace(monkeypatch, workspace["ws"])
+    bad = [make_row(status="error") for _ in range(10)]
+    make_csv(workspace["baseline"] / workspace["workload"] / "trace_data.csv", bad)
+    make_csv(workspace["treatment"] / workspace["workload"] / "trace_data.csv", bad)
+    monkeypatch.setattr(sys, "argv", ["throughput_over_time.py", "--run", workspace["run"]])
+    with pytest.raises(SystemExit) as exc:
+        tot.main()
+    assert exc.value.code == 1
+    assert "no throughput data" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

Closes #560. Fills in the catalog scaffolded by #548 with the five entries that PR body called out as "trivial per-file follow-ups once the scaffolding lands":

- `ttft-cdf`, `tpot-cdf`, `e2e-cdf` — one panel per workload, baseline vs treatment overlaid empirical CDF, three metric wrappers over a shared `_cdf.cdf_main`.
- `throughput-over-time` — sends/sec vs time, phases as lines, workloads as panels.
- `error-rate` — per-workload table of total / errors / rate / top non-ok statuses. The only entry that does NOT filter `status == "ok"` (errors are the metric).

`list_analyses.py` output goes from 2 → 7 entries with no warnings.

## Design decisions worth reviewer attention

1. **`_common.py` + `_cdf.py` shared helpers.** Rather than duplicate `resolve_run` / `display_name` / `load_csv` / `discover_workloads` across five scripts, I extracted them into `analyses/_common.py`. Underscore-prefixed so it's clearly a helper, not a catalog entry (the discovery machinery already ignores non-`.md` files, but the prefix documents intent). CDF plotting lives in `analyses/_cdf.py` so `error_rate.py` doesn't drag in matplotlib. Alternative: inline everything into each of the five scripts (matches `latency_table.py`'s self-contained pattern). Reviewer's call — happy to inline if that's the house preference.

2. **`throughput-over-time` uses `send_time_us`, not `arrival_time_us`.** The SKILL.md pedagogical snippet used `arrival_time_us`, but `arrival_time_us` isn't in `_common.REQUIRED_COLS` (which mirrors `latency_table.py`'s `REQUIRED_COLS`). Using `send_time_us` keeps the column-set contract consistent across the catalog. Semantic difference: sends-per-second measures load offered from the client, which is the natural view for "did the two phases see the same load shape?". Documented in `throughput-over-time.md`.

3. **`test_list_analyses.py::test_real_catalog_has_two_entries` relaxed to subset check.** The old assertion was `names == {latency-table, per-request-scatter}` — hard-coded exact-count. Renamed to `test_real_catalog_contains_expected_entries` with the seven-entry set and `missing = expected - names; assert not missing`. This tolerates future additions without another test edit, but a *removal* still fails loudly.

4. **SKILL.md sweep.** The throughput-over-time example snippet (lines 258–284 pre-PR) is now redundant with the catalog entry — deleted. The TTFT histogram example is preserved as the one-off-script template for the fallback flow, with a note explaining when to reach for the one-off vs the CDF entry.

## What warrants extra scrutiny

- **Test coverage.** New tests cover: `_empirical_cdf` unit, each metric wrapper produces a valid PNG, TPOT-all-single-token exits cleanly, all-error rows exits cleanly, unknown metric raises, config-default run resolution. Throughput adds `_rate_series` bucketing tests. Error-rate adds `_format_pct` / `_format_row` unit tests plus a happy path with mixed statuses. If a reviewer wants finer-grained coverage of a particular script's plotting output (matplotlib artefact inspection beyond "file exists and non-empty"), say so — I punted on that in favor of the smoke-test standard `test_latency_table.py` uses.

- **Import contract.** Scripts `import _common` / `import _cdf` at the top level; this works when run as `python analyses/foo.py` (sys.path[0] = the script dir) and when tests import them (conftest.py prepends `analyses/` to sys.path). If the skill runner ever invokes them differently (e.g., as a module) this will need revisiting — but the SKILL.md contract is `python .../analyses/<script> --run <name>`, so it holds.

## Verification

- [x] `python3 .claude/skills/sim2real-analyze/scripts/list_analyses.py` → emits 7 entries, no stderr warnings
- [x] `ruff check pipeline/ .claude/skills/ --select F` → clean
- [x] `pytest` full CI suite (pipeline + all `.claude/skills/*/tests/`) → 1817 passed, 1 skipped, 2 xfailed
- [x] Smoke test — each new script runs end-to-end on a synthetic workspace produced by tests; PNGs render at nonzero size, text file writes
- [ ] Manual smoke of `/sim2real-analyze` interactive loop against a real run — not exercised in this session (no local run available), reviewer or follow-up

## Deferred, still

Bundle analyses (`latency-pairwise-*`, `claim-verification-report`, heatmaps) remain deferred — they need the unlanded `sim2real resolve` refactor. Explicitly out of scope per #560's Non-goals.

## Test plan

- [ ] Reviewer confirms `_common.py` extraction is the right level (vs inline duplication)
- [ ] Reviewer sanity-checks `send_time_us` vs `arrival_time_us` throughput semantic
- [ ] Reviewer runs `/sim2real-analyze` menu against a real run and confirms all five entries are offered