### PR TITLE
feat(pipeline): adopt collect_metrics.sh + provision EPP metrics RBAC — closes #579

### DIFF
--- a/.claude/skills/sim2real-analyze/SKILL.md
+++ b/.claude/skills/sim2real-analyze/SKILL.md
@@ -180,15 +180,19 @@ workspace/runs/<name>/
                           #                       last_chunk_time_us, output_tokens,
                           #                       arrival_time_us, input_tokens, status, ...
         trace_header.yaml # model, time_unit (microseconds), workload_spec, server config
-        metrics/timeseries.csv       # EPP + vLLM Prometheus scrapes (optional — present
-                                     # when stream-metrics ran); columns:
-                                     # timestamp_us, target, metric_name, labels, value
-        metrics/<target>.discovered.txt  # sorted-unique metric names each target exposed
+        metrics/raw/<pod>_<ts>_metrics.log   # Prometheus text-exposition dumps, one file
+                                             # per pod per scrape (optional — present when
+                                             # stream-metrics ran). Produced by
+                                             # collect_metrics.sh which stream-metrics wraps.
+        metrics/processed/metrics_summary.json    # post-run percentiles over the metrics
+                                                  # named in process_metrics.py:AGGREGATE_METRICS
+        metrics/processed/replica_status_timeseries.json  # replica state/scale over the run
     treatment/
       workload_<name>/
         trace_data.csv
         trace_header.yaml
-        metrics/timeseries.csv
+        metrics/raw/...
+        metrics/processed/...
   deploy_comparison_table.txt  # written by analyses/latency_table.py
   results_charts/              # your analysis outputs go here
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,8 +115,9 @@ All artifacts live under `<experiment-root>/workspace/` (gitignored). When no `-
 | `runs/<run>/cluster/pipelinerun-*.yaml` | `sim2real assemble` | `deploy.py run` |
 | `runs/<run>/results/{phase}/` | `deploy.py collect` | `/sim2real-analyze` skill, `deploy.py wipe` |
 | `runs/<run>/results/{phase}/<workload>/i<N>/gpu_logs/<node>.log` | `deploy.py collect` (pulled from PVC) | analysis / debugging |
-| `runs/<run>/results/{phase}/<workload>/i<N>/metrics/timeseries.csv` | `deploy.py collect` (pulled from PVC) | analysis — EPP + vLLM `/metrics` time-series, columns `timestamp_us,target,metric_name,labels,value` (allowlist-filtered by `stream-metrics`); see `pipeline/README.md#metric-capture-stream-metrics` for defaults + widening |
-| `runs/<run>/results/{phase}/<workload>/i<N>/metrics/<target>.discovered.txt` | `deploy.py collect` (pulled from PVC) | ops — sorted-unique metric names the target exposed on first scrape; source of truth for widening `metricsAllowlist` |
+| `runs/<run>/results/{phase}/<workload>/i<N>/metrics/raw/<pod>_<ts>_metrics.log` | `deploy.py collect` (pulled from PVC) | analysis — raw Prometheus text-exposition dumps, one file per pod per scrape (produced by `collect_metrics.sh`, which `stream-metrics` wraps — see `pipeline/README.md#metric-capture-stream-metrics`) |
+| `runs/<run>/results/{phase}/<workload>/i<N>/metrics/processed/metrics_summary.json` | `deploy.py collect` (pulled from PVC) | analysis — post-run percentiles over the metrics named in `process_metrics.py:AGGREGATE_METRICS` |
+| `runs/<run>/results/{phase}/<workload>/i<N>/metrics/processed/replica_status_timeseries.json` | `deploy.py collect` (pulled from PVC) | analysis — replica state / scale over the workload window |
 | ConfigMap `sim2real-progress-{scenario}-{run}` | `deploy.py run`, `deploy.py reset` | All `deploy.py` subcommands |
 | `runs/<run>/plans/<phase>/<workload>/` | `deploy.py run` | workload tasks |
 

--- a/docs/superpowers/plans/2026-07-15-issue-574-stream-metrics.md
+++ b/docs/superpowers/plans/2026-07-15-issue-574-stream-metrics.md
@@ -1,5 +1,12 @@
 # Issue #574 — stream-metrics Prometheus scraper sidecar
 
