### PR TITLE
feat(deploy): accept multiple values on --status filter

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -397,7 +397,7 @@ The parser accepts a legacy no-suffix form (`wl-<workload>|<package>`) and reads
 | `--workload NAME…` | Workload dimension | Multiple values are OR'd within the flag. Glob patterns supported (see below). |
 | `--package NAME…` | Package dimension | Multiple values are OR'd within the flag. Glob patterns supported (see below). |
 | `--iteration SPEC` | Iteration dimension | Grammar below. |
-| `--status STATE` | Progress state (`pending` / `running` / `done` / `failed` / `timed-out` / `stalled`) | Not available on every subcommand — see per-subcommand tables. |
+| `--status STATE…` | Progress state (`pending` / `running` / `done` / `failed` / `timed-out` / `stalled`) | Multiple values are OR'd within the flag (comma or space-separated). Not available on every subcommand — see per-subcommand tables. |
 
 Different flags compose as AND: `--workload X --package baseline --iteration 1,3` narrows to iterations 1 and 3 of workload X's baseline package.
 
@@ -431,7 +431,7 @@ python pipeline/deploy.py pairs   [flags]   # list available pair keys, workload
 | `--workload NAME…` | — | Scope execution to pairs matching these workloads (comma or space-separated; globs OK) |
 | `--package NAME…` | — | Scope execution to pairs matching these packages (comma or space-separated; globs OK) |
 | `--iteration SPEC` | — | Scope to iteration(s): `'2'`, `'1,3'`, `'1-3'`, `'1,3-5'` |
-| `--status STATE` | — | Scope execution to pairs with this status (e.g. `failed`, `timed-out`) |
+| `--status STATE…` | — | Scope execution to pairs matching these statuses (comma or space-separated; e.g. `failed`, `timed-out`) |
 | `--skip-teardown` | — | Skip the Tekton teardown task, leaving namespace resources intact for debugging |
 | `--preserve-pipelineruns` | — | Do not delete PipelineRun objects after completion (keeps TaskRun logs for debugging) |
 | `--force` | — | Reset non-pending pairs to `pending`, cleaning cluster resources (PipelineRuns + Helm) for pairs with assigned namespaces |
@@ -467,7 +467,7 @@ python pipeline/deploy.py pairs   [flags]   # list available pair keys, workload
 | `--workload NAME…` | Filter by workload names (comma or space-separated; globs OK) |
 | `--package NAME…` | Filter by package names (comma or space-separated; globs OK) |
 | `--iteration SPEC` | Scope to iteration(s): `'2'`, `'1,3'`, `'1-3'`, `'1,3-5'` |
-| `--status STATE` | Filter by status (e.g. `running`, `done`, `failed`) |
+| `--status STATE…` | Filter by status names (comma or space-separated; e.g. `running`, `done`, `failed`) |
 | `-s`, `--silent` | Suppress the per-pair table and banner; print only the summary line (machine-readable) |
 
 **`deploy.py collect`** — extracts results from the cluster PVC and writes to `workspace/runs/<run>/results/{phase}/<workload>/i<N>/` (one subdirectory per iteration). Repeated collects are incremental at iteration granularity: each `i<N>/trace_data.csv` on the current slot's PVC is compared to its local copy and skipped if the local mtime is at least as new. Iterations that live on other slots' PVCs (e.g. when replicas of one `(phase, workload)` pair dispatch across cluster slots) are left untouched on local disk — the workload directory is never wiped as a whole. If the mtime probe fails (e.g., pod not running), collection falls back to a full copy — this is the expected degradation path. Like `deploy.py run`, the run's cluster is resolved from `workspace/runs/<R>/run_metadata.json:cluster_id`; missing `runs/<R>/` or `runs/<R>/cluster/` exits with `run 'sim2real assemble --run <R>' first`, and a missing / unparseable `run_metadata.json` or missing `cluster_id` exits with `run metadata corrupted; re-assemble`.
@@ -494,7 +494,7 @@ When `--only` or `--workload` is given, only matching workload subdirectories ar
 | `--workload NAME…` | Scope reset to pairs matching these workloads (comma or space-separated; globs OK) |
 | `--package NAME…` | Scope reset to pairs matching these packages (comma or space-separated; globs OK) |
 | `--iteration SPEC` | Scope to iteration(s): `'2'`, `'1,3'`, `'1-3'`, `'1,3-5'` |
-| `--status STATE` | Scope reset to pairs with this status |
+| `--status STATE…` | Scope reset to pairs matching these statuses (comma or space-separated) |
 | `--preserve-done-status` | Keep done pairs' status unchanged (cluster cleanup only) |
 | `--dry-run` | Print what would be reset without acting |
 

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -2443,7 +2443,7 @@ def _apply_run_filters(progress: dict, args) -> set:
     only = _parse_list(getattr(args, "only", None))
     workload = _parse_list(getattr(args, "workload", None))
     package = _parse_list(getattr(args, "package", None))
-    status_filter = getattr(args, "status", None)
+    status_filter = _parse_list(getattr(args, "status", None))
     iteration_spec = getattr(args, "iteration", None)
 
     # Parse --iteration up-front so malformed specs fail before any other work.
