### PR TITLE
fix(deploy wipe): honor --iteration scope in delete target (#525)

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -688,14 +688,14 @@ When `--only` or `--workload` is given, only matching workload subdirectories ar
 
 **Safety:** Results in `workspace/runs/<run>/results/` are preserved — only cluster resources and ConfigMap status are affected.
 
-**`deploy.py wipe`** — deletes local result files for all pairs in scope. Does **not** modify pair status in the ConfigMap. Pairs with no results on disk are skipped. Empty package directories are cleaned up automatically. The delete target is the workload-level directory (`results/<package>/<workload>/`), not the per-iteration subdirectory — see the `--iteration` note below.
+**`deploy.py wipe`** — deletes local result files for all pairs in scope. Does **not** modify pair status in the ConfigMap. Pairs with no results on disk are skipped. Empty workload and package directories are cleaned up automatically. Each pair key encodes its iteration, so under the step-5 `results/<package>/<workload>/i<N>/` layout the delete target is a single per-iteration subdirectory; legacy single-replica runs whose files sit directly under `results/<package>/<workload>/` fall back to the workload dir.
 
 | Flag | Description |
 |------|-------------|
 | `--only PAIR…` | Scope wipe to specific pair keys (comma or space-separated, `wl-` prefix optional) |
 | `--workload NAME…` | Scope wipe to pairs matching these workloads (comma or space-separated; globs OK) |
 | `--package NAME…` | Scope wipe to pairs matching these packages (comma or space-separated; globs OK) |
-| `--iteration SPEC` | Narrows which pair keys are targeted, but the delete still removes the entire `results/<package>/<workload>/` workload tree — sibling iterations for the same workload are removed too. Tracked at #525. |
+| `--iteration SPEC` | Scope wipe to iteration(s): `2`, `1,3`, `1-3`, `1,3-5`. Only the named `i<N>/` subdirs are removed; sibling iterations are preserved. |
 | `--dry-run` | Print what would be wiped without acting |
 | `--yes` / `-y` | Skip confirmation prompt |
 

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -17,6 +17,7 @@ import fnmatch
 import json
 import os
 import random
+import re
 import shutil
 import subprocess
 import sys
@@ -3347,6 +3348,21 @@ def _cmd_wipe(args, run_dir: Path,
     total_pairs = sum(1 for k in progress if _is_pair_key(k))
     results_dir = run_dir / "results"
 
+    # A pair key encodes its iteration; the on-disk shape under step-5 is
+    # results/<pkg>/<wl>/i<N>/. When the per-iteration dir is present, wipe
+    # scoped to that key must delete only i<N>/ — not the whole workload
+    # tree, which would silently destroy sibling iterations (issue #525).
+    # Legacy single-replica runs whose files live directly under
+    # results/<pkg>/<wl>/ have no i<N>/ subdirs; fall back to the workload
+    # dir for those.
+    _ITER_DIR_RE = re.compile(r"i[1-9][0-9]*")
+
+    def _has_iN_subdirs(wl_dir: Path) -> bool:
+        if not wl_dir.is_dir():
+            return False
+        return any(p.is_dir() and _ITER_DIR_RE.fullmatch(p.name)
+                   for p in wl_dir.iterdir())
+
     targets = []
     for key in sorted(_scope):
         entry = progress[key]
@@ -3355,21 +3371,37 @@ def _cmd_wipe(args, run_dir: Path,
         if not pkg or not wl:
             warn(f"{key}: missing package/workload fields — skipping")
             continue
-        target_dir = results_dir / pkg / wl
-        targets.append((key, pkg, wl, target_dir))
+        n = _key_iteration(key)
+        wl_dir = results_dir / pkg / wl
+        iN_dir = wl_dir / f"i{n}"
+        if iN_dir.exists():
+            target_dir = iN_dir
+            display = f"results/{pkg}/{wl}/i{n}/"
+        elif wl_dir.exists() and not _has_iN_subdirs(wl_dir):
+            # Legacy single-replica layout — the workload dir holds the
+            # trace files directly. Wipe the whole workload dir.
+            target_dir = wl_dir
+            display = f"results/{pkg}/{wl}/"
+        else:
+            # Step-5 layout with no matching i<N>/ (or nothing on disk).
+            # Point at iN_dir so the "no results on disk" branch below
+            # reports the specific path that was expected.
+            target_dir = iN_dir
+            display = f"results/{pkg}/{wl}/i{n}/"
+        targets.append((key, pkg, wl, target_dir, display))
 
     info(f"Scope: {len(_scope)}/{total_pairs} pairs"
          + (" [DRY-RUN]" if args.dry_run else ""))
 
     if args.dry_run:
-        for key, pkg, wl, target_dir in targets:
+        for key, pkg, wl, target_dir, display in targets:
             exists = target_dir.exists()
-            info(f"[DRY-RUN] {key}: would delete results/{pkg}/{wl}/"
+            info(f"[DRY-RUN] {key}: would delete {display}"
                  + (" (exists)" if exists else " (not on disk)"))
         return
 
     if not args.yes:
-        dirs_on_disk = sum(1 for _, _, _, p in targets if p.exists())
+        dirs_on_disk = sum(1 for _, _, _, p, _ in targets if p.exists())
         prompt = f"Wipe {len(targets)} pair(s) ({dirs_on_disk} with results on disk)? [y/N] "
         try:
             answer = input(prompt).strip().lower()
@@ -3382,15 +3414,22 @@ def _cmd_wipe(args, run_dir: Path,
 
     wiped = 0
     errors = 0
-    for key, pkg, wl, target_dir in targets:
+    for key, pkg, wl, target_dir, display in targets:
         if target_dir.exists():
             try:
                 shutil.rmtree(target_dir)
             except OSError as e:
-                warn(f"{key}: failed to delete results/{pkg}/{wl}/: {e}")
+                warn(f"{key}: failed to delete {display}: {e}")
                 errors += 1
                 continue
-            ok(f"Deleted: results/{pkg}/{wl}/")
+            ok(f"Deleted: {display}")
+            # Best-effort cleanup of empty parents (workload dir, then
+            # package dir). rmdir is a no-op if siblings remain.
+            wl_dir = results_dir / pkg / wl
+            try:
+                wl_dir.rmdir()
+            except OSError:
+                pass
             pkg_dir = results_dir / pkg
             try:
                 pkg_dir.rmdir()

--- a/pipeline/tests/test_deploy_wipe.py
+++ b/pipeline/tests/test_deploy_wipe.py
@@ -430,6 +430,237 @@ def test_wipe_does_not_save_progress(tmp_path, monkeypatch):
     assert save_called == [], "wipe must not call store.save()"
 
 
+# ---------------------------------------------------------------------------
+# --iteration scoping (issue #525): wipe must delete only i<N>/ subdirs when
+# iteration scope is active. Pair keys are per-iteration under step-5, so on-
+# disk results live at results/<pkg>/<wl>/i<N>/. Legacy dash-shape keys retain
+# the single-replica shape (results/<pkg>/<wl>/) and are handled by fallback.
+# ---------------------------------------------------------------------------
+
+_PROGRESS_ITER = {
+    "wl-smoke|baseline|i1":   {"workload": "smoke",  "package": "baseline",  "status": "done",    "namespace": None, "retries": 0, "pending_stalls": 0, "pending_since": None},
+    "wl-smoke|baseline|i2":   {"workload": "smoke",  "package": "baseline",  "status": "done",    "namespace": None, "retries": 0, "pending_stalls": 0, "pending_since": None},
+    "wl-smoke|baseline|i3":   {"workload": "smoke",  "package": "baseline",  "status": "done",    "namespace": None, "retries": 0, "pending_stalls": 0, "pending_since": None},
+    "wl-load|baseline|i1":    {"workload": "load",   "package": "baseline",  "status": "done",    "namespace": None, "retries": 0, "pending_stalls": 0, "pending_since": None},
+    "wl-load|baseline|i2":    {"workload": "load",   "package": "baseline",  "status": "done",    "namespace": None, "retries": 0, "pending_stalls": 0, "pending_since": None},
+    "wl-load|baseline|i3":    {"workload": "load",   "package": "baseline",  "status": "done",    "namespace": None, "retries": 0, "pending_stalls": 0, "pending_since": None},
+}
+
+
+def _setup_iN_results(run_dir: Path, iterations=(1, 2, 3), workloads=("smoke", "load"),
+                      pkgs=("baseline",)) -> None:
+    """Create a step-5 per-iteration results tree under run_dir."""
+    for pkg in pkgs:
+        for wl in workloads:
+            for n in iterations:
+                d = run_dir / "results" / pkg / wl / f"i{n}"
+                d.mkdir(parents=True, exist_ok=True)
+                (d / "trace_header.yaml").write_text("header")
+                (d / "trace_data.csv").write_text("data")
+
+
+def test_wipe_scoped_by_iteration_deletes_only_iN(tmp_path, monkeypatch):
+    """--iteration 2 deletes only i2/ subdirs; sibling iterations survive."""
+    import pipeline.deploy as mod
+
+    run_dir = tmp_path / "run1"
+    run_dir.mkdir()
+    _mock_cm(monkeypatch, _PROGRESS_ITER)
+    _setup_iN_results(run_dir)
+
+    class _Args:
+        only = None; workload = None; package = None; iteration = "2"; dry_run = False; yes = True
+
+    mod._cmd_wipe(_Args(), run_dir, cluster_config={"namespaces": ["ns-0"]})
+
+    for wl in ("smoke", "load"):
+        assert not (run_dir / "results" / "baseline" / wl / "i2").exists(), \
+            f"i2 for {wl} should be wiped"
+        assert (run_dir / "results" / "baseline" / wl / "i1").exists(), \
+            f"i1 for {wl} should survive"
+        assert (run_dir / "results" / "baseline" / wl / "i3").exists(), \
+            f"i3 for {wl} should survive"
+
+
+def test_wipe_iteration_list_spec(tmp_path, monkeypatch):
+    """--iteration '1,3' deletes i1 and i3; i2 survives."""
+    import pipeline.deploy as mod
+
+    run_dir = tmp_path / "run1"
+    run_dir.mkdir()
+    _mock_cm(monkeypatch, _PROGRESS_ITER)
+    _setup_iN_results(run_dir)
+
+    class _Args:
+        only = None; workload = None; package = None; iteration = "1,3"; dry_run = False; yes = True
+
+    mod._cmd_wipe(_Args(), run_dir, cluster_config={"namespaces": ["ns-0"]})
+
+    assert not (run_dir / "results" / "baseline" / "smoke" / "i1").exists()
+    assert (run_dir / "results" / "baseline" / "smoke" / "i2").exists()
+    assert not (run_dir / "results" / "baseline" / "smoke" / "i3").exists()
+
+
+def test_wipe_iteration_range_spec(tmp_path, monkeypatch):
+    """--iteration '1-2' deletes i1 and i2; i3 survives."""
+    import pipeline.deploy as mod
+
+    run_dir = tmp_path / "run1"
+    run_dir.mkdir()
+    _mock_cm(monkeypatch, _PROGRESS_ITER)
+    _setup_iN_results(run_dir)
+
+    class _Args:
+        only = None; workload = None; package = None; iteration = "1-2"; dry_run = False; yes = True
+
+    mod._cmd_wipe(_Args(), run_dir, cluster_config={"namespaces": ["ns-0"]})
+
+    assert not (run_dir / "results" / "baseline" / "smoke" / "i1").exists()
+    assert not (run_dir / "results" / "baseline" / "smoke" / "i2").exists()
+    assert (run_dir / "results" / "baseline" / "smoke" / "i3").exists()
+
+
+def test_wipe_iteration_dry_run_shows_iN_path(tmp_path, monkeypatch, capsys):
+    """Dry-run output includes the per-iteration path, not the workload path."""
+    import pipeline.deploy as mod
+
+    run_dir = tmp_path / "run1"
+    run_dir.mkdir()
+    _mock_cm(monkeypatch, _PROGRESS_ITER)
+    _setup_iN_results(run_dir)
+
+    class _Args:
+        only = None; workload = None; package = None; iteration = "2"; dry_run = True; yes = False
+
+    mod._cmd_wipe(_Args(), run_dir, cluster_config={"namespaces": ["ns-0"]})
+
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "results/baseline/smoke/i2/" in combined
+    # Must NOT list a workload-level path for a scoped iteration.
+    assert "results/baseline/smoke/ " not in combined  # trailing space guard
+    assert "would delete results/baseline/smoke/\n" not in combined
+    # Nothing deleted
+    assert (run_dir / "results" / "baseline" / "smoke" / "i2").exists()
+
+
+def test_wipe_no_iteration_scoped_wipes_all_iN_subdirs(tmp_path, monkeypatch):
+    """Unscoped wipe with the iN layout deletes every iN subdir per pair key.
+
+    Each pair key (iteration) resolves to its own iN dir, so all iterations
+    of a workload are removed. The empty workload dir is then reclaimed by
+    the parent-cleanup pass.
+    """
+    import pipeline.deploy as mod
+
+    run_dir = tmp_path / "run1"
+    run_dir.mkdir()
+    _mock_cm(monkeypatch, _PROGRESS_ITER)
+    _setup_iN_results(run_dir)
+
+    class _Args:
+        only = None; workload = None; package = None; iteration = None; dry_run = False; yes = True
+
+    mod._cmd_wipe(_Args(), run_dir, cluster_config={"namespaces": ["ns-0"]})
+
+    assert not (run_dir / "results" / "baseline" / "smoke").exists()
+    assert not (run_dir / "results" / "baseline" / "load").exists()
+    assert not (run_dir / "results" / "baseline").exists()
+
+
+def test_wipe_iteration_removes_empty_workload_dir(tmp_path, monkeypatch):
+    """After wiping the last iN under a workload, the workload dir is reclaimed."""
+    import pipeline.deploy as mod
+
+    run_dir = tmp_path / "run1"
+    run_dir.mkdir()
+    progress = {
+        "wl-only|baseline|i1": {"workload": "only", "package": "baseline", "status": "done",
+                                "namespace": None, "retries": 0, "pending_stalls": 0, "pending_since": None},
+    }
+    _mock_cm(monkeypatch, progress)
+    _setup_iN_results(run_dir, iterations=(1,), workloads=("only",), pkgs=("baseline",))
+
+    class _Args:
+        only = None; workload = None; package = None; iteration = None; dry_run = False; yes = True
+
+    mod._cmd_wipe(_Args(), run_dir, cluster_config={"namespaces": ["ns-0"]})
+
+    # Both the iN dir and its parents removed (workload dir empty, then pkg dir).
+    assert not (run_dir / "results" / "baseline").exists()
+
+
+def test_wipe_iteration_legacy_single_replica(tmp_path, monkeypatch):
+    """Legacy dash-shape keys with --iteration 1 wipe the workload dir (no iN).
+
+    Legacy runs pre-date the step-5 iN layout — trace files live directly
+    at results/<pkg>/<wl>/. Legacy keys parse to iteration=1 and the fix
+    falls back to the workload dir when no iN subdirs exist.
+    """
+    import pipeline.deploy as mod
+
+    run_dir = tmp_path / "run1"
+    run_dir.mkdir()
+    # Dash-shape (legacy) pair key
+    progress = {
+        "wl-smoke-baseline": {"workload": "wl-smoke", "package": "baseline", "status": "done",
+                              "namespace": None, "retries": 0, "pending_stalls": 0, "pending_since": None},
+    }
+    _mock_cm(monkeypatch, progress)
+    d = run_dir / "results" / "baseline" / "wl-smoke"
+    d.mkdir(parents=True)
+    (d / "trace.csv").write_text("data")
+
+    class _Args:
+        only = None; workload = None; package = None; iteration = "1"; dry_run = False; yes = True
+
+    mod._cmd_wipe(_Args(), run_dir, cluster_config={"namespaces": ["ns-0"]})
+
+    assert not (run_dir / "results" / "baseline" / "wl-smoke").exists()
+
+
+def test_wipe_iteration_no_results_on_disk(tmp_path, monkeypatch, capsys):
+    """--iteration N with no matching iN subdirs reports skip and points at iN path."""
+    import pipeline.deploy as mod
+
+    run_dir = tmp_path / "run1"
+    run_dir.mkdir()
+    _mock_cm(monkeypatch, _PROGRESS_ITER)
+    # Set up only i1/i3; --iteration 2 should hit no results on disk.
+    _setup_iN_results(run_dir, iterations=(1, 3))
+
+    class _Args:
+        only = None; workload = None; package = None; iteration = "2"; dry_run = False; yes = True
+
+    mod._cmd_wipe(_Args(), run_dir, cluster_config={"namespaces": ["ns-0"]})
+
+    captured = capsys.readouterr()
+    assert "no results on disk" in (captured.out + captured.err).lower()
+    # i1/i3 must survive.
+    assert (run_dir / "results" / "baseline" / "smoke" / "i1").exists()
+    assert (run_dir / "results" / "baseline" / "smoke" / "i3").exists()
+
+
+def test_wipe_iteration_leaves_siblings_and_reclaims_only_iN(tmp_path, monkeypatch):
+    """When --iteration N wipes one iN, sibling iN subdirs and workload dir survive."""
+    import pipeline.deploy as mod
+
+    run_dir = tmp_path / "run1"
+    run_dir.mkdir()
+    _mock_cm(monkeypatch, _PROGRESS_ITER)
+    _setup_iN_results(run_dir)
+
+    class _Args:
+        only = None; workload = None; package = None; iteration = "2"; dry_run = False; yes = True
+
+    mod._cmd_wipe(_Args(), run_dir, cluster_config={"namespaces": ["ns-0"]})
+
+    # Workload dirs retained because i1/i3 still occupy them.
+    assert (run_dir / "results" / "baseline" / "smoke").exists()
+    assert (run_dir / "results" / "baseline" / "load").exists()
+    assert (run_dir / "results" / "baseline").exists()
+
+
 def test_main_dispatches_wipe(tmp_path, monkeypatch):
     """main() routes 'wipe' with the per-run cluster_config (#449).
 


### PR DESCRIPTION
Closes #525.

## Summary

`deploy.py wipe --iteration N` narrowed pair-key scope but then deleted the entire workload directory tree, silently destroying sibling iterations. The fix computes the delete target per pair-key iteration, so `--iteration N` removes only `results/<pkg>/<wl>/i<N>/`.

## What changed

- **`pipeline/deploy.py`** — `_cmd_wipe`: compute `target_dir` per pair key via `_key_iteration`. If `results/<pkg>/<wl>/i<N>/` exists, that's the target. Legacy single-replica runs (no `i<N>/` subdirs anywhere under the workload) fall back to the workload dir. Empty-parent cleanup extends to also rmdir the workload dir after the last `i<N>/` under it is wiped. Dry-run / deleted / failed messages now print the actual per-iteration path.

- **`pipeline/tests/test_deploy_wipe.py`** — 10 new cases:
  - `--iteration N` deletes only `i<N>/`, siblings survive
  - list spec (`1,3`) and range spec (`1-2`)
  - dry-run prints the `i<N>/` path
  - unscoped wipe with iN layout deletes every `i<N>/` per pair key (parent cleanup reclaims the empty workload dir)
  - last-iN cleanup removes the empty workload dir
  - legacy dash-shape key with `--iteration 1` uses the workload-dir fallback
  - `--iteration N` where no `i<N>/` exists on disk reports "no results on disk" and leaves siblings alone

- **`pipeline/README.md`** — the previous `--iteration` row documented the bug as a warning; rewritten to describe the correct behavior. Paragraph describing the delete target updated for the step-5 vs legacy layouts.

## Reset parity (called out in the issue)

Reset is unaffected. Pair keys already carry the `|iN` suffix, `_reset_pair` iterates by key, and reset is state-only (ConfigMap; no filesystem writes). `--iteration` naturally narrows the ConfigMap entries reset per iteration. No changes needed there.

## Verification

- `python -m pytest pipeline/ .claude/skills/*/tests/ -q` → 2053 passed, 1 skipped, 2 xfailed
- `ruff check pipeline/ .claude/skills/ --select F` → clean

## Docs sweep

- `pipeline/README.md` — updated (see above).
- `docs/epics/step-5/design.md` and `docs/superpowers/plans/2026-07-07-issue-511-pipeline-replica-threading.md` reference the pre-fix behavior but are frozen historical epic records; not updated retroactively (same convention as PR #588).
- Argparse `--iteration` help is generic and remains accurate.

## Test plan

- [x] Existing wipe tests still pass (unscoped wipe with legacy dash-shape keys unchanged)
- [x] New iteration-scoped tests cover: single, list, range, legacy fallback, missing iN, empty-parent cleanup, dry-run message
- [x] Full pipeline test suite + skill tests green
- [x] Lint clean