### PR TITLE
fix(check): resolve + enumerate blind to replica-shape runs with path-string workloads (#572)

### DIFF
--- a/.claude/skills/sim2real-check/scripts/enumerate_iterations.py
+++ b/.claude/skills/sim2real-check/scripts/enumerate_iterations.py
@@ -278,7 +278,20 @@ def _detect_shape(
 
 
 def _names(items) -> list[str]:
-    """Extract ``name`` field from a list of manifest dicts."""
+    """Extract workload/baseline/algorithm identifiers from a manifest list.
+
+    Two entry shapes are supported so the same helper serves all three
+    manifest sections:
+
+    - Dict entries with a ``name:`` field (baselines, algorithms, and
+      workloads in older/hand-edited manifests) — emit ``name``.
+    - String entries (workloads written by ``sim2real assemble`` as file
+      paths, e.g. ``workloads/code_generation_4.yaml``) — emit
+      ``Path(s).stem`` so the identifier matches the on-disk directory
+      name that ``_detect_shape`` compares against. Bug #572.
+
+    Empty strings and non-str/non-dict entries are silently skipped.
+    """
     if not isinstance(items, list):
         return []
     out = []
@@ -287,6 +300,10 @@ def _names(items) -> list[str]:
             name = it.get("name")
             if isinstance(name, str) and name:
                 out.append(name)
+        elif isinstance(it, str) and it:
+            stem = Path(it).stem
+            if stem:
+                out.append(stem)
     return out
 
 

--- a/.claude/skills/sim2real-check/tests/test_enumerate_iterations.py
+++ b/.claude/skills/sim2real-check/tests/test_enumerate_iterations.py
@@ -22,6 +22,7 @@ def _make_run(
     workloads: list[str],
     translation_algorithms: list[str] | None = None,
     disk_layout: dict | None = None,
+    workloads_as_paths: bool = False,
 ) -> Path:
     """Materialize a run under ``root/workspace/`` with the given shape.
 
@@ -75,6 +76,7 @@ def _make_run(
             algorithms=algorithms,
             baselines=baselines,
             workloads=workloads,
+            workloads_as_paths=workloads_as_paths,
         )
     )
 
@@ -105,12 +107,22 @@ def _manifest_yaml(
     algorithms: list[str],
     baselines: list[str],
     workloads: list[str],
+    workloads_as_paths: bool = False,
 ) -> str:
-    """Minimal manifest.assembly.yaml the enumerator can read."""
+    """Minimal manifest.assembly.yaml the enumerator can read.
+
+    ``workloads_as_paths=True`` writes workload entries as file-path
+    strings (``workloads/<w>.yaml``) matching what ``sim2real assemble``
+    writes to ``manifest.assembly.yaml`` in v3. Default False keeps the
+    legacy dict shape used by earlier tests.
+    """
     lines = [f"replicas: {replicas}"]
     lines.append("workloads:")
     for w in workloads:
-        lines.append(f"  - name: {w}")
+        if workloads_as_paths:
+            lines.append(f"  - workloads/{w}.yaml")
+        else:
+            lines.append(f"  - name: {w}")
     lines.append("baselines:")
     for b in baselines:
         lines.append(f"  - name: {b}")
@@ -391,3 +403,65 @@ def test_main_exit_code_on_missing_iteration(tmp_path):
     )
     rc = ei.main(["--run", "trial", "--experiment-root", str(tmp_path)])
     assert rc == 1
+
+
+# ── Bug #572: _names accepts string entries + end-to-end path-string case ────
+
+
+def test_names_accepts_dict_entries():
+    """Legacy shape: dict with a ``name:`` field."""
+    assert ei._names([{"name": "a"}, {"name": "b"}]) == ["a", "b"]
+
+
+def test_names_accepts_string_entries():
+    """Bug #572: workload entries in manifest.assembly.yaml written by
+    ``sim2real assemble`` are path strings. ``_names`` must derive the
+    workload identifier from ``Path(s).stem``."""
+    got = ei._names(
+        [
+            "workloads/code_generation_4.yaml",
+            "workloads/interactive_chat_20.yaml",
+        ]
+    )
+    assert got == ["code_generation_4", "interactive_chat_20"]
+
+
+def test_names_accepts_mixed_dict_and_string_entries():
+    """Neither branch shadows the other."""
+    assert ei._names([{"name": "a"}, "workloads/b.yaml"]) == ["a", "b"]
+
+
+def test_names_silently_skips_junk():
+    """Non-str/non-dict entries and empty strings are dropped."""
+    assert ei._names([None, "", 42, {"name": ""}, [], {}]) == []
+
+
+def test_names_bare_string_no_extension():
+    """A bare identifier (no ``.yaml``) still passes through — ``Path.stem``
+    returns the string unchanged when there's no suffix."""
+    assert ei._names(["code_generation_4"]) == ["code_generation_4"]
+
+
+def test_end_to_end_path_string_workloads_replica_shape(tmp_path, capsys):
+    """Bug #572 regression: manifest with workload path strings + replica
+    disk shape used to yield zero rows. Must now enumerate the full grid.
+    """
+    _make_run(
+        tmp_path,
+        run_name="trial",
+        replicas=2,
+        algorithms=["sim2real-ac"],
+        baselines=["baseline"],
+        workloads=["wl-chat", "wl-code"],
+        workloads_as_paths=True,
+    )
+    rc = ei.main(["--run", "trial", "--experiment-root", str(tmp_path)])
+    payload = json.loads(capsys.readouterr().out)
+    # 2 phases (baseline + sim2real-ac) x 2 workloads x 2 iterations = 8 PRESENT
+    assert payload["counts"]["PRESENT"] == 8
+    assert payload["counts"]["MISSING"] == 0
+    assert payload["counts"]["SKIP"] == 0
+    assert rc == 0
+    # Confirm the workload identifiers resolved to stems (not paths).
+    workloads_seen = {r["workload"] for r in payload["rows"]}
+    assert workloads_seen == {"wl-chat", "wl-code"}

--- a/docs/epics/step-3/design.md
+++ b/docs/epics/step-3/design.md
@@ -161,8 +161,8 @@ sim2real resolve --run <name> [--experiment-root <path>]
 - `cluster_config_path`: composed as `<experiment-root>/workspace/clusters/<cluster_id>/cluster_config.json`. Exists check performed; emitted as-is if present, `null` if the file is absent (partial workspace).
 - `translation.*`: `translation_output.json` (via `pipeline/lib/translation_ref.py:read_translation_output`) + filesystem probes for generated dirs.
 - `results.phases_declared`: union of `baselines[].name` + `algorithms[].name` from `manifest.assembly.yaml`. Represents what SHOULD have run.
-- `results.phases_with_data`: `phases_declared` filtered to entries whose subdir contains at least one workload with `trace_data.csv`. Predicate: `results/<phase>/*/trace_data.csv` — one-level glob (not recursive; avoids false positives from `plans/*.csv` or similar sibling dirs). Invariant: `phases_with_data ⊆ phases_declared`.
-- `results.workloads_by_phase`: filesystem listing of `results/<phase>/*/trace_data.csv` (per-phase). Predicate matches `phases_with_data`'s definition.
+- `results.phases_with_data`: `phases_declared` filtered to entries whose subdir contains at least one workload with `trace_data.csv`. Predicate accepts either shape: `results/<phase>/<workload>/trace_data.csv` (legacy flat) OR `results/<phase>/<workload>/iN/trace_data.csv` where `iN` matches `^i[1-9][0-9]*$` (replica shape written by `sim2real assemble` when `replicas > 1`). See `pipeline/lib/resolve.py:_workload_has_data` (issue #572). Invariant: `phases_with_data ⊆ phases_declared`.
+- `results.workloads_by_phase`: filesystem listing per-phase using the same predicate as `phases_with_data`.
 - `cluster_scenarios.*`: filesystem listing of `cluster/*.yaml`.
 - `manifest_assembly.*`: parsed `manifest.assembly.yaml`.
 

--- a/pipeline/lib/resolve.py
+++ b/pipeline/lib/resolve.py
@@ -21,6 +21,7 @@ config detail) — those remain the check skill's responsibility.
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import Any
 
@@ -30,6 +31,36 @@ from pipeline.lib import layout, translation_ref
 
 
 SCHEMA_VERSION = 1
+
+# Same grammar the sim2real-check enumerator uses (i1, i2, i10, ...).
+# Rejects i0, i01, iabc. Kept in sync manually — if the enumerator's
+# _ITER_DIR_RE ever loosens or tightens, mirror the change here.
+_ITER_DIR_RE = re.compile(r"^i[1-9][0-9]*$")
+
+
+def _workload_has_data(wl: Path) -> bool:
+    """Return True if ``wl`` contains ``trace_data.csv`` in either shape.
+
+    - Legacy flat: ``<workload>/trace_data.csv``.
+    - Replica: at least one ``<workload>/iN/trace_data.csv`` with ``iN``
+      matching the iteration-dir grammar.
+
+    Bug #572: prior to this helper the predicate was flat-only, so
+    replica-shape runs (the shape ``sim2real assemble`` produces when
+    ``manifest.assembly.yaml:replicas > 1``) reported zero workloads and
+    fed an empty input list into the ``sim2real-check`` skill.
+    """
+    if (wl / "trace_data.csv").exists():
+        return True
+    try:
+        return any(
+            _ITER_DIR_RE.match(child.name)
+            and (child / "trace_data.csv").exists()
+            for child in wl.iterdir()
+            if child.is_dir()
+        )
+    except OSError:
+        return False
 
 
 class ResolveError(Exception):
@@ -201,9 +232,9 @@ def _build_results_section(run_dir: Path, manifest_assembly: dict | None) -> dic
     ``phases_declared`` is the union of baseline names + algorithm names
     from ``manifest.assembly.yaml``. ``phases_with_data`` filters that
     list to entries whose subdir contains at least one workload with
-    ``trace_data.csv``. Predicate is one-level glob
-    ``results/<phase>/*/trace_data.csv`` (not recursive) — avoids false
-    positives from sibling dirs like ``plans/``.
+    ``trace_data.csv`` in either shape: legacy flat
+    ``<workload>/trace_data.csv`` or replica
+    ``<workload>/iN/trace_data.csv``. See ``_workload_has_data``.
     """
     results_dir = run_dir / "results"
     declared = _phases_declared_from_manifest(manifest_assembly)
@@ -217,7 +248,7 @@ def _build_results_section(run_dir: Path, manifest_assembly: dict | None) -> dic
             phase_workloads = sorted(
                 wl.name
                 for wl in phase_dir.iterdir()
-                if wl.is_dir() and (wl / "trace_data.csv").exists()
+                if wl.is_dir() and _workload_has_data(wl)
             )
             if phase_workloads:
                 with_data.append(phase)

--- a/pipeline/tests/test_resolve.py
+++ b/pipeline/tests/test_resolve.py
@@ -53,6 +53,8 @@ def _make_run(
     write_manifest: bool = True,
     write_cluster_config: bool = True,
     results_layout: dict[str, list[str]] | None = None,
+    results_shape: str = "flat",
+    replicas: int = 2,
     write_cluster_scenarios: bool = True,
     include_pipelineruns: bool = True,
 ) -> Path:
@@ -139,12 +141,26 @@ def _make_run(
             {"cluster_id": cluster_id, "namespaces": ["ns-0"]},
         )
 
-    # results/<phase>/<workload>/trace_data.csv
+    # results/<phase>/<workload>/... — layout depends on ``results_shape``:
+    #   "flat"    → <workload>/trace_data.csv (legacy)
+    #   "replica" → <workload>/i{1..replicas}/trace_data.csv
+    #   "mixed"   → first workload uses replica, remainder use flat
+    if results_shape not in ("flat", "replica", "mixed"):
+        raise ValueError(f"unknown results_shape: {results_shape!r}")
     for phase, phase_workloads in results_layout.items():
-        for wl in phase_workloads:
+        for idx, wl in enumerate(phase_workloads):
             wl_dir = run_dir / "results" / phase / wl
             wl_dir.mkdir(parents=True, exist_ok=True)
-            (wl_dir / "trace_data.csv").write_text("dummy,csv\n")
+            use_replica = results_shape == "replica" or (
+                results_shape == "mixed" and idx == 0
+            )
+            if use_replica:
+                for i in range(1, replicas + 1):
+                    iter_dir = wl_dir / f"i{i}"
+                    iter_dir.mkdir(parents=True, exist_ok=True)
+                    (iter_dir / "trace_data.csv").write_text("dummy,csv\n")
+            else:
+                (wl_dir / "trace_data.csv").write_text("dummy,csv\n")
 
     # cluster scenario yamls
     if write_cluster_scenarios:
@@ -252,6 +268,66 @@ class TestResolveRunHappyPath:
             "code_generation_10",
             "code_generation_4",
         ]
+
+    def test_populates_results_section_replica_shape(self, tmp_path):
+        """Bug #572: replica-shape runs put trace_data.csv under iN/. The
+        one-level predicate used to miss them and return empty."""
+        _make_run(
+            tmp_path,
+            results_shape="replica",
+            replicas=2,
+            results_layout={
+                "softreflective": ["code_generation_4", "code_generation_10"]
+            },
+        )
+        result = resolve.resolve_run(tmp_path, "trial-1")
+        assert result["results"]["phases_with_data"] == ["softreflective"]
+        assert result["results"]["workloads_by_phase"]["softreflective"] == [
+            "code_generation_10",
+            "code_generation_4",
+        ]
+
+    def test_populates_results_section_mixed_shape(self, tmp_path):
+        """Mixed-shape run: one workload replica, another flat. Both
+        must be reported — the predicate accepts either shape."""
+        _make_run(
+            tmp_path,
+            results_shape="mixed",
+            replicas=2,
+            results_layout={
+                "softreflective": ["code_generation_4", "code_generation_10"]
+            },
+        )
+        result = resolve.resolve_run(tmp_path, "trial-1")
+        assert result["results"]["phases_with_data"] == ["softreflective"]
+        assert result["results"]["workloads_by_phase"]["softreflective"] == [
+            "code_generation_10",
+            "code_generation_4",
+        ]
+
+    def test_results_section_ignores_malformed_iter_dirs(self, tmp_path):
+        """A workload whose only children are non-iN dirs (or malformed iN
+        names like i0, iabc) reports no data. Guards against the naive
+        `any(child/trace_data.csv)` fix that would false-positive on
+        stray dirs like ``plans/`` or ``metrics/``."""
+        _make_run(
+            tmp_path,
+            results_layout={"softreflective": []},
+        )
+        # Materialize a workload dir with only bogus iteration-like children
+        # that DO contain trace_data.csv. The strict predicate must still
+        # report the phase as empty.
+        wl_dir = (
+            tmp_path / "workspace" / "runs" / "trial-1"
+            / "results" / "softreflective" / "code_generation_4"
+        )
+        wl_dir.mkdir(parents=True, exist_ok=True)
+        for bogus in ("i0", "iabc", "plans", "metrics"):
+            (wl_dir / bogus).mkdir()
+            (wl_dir / bogus / "trace_data.csv").write_text("bogus\n")
+        result = resolve.resolve_run(tmp_path, "trial-1")
+        assert result["results"]["phases_with_data"] == []
+        assert result["results"]["workloads_by_phase"] == {}
 
     def test_populates_cluster_scenarios(self, tmp_path):
         _make_run(tmp_path)


### PR DESCRIPTION
## Summary

Two silent-empty predicates surfaced by `/sim2real-check --run=<replica-run>`:

- **`pipeline/lib/resolve.py:_build_results_section`** used a one-level predicate (`wl/trace_data.csv`). Replica-shape runs — the shape `sim2real assemble` produces when `manifest.assembly.yaml:replicas > 1` — store `trace_data.csv` under `wl/iN/`, so `phases_with_data` returned `[]` and `workloads_by_phase` returned `{}` despite data on disk. Extracted a `_workload_has_data` helper that accepts either legacy flat shape or replica shape (`iN` dirs matching `^i[1-9][0-9]*$`, same grammar as the enumerator's `_ITER_DIR_RE`).

- **`.claude/skills/sim2real-check/scripts/enumerate_iterations.py:_names`** filtered to dict entries with a `name:` field. `manifest.assembly.yaml` written by `sim2real assemble` lists workloads as file-path strings (`workloads/foo.yaml`), which were silently dropped — the enumerator returned `{counts: {PRESENT: 0, MISSING: 0, SKIP: 0}}` on any replica run. Added a `str` branch that emits `Path(s).stem` so identifiers match the on-disk directory names `_detect_shape` compares against.

## Verification against real data

Repro from `kalantar-msb/softr` `trial-2` (3 phases × 12 workloads × 2 iterations = 72 `trace_data.csv` on disk):

| | Before | After |
|---|---|---|
| `sim2real resolve --run trial-2` → `phases_with_data` | `[]` | `["baseline","constantceiling","softreflective"]` |
| `sim2real resolve --run trial-2` → `workloads_by_phase[phase]` | `{}` | 12 workloads each |
| `enumerate_iterations.py --run trial-2` → `counts.PRESENT` | `0` | `72` |

## Test plan

- [x] `pipeline/tests/test_resolve.py`: added replica-shape, mixed-shape, and malformed-iN-dir cases (extended `_make_run` with `results_shape` / `replicas` kwargs).
- [x] `.claude/skills/sim2real-check/tests/test_enumerate_iterations.py`: `_names` unit tests for dict / str / mixed / junk / bare-string inputs, plus an end-to-end path-string-workloads test on a replica-shape run.
- [x] Full CI test set: 1887 passed, 1 skipped, 2 xfailed (no regressions).
- [x] `ruff check pipeline/ .claude/skills/ --select F`: clean.
- [x] End-to-end verification on `kalantar-msb/softr trial-2` (see table above).

## Reviewer attention

- The two predicates are symmetric in the grammar they accept (`^i[1-9][0-9]*$`). `resolve.py` maintains its own `_ITER_DIR_RE` rather than importing the enumerator's — they're separate packages and the enumerator isn't on `sys.path` for the library. Kept-in-sync comment added on the resolve-side constant.
- The strict-predicate guard test (`test_results_section_ignores_malformed_iter_dirs`) exists to prevent a naive fix (`any(child/trace_data.csv for child in iterdir)`) that would false-positive on `plans/` or `metrics/` sibling dirs — the concern the pre-fix docstring called out.
- `_names` fix widens semantics: string entries now silently derive identifiers from `Path.stem`. For workloads this matches how `_detect_shape` matches directory names. Baselines and algorithms have always used the dict shape and continue to work unchanged.

## Docs sweep

- Updated `docs/epics/step-3/design.md` (`phases_with_data` predicate description) to reflect the new shape-tolerant behavior.
- No `README.md` / `pipeline/README.md` references to the affected predicates.

Closes #572

Base: main