@@ -2506,7 +2506,8 @@ def _apply_run_filters(progress: dict, args) -> set:
         package_set = set(package)
         candidates = {k for k in candidates if pair_entries[k].get("package") in package_set}
     if status_filter:
-        candidates = {k for k in candidates if pair_entries[k].get("status") == status_filter}
+        status_set = set(status_filter)
+        candidates = {k for k in candidates if pair_entries[k].get("status") in status_set}
     if iteration_set is not None:
         candidates = {k for k in candidates if _key_iteration(k) in iteration_set}
     return candidates
@@ -2537,7 +2538,7 @@ def _report_filter_mismatch(progress: dict, args) -> None:
     only = _parse_list(getattr(args, "only", None))
     workload = _parse_list(getattr(args, "workload", None))
     package = _parse_list(getattr(args, "package", None))
-    status_filter = getattr(args, "status", None)
+    status_filter = _parse_list(getattr(args, "status", None))
     iteration_spec = getattr(args, "iteration", None)
 
     parts = []
@@ -2548,7 +2549,7 @@ def _report_filter_mismatch(progress: dict, args) -> None:
     if package is not None:
         parts.append(f"--package '{','.join(package)}'")
     if status_filter is not None:
-        parts.append(f"--status '{status_filter}'")
+        parts.append(f"--status '{','.join(status_filter)}'")
     if iteration_spec is not None:
         parts.append(f"--iteration '{iteration_spec}'")
 
@@ -3763,7 +3764,7 @@ Examples:
     status_p.add_argument("--only",     nargs="+", metavar="PAIR",  help="Scope to specific pair keys (comma or space-separated, wl- prefix optional)")
     status_p.add_argument("--workload", nargs="+", metavar="NAME",  help="Scope to pairs matching these workloads (comma or space-separated)")
     status_p.add_argument("--package",  nargs="+", metavar="NAME",  help="Scope to pairs matching these packages (comma or space-separated)")
