### PR TITLE
fix(deploy,remote): mirror EXPERIMENT_ROOT into layout at startup

### DIFF
--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -138,6 +138,63 @@ def _discover_phases(cluster_dir: "Path") -> list[str]:
 
 # ── Setup config ─────────────────────────────────────────────────────────────
 
+# Set to "1" in build_orchestrator_job's env spec so downstream deploy.py
+# error paths can distinguish "user is running this locally" from "running
+# inside the orchestrator pod" and emit a hint the operator can act on
+# (issue #562).
+_ORCHESTRATOR_POD_ENV = "SIM2REAL_ORCHESTRATOR_POD"
+
+
+def _in_orchestrator_pod() -> bool:
+    return os.environ.get(_ORCHESTRATOR_POD_ENV) == "1"
+
+
+def _no_namespaces_hint() -> str:
+    """Return the operator-actionable "no namespaces" message for this context.
+
+    In the pod: the cluster_config that was uploaded via the run-inputs
+    ConfigMap didn't carry a ``namespaces`` list — an ``assemble``/pod-input
+    problem, not a cluster-provisioning problem. Running ``cluster.py`` here
+    is impossible; the pointer at ``sim2real assemble`` is what recovers.
+
+    Locally: the historical hint at ``cluster.py provision --namespaces``
+    is correct — this is where the operator adds namespaces to the
+    cluster's ``cluster_config.json``.
+    """
+    if _in_orchestrator_pod():
+        return (
+            "No namespaces in the run-inputs cluster_config — the uploaded "
+            "ConfigMap is missing them. Re-run 'sim2real assemble --run <N>' "
+            "locally (ensure the target cluster has namespaces provisioned) "
+            "and then 'deploy.py run --remote' again."
+        )
+    return "No namespaces configured. Run cluster.py provision with --namespaces."
+
+
+def _init_experiment_root(args) -> Path:
+    """Resolve EXPERIMENT_ROOT from CLI args and mirror it into ``layout``.
+
+    Every subsequent path resolution — ``layout.workspace_dir()``,
+    ``layout.cluster_config_path()``, ``cluster_ops.read_cluster_config()``
+    — reads from ``layout._EXPERIMENT_ROOT`` via ``layout.experiment_root()``.
+    That accessor falls back to ``Path.cwd()`` when the module global is
+    unset, which is subtly wrong in any context where ``--experiment-root``
+    differs from the current working directory — most visibly the
+    orchestrator pod, whose Dockerfile pins ``WORKDIR /app`` while the
+    entrypoint receives ``--experiment-root /data`` (issue #562).
+
+    Wiring layout at startup means every downstream consumer sees the same
+    experiment root the deploy.py module global does. ``set_experiment_root``
+    is idempotent, so re-calling in main is safe.
+    """
+    global EXPERIMENT_ROOT
+    EXPERIMENT_ROOT = (
+        Path(args.experiment_root).resolve() if args.experiment_root else Path.cwd()
+    )
+    layout.set_experiment_root(EXPERIMENT_ROOT)
+    return EXPERIMENT_ROOT
+
+
 def _load_setup_config() -> dict:
     path = EXPERIMENT_ROOT / "workspace" / "setup_config.json"
     if not path.exists():
@@ -2740,7 +2797,7 @@ def _cmd_run(args, run_dir: Path, cluster_config: dict) -> None:
 
     namespaces = cluster_config.get("namespaces") or []
     if not namespaces or not namespaces[0]:
-        err("No namespaces configured. Run cluster.py provision with --namespaces."); sys.exit(1)
+        err(_no_namespaces_hint()); sys.exit(1)
 
     registry_secret_name = (
         (cluster_config.get("secret_names") or {}).get("registry_creds") or ""
@@ -2760,7 +2817,7 @@ def _cmd_run(args, run_dir: Path, cluster_config: dict) -> None:
     cluster_dir = run_dir / "cluster"
     primary_ns = _configmap_namespace(cluster_config, namespaces)
     if not primary_ns:
-        err("No namespace configured. Run cluster.py provision with --namespaces."); sys.exit(1)
+        err(_no_namespaces_hint()); sys.exit(1)
     store = _make_progress_store(primary_ns, run_dir)
 
     # Derive GPU resource type from baseline scenario
@@ -3793,8 +3850,7 @@ def main():
     if not machine_readable:
         print(_c("36", "\n━━━ sim2real-deploy ━━━\n"))
 
-    global EXPERIMENT_ROOT
-    EXPERIMENT_ROOT = Path(args.experiment_root).resolve() if args.experiment_root else Path.cwd()
+    _init_experiment_root(args)
 
     setup_config = _load_setup_config()
 

--- a/pipeline/lib/remote.py
+++ b/pipeline/lib/remote.py
@@ -191,7 +191,13 @@ def build_orchestrator_job(
                         "name": "orchestrator",
                         "image": image,
                         "args": args,
-                        "env": [{"name": "PYTHONUNBUFFERED", "value": "1"}],
+                        "env": [
+                            {"name": "PYTHONUNBUFFERED", "value": "1"},
+                            # Marker so downstream deploy.py code paths can
+                            # emit pod-appropriate error hints instead of the
+                            # local "run cluster.py provision" message (#562).
+                            {"name": "SIM2REAL_ORCHESTRATOR_POD", "value": "1"},
+                        ],
                         "volumeMounts": [
                             {"name": "workspace", "mountPath": workspace_path},
                         ],

--- a/pipeline/tests/test_deploy_remote.py
+++ b/pipeline/tests/test_deploy_remote.py
@@ -882,3 +882,80 @@ def test_run_remote_skips_validation_when_configmap_unreachable(monkeypatch, tmp
     combined = captured.out + captured.err
     assert "ConfigMap unreachable" in combined
     assert "skipping pre-flight filter validation" in combined
+
+
+# ── _init_experiment_root — mirror args into layout (#562) ──────────────────
+
+def test_init_experiment_root_mirrors_arg_into_layout(tmp_path, monkeypatch):
+    """When --experiment-root is passed, layout.experiment_root() returns it,
+    NOT Path.cwd(). Regression guard for #562: without this, an orchestrator
+    pod (WORKDIR /app, --experiment-root /data) would resolve every
+    layout-mediated path against /app and read empty cluster_config.
+    """
+    from pipeline.lib import layout
+    # Force cwd to differ from experiment_root so the fallback would
+    # produce the wrong answer if the fix were removed.
+    other = tmp_path / "elsewhere"
+    other.mkdir()
+    monkeypatch.chdir(other)
+    exp_root = tmp_path / "workspace-root"
+    exp_root.mkdir()
+
+    args = argparse.Namespace(experiment_root=str(exp_root))
+    resolved = mod._init_experiment_root(args)
+
+    assert resolved == exp_root
+    assert layout.experiment_root() == exp_root
+    assert layout.experiment_root() != other
+
+
+def test_init_experiment_root_falls_back_to_cwd_when_arg_absent(tmp_path, monkeypatch):
+    """No --experiment-root → uses cwd for both the module global and layout."""
+    from pipeline.lib import layout
+    monkeypatch.chdir(tmp_path)
+    args = argparse.Namespace(experiment_root=None)
+    resolved = mod._init_experiment_root(args)
+
+    assert resolved == tmp_path
+    assert layout.experiment_root() == tmp_path
+
+
+def test_init_experiment_root_empty_string_treated_as_absent(tmp_path, monkeypatch):
+    """argparse-style empty-string arg (falsy) should fall back to cwd, not
+    resolve to Path('')."""
+    from pipeline.lib import layout
+    monkeypatch.chdir(tmp_path)
+    args = argparse.Namespace(experiment_root="")
+    resolved = mod._init_experiment_root(args)
+    assert resolved == tmp_path
+    assert layout.experiment_root() == tmp_path
+
+
+# ── _no_namespaces_hint — pod-vs-local context detection (#562) ─────────────
+
+def test_no_namespaces_hint_local_context(monkeypatch):
+    monkeypatch.delenv("SIM2REAL_ORCHESTRATOR_POD", raising=False)
+    msg = mod._no_namespaces_hint()
+    assert "cluster.py provision" in msg
+    assert "run-inputs" not in msg
+
+
+def test_no_namespaces_hint_pod_context(monkeypatch):
+    monkeypatch.setenv("SIM2REAL_ORCHESTRATOR_POD", "1")
+    msg = mod._no_namespaces_hint()
+    # In the pod, hint should NOT tell the operator to run cluster.py —
+    # they can't from inside the pod.
+    assert "cluster.py provision" not in msg
+    # And it should point at the actual recovery step (re-assemble).
+    assert "sim2real assemble" in msg
+
+
+def test_no_namespaces_hint_pod_env_var_only_matches_exact_one(monkeypatch):
+    """A stray truthy-looking value like '0' or 'false' must NOT flip the
+    branch — only the literal '1' set by build_orchestrator_job counts."""
+    monkeypatch.setenv("SIM2REAL_ORCHESTRATOR_POD", "0")
+    assert "cluster.py provision" in mod._no_namespaces_hint()
+    monkeypatch.setenv("SIM2REAL_ORCHESTRATOR_POD", "false")
+    assert "cluster.py provision" in mod._no_namespaces_hint()
+    monkeypatch.setenv("SIM2REAL_ORCHESTRATOR_POD", "")
+    assert "cluster.py provision" in mod._no_namespaces_hint()

--- a/pipeline/tests/test_deploy_remote.py
+++ b/pipeline/tests/test_deploy_remote.py
@@ -7,6 +7,23 @@ import pytest
 from unittest.mock import patch
 
 import pipeline.deploy as mod
+from pipeline.lib import layout
+
+
+@pytest.fixture(autouse=True)
+def _reset_layout_experiment_root():
+    """Clear layout._EXPERIMENT_ROOT before and after every test.
+
+    Tests that call mod._init_experiment_root() (or otherwise invoke
+    layout.set_experiment_root) mutate module-global state that would
+    otherwise leak into later tests, producing order-dependent failures.
+    Matches the pattern used across test_layout.py, test_cluster_ops.py,
+    test_build.py, test_resolve.py, and every other file that touches
+    layout state.
+    """
+    layout._EXPERIMENT_ROOT = None
+    yield
+    layout._EXPERIMENT_ROOT = None
 
 
 def _make_run_args(*, remote=False, workload=None, only=None, package=None,
@@ -959,3 +976,85 @@ def test_no_namespaces_hint_pod_env_var_only_matches_exact_one(monkeypatch):
     assert "cluster.py provision" in mod._no_namespaces_hint()
     monkeypatch.setenv("SIM2REAL_ORCHESTRATOR_POD", "")
     assert "cluster.py provision" in mod._no_namespaces_hint()
+
+
+# ── _load_run_cluster_config — end-to-end with cwd ≠ experiment_root (#562) ──
+
+def test_load_run_cluster_config_reads_from_experiment_root_not_cwd(tmp_path, monkeypatch):
+    """The exact regression #562 calls out: an orchestrator pod with
+    cwd=/app and --experiment-root=/data was hitting layout.experiment_root()
+    → Path.cwd() = /app → wrong workspace → empty config.
+
+    This test locks that path down end-to-end through _load_run_cluster_config:
+    with cwd pointed at a directory that has NO workspace/, the loader must
+    still find the cluster_config.json under the workspace anchored at
+    layout._EXPERIMENT_ROOT. If a future refactor drops layout and reads
+    from mod.EXPERIMENT_ROOT directly (or Path.cwd() again), this test
+    fails.
+    """
+    cluster_id = "test-cluster"
+    run_name = "trial-1"
+
+    # Realistic workspace layout under tmp_path (the "experiment root").
+    exp_root = tmp_path / "experiment"
+    workspace = exp_root / "workspace"
+    (workspace / "clusters" / cluster_id).mkdir(parents=True)
+    (workspace / "clusters" / cluster_id / "cluster_config.json").write_text(
+        json.dumps({"namespaces": ["ns-x", "ns-y"], "secret_names": {}})
+    )
+    run_dir = workspace / "runs" / run_name
+    (run_dir / "cluster").mkdir(parents=True)
+    (run_dir / "run_metadata.json").write_text(
+        json.dumps({"cluster_id": cluster_id, "scenario": "s"})
+    )
+
+    # Cwd anywhere BUT the experiment root. Without the fix, layout would
+    # anchor here and every subsequent path resolution would miss.
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    # Simulate what main() does at startup: mirror --experiment-root into
+    # layout via the extracted helper.
+    args = argparse.Namespace(experiment_root=str(exp_root))
+    mod._init_experiment_root(args)
+
+    # Sanity: layout was actually redirected away from cwd.
+    assert layout.experiment_root() == exp_root.resolve()
+    assert layout.experiment_root() != elsewhere
+
+    # The behavior we're guarding: run_dir is under exp_root, loader
+    # follows run_metadata.json → cluster_ops.read_cluster_config →
+    # layout.cluster_config_path → succeeds despite cwd being elsewhere.
+    cfg = mod._load_run_cluster_config(run_dir)
+    assert cfg["namespaces"] == ["ns-x", "ns-y"]
+
+
+def test_load_run_cluster_config_returns_empty_when_config_absent(tmp_path, monkeypatch):
+    """Symmetric coverage: when cluster_config.json is genuinely missing
+    from the workspace, the loader returns {} (silent empty). This is the
+    behavior _cmd_run relies on to emit the "No namespaces" hint at line
+    2800. Guards against a future change that swaps the empty-dict return
+    for an exception, which would surface as a raw traceback instead of
+    the pod-appropriate hint.
+    """
+    cluster_id = "test-cluster"
+    run_name = "trial-1"
+
+    exp_root = tmp_path / "experiment"
+    workspace = exp_root / "workspace"
+    # Note: no clusters/<id>/cluster_config.json — this is the point.
+    run_dir = workspace / "runs" / run_name
+    (run_dir / "cluster").mkdir(parents=True)
+    (run_dir / "run_metadata.json").write_text(
+        json.dumps({"cluster_id": cluster_id, "scenario": "s"})
+    )
+
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+    args = argparse.Namespace(experiment_root=str(exp_root))
+    mod._init_experiment_root(args)
+
+    cfg = mod._load_run_cluster_config(run_dir)
+    assert cfg == {}

--- a/pipeline/tests/test_remote.py
+++ b/pipeline/tests/test_remote.py
@@ -267,6 +267,17 @@ def test_job_orchestrator_unbuffered():
     assert env["PYTHONUNBUFFERED"] == "1"
 
 
+def test_job_orchestrator_pod_marker_env_var_set():
+    """`SIM2REAL_ORCHESTRATOR_POD=1` is set so deploy.py error paths can emit
+    pod-appropriate hints instead of the local "run cluster.py provision"
+    message (#562).
+    """
+    job = _build_job()
+    container = job["spec"]["template"]["spec"]["containers"][0]
+    env = {e["name"]: e["value"] for e in container["env"]}
+    assert env.get("SIM2REAL_ORCHESTRATOR_POD") == "1"
+
+
 def test_job_workspace_is_writable_emptydir():
     """Orchestrator mounts a writable emptyDir at /data/workspace."""
     job = _build_job()


### PR DESCRIPTION
Closes #562.

## What was broken

`deploy.py --run <N> run --remote` against a fully-provisioned workspace: local pre-flight passes, orchestrator Job launches, then the pod exits ~5s later with:

```
[ERROR] No namespaces configured. Run cluster.py provision with --namespaces.
```

The ConfigMap **was** mounted and the initContainer **did** copy `cluster_config.json` to `/data/workspace/clusters/<id>/cluster_config.json`. The pod just wasn't looking there: `Dockerfile:25` pins `WORKDIR /app`, the entrypoint receives `--experiment-root /data`, and `deploy.py:main` set its own module-level `EXPERIMENT_ROOT` **but never called `layout.set_experiment_root(EXPERIMENT_ROOT)`**. Every downstream `layout.experiment_root()` call fell back to `Path.cwd() = /app`, so `cluster_ops.read_cluster_config` searched `/app/workspace/…` (empty) and returned `{}` silently. `_cmd_run` then saw no namespaces and emitted a hint the pod can't act on.

## What changed

**1. `pipeline/deploy.py`** — extract `_init_experiment_root(args)` (lines 174–194) that resolves the arg **and** calls `layout.set_experiment_root(...)` in one shot. `main()` calls it (line 3853) instead of inlining the resolution. This is the one-line fix; the extraction just makes it independently testable.

**2. `pipeline/deploy.py`** — introduce `_no_namespaces_hint()` (lines 145–172) which detects the `SIM2REAL_ORCHESTRATOR_POD=1` env var and emits a hint pointing at `sim2real assemble` when inside the pod, keeping the historical `cluster.py provision` hint locally. Applied to the two pod-reachable sites in `_cmd_run` (line 2800 and 2820). The other seven sites of the same error string live on local-only code paths — unchanged per the issue's scoping note.

**3. `pipeline/lib/remote.py`** — `build_orchestrator_job` sets `SIM2REAL_ORCHESTRATOR_POD=1` in the container env so the marker is in place when the pod's deploy.py runs.

## What warrants reviewer attention

1. **`_init_experiment_root` vs an inline one-liner in `main()`.** I extracted it so the specific "cwd != experiment_root" regression is unit-testable without invoking `main()` (which needs a real workspace, real args, and does a lot before the check). Alternative: put the two lines inline in `main()` and skip the extraction. The extraction adds ~20 lines (including docstring) but buys three focused regression tests. Reviewer's call.

2. **Env-var marker approach for pod detection.** Alternative was checking `cwd != EXPERIMENT_ROOT` at error time — but post-fix those are equal in the pod, so we'd lose the disambiguator. The env var is set by the same place that builds the Job spec (`build_orchestrator_job` in `remote.py`), so the linkage is co-located and testable. Downside: two files must stay in sync (the constant `_ORCHESTRATOR_POD_ENV` in `deploy.py` and the string in `remote.py`). Considered exporting the constant from `remote.py` but that creates an import cycle risk; kept them as parallel literals with a test asserting the produced Job spec has the exact value.

3. **Scope: only 2 of 9 "run cluster.py provision" sites changed.** The issue's "Suggested direction 2" targets the pod-reachable sites (`_cmd_run` at 2800/2820). The other seven live on `_cmd_status`, `_cmd_collect`, `_cmd_reset`, `_cmd_wipe`, `_cmd_run_remote`, and the `main` branches for `build` and `stop` — all local-only paths where the historical hint is correct. Deliberately left alone; the issue's "adjacent audit findings" section flagged them as separate scope decisions.

## What I did NOT do

- **Did NOT audit adjacent trap sites** (`sim2real.py:1178,1194,1490`, `assemble_run.py:787`). They're only reachable from local CLI paths today, so the primary bug is fixed. Each is a latent version of the same trap; recorded in the issue as "audit findings", left for a follow-up.
- **Did NOT change `layout.experiment_root()` fallback behavior.** The issue flagged this as higher blast-radius; keeping it out of this PR.

## Verification

- `python3 -m pytest pipeline/ .claude/skills/*/tests/` → **1824 passed, 1 skipped, 2 xfailed** (delta +7 = new tests here)
- `ruff check pipeline/ .claude/skills/ --select F` → clean
- Sweep for stale refs: the exact old error string appears in seven `docs/superpowers/plans/*.md` files — historical planning-doc snapshots of past code state, not live docs. Left alone. No SKILL.md, README, or CLAUDE.md mentions the string or the new env var.

## Test plan

- [x] `_init_experiment_root` mirrors arg into layout when cwd differs — regression guard for the exact bug
- [x] `_init_experiment_root` falls back to cwd when arg absent / empty
- [x] Job spec includes `SIM2REAL_ORCHESTRATOR_POD=1` env var
- [x] `_no_namespaces_hint` returns local hint (with `cluster.py provision`) when env var absent
- [x] `_no_namespaces_hint` returns pod hint (with `sim2real assemble`, no `cluster.py`) when env var == "1"
- [x] `_no_namespaces_hint` only flips on literal "1" — not on truthy-looking "0", "false", or ""
- [ ] Manual smoke: `deploy.py --run <N> run --remote` against a real cluster — reviewer or follow-up