### PR TITLE
fix(tekton): give stream-gpu-stats an explicit 2h TaskRun timeout

### DIFF
--- a/pipeline/lib/tekton.py
+++ b/pipeline/lib/tekton.py
@@ -10,6 +10,7 @@ _SCENARIO_FILE_PATH = "/tmp/llmdbench-config/scenario.yaml"
 # whose timeout exceeds the enclosing pipeline timeout.
 _TASK_TIMEOUTS: dict[str, str] = {
     "stream-epp-logs": "2h",
+    "stream-gpu-stats": "2h",
     "run-workload-blis-observe-binary": "90m",
 }
 


### PR DESCRIPTION
Closes #566.

## Summary

Adds `"stream-gpu-stats": "2h"` to `_TASK_TIMEOUTS` in `pipeline/lib/tekton.py`, aligning it with the existing `stream-epp-logs` override.

## Why

Before this change, `stream-gpu-stats` had no entry in `_TASK_TIMEOUTS`, so its TaskRun inherited Tekton's default 1h timeout. Any workload running longer than 1h therefore failed its entire PipelineRun even when the workload itself completed successfully:

1. `stream-gpu-stats` hits 1h → PipelineRun enters `stopping` mode.
2. `collect-results` (`runAfter: run-workload-blis-observe-binary`) is skipped with `skippedTasks[].reason: "PipelineRun was stopping"`.
3. Without `collect-results`, the `epp_stream_done` / `gpu_stream_done` sentinels are never written.
4. `stream-epp-logs` polls for its sentinel until its own 2h timeout fires.

Result: 6 of 9 failed pairs in trial-2 (softr / kalantar-msb, 2026-07-10), all `reasoning_1_2`, traced to this exact cascade. Their `run-workload-blis-observe-binary` TaskRuns all completed `Succeeded` in 1h06m – 1h11m — the data was on the PVC; only the streamers were lost.

## Why 2h

Stream tasks start when `llmdbenchmark-standup` finishes, at the same moment as `run-workload`. `run-workload` is capped at 90m by its own override; `collect-results` adds seconds/minutes. Total stream-task wall time is bounded by ~95m under current caps, so 2h leaves ~25m headroom.

Once `stream-gpu-stats` no longer trips the 1h ceiling, the PipelineRun stops entering "stopping" mode, `collect-results` runs, the sentinel gets written, and both streamers exit cleanly seconds after `run-workload` — the 2h on `stream-epp-logs` won't be exercised either.

## Test plan

- [x] `pytest pipeline/tests/test_tekton.py -v` — 28 tests pass, including `test_make_pipelinerun_scenario_task_run_specs` which asserts the emitted `taskRunSpecs` matches `_TASK_TIMEOUTS`. That equality holds through the change (both sides now contain the new entry), so the test transitively verifies that generated PipelineRuns will carry `pipelineTaskName: stream-gpu-stats, timeout: 2h`.
- [x] `pytest pipeline/` — full pipeline suite: 1616 passed, 2 xfailed (pre-existing).
- [x] `ruff check pipeline/ --select F` — clean.

## Sweep for stale references

Searched `pipeline/**/*.py`, `docs/**/*.md`, and `.claude/skills/**/*.md` for `_TASK_TIMEOUTS`, `stream-gpu-stats`, and `stream-epp-logs`:
- `pipeline/tests/test_tekton.py:82-92` — uses `_TASK_TIMEOUTS` symmetrically (`assert by_task == _TASK_TIMEOUTS`), so it stays green automatically. The issue's "tests to update" note turned out to be over-cautious.
- `pipeline/tests/test_pipeline_yaml.py` — verifies wiring / param plumbing in `pipeline.yaml`, doesn't reference timeout values.
- `docs/superpowers/plans/2026-07-07-issue-511-pipeline-replica-threading.md` and `docs/proposals/replicas-as-pair-keys.md` — reference the dict's location or task names, don't pin its contents.

No updates needed elsewhere.

## Out of scope

The belt-and-suspenders alternative called out in the issue (move sentinel-write out of `collect-results` or make it a `finally` task) is a separate hardening — not required for this fix and not included here.

The three other trial-2 failures (interactive-chat-20 / interactive-chat-80 / reasoning-0-7 at 18:10 UTC) are a distinct infra-caused event and are tracked in the companion issue #567.