-    status_p.add_argument("--status",   metavar="STATE", help="Scope to pairs with this status (e.g. running, done, failed)")
+    status_p.add_argument("--status",   nargs="+", metavar="STATE", help="Scope to pairs matching these statuses (comma or space-separated; e.g. running, done, failed)")
     status_p.add_argument("--iteration", metavar="SPEC", dest="iteration",
                           help="Scope to iteration(s): '2', '1,3', '1-3', '1,3-5'")
     status_p.add_argument("-s", "--silent", action="store_true",
@@ -3781,7 +3782,7 @@ Examples:
     run_p.add_argument("--only",         nargs="+", metavar="PAIR",  help="Scope execution to specific pair keys (comma or space-separated, wl- prefix optional)")
     run_p.add_argument("--workload",     nargs="+", metavar="NAME",  help="Scope execution to pairs matching these workloads (comma or space-separated)")
     run_p.add_argument("--package",      nargs="+", metavar="NAME",  help="Scope execution to pairs matching these packages (comma or space-separated)")
-    run_p.add_argument("--status",       metavar="STATE", help="Scope execution to pairs with this status (e.g. failed, timed-out)")
+    run_p.add_argument("--status",       nargs="+", metavar="STATE", help="Scope execution to pairs matching these statuses (comma or space-separated; e.g. failed, timed-out)")
     run_p.add_argument("--iteration",    metavar="SPEC", dest="iteration",
                        help="Scope execution to iteration(s): '2', '1,3', '1-3', '1,3-5'")
     run_p.add_argument("--force",        action="store_true",
@@ -3813,7 +3814,7 @@ Examples:
     reset_p.add_argument("--only",     nargs="+", metavar="PAIR",  help="Scope to specific pair keys (comma or space-separated, wl- prefix optional)")
     reset_p.add_argument("--workload", nargs="+", metavar="NAME",  help="Scope to pairs matching these workloads (comma or space-separated)")
     reset_p.add_argument("--package",  nargs="+", metavar="NAME",  help="Scope to pairs matching these packages (comma or space-separated)")
-    reset_p.add_argument("--status",   metavar="STATE", help="Scope to pairs with this status")
+    reset_p.add_argument("--status",   nargs="+", metavar="STATE", help="Scope to pairs matching these statuses (comma or space-separated)")
     reset_p.add_argument("--iteration", metavar="SPEC", dest="iteration",
                          help="Scope to iteration(s): '2', '1,3', '1-3', '1,3-5'")
     reset_p.add_argument("--preserve-done-status", action="store_true", dest="preserve_done_status",

--- a/pipeline/tests/test_deploy_run.py
+++ b/pipeline/tests/test_deploy_run.py
@@ -781,6 +781,28 @@ def test_apply_run_filters_by_status():
     assert result == {"wl-heavy-baseline"}
 
 
+def test_apply_run_filters_by_status_multi_list():
+    """--status accepts a list (nargs='+' shape) and matches pairs in any listed status."""
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = None; workload = None; package = None; status = ["failed", "timed-out"]
+
+    result = _apply_run_filters(dict(_PROGRESS), _Args())
+    assert result == {"wl-heavy-baseline", "wl-load-treatment"}
+
+
+def test_apply_run_filters_by_status_comma_string():
+    """--status accepts a single comma-separated string and matches pairs in any listed status."""
+    from pipeline.deploy import _apply_run_filters
+
+    class _Args:
+        only = None; workload = None; package = None; status = "failed,timed-out"
+
+    result = _apply_run_filters(dict(_PROGRESS), _Args())
+    assert result == {"wl-heavy-baseline", "wl-load-treatment"}
+
+
 def test_apply_run_filters_compose():
     from pipeline.deploy import _apply_run_filters
 
@@ -1415,6 +1437,18 @@ def test_report_filter_mismatch_multi_value_formatting(capsys):
     captured = capsys.readouterr().err
     assert "--workload 'wl-smoke,wl-heavy'" in captured
     assert "--package 'baseline,treatment'" in captured
+
+
+def test_report_filter_mismatch_status_list_formatting(capsys):
+    """_report_filter_mismatch formats a --status list with commas, matching --workload/--package."""
+    from pipeline.deploy import _report_filter_mismatch
+
+    class _Args:
+        only = None; workload = None; package = None; status = ["failed", "timed-out"]
+
+    _report_filter_mismatch(dict(_PROGRESS), _Args())
+    captured = capsys.readouterr().err
+    assert "--status 'failed,timed-out'" in captured
 
 
 def test_collect_run_flags_list_values():


### PR DESCRIPTION
Closes #569.

## Summary

Aligns `--status` with the shape of `--only` / `--workload` / `--package` on the three subcommands that expose it (`status`, `run`, `reset`). All four filters now accept comma- or space-separated multi-value input, and the mismatch diagnostic prints `--status` with the same comma-joined format as its siblings.

## Why

After a run with mixed `failed` and `timed-out` outcomes, there was no way to say "scope both classes" without either running the command twice or enumerating every affected pair via `--only`. The other three scope flags handle this cleanly; `--status` was the odd one out.

## What changed

- **CLI decls (3 sites in `pipeline/deploy.py`):** `--status` on `status_p:3766`, `run_p:3784`, and `reset_p:3816` gain `nargs="+"`; help text mirrors the `--workload` / `--package` wording (comma or space-separated).
- **Filter application (`_apply_run_filters`):** `status_filter` now goes through `_parse_list` (the same helper `--only` / `--workload` / `--package` use). The filter check switches from `==` to set membership.
- **Mismatch diagnostic (`_report_filter_mismatch`):** `status_filter` also parsed via `_parse_list`, and the "no pairs matched" line renders `--status 'a,b'` matching the sibling flags' shape.

`_parse_list` at `pipeline/deploy.py:2377` already handles both raw strings and lists, so:
- Existing tests passing `status = "failed"` (raw string) continue to pass unchanged.
- Argparse's new list output from `nargs="+"` passes through the same helper.
- `deploy.py run --remote` uses `_collect_run_flags` to forward filters to the in-cluster Job; that helper already handles both `list` and raw-string values, so multi-value `--status` composes with `--remote` for free.

## Test plan

- [x] `pytest pipeline/tests/test_deploy_run.py -v -k "status or filter_mismatch"` — 47 pass.
- [x] `pytest pipeline/` — 1619 passed (was 1616 pre-#568, 1618 post-#568). +3 new tests here:
  - `test_apply_run_filters_by_status_multi_list` — list form `["failed", "timed-out"]` matches pairs in either status.
  - `test_apply_run_filters_by_status_comma_string` — comma-string form `"failed,timed-out"` matches the same set.
  - `test_report_filter_mismatch_status_list_formatting` — mismatch print emits `--status 'failed,timed-out'` matching sibling shape.
- [x] `ruff check pipeline/ --select F` — clean.
- [x] Argparse end-to-end verified for all three subcommands: space-separated, comma-separated, and single-value invocations all produce lists that `_parse_list` flattens correctly.

## Documentation swept

Grepped `**/*.md` for `--status`. Updated four rows in `pipeline/README.md`:
- Line 400 (shared filter table): `--status STATE` → `--status STATE…`, description now mentions multi-value.
- Line 434 (`run` table), line 470 (`status` table), line 497 (`reset` table): same treatment.

Left as-is (still accurate after the change):
- `docs/epics/step-5/design.md:349` — mentions `--status` in a filter list, no shape claim.
- `docs/proposals/replicas-as-pair-keys.md:117` — historical proposal, mentions `--status` in a filter list.
- `docs/superpowers/plans/2026-07-07-issue-514-step-5-docs.md` — historical plan doc for issue #514.

## Deliberately out of scope

The issue's item #3 (validating status values against the canonical vocabulary `pending / running / done / failed / timed-out / stalled` and surfacing `unrecognized values` like `--workload` does) is explicitly labeled optional in the issue. Skipped here to keep the change focused on the shape asymmetry. Can be filed as a follow-up if the operator experience of a silent no-match still surprises people after this lands.