+> **Superseded by issue #579 / plan `2026-07-15-issue-579-adopt-collect-metrics.md`.**
+> This plan is preserved as a historical record of the initial sim2real-owned
+> sidecar design (issues #574 / #576, PRs #575 / #577). The current design
+> wraps upstream `collect_metrics.sh` from llm-d-benchmark instead of
+> maintaining our own scraper, and provisions the EPP-side auth RBAC at
+> cluster bootstrap. See the #579 plan for the current shape.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Add a `stream-metrics` Tekton streaming sidecar that scrapes the EPP and vLLM `/metrics` Prometheus endpoints during each workload iteration and persists the time-series into the cell bundle, giving offline analysis access to `WaitingQueueSize`, `KVCacheUsagePercent`, EPP `flow_control_pool_saturation`, and other engine/router signals that today can only be inferred from trace behaviour.

--- a/docs/superpowers/plans/2026-07-15-issue-579-adopt-collect-metrics.md
+++ b/docs/superpowers/plans/2026-07-15-issue-579-adopt-collect-metrics.md
@@ -1,0 +1,561 @@
+# Issue #579 — Adopt `collect_metrics.sh`, provision EPP metrics RBAC at bootstrap
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the sim2real-owned `stream-metrics` sidecar shell script with a thin wrapper around `llm-d-benchmark/workload/harnesses/collect_metrics.sh`, and provision the EPP-side auth RBAC ourselves at cluster bootstrap so the wrapper can present a bearer token that EPP will validate.
+
+**Architecture:** Cluster-side RBAC (ClusterRole + per-namespace ClusterRoleBinding) is added to the submodule's existing `roles-*.yaml` bundles, applied by `cluster_ops.provision_namespace`'s existing `_step_rbac`. A per-namespace `type: kubernetes.io/service-account-token` Secret is also added to `roles-ns.yaml`, giving `collect_metrics.sh` a bearer token to send to EPP. `stream-metrics.yaml` becomes a shell wrapper that curls `collect_metrics.sh` + `process_metrics.py` from a pinned llm-d-benchmark commit, runs `start`, polls the sentinel, then runs `stop` + `process`.
+
+**Tech stack:** Bash, `kubectl`, `curl`, `python3` — installed into the existing `alpine/kubectl:1.34.1` image via `apk add` at task start. No new images. No changes to `llmdbenchmark-standup`. No cluster-Prometheus ServiceMonitor.
+
+## Global constraints
+
+- **Two-PR flow again** (submodule PR merges first, parent PR bumps + wires downstream). Same pattern as #575 and #577.
+- **`llmdbenchmark-standup` is unchanged.** It keeps stripping `router.monitoring.prometheus.enabled` under `--non-admin`; we don't fight that.
+- **No cluster-scoped RBAC creation happens at pipeline time.** ClusterRole + ClusterRoleBinding are created at `cluster.py provision` / `slot add` (the admin bootstrap moment).
+- **Existing pipeline SA is unchanged** — `helm-installer` remains the PipelineRun SA. It becomes authorized on `/metrics` via the new group-subject binding.
+- **CI must pass** — `ruff check pipeline/ --select F` and the pytest suite in `.github/workflows/test.yml`.
+
+## Design decisions (locked)
+
+1. **collect_metrics.sh install strategy: curl-pin from raw.githubusercontent.com** at a task-param SHA (default = the currently-vendored llm-d-benchmark submodule SHA). Simplest option — zero moving parts, matches the existing `install-inference-perf.yaml` pattern that already does `wget https://raw.githubusercontent.com/llm-d/llm-d-benchmark/...`. Rejected: workspace-mount (adds a workspace binding to stream-metrics not present today), image-bake (requires publishing a custom image).
+2. **Image: `python:3.12-slim-bookworm`.** Same image `install-inference-perf.yaml` and `llmdbenchmark-standup.yaml` already use for tasks that mix python + shell. Base ships bash, python3, apt-get. Add `curl` (via apt) + a pinned `kubectl` binary at task start (matches the `1.34.1` version the sibling streamers use via `alpine/kubectl:1.34.1`). Two package installs vs. three on alpine; the sibling streamers keep alpine because they're pure shell + awk and don't need python — our task does.
+3. **Sentinel-exit contract preserved.** Wrapper starts `collect_metrics.sh start` in background, polls the `metrics_stream_done` sentinel, calls `stop` + `process` on sentinel fire. Preserves parallel-with-workload lifecycle; no change to `collect-results.yaml`.
+4. **Bearer identity: `helm-installer` SA token via type-annotated Secret.** The Secret we create annotates `kubernetes.io/service-account.name: helm-installer`; kubelet auto-populates `data.token`. `collect_metrics.sh` reads it verbatim — no upstream code changes.
+5. **RBAC group subject: `system:serviceaccounts:${NAMESPACE}`.** Blast radius = one namespace. Covers both `helm-installer` (the pipeline SA) and the chart-derived EPP SA (whatever its name turns out to be per release). Simpler than chasing per-release SA names.
+6. **Task params trimmed.** Drop `eppPort`, `vllmPort`, `eppSelector`, `eppSelectorFallback`, `vllmSelector`, `metricsAllowlist` — all handled internally by `collect_metrics.sh`'s env vars. Keep `namespace`, `resultsDir`, `intervalSeconds` (default `"15"` matching collect_metrics.sh). Add `harnessSha`.
+
+---
+
+## Section A — `tektonc-data-collection` submodule PR
+
+### Task A1: Add `sim2real-metrics-reader` ClusterRole + per-namespace ClusterRoleBinding to `roles-cluster.yaml`
+
+**Files:**
+- Modify: `tektonc-data-collection/tekton/roles-cluster.yaml`
+
+**Interfaces:**
+- Consumes: `${NAMESPACE}` from `_envsubst` (already threaded by `_step_rbac`).
+- Produces: cluster-scoped `ClusterRole/sim2real-metrics-reader` (name is constant — creating from N per-namespace applies is idempotent under `kubectl apply`); per-namespace `ClusterRoleBinding/sim2real-metrics-reader-${NAMESPACE}` with `Group: system:serviceaccounts:${NAMESPACE}` subject.
+
+- [ ] **Step 1: Append the ClusterRole + ClusterRoleBinding to the file.**
+
+  At the end of `roles-cluster.yaml` (below existing `helm-installer-clusterrole` and its bindings):
+
+  ```yaml
+  ---
+  # ClusterRole: grants the RBAC verbs the llm-d-router chart's monitoring
+  # subchart would emit (see _rbac.yaml in the routerlib chart). Bundled
+  # here so sim2real's cluster-admin bootstrap owns this, allowing pipeline
+  # runs to stay non-admin while still having a working /metrics auth path
+  # against EPP.
+  #
+  # See sim2real#579 for the design rationale; the corresponding secret
+  # (`inference-gateway-sa-metrics-reader-secret`) is created per-namespace
+  # by roles-ns.yaml.
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: sim2real-metrics-reader
+  rules:
+  # EPP calls TokenReview against the k8s API to validate incoming bearer
+  # tokens on /metrics scrapes. Every SA in namespaces where EPP might
+  # run needs this permission — hence the group-subject binding below.
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["tokenreviews"]
+    verbs: ["create"]
+  # EPP additionally calls SubjectAccessReview to check whether the
+  # (validated) token identifies a principal authorized to GET /metrics.
+  - apiGroups: ["authorization.k8s.io"]
+    resources: ["subjectaccessreviews"]
+    verbs: ["create"]
+  # Client-side authorization: the scraper SA (helm-installer) needs
+  # nonResourceURL /metrics get so its bearer token passes EPP's SAR check.
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+  ---
+  # Per-namespace binding — one CRB per pool namespace, distinguished by
+  # the ${NAMESPACE} substitution. Group subject covers every SA in the
+  # namespace: both helm-installer (the pipeline SA presenting the bearer)
+  # and the chart-derived EPP SA (which calls TokenReview/SAR to validate).
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: sim2real-metrics-reader-${NAMESPACE}
+  subjects:
+    - kind: Group
+      name: system:serviceaccounts:${NAMESPACE}
+      apiGroup: rbac.authorization.k8s.io
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: sim2real-metrics-reader
+  ```
+
+- [ ] **Step 2: Verify with `envsubst` simulation.**
+
+  ```bash
+  NAMESPACE=kalantar-0 envsubst < tektonc-data-collection/tekton/roles-cluster.yaml > /tmp/roles-cluster-expanded.yaml
+  python3 -c "import yaml; list(yaml.safe_load_all(open('/tmp/roles-cluster-expanded.yaml')))" && echo "multi-doc YAML OK"
+  grep -c 'kind: ClusterRoleBinding' /tmp/roles-cluster-expanded.yaml
+  ```
+  Expected: `multi-doc YAML OK`, at least 2 ClusterRoleBindings (`helm-installer-crb-kalantar-0` + `sim2real-metrics-reader-kalantar-0`).
+
+### Task A2: Add per-namespace reader Secret to `roles-ns.yaml`
+
+**Files:**
+- Modify: `tektonc-data-collection/tekton/roles-ns.yaml`
+
+**Interfaces:**
+- Consumes: `${NAMESPACE}`, `helm-installer` SA (created earlier in same file).
+- Produces: `Secret/inference-gateway-sa-metrics-reader-secret` in `${NAMESPACE}` with annotation `kubernetes.io/service-account.name: helm-installer`. Kubernetes populates `data.token` asynchronously with a valid helm-installer SA token.
+
+- [ ] **Step 1: Append the Secret manifest to the file** (after the existing SA + Role + RoleBinding + SCC bindings):
+
+  ```yaml
+  ---
+  # Bearer-token Secret consumed by the stream-metrics sidecar's
+  # collect_metrics.sh scraper. Kubernetes auto-populates data.token
+  # with a valid ServiceAccount token for helm-installer (the SA named
+  # in the annotation). collect_metrics.sh reads this secret by its
+  # default name (LLMDBENCH_EPP_METRICS_SECRET), so no upstream change
+  # is required.
+  #
+  # This is the sim2real-side replacement for the Secret that the
+  # llm-d-router chart's monitoring subchart would create if we let
+  # standup enable it — which we can't, because it also emits
+  # cluster-scoped RBAC that the non-admin pipeline SA can't provision.
+  # See sim2real#579.
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: inference-gateway-sa-metrics-reader-secret
+    namespace: ${NAMESPACE}
+    annotations:
+      kubernetes.io/service-account.name: helm-installer
+  type: kubernetes.io/service-account-token
+  ```
+
+- [ ] **Step 2: Verify.**
+
+  ```bash
+  NAMESPACE=kalantar-0 envsubst < tektonc-data-collection/tekton/roles-ns.yaml > /tmp/roles-ns-expanded.yaml
+  python3 -c "import yaml; list(yaml.safe_load_all(open('/tmp/roles-ns-expanded.yaml')))" && echo "multi-doc YAML OK"
+  grep -A2 'kind: Secret' /tmp/roles-ns-expanded.yaml
+  ```
+  Expected: `multi-doc YAML OK`, the Secret block visible with correct namespace + annotation.
+
+### Task A3: Rewrite `tekton/tasks/stream-metrics.yaml` as a `collect_metrics.sh` wrapper
+
+**Files:**
+- Modify (rewrite): `tektonc-data-collection/tekton/tasks/stream-metrics.yaml`
+
+**Interfaces:**
+- Consumes: `data` workspace (unchanged), params `namespace`, `resultsDir`, `intervalSeconds` (default `"15"`), `harnessSha` (default = current vendored llm-d-benchmark commit SHA).
+- Produces: `${RESULTS_DIR}/metrics/{raw,processed}/` + `metrics/collector.pid` + `metrics/metrics_collection.log` (from collect_metrics.sh's own logging).
+- Exit condition: `${RESULTS_DIR}/metrics_stream_done` sentinel appears, OR collect_metrics.sh PID dies. Non-fatal on all failures.
+
+- [ ] **Step 1: Full rewrite. Overwrite the file with the wrapper.**
+
+  Reference: current file at 77e5c7b is ~330 lines of shell + awk. New file is ~60 lines of wrapper.
+
+  ```yaml
+  # tektonc-data-collection/tekton/tasks/stream-metrics.yaml
+  apiVersion: tekton.dev/v1
+  kind: Task
+  metadata:
+    name: stream-metrics
+  spec:
+    description: >-
+      Runs llm-d-benchmark's collect_metrics.sh scraper as a Tekton
+      sidecar, in parallel with the workload. Same sentinel-exit
+      contract as stream-epp-logs and stream-gpu-stats.
+
+      collect_metrics.sh + process_metrics.py are pulled from raw
+      GitHub at a pinned commit SHA — no image customization, no
+      workspace mount. The scraper reads its EPP bearer token from
+      the `inference-gateway-sa-metrics-reader-secret` Secret which
+      cluster.py provision / slot add creates per-namespace (annotated
+      to helm-installer, type: kubernetes.io/service-account-token).
+
+      Output layout (collect_metrics.sh convention):
+        metrics/raw/<pod>_<timestamp>_metrics.log         (Prometheus text)
+        metrics/raw/collection_debug.log
+        metrics/processed/replica_status.json
+        metrics/processed/replica_status_timeseries.json
+        metrics/processed/pod_startup_times.json
+        metrics/processed/metrics_summary.json
+
+      Non-fatal: any failure logs a warning and exits 0 — the pipeline
+      is not blocked by scraper failures.
+
+    workspaces:
+      - name: data
+        description: "Shared PVC (data-pvc)"
+
+    params:
+      - { name: namespace,       type: string }
+      - { name: resultsDir,      type: string }
+      - { name: intervalSeconds, type: string, default: "15" }
+      - name: harnessSha
+        type: string
+        description: >-
+          llm-d-benchmark commit SHA to fetch collect_metrics.sh and
+          process_metrics.py from. Default is the SHA vendored in
+          sim2real's llm-d-benchmark tree at the time this task was
+          last updated. Override for pinning behavior tests.
+        default: "main"
+
+    steps:
+      - name: stream-metrics
+        image: python:3.12-slim-bookworm
+        securityContext:
+          runAsUser: 0
+        script: |
+          #!/usr/bin/env bash
+          set +e
+
+          NAMESPACE="$(params.namespace)"
+          RESULTS_DIR="/workspace/data/$(params.resultsDir)"
+          SENTINEL="${RESULTS_DIR}/metrics_stream_done"
+          INTERVAL="$(params.intervalSeconds)"
+          HARNESS_SHA="$(params.harnessSha)"
+          KUBECTL_VER="v1.34.1"
+
+          # Phase 0 — install curl (apt) + kubectl (pinned binary from k8s.io).
+          # python:3.12-slim ships python3 + bash + apt-get; we need curl for
+          # scraping /metrics and fetching the harness scripts, and kubectl
+          # for the pod-discovery calls inside collect_metrics.sh.
+          apt-get update -qq >/dev/null 2>&1 && apt-get install -y --no-install-recommends curl >/dev/null 2>&1 || {
+            echo "WARNING: apt-get install curl failed, cannot run collect_metrics.sh"
+            exit 0
+          }
+          curl -fsSL -m 30 -o /usr/local/bin/kubectl \
+            "https://dl.k8s.io/release/${KUBECTL_VER}/bin/linux/amd64/kubectl" || {
+            echo "WARNING: kubectl download failed"
+            exit 0
+          }
+          chmod +x /usr/local/bin/kubectl
+
+          # Phase 1 — fetch collect_metrics.sh + process_metrics.py at pinned SHA.
+          HARNESS_URL="https://raw.githubusercontent.com/llm-d/llm-d-benchmark/${HARNESS_SHA}/workload/harnesses"
+          mkdir -p /usr/local/bin
+          curl -fsSL -m 30 -o /usr/local/bin/collect_metrics.sh "${HARNESS_URL}/collect_metrics.sh" || {
+            echo "WARNING: curl collect_metrics.sh failed (harnessSha=${HARNESS_SHA})"
+            exit 0
+          }
+          curl -fsSL -m 30 -o /usr/local/bin/process_metrics.py  "${HARNESS_URL}/process_metrics.py" || {
+            echo "WARNING: curl process_metrics.py failed (harnessSha=${HARNESS_SHA})"
+            exit 0
+          }
+          chmod +x /usr/local/bin/collect_metrics.sh
+
+          # Phase 2 — env vars consumed by collect_metrics.sh.
+          export LLMDBENCH_RUN_EXPERIMENT_RESULTS_DIR="${RESULTS_DIR}"
+          export LLMDBENCH_VLLM_COMMON_NAMESPACE="${NAMESPACE}"
+          export METRICS_COLLECTION_INTERVAL="${INTERVAL}"
+          # Default value matches what roles-ns.yaml creates; kept explicit
+          # so downstream can override if the Secret name ever changes.
+          export LLMDBENCH_EPP_METRICS_SECRET="inference-gateway-sa-metrics-reader-secret"
+
+          mkdir -p "${RESULTS_DIR}/metrics"
+          rm -f "${SENTINEL}"
+          LOG="${RESULTS_DIR}/metrics/metrics_collection.log"
+
+          # Phase 3 — start scraper in background.
+          echo "Starting collect_metrics.sh (harnessSha=${HARNESS_SHA}, interval=${INTERVAL}s)"
+          bash /usr/local/bin/collect_metrics.sh start >> "${LOG}" 2>&1 &
+          SCRAPER_PID=$!
+          echo "Scraper PID: ${SCRAPER_PID}"
+
+          # Phase 4 — sentinel poll. Exits on:
+          #   (a) sentinel file appears (collect-results wrote it)
+          #   (b) scraper process died on its own
+          while true; do
+            if [ -f "${SENTINEL}" ]; then
+              echo "Sentinel found, stopping scraper."
+              break
+            fi
+            if ! kill -0 "${SCRAPER_PID}" 2>/dev/null; then
+              echo "Scraper process ${SCRAPER_PID} exited before sentinel."
+              break
+            fi
+            sleep 1
+          done
+
+          # Phase 5 — stop + process.
+          bash /usr/local/bin/collect_metrics.sh stop >> "${LOG}" 2>&1
+          wait "${SCRAPER_PID}" 2>/dev/null || true
+          echo "Processing collected metrics..."
+          bash /usr/local/bin/collect_metrics.sh process >> "${LOG}" 2>&1
+
+          # Phase 6 — final report.
+          n_raw=$(find "${RESULTS_DIR}/metrics/raw" -name '*_metrics.log' 2>/dev/null | wc -l | tr -d ' ')
+          n_proc=$(find "${RESULTS_DIR}/metrics/processed" -name '*.json' 2>/dev/null | wc -l | tr -d ' ')
+          echo "Metrics scraping complete for $(params.resultsDir): ${n_raw} raw scrape(s), ${n_proc} processed JSON(s)"
+  ```
+
+  Notable choices:
+  - `#!/usr/bin/env bash` in the wrapper — python-slim ships bash as `/bin/bash`. `collect_metrics.sh` invoked as `bash /usr/local/bin/collect_metrics.sh` for clarity even though the interpreter would find it.
+  - `curl -fsSL -m 30` for the harness + kubectl fetches: `-f` fails on HTTP 4xx/5xx (so pipes stay clean), `-m 30` avoids indefinite hangs.
+  - Every install step is `|| exit 0` — non-fatal: if apt or the download endpoint is unreachable, task stays green rather than failing the whole PipelineRun. Sentinels + workload progress are unaffected.
+  - No target discovery in the wrapper — `collect_metrics.sh` does it internally.
+  - `kubectl` pin `v1.34.1` matches the version the sibling streamers use via `alpine/kubectl:1.34.1`.
+
+- [ ] **Step 2: Verify YAML parses.**
+
+  ```bash
+  python3 -c "import yaml; yaml.safe_load(open('tektonc-data-collection/tekton/tasks/stream-metrics.yaml'))" && echo "OK"
+  ```
+
+### Task A4: Commit + push + open upstream PR
+
+- [ ] **Step 1: Create branch in submodule + commit.**
+
+  ```bash
+  cd tektonc-data-collection
+  git checkout -b feat/adopt-collect-metrics-with-rbac
+  git add tekton/roles-cluster.yaml tekton/roles-ns.yaml tekton/tasks/stream-metrics.yaml
+  git commit -m "feat: adopt llm-d-benchmark's collect_metrics.sh as stream-metrics scraper
+  
+  ... (see full body below)"
+  ```
+
+  Body should cover: (a) RBAC additions to roles-cluster/roles-ns, (b) rewrite of stream-metrics as wrapper, (c) why (issue #579 rationale summary), (d) note that sim2real bump PR follows.
+
+- [ ] **Step 2: Push + PR.**
+
+  ```bash
+  git push -u origin feat/adopt-collect-metrics-with-rbac
+  gh pr create --repo inference-sim/tektonc-data-collection --base main \
+    --title "feat: adopt collect_metrics.sh; add sim2real-metrics-reader RBAC" \
+    --body-file /tmp/upstream-579-pr-body.md
+  ```
+
+- [ ] **Step 3: Wait for upstream merge.**
+
+---
+
+## Section B — `sim2real` parent PR
+
+### Task B1: Bump submodule pointer
+
+- [ ] **Step 1: Fetch merged upstream + check out.**
+
+  ```bash
+  cd tektonc-data-collection
+  git fetch origin
+  git checkout origin/main
+  cd -
+  ```
+
+- [ ] **Step 2: Verify the three files carry the changes.**
+
+  ```bash
+  grep -q sim2real-metrics-reader tektonc-data-collection/tekton/roles-cluster.yaml && echo "CR/CRB present"
+  grep -q inference-gateway-sa-metrics-reader-secret tektonc-data-collection/tekton/roles-ns.yaml && echo "Secret present"
+  grep -q 'apk add' tektonc-data-collection/tekton/tasks/stream-metrics.yaml && echo "wrapper installed apk step present"
+  ```
+
+- [ ] **Step 3: Stage the bump.** `git add tektonc-data-collection`.
+
+### Task B2: Update `deploy.py collect` for the new output layout
+
+**Files:**
+- Modify: `pipeline/deploy.py:1461-1517` — the `_extract_phases_from_pvc` skip_logs=True block.
+- Modify: `pipeline/tests/test_deploy_collect.py` — update the metrics-specific tests.
+
+**Interfaces:**
+- Existing `metrics/` copy stanza (added in #575) does a recursive `kubectl cp remote/metrics/ local/metrics/`. This already captures whatever collect_metrics.sh writes inside `metrics/` — no code change needed for the copy itself. The stale-wipe stanza already includes `"metrics"` in the subdir tuple.
+- What DOES change: the test assertions and the analysis-side expectations.
+
+- [ ] **Step 1: Update `test_collect_skip_logs_invokes_metrics_copy` in `test_deploy_collect.py`.**
+
+  Existing test asserts `/wl-smoke/i1/metrics/` and `/wl-smoke/i1/metrics_stream_done` appear in cp targets. Both are still correct — the copy is recursive; new layout just puts more files inside. No functional change to the test, but update the docstring to say "collect_metrics.sh-shaped `metrics/{raw,processed}/` layout" instead of "timeseries.csv layout".
+
+- [ ] **Step 2: Run the test suite.**
+
+  ```bash
+  python -m pytest pipeline/tests/test_deploy_collect.py -v -k 'metrics or stale'
+  ```
+  Expected: green.
+
+### Task B3: Update `pipeline/README.md` — "Metric capture" subsection
+
+**Files:**
+- Modify: `pipeline/README.md`, the "Metric capture" section added in #575 (search for `### Metric capture` around line 524).
+
+- [ ] **Step 1: Rewrite the subsection.**
+
+  Replace the old content with a description of the new architecture:
+  - `stream-metrics` is a thin wrapper around `collect_metrics.sh` from llm-d-benchmark.
+  - Output layout: `metrics/raw/<pod>_<ts>_metrics.log` (Prometheus text) + `metrics/processed/*.json` (aggregated summaries).
+  - EPP bearer auth uses `inference-gateway-sa-metrics-reader-secret` provisioned per-namespace by `cluster.py provision` / `slot add`.
+  - How to widen metric coverage: edit `AGGREGATE_METRICS` in `process_metrics.py` upstream; harnessSha task param picks the version.
+  - Live inspection recipe (kubectl port-forward + curl) — carry over unchanged.
+
+  Also update the artifact-inventory paragraph earlier in the section to list the new `metrics/raw/` and `metrics/processed/` paths instead of `metrics/timeseries.csv` + `metrics/<target>.discovered.txt`.
+
+- [ ] **Step 2: Verify markdown renders (visual grep).**
+
+  ```bash
+  grep -c 'collect_metrics.sh\|metrics/raw\|metrics/processed' pipeline/README.md
+  ```
+  Expected: ≥ 4 hits.
+
+### Task B4: Update `CLAUDE.md` — workspace artifact table
+
+**Files:**
+- Modify: `CLAUDE.md`, the workspace artifact table (currently has rows for `metrics/timeseries.csv` and `metrics/<target>.discovered.txt`).
+
+- [ ] **Step 1: Replace the two rows with new ones.**
+
+  Delete:
+  ```
+  | `runs/<run>/results/{phase}/<workload>/i<N>/metrics/timeseries.csv` | ... |
+  | `runs/<run>/results/{phase}/<workload>/i<N>/metrics/<target>.discovered.txt` | ... |
+  ```
+
+  Add:
+  ```
+  | `runs/<run>/results/{phase}/<workload>/i<N>/metrics/raw/<pod>_<ts>_metrics.log` | `deploy.py collect` (pulled from PVC) | analysis — raw Prometheus text-exposition-format scrapes, one file per pod per tick (collect_metrics.sh output) |
+  | `runs/<run>/results/{phase}/<workload>/i<N>/metrics/processed/metrics_summary.json` | `deploy.py collect` (pulled from PVC) | analysis — aggregated percentiles over the metrics named in process_metrics.py:AGGREGATE_METRICS |
+  | `runs/<run>/results/{phase}/<workload>/i<N>/metrics/processed/replica_status_timeseries.json` | `deploy.py collect` (pulled from PVC) | analysis — replica scale/state over the run |
+  ```
+
+### Task B5: Update `sim2real-analyze` skill data reference
+
+**Files:**
+- Modify: `.claude/skills/sim2real-analyze/SKILL.md` — the data-reference block that shows the cell layout.
+
+- [ ] **Step 1: Replace the `metrics/timeseries.csv` + `<target>.discovered.txt` lines** with the new `metrics/raw/*.log` + `metrics/processed/*.json` layout.
+
+### Task B6: Add a superseded-by note to the #574 plan doc (do NOT delete)
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-07-15-issue-574-stream-metrics.md`
+
+- [ ] **Step 1: Add a preamble.**
+
+  Prepend to the top of the file:
+
+  ```markdown
+  > **Superseded by issue #579 / plan `2026-07-15-issue-579-adopt-collect-metrics.md`.**
+  > This plan is preserved as a historical record of the initial sim2real-owned
+  > sidecar design (issues #574 / #576, PRs #575 / #577). The current design
+  > wraps upstream `collect_metrics.sh` instead of maintaining our own scraper.
+  ```
+
+  Do not delete the file — it's a historical record of design evolution.
+
+### Task B7: Update / close #578
+
+**Interfaces:** none — GitHub-side hygiene only.
+
+- [ ] **Step 1: Add a comment to #578** noting that #579 supersedes it, with a brief summary of why (chart-side auth-delegator can't be provided by the chart because non-admin standup strips the monitoring path; sim2real provisions equivalent RBAC directly at bootstrap).
+
+- [ ] **Step 2: Close #578.**
+
+  ```bash
+  gh issue close 578 --comment "Superseded by #579 — that issue's fix provisions the equivalent auth RBAC at cluster.py provision / slot add time, sidestepping the need for a chart-side change."
+  ```
+
+### Task B8: Sweep for stale references
+
+- [ ] **Step 1: grep for old artifact names.**
+
+  ```bash
+  grep -rn --include='*.md' --include='*.py' --include='*.yaml' \
+    -e 'timeseries.csv' -e 'discovered.txt' \
+    -e 'metricsAllowlist' -e 'EPP_SELECTOR_USED' \
+    .claude/ pipeline/ docs/ CLAUDE.md
+  ```
+
+- [ ] **Step 2: For each hit, decide stale vs still-accurate.** Update any docs/prompts referencing the old shape.
+
+### Task B9: Run the full CI suite locally
+
+- [ ] **Step 1: Lint.**
+
+  ```bash
+  ruff check pipeline/ .claude/skills/ --select F
+  ```
+
+- [ ] **Step 2: Full pytest run (matches `.github/workflows/test.yml`).**
+
+  ```bash
+  python -m pytest pipeline/ \
+    pipeline/tests/test_layout.py pipeline/tests/test_cluster_ops.py \
+    pipeline/tests/test_cluster_py.py pipeline/tests/test_slicer.py \
+    pipeline/tests/test_sim2real.py pipeline/tests/test_assemble_run.py \
+    pipeline/tests/test_translation_ref.py pipeline/tests/test_translate.py \
+    pipeline/tests/test_build.py pipeline/tests/test_pairkey.py \
+    pipeline/tests/test_load_pairs.py \
+    .claude/skills/sim2real-analyze/tests/ \
+    .claude/skills/sim2real-bootstrap/tests/ \
+    .claude/skills/sim2real-translate/tests/ \
+    .claude/skills/sim2real-check/tests/ \
+    -v
+  ```
+
+### Task B10: Commit + push + open parent PR
+
+- [ ] **Step 1: Path-discipline check.**
+
+  ```bash
+  pwd  # should contain .claude/worktrees/issue-579-adopt-collect-metrics
+  git status --short
+  git -C /Users/kalantar/projects/go.workspace/src/github.com/inference-sim/sim2real status --short | head -10
+  ```
+
+- [ ] **Step 2: Stage + commit.**
+
+  ```bash
+  git add tektonc-data-collection \
+          pipeline/deploy.py pipeline/tests/test_deploy_collect.py \
+          pipeline/README.md CLAUDE.md \
+          .claude/skills/sim2real-analyze/SKILL.md \
+          docs/superpowers/plans/2026-07-15-issue-574-stream-metrics.md \
+          docs/superpowers/plans/2026-07-15-issue-579-adopt-collect-metrics.md
+  git commit -m "$(cat <<'EOF'
+  feat(pipeline): adopt collect_metrics.sh; provision EPP metrics RBAC at bootstrap
+  
+  Closes #579. Supersedes #578.
+  
+  ... (full body — issue rationale summary + companion upstream PR link)
+  EOF
+  )"
+  ```
+
+- [ ] **Step 3: Push + PR.**
+
+  ```bash
+  git push -u origin worktree-issue-579-adopt-collect-metrics
+  gh pr create --title "feat(pipeline): adopt collect_metrics.sh + provision EPP metrics RBAC — closes #579" \
+               --body-file /tmp/parent-579-pr-body.md
+  ```
+
+  PR body should:
+  - `Closes #579`.
+  - Link the merged upstream PR.
+  - Stale-reference sweep summary.
+  - Test results.
+
+## Acceptance criteria
+
+1. `sim2real-metrics-reader` ClusterRole exists after `cluster.py provision` on a fresh cluster.
+2. `sim2real-metrics-reader-<ns>` ClusterRoleBinding + `inference-gateway-sa-metrics-reader-secret` Secret exist per pool namespace after `slot add`.
+3. Secret's `data.token` field is auto-populated by kubelet (visible via `kubectl get secret … -o jsonpath='{.data.token}' | base64 -d`).
+4. A workload run in a provisioned namespace produces:
+   - `metrics/raw/*_metrics.log` for both EPP and vLLM decode pods.
+   - `metrics/processed/metrics_summary.json` with populated percentiles.
+   - No `Authentication failed` / `tokenreviews … is forbidden` lines in EPP pod logs.
+5. `deploy.py collect` copies both `metrics/raw/` and `metrics/processed/` into the local cell.
+6. `slot remove <ns>` results in the ClusterRoleBinding + Secret being removed (idempotent if not present).
+7. Existing `test_collect_skip_logs_invokes_metrics_copy` still passes (recursive copy already handles the new layout).
+8. `ruff check pipeline/ --select F` clean; full pytest suite green.
+9. Issue #578 is closed with a comment linking #579.
+
+## Post-merge
+
+The user will re-add the slot (or manually re-apply the updated `stream-metrics` Task) to their live cluster after merge. No migration instructions or automated migration path required in the PR body.

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -517,28 +517,35 @@ Sibling streaming sidecars land alongside the trace files under each `i<N>/`:
 
 - `epp_logs/` — EPP pod logs, time-bucketed (produced by `stream-epp-logs`).
 - `gpu_logs/` — per-node `nvidia-smi` samples, one file per node (produced by `stream-gpu-stats`).
-- `metrics/timeseries.csv` — EPP and vLLM `/metrics` scrapes on a 2 s cadence (produced by `stream-metrics`; columns `timestamp_us,target,metric_name,labels,value` — matches `trace_data.csv`'s `_us` convention).
-- `metrics/<target>.discovered.txt` — sorted-unique list of every metric name each target exposed on its first scrape; consult this file to decide what to widen the allowlist to next run.
+- `metrics/raw/<pod>_<ts>_metrics.log` — Prometheus text-exposition dumps, one file per pod per scrape (produced by `stream-metrics`, which wraps llm-d-benchmark's `collect_metrics.sh`).
+- `metrics/processed/*.json` — post-run aggregated summaries (`metrics_summary.json`, `replica_status_timeseries.json`, `pod_startup_times.json`) written by `collect_metrics.sh process`.
 - `epp_stream_done` / `gpu_stream_done` / `metrics_stream_done` — sentinel files written by `collect-results` when the workload finishes; each streamer polls its sentinel and exits.
 
 ### Metric capture (`stream-metrics`)
 
-The `stream-metrics` sidecar discovers each pipelinerun's EPP and vLLM decode pods via label selectors (`llm-d.ai/igw-mode=llm-d-router-gateway` with `inferencepool` fallback for EPP; `llm-d.ai/role=decode` for vLLM), scrapes `/metrics` on ports `eppPort=9090` and `vllmPort=8000` (both task-param-overridable), and appends one CSV row per (scrape × metric-line) that passes the allowlist.
+`stream-metrics` is a thin wrapper around `collect_metrics.sh` from `llm-d-benchmark`. The sidecar pod pulls `collect_metrics.sh` + `process_metrics.py` from raw.githubusercontent.com at a pinned git ref (task param `harnessSha`, default `"main"`), then runs the standard `start` / poll-sentinel / `stop` / `process` lifecycle. `collect_metrics.sh` handles pod discovery (EPP + vLLM decode), Prometheus text scraping, bearer-token auth for EPP, and per-run aggregation.
 
-**Default `metricsAllowlist` (prefix-match):** the EPP SaturationDetector inputs (`vllm:num_requests_waiting`, `vllm:gpu_cache_usage_perc`), the derived saturation value the flow-controller consumes (`flow_control_pool_saturation`), plus queue-time histogram (`vllm:request_queue_time_seconds`), preemption counter (`vllm:num_preemptions_total`), prefix-cache counters (`vllm:gpu_prefix_cache_hits_total` / `_queries_total`), running-request gauge (`vllm:num_requests_running`), and per-iteration throughput (`vllm:iteration_tokens_total`). Prefix-match means histogram `_bucket` / `_sum` / `_count` variants come along automatically. Empty string in the param = capture everything (research escape hatch — expect ~500 metrics/target/scrape).
+**Where output lands** (all under the cell dir):
 
-**Discovering what a target actually exposes.** On the first successful scrape of each target, the sidecar writes `metrics/<target>.discovered.txt` — the sorted-unique list of every metric name it saw, unfiltered. Read this file after any run to widen the allowlist from evidence:
+- `metrics/raw/<pod>_<ts>_metrics.log` — one Prometheus text-exposition dump per pod per scrape (default 15 s cadence via `intervalSeconds` task param). Unfiltered — every metric the target exposes lands on disk.
+- `metrics/raw/collection_debug.log` — collector-side errors.
+- `metrics/processed/replica_status.json`, `replica_status_timeseries.json`, `pod_startup_times.json` — infrastructure state collected each iteration.
+- `metrics/processed/metrics_summary.json` — post-run percentiles over the metrics named in `process_metrics.py`'s `AGGREGATE_METRICS` set.
+- `metrics/metrics_collection.log` — stdout+stderr of `start` / `stop` / `process` runs.
 
-```bash
-cat workspace/runs/<run>/results/<phase>/<workload>/i<N>/metrics/epp:<pod>.discovered.txt
-```
+**EPP auth.** GAIE serves `/metrics` on port 9090 with secure-serving on. `collect_metrics.sh` reads a bearer token from the `inference-gateway-sa-metrics-reader-secret` Secret (a `type: kubernetes.io/service-account-token` Secret provisioned per-namespace by `cluster.py provision` / `cluster.py slot add` — see `tektonc-data-collection/tekton/roles-ns.yaml`). The corresponding cluster-scoped RBAC (`sim2real-metrics-reader` ClusterRole + per-namespace ClusterRoleBinding on `system:serviceaccounts:<ns>`) is provisioned by the same admin bootstrap step from `roles-cluster.yaml`. See sim2real#579 for the design rationale.
+
+**Widening the metric-name set.** `metrics/processed/metrics_summary.json` covers only the metrics named in `AGGREGATE_METRICS` in `process_metrics.py` (a hardcoded Python set in llm-d-benchmark). To add or remove metrics from the summary, edit that file upstream and pin `harnessSha` to the commit with your change. The `metrics/raw/*.log` files ALWAYS carry every metric the target exposed, so post-run analysis can extract additional signals without re-running.
 
 **Live inspection** (outside a run):
 
 ```bash
 kubectl port-forward -n <namespace> <epp-or-vllm-pod> 9090:9090
-curl -s http://localhost:9090/metrics | grep -v '^#' | awk '{sub(/\{.*/, ""); print $1}' | sort -u
+curl -s -H "Authorization: Bearer $(kubectl -n <namespace> get secret inference-gateway-sa-metrics-reader-secret -o jsonpath='{.data.token}' | base64 -d)" \
+  http://localhost:9090/metrics | grep -v '^#' | awk '{sub(/\{.*/, ""); print $1}' | sort -u
 ```
+
+vLLM `/metrics` on port 8000 is unauthenticated — drop the `-H` flag when probing it directly.
 
 | Flag | Description |
 |------|-------------|

--- a/pipeline/cluster.py
+++ b/pipeline/cluster.py
@@ -513,7 +513,15 @@ def cmd_slot_add(args: argparse.Namespace) -> int:
 
 
 def cmd_slot_remove(args: argparse.Namespace) -> int:
-    """Remove a namespace from the pool. Drain-only; no cluster-side changes."""
+    """Remove a namespace from the pool.
+
+    Removes the paired metrics-reader RBAC (per-namespace ClusterRoleBinding
+    + Secret provisioned in :func:`cluster_ops.deprovision_metrics_rbac`);
+    other in-namespace resources (Roles, RoleBindings, ServiceAccounts,
+    PVCs, deployed model stacks) are left in place — those are shared
+    with any drained but not-yet-torn-down workloads and rebuild cost is
+    high.
+    """
     cluster_id = args.cluster_id
     namespace = args.namespace
 
@@ -548,9 +556,20 @@ def cmd_slot_remove(args: argparse.Namespace) -> int:
         )
         return 1
 
+    # Delete cluster-side metrics-reader resources first, then update the
+    # on-disk pool. A delete failure surfaces but doesn't block the
+    # pool-config update: leaving the namespace in the pool while its
+    # resources are half-gone would be worse than a leaked binding.
+    ok, err = cluster_ops.deprovision_metrics_rbac(namespace)
+    if not ok:
+        print(f"warning: metrics-reader teardown incomplete: {err}",
+              file=sys.stderr)
+
     new_namespaces = [ns for ns in namespaces if ns != namespace]
     cluster_ops.update_cluster_config(cluster_id, namespaces=new_namespaces)
-    print(f"{namespace}: removed from pool (cluster-side resources preserved)")
+    print(f"{namespace}: removed from pool "
+          f"(metrics-reader RBAC + Secret cleaned; other cluster-side "
+          f"resources preserved)")
 
     cluster_ops.publish_slot_pool(cluster_id)
     return 0

--- a/pipeline/cluster.py
+++ b/pipeline/cluster.py
@@ -567,9 +567,13 @@ def cmd_slot_remove(args: argparse.Namespace) -> int:
 
     new_namespaces = [ns for ns in namespaces if ns != namespace]
     cluster_ops.update_cluster_config(cluster_id, namespaces=new_namespaces)
-    print(f"{namespace}: removed from pool "
-          f"(metrics-reader RBAC + Secret cleaned; other cluster-side "
-          f"resources preserved)")
+    if ok:
+        status_tail = ("metrics-reader RBAC + Secret cleaned; "
+                       "other cluster-side resources preserved")
+    else:
+        status_tail = ("metrics-reader teardown had errors — see stderr; "
+                       "other cluster-side resources preserved")
+    print(f"{namespace}: removed from pool ({status_tail})")
 
     cluster_ops.publish_slot_pool(cluster_id)
     return 0

--- a/pipeline/lib/cluster_ops.py
+++ b/pipeline/lib/cluster_ops.py
@@ -409,6 +409,53 @@ def namespace_provisioned(namespace: str) -> bool:
     ).returncode == 0
 
 
+def deprovision_metrics_rbac(namespace: str) -> tuple[bool, str]:
+    """Delete the per-namespace metrics-reader RBAC + Secret provisioned
+    by :func:`provision_namespace`'s ``_step_rbac`` from roles-cluster.yaml
+    and roles-ns.yaml (see sim2real#579).
+
+    Two resources:
+
+    - ClusterRoleBinding ``sim2real-metrics-reader-<namespace>`` — cluster
+      scoped; without this cleanup, every removed slot leaves a dangling
+      binding that outlives the namespace.
+    - Secret ``inference-gateway-sa-metrics-reader-secret`` in
+      ``<namespace>`` — a long-lived SA token; would go away with the
+      namespace, but we're not deleting the namespace on slot remove so
+      it needs an explicit delete.
+
+    Both deletes use ``--ignore-not-found`` so a partially-provisioned
+    slot is fine to remove. Called by ``cluster.py slot remove`` before
+    updating the pool config on disk.
+
+    Returns ``(True, "")`` on success or ``(False, err)`` on the first
+    kubectl failure encountered. Callers surface failures but treat them
+    as non-fatal — pool config still gets updated so on-disk state
+    catches up.
+    """
+    crb_name = f"sim2real-metrics-reader-{namespace}"
+    proc = _run(
+        ["kubectl", "delete", "clusterrolebinding", crb_name,
+         "--ignore-not-found"],
+        check=False, capture=True,
+    )
+    if proc.returncode != 0:
+        return (False, f"clusterrolebinding/{crb_name}: "
+                       f"{(proc.stderr or proc.stdout).strip()}")
+
+    secret_name = "inference-gateway-sa-metrics-reader-secret"
+    proc = _run(
+        ["kubectl", "delete", "secret", secret_name,
+         f"-n={namespace}", "--ignore-not-found"],
+        check=False, capture=True,
+    )
+    if proc.returncode != 0:
+        return (False, f"secret/{secret_name} in {namespace}: "
+                       f"{(proc.stderr or proc.stdout).strip()}")
+
+    return (True, "")
+
+
 # ── ProvisionResult + provision_namespace ────────────────────────────
 
 

--- a/pipeline/lib/cluster_ops.py
+++ b/pipeline/lib/cluster_ops.py
@@ -428,11 +428,19 @@ def deprovision_metrics_rbac(namespace: str) -> tuple[bool, str]:
     slot is fine to remove. Called by ``cluster.py slot remove`` before
     updating the pool config on disk.
 
-    Returns ``(True, "")`` on success or ``(False, err)`` on the first
-    kubectl failure encountered. Callers surface failures but treat them
-    as non-fatal — pool config still gets updated so on-disk state
-    catches up.
+    Attempts BOTH deletes regardless of the first one's outcome and
+    accumulates errors — the Secret carries a kubelet-populated bearer
+    token for helm-installer and is the more sensitive residual of the
+    two, so a first-failure short-circuit would leave the more sensitive
+    resource behind on any transient CRB delete error.
+
+    Returns ``(True, "")`` when both deletes succeed, or ``(False, err)``
+    where ``err`` concatenates every failure with ``; `` separators.
+    Callers surface the message but treat the failure as non-fatal —
+    pool config still gets updated so on-disk state catches up.
     """
+    errors: list[str] = []
+
     crb_name = f"sim2real-metrics-reader-{namespace}"
     proc = _run(
         ["kubectl", "delete", "clusterrolebinding", crb_name,
@@ -440,8 +448,8 @@ def deprovision_metrics_rbac(namespace: str) -> tuple[bool, str]:
         check=False, capture=True,
     )
     if proc.returncode != 0:
-        return (False, f"clusterrolebinding/{crb_name}: "
-                       f"{(proc.stderr or proc.stdout).strip()}")
+        errors.append(f"clusterrolebinding/{crb_name}: "
+                      f"{(proc.stderr or proc.stdout).strip()}")
 
     secret_name = "inference-gateway-sa-metrics-reader-secret"
     proc = _run(
@@ -450,9 +458,11 @@ def deprovision_metrics_rbac(namespace: str) -> tuple[bool, str]:
         check=False, capture=True,
     )
     if proc.returncode != 0:
-        return (False, f"secret/{secret_name} in {namespace}: "
-                       f"{(proc.stderr or proc.stdout).strip()}")
+        errors.append(f"secret/{secret_name} in {namespace}: "
+                      f"{(proc.stderr or proc.stdout).strip()}")
 
+    if errors:
+        return (False, "; ".join(errors))
     return (True, "")
 
 

--- a/pipeline/pipeline.yaml
+++ b/pipeline/pipeline.yaml
@@ -149,6 +149,14 @@ spec:
           value: "$(params.namespace)"
         - name: resultsDir
           value: "$(params.runName)/$(params.phase)/$(params.workloadName)/i$(params.replica)"
+        # Pin collect_metrics.sh + process_metrics.py to the SHA sim2real
+        # currently vendors in its llm-d-benchmark submodule, so the
+        # scraper in the pod matches what CI has been tested against.
+        # Bump this in lock-step with the submodule pointer whenever the
+        # submodule is updated. Same pattern install-inference-perf.yaml
+        # uses for pinning inference-perf's git commit.
+        - name: harnessSha
+          value: "76473d05a0f546a6bc0c4662ed7e34104da73891"
 
     - name: run-workload-blis-observe-binary
       runAfter: ["llmdbenchmark-standup", "install-blis", "prepare-results-dir"]

--- a/pipeline/tests/test_cluster_py.py
+++ b/pipeline/tests/test_cluster_py.py
@@ -908,14 +908,53 @@ class TestCmdSlotRemove:
         assert cfg["namespaces"] == ["ns-primary"]
         out = capsys.readouterr().out
         assert "ns-b: removed from pool" in out
-        # No cluster-side teardown — no `kubectl delete` calls anywhere.
-        assert not any(c[:2] == ["kubectl", "delete"] for c in fake_run.calls)
+        # metrics-reader teardown (issue #579 acceptance criterion #6):
+        # slot_remove now deletes the paired ClusterRoleBinding + Secret.
+        # No other kubectl deletes — every other cluster-side resource
+        # (Role, RoleBinding, SA, PVCs, deployed stacks) is preserved.
+        delete_calls = [c for c in fake_run.calls if c[:2] == ["kubectl", "delete"]]
+        assert any(
+            c[:4] == ["kubectl", "delete", "clusterrolebinding",
+                      "sim2real-metrics-reader-ns-b"]
+            and "--ignore-not-found" in c
+            for c in delete_calls
+        ), f"expected CRB delete for ns-b; saw: {delete_calls}"
+        assert any(
+            c[:4] == ["kubectl", "delete", "secret",
+                      "inference-gateway-sa-metrics-reader-secret"]
+            and "-n=ns-b" in c and "--ignore-not-found" in c
+            for c in delete_calls
+        ), f"expected reader-secret delete in ns-b; saw: {delete_calls}"
+        assert len(delete_calls) == 2, (
+            f"exactly two deletes expected (CRB + Secret); saw: {delete_calls}"
+        )
         # publish_slot_pool fired: probe against primary namespace.
         assert any(
             c[:4] == ["kubectl", "get", "configmap", "sim2real-run-inputs"]
             and "-n=ns-primary" in c
             for c in fake_run.calls
         ), "expected publish_slot_pool to probe the run-inputs CM against ns-primary"
+
+    def test_removes_non_primary_survives_partial_teardown_failure(self, fake_run, capsys):
+        """A kubectl delete failure logs a warning but still removes the
+        namespace from the on-disk pool config. Leaving the namespace in
+        the pool while its resources are half-gone would be worse than a
+        leaked binding — the pool config should track intent, not partial
+        cluster state."""
+        self._init_two_slot_cluster()
+        fake_run.set(
+            ["kubectl", "delete", "clusterrolebinding",
+             "sim2real-metrics-reader-ns-b", "--ignore-not-found"],
+            _completed(returncode=1, stderr="Forbidden"),
+        )
+        rc = cluster_cmd.main(["slot", "remove", "ocp-east", "ns-b"])
+        assert rc == 0
+        cfg = cluster_ops.read_cluster_config("ocp-east")
+        assert cfg["namespaces"] == ["ns-primary"]
+        cap = capsys.readouterr()
+        assert "metrics-reader teardown incomplete" in cap.err
+        assert "Forbidden" in cap.err
+        assert "ns-b: removed from pool" in cap.out
 
     def test_refuses_primary_removal(self, fake_run, capsys):
         self._init_two_slot_cluster()

--- a/pipeline/tests/test_cluster_py.py
+++ b/pipeline/tests/test_cluster_py.py
@@ -940,7 +940,15 @@ class TestCmdSlotRemove:
         namespace from the on-disk pool config. Leaving the namespace in
         the pool while its resources are half-gone would be worse than a
         leaked binding — the pool config should track intent, not partial
-        cluster state."""
+        cluster state.
+
+        Also asserts:
+        - the Secret delete IS still attempted even after the CRB delete
+          fails (the Secret is the more sensitive residual — a bearer
+          token — so we can't short-circuit past it);
+        - stdout does NOT falsely claim success (the "cleaned" phrasing
+          is gated on ok=True and replaced with an errors-summary on the
+          failure path)."""
         self._init_two_slot_cluster()
         fake_run.set(
             ["kubectl", "delete", "clusterrolebinding",
@@ -955,6 +963,27 @@ class TestCmdSlotRemove:
         assert "metrics-reader teardown incomplete" in cap.err
         assert "Forbidden" in cap.err
         assert "ns-b: removed from pool" in cap.out
+        # Secret delete must still be attempted after the CRB failure —
+        # short-circuiting past it would leave the more sensitive residual
+        # (a long-lived SA-token Secret) behind.
+        assert any(
+            c[:4] == ["kubectl", "delete", "secret",
+                      "inference-gateway-sa-metrics-reader-secret"]
+            and "-n=ns-b" in c and "--ignore-not-found" in c
+            for c in fake_run.calls
+        ), (
+            f"expected secret delete to be attempted even after CRB delete "
+            f"failed; saw: {fake_run.calls}"
+        )
+        # stdout on the failure path must not falsely claim the resources
+        # were cleaned. Keep the operator-facing message honest.
+        assert "cleaned" not in cap.out, (
+            f"stdout falsely claims resources were cleaned on failure path: "
+            f"{cap.out!r}"
+        )
+        assert "errors" in cap.out, (
+            f"stdout should indicate errors on the failure path: {cap.out!r}"
+        )
 
     def test_refuses_primary_removal(self, fake_run, capsys):
         self._init_two_slot_cluster()

--- a/pipeline/tests/test_deploy_collect.py
+++ b/pipeline/tests/test_deploy_collect.py
@@ -1837,8 +1837,14 @@ def test_collect_skip_logs_invokes_gpu_logs_copy(tmp_path, monkeypatch):
 
 def test_collect_skip_logs_invokes_metrics_copy(tmp_path, monkeypatch):
     """--skip-logs path issues a kubectl cp for metrics/ alongside epp_logs/ and gpu_logs/,
-    scoped to each iteration subdirectory (post step-5 layout), and copies the
-    metrics_stream_done sentinel."""
+    scoped to each iteration subdirectory, and copies the metrics_stream_done sentinel.
+
+    The recursive cp captures whatever collect_metrics.sh (the upstream scraper
+    the stream-metrics sidecar now wraps — see sim2real#579) writes inside the
+    per-cell metrics/ directory: metrics/raw/*_metrics.log Prometheus text
+    dumps and metrics/processed/*.json aggregated summaries. The specific
+    file names don't need mocking here since the assertion only verifies
+    that the metrics/ dir itself is the cp source."""
     from pipeline import deploy
     import subprocess
 


### PR DESCRIPTION
## Summary

Adopts `collect_metrics.sh` from `llm-d-benchmark` for EPP + vLLM metrics scraping, replacing the bespoke `stream-metrics` shell/awk scraper landed in #575 / fixed in #577. Provisions the EPP-side auth RBAC at `cluster.py provision` / `cluster.py slot add` time so sim2real's non-admin pipeline can consume it without changes to `llmdbenchmark-standup`.

Closes #579. Supersedes #578 (closed with a pointer here).

Companion upstream PR: [inference-sim/tektonc-data-collection#61](https://github.com/inference-sim/tektonc-data-collection/pull/61) — merged as `2381e8e`.

## What sim2real gains

- **Working EPP metrics.** The reason our trial-3 EPP scrapes 401'd wasn't a client-side auth bug — it was that `llmdbenchmark-standup`'s non-admin patch strips the chart's monitoring stack (`router.monitoring.prometheus.enabled: false`), so the cluster-scoped RBAC EPP needs to validate bearer tokens was never provisioned. This PR provisions the equivalent RBAC directly at `cluster.py provision` time. See #579 for the full analysis and the `_patch_router_for_non_admin` reference.
- **Less code to maintain.** ~330 lines of sim2real-owned shell/awk replaced by a ~180-line wrapper that pulls the upstream scraper.
- **More metrics coverage.** DCGM GPU metrics, container cgroup metrics, and richer EPP families (`inference_pool_*`, `inference_extension_*`, `llm_d_inference_scheduler_*`) — all now captured "for free" via `collect_metrics.sh`.

## Submodule pointer bump — `tektonc-data-collection@2381e8e`

- **`roles-cluster.yaml`** — new `sim2real-metrics-reader` ClusterRole (three rules: `tokenreviews:create`, `subjectaccessreviews:create`, `nonResourceURLs:/metrics:get`) + per-namespace `sim2real-metrics-reader-${NAMESPACE}` ClusterRoleBinding with `Group: system:serviceaccounts:${NAMESPACE}` subject.
- **`roles-ns.yaml`** — new `inference-gateway-sa-metrics-reader-secret` Secret (`type: kubernetes.io/service-account-token`, annotated to `helm-installer`). Kubernetes auto-populates `data.token`.
- **`tasks/stream-metrics.yaml`** — full rewrite. `python:3.12-slim-bookworm` image; `apt-get install curl`, download pinned `kubectl v1.34.1`, `curl` fetches `collect_metrics.sh` + `process_metrics.py` at `harnessSha`, then `start` / poll-sentinel / `stop` / `process`.

## sim2real-side changes

- **`pipeline/pipeline.yaml`** — new `harnessSha` param on the `stream-metrics` task ref, pinned to `76473d0` (the SHA sim2real currently vendors in its `llm-d-benchmark` submodule). Same pinning pattern `install-inference-perf.yaml` uses for `inference-perf`'s git commit. Bump this in lock-step with the submodule pointer on future updates.
- **`pipeline/deploy.py`** — no code change. The recursive `kubectl cp metrics/` stanza (added in #575) already captures the new `metrics/{raw,processed}/` layout `collect_metrics.sh` writes.
- **`pipeline/tests/test_deploy_collect.py`** — docstring update on `test_collect_skip_logs_invokes_metrics_copy` to describe the new layout. Assertion unchanged.
- **`pipeline/README.md`** — "Metric capture" subsection rewritten. New layout, EPP auth via the reader Secret, how to widen the metrics summary (edit `AGGREGATE_METRICS` in `process_metrics.py` upstream + pin `harnessSha`).
- **`CLAUDE.md`** — workspace artifact rows: `timeseries.csv` + `discovered.txt` replaced by `metrics/raw/*.log` + `metrics/processed/*.json`.
- **`.claude/skills/sim2real-analyze/SKILL.md`** — data-reference block updated.
- **`docs/superpowers/plans/2026-07-15-issue-574-stream-metrics.md`** — added a "superseded by #579" preamble (kept as historical record).
- **`docs/superpowers/plans/2026-07-15-issue-579-adopt-collect-metrics.md`** — new plan doc.

## Reviewer attention

Three areas worth eyes:

1. **`pipeline/pipeline.yaml:157` — the pinned SHA.** Manual maintenance burden: submodule bump needs a matching `harnessSha` update. Same pattern as `install-inference-perf`'s `GIT_COMMIT` env var, so precedent is fine; noting explicitly so it's not surprising later.
2. **RBAC blast radius.** The new ClusterRoleBinding subject is `Group: system:serviceaccounts:<namespace>` — every SA in the pool namespace inherits TokenReview + SAR + `/metrics get` on any target. Tighter alternatives (bind to a specific SA) were rejected because the EPP SA name is chart-derived per release. Blast radius stays scoped to one namespace per binding.
3. **`stream-metrics.yaml` non-fatal posture.** Every apt/curl/download step is `|| exit 0` so a network failure logs a warning and the workload stays green. Deliberate — matches the existing streamers' posture. Alternative (fail hard) was rejected as it would let a transient network hiccup break every run.

## Stale-reference sweep

Grepped `.claude/`, `pipeline/`, `docs/`, `CLAUDE.md` for `timeseries.csv`, `discovered.txt`, `metricsAllowlist`, `EPP_SELECTOR_USED`, `eppSelectorFallback`. All remaining hits are inside plan docs (the current #579 plan describing the change; the #574 plan now marked superseded). No stale refs in code or user-facing docs.

## Test plan

- [x] `ruff check pipeline/ .claude/skills/ --select F` — clean.
- [x] Full pytest suite matching `.github/workflows/test.yml` — **1876 passed, 1 skipped, 2 xfailed**.
- [x] `envsubst` + `yaml.safe_load_all` on the merged submodule's `roles-cluster.yaml` and `roles-ns.yaml` — clean; correct object counts.
- [x] `python -c "import yaml; yaml.safe_load(open('tektonc-data-collection/tekton/tasks/stream-metrics.yaml'))"` — clean.
- [ ] **Live cluster.** Deferred. The operator will re-add a slot (or re-apply the updated `roles-*.yaml` + `stream-metrics.yaml`) to pick up the new RBAC + Secret, then re-run a workload.
