### PR TITLE
fix(reset): sweep HTTPRoutes orphaned by teardown (#603)

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -674,7 +674,7 @@ When `--only` or `--workload` is given, only matching workload subdirectories ar
 
 **`deploy.py stop`** — deletes the `sim2real-orchestrator` Kubernetes Job (with cascading pod deletion) in the primary namespace. Only meaningful when the orchestrator runs as an in-cluster Job. Pair state is left as-is. If no remote orchestrator Job exists, prints a message and returns. Use `reset` separately to clear failed/stalled pair state.
 
-**`deploy.py reset`** — resets all non-pending pairs to `pending` and removes their cluster resources (PipelineRuns, Helm releases). This includes `done` pairs — use `--preserve-done-status` to clean up cluster resources for done pairs without re-queuing them.
+**`deploy.py reset`** — resets all non-pending pairs to `pending` and removes their cluster resources (PipelineRuns, Helm releases, and orphaned HTTPRoutes). This includes `done` pairs — use `--preserve-done-status` to clean up cluster resources for done pairs without re-queuing them. HTTPRoutes rendered by llm-d-benchmark's `08_httproute` template are applied directly to the cluster (no helm-release annotation, no ownerReference to their InferencePool), so neither `helm uninstall` nor Kubernetes GC removes them at teardown; reset sweeps any HTTPRoute whose backend InferencePool no longer exists (routes with a live backend are never touched), clearing debris that would otherwise strand on the shared gateway and steal traffic (issue #603).
 
 | Flag | Description |
 |------|-------------|

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -2214,6 +2214,62 @@ def _uninstall_orphaned_helm(key: str, namespace: str) -> None:
                 warn(f"Failed to uninstall {release} in {namespace}")
 
 
+def _sweep_orphaned_httproutes(namespace: str) -> None:
+    """Delete HTTPRoutes whose backend InferencePool no longer exists (issue #603).
+
+    Model HTTPRoutes are rendered by llm-d-benchmark's 08_httproute template and
+    applied directly to the cluster — they carry no ``meta.helm.sh/release-name``
+    annotation and no ownerReference to their InferencePool. So when a model is
+    torn down, ``helm uninstall`` cannot remove them (helm does not own them) and
+    Kubernetes garbage collection cannot either (no ownerReference to the deleted
+    InferencePool). The route is stranded on the shared gateway with a catch-all
+    '/'; Gateway API resolves '/'-vs-'/' by oldest-wins, so an accumulated stale
+    route eventually steals traffic and returns 500 (breaks the next standup's
+    smoketest health check).
+
+    We sweep them after helm uninstall, keyed on a DANGLING InferencePool
+    backendRef so a route whose backend is still live (e.g. a concurrent pair in
+    the same namespace) is never touched. If the InferencePool API is unavailable
+    we no-op rather than risk over-deleting.
+    """
+    pools = run(["kubectl", "get", "inferencepool", "-n", namespace,
+                 "-o", "jsonpath={.items[*].metadata.name}"], check=False, capture=True)
+    if pools.returncode != 0:
+        # CRD/API unavailable: cannot tell live from dead — do nothing.
+        return
+    live = set(pools.stdout.split())
+
+    got = run(["kubectl", "get", "httproute", "-n", namespace, "-o", "json"],
+              check=False, capture=True)
+    if got.returncode != 0:
+        return
+    try:
+        routes = json.loads(got.stdout).get("items", [])
+    except (ValueError, TypeError):
+        return
+
+    for r in routes:
+        name = (r.get("metadata") or {}).get("name", "")
+        if not name:
+            continue
+        pool_backends = [
+            b.get("name")
+            for rule in (r.get("spec") or {}).get("rules", []) or []
+            for b in (rule.get("backendRefs") or []) or []
+            if b.get("kind") == "InferencePool"
+        ]
+        # Only sweep routes that reference at least one InferencePool AND have no
+        # live one — i.e. genuinely dangling. Routes to a live pool, or to plain
+        # Services (no InferencePool backend), are left untouched.
+        if pool_backends and all(b not in live for b in pool_backends):
+            dr = run(["kubectl", "delete", "httproute", name, "-n", namespace,
+                      "--ignore-not-found"], check=False, capture=True)
+            if dr.returncode == 0:
+                ok(f"Swept orphaned HTTPRoute {name} (dead InferencePool backend) in {namespace}")
+            else:
+                warn(f"Failed to sweep orphaned HTTPRoute {name} in {namespace}")
+
+
 def _reset_pair(key: str, entry: dict, discovered: dict, *,
                 dry_run: bool = False, namespaces: list[str] | None = None,
                 preserve_done_status: bool = False) -> bool:
@@ -2276,10 +2332,12 @@ def _reset_pair(key: str, entry: dict, discovered: dict, *,
         info(f"[DRY-RUN] {key}: would delete pipelinerun {pr_name or '(unknown)'} in {target}")
         if not is_done:
             info(f"[DRY-RUN] {key}: would uninstall all helm releases in {target}")
+            info(f"[DRY-RUN] {key}: would sweep orphaned HTTPRoutes in {target}")
         else:
             completed_ns = entry.get("completed_namespace")
             if completed_ns:
                 info(f"[DRY-RUN] {key}: would check for orphaned helm releases in {completed_ns}")
+                info(f"[DRY-RUN] {key}: would sweep orphaned HTTPRoutes in {completed_ns}")
         return True
 
     # Delete PipelineRun
@@ -2314,6 +2372,7 @@ def _reset_pair(key: str, entry: dict, discovered: dict, *,
         completed_ns = entry.get("completed_namespace")
         if completed_ns:
             _uninstall_orphaned_helm(key, completed_ns)
+            _sweep_orphaned_httproutes(completed_ns)
         if not preserve_done_status:
             entry["status"] = "pending"
             entry["namespace"] = None
@@ -2348,6 +2407,11 @@ def _reset_pair(key: str, entry: dict, discovered: dict, *,
             if helm_failed:
                 warn(f"{key}: some releases failed to uninstall — state NOT reset")
                 return False
+        # Sweep HTTPRoutes orphaned by teardown (issue #603): they are not
+        # helm-owned and not GC'd, so helm uninstall above never removes them.
+        # Runs even when no live releases remain, to clear debris left by prior
+        # runs in this namespace slot.
+        _sweep_orphaned_httproutes(ns)
     else:
         # PipelineRun was known but no namespace recorded — helm needs the
         # namespace, so cleanup is skipped. Warn rather than silently report

--- a/pipeline/deploy.py
+++ b/pipeline/deploy.py
@@ -2214,7 +2214,7 @@ def _uninstall_orphaned_helm(key: str, namespace: str) -> None:
                 warn(f"Failed to uninstall {release} in {namespace}")
 
 
-def _sweep_orphaned_httproutes(namespace: str) -> None:
+def _sweep_orphaned_httproutes(key: str, namespace: str) -> None:
     """Delete HTTPRoutes whose backend InferencePool no longer exists (issue #603).
 
     Model HTTPRoutes are rendered by llm-d-benchmark's 08_httproute template and
@@ -2235,17 +2235,25 @@ def _sweep_orphaned_httproutes(namespace: str) -> None:
     pools = run(["kubectl", "get", "inferencepool", "-n", namespace,
                  "-o", "jsonpath={.items[*].metadata.name}"], check=False, capture=True)
     if pools.returncode != 0:
-        # CRD/API unavailable: cannot tell live from dead — do nothing.
+        # CRD/API unavailable: cannot tell live from dead — do nothing, but warn.
+        # Silently no-op'ing here would let the exact orphaned-route leak this
+        # sweep exists to fix recur with zero operator signal (issue #603).
+        warn(f"{key}: cannot list InferencePools in {namespace} — skipping "
+             f"HTTPRoute sweep (orphaned routes may remain)")
         return
     live = set(pools.stdout.split())
 
     got = run(["kubectl", "get", "httproute", "-n", namespace, "-o", "json"],
               check=False, capture=True)
     if got.returncode != 0:
+        warn(f"{key}: cannot list HTTPRoutes in {namespace} — skipping sweep "
+             f"(orphaned routes may remain)")
         return
     try:
         routes = json.loads(got.stdout).get("items", [])
     except (ValueError, TypeError):
+        warn(f"{key}: unparseable HTTPRoute list in {namespace} — skipping sweep "
+             f"(orphaned routes may remain)")
         return
 
     for r in routes:
@@ -2267,7 +2275,8 @@ def _sweep_orphaned_httproutes(namespace: str) -> None:
             if dr.returncode == 0:
                 ok(f"Swept orphaned HTTPRoute {name} (dead InferencePool backend) in {namespace}")
             else:
-                warn(f"Failed to sweep orphaned HTTPRoute {name} in {namespace}")
+                warn(f"{key}: failed to sweep orphaned HTTPRoute {name} in "
+                     f"{namespace}: {dr.stderr.strip()}")
 
 
 def _reset_pair(key: str, entry: dict, discovered: dict, *,
@@ -2306,8 +2315,10 @@ def _reset_pair(key: str, entry: dict, discovered: dict, *,
             if completed_ns:
                 if dry_run:
                     info(f"[DRY-RUN] {key}: would check for orphaned helm releases in {completed_ns}")
+                    info(f"[DRY-RUN] {key}: would sweep orphaned HTTPRoutes in {completed_ns}")
                 else:
                     _uninstall_orphaned_helm(key, completed_ns)
+                    _sweep_orphaned_httproutes(key, completed_ns)
         elif not dry_run:
             # Terminal pair (callers only reset non-pending pairs) with no
             # namespace recorded — helm cleanup is skipped. Warn rather than
@@ -2372,7 +2383,7 @@ def _reset_pair(key: str, entry: dict, discovered: dict, *,
         completed_ns = entry.get("completed_namespace")
         if completed_ns:
             _uninstall_orphaned_helm(key, completed_ns)
-            _sweep_orphaned_httproutes(completed_ns)
+            _sweep_orphaned_httproutes(key, completed_ns)
         if not preserve_done_status:
             entry["status"] = "pending"
             entry["namespace"] = None
@@ -2411,7 +2422,7 @@ def _reset_pair(key: str, entry: dict, discovered: dict, *,
         # helm-owned and not GC'd, so helm uninstall above never removes them.
         # Runs even when no live releases remain, to clear debris left by prior
         # runs in this namespace slot.
-        _sweep_orphaned_httproutes(ns)
+        _sweep_orphaned_httproutes(key, ns)
     else:
         # PipelineRun was known but no namespace recorded — helm needs the
         # namespace, so cleanup is skipped. Warn rather than silently report

--- a/pipeline/tests/test_deploy_reset.py
+++ b/pipeline/tests/test_deploy_reset.py
@@ -1014,7 +1014,7 @@ def test_sweep_deletes_only_dangling_httproute(monkeypatch):
     monkeypatch.setattr(mod, "run", _sweep_fake_run(
         calls, pools_out="qwen-live-router", routes_out=_SWEEP_ROUTES))
 
-    mod._sweep_orphaned_httproutes("kalantar-0")
+    mod._sweep_orphaned_httproutes("wl-x-baseline", "kalantar-0")
 
     assert _deleted_httproutes(calls) == ["qwen-stale"]
 
@@ -1026,7 +1026,7 @@ def test_sweep_noop_when_inferencepool_api_unavailable(monkeypatch):
     monkeypatch.setattr(mod, "run", _sweep_fake_run(
         calls, pools_rc=1, routes_out=_SWEEP_ROUTES))
 
-    mod._sweep_orphaned_httproutes("kalantar-0")
+    mod._sweep_orphaned_httproutes("wl-x-baseline", "kalantar-0")
 
     assert _deleted_httproutes(calls) == []
     # must not even enumerate routes once liveness can't be judged
@@ -1041,7 +1041,7 @@ def test_sweep_keeps_routes_when_all_backends_live(monkeypatch):
         calls, pools_out="qwen-stale-router qwen-live-router",
         routes_out=_SWEEP_ROUTES))
 
-    mod._sweep_orphaned_httproutes("kalantar-0")
+    mod._sweep_orphaned_httproutes("wl-x-baseline", "kalantar-0")
 
     assert _deleted_httproutes(calls) == []
 
@@ -1075,4 +1075,114 @@ def test_reset_pair_invokes_sweep_even_with_no_releases(monkeypatch):
     deleted = set(_deleted_httproutes(calls))
     assert deleted == {"qwen-stale", "qwen-live"}   # both InferencePool routes dangle
     assert "plain-svc-route" not in deleted         # no InferencePool backend
+    assert entry["status"] == "pending"
+
+
+# A single route fronting two InferencePool backends — one dead, one still live.
+# Guards the all()-not-any() deletion semantics: the route still serves traffic
+# through the live backend, so it must NOT be swept.
+_SWEEP_ROUTES_MIXED = _json.dumps({"items": [
+    {"metadata": {"name": "qwen-mixed"},
+     "spec": {"rules": [{"backendRefs": [
+         {"kind": "InferencePool", "name": "qwen-stale-router"},
+         {"kind": "InferencePool", "name": "qwen-live-router"}]}]}},
+]})
+
+
+def test_sweep_keeps_route_with_one_live_backend_among_dead(monkeypatch):
+    """A route with a mix of dead and live InferencePool backends is kept.
+
+    Deletion is gated on ALL backends being dead (deploy.py's
+    ``all(b not in live ...)``); a route still serving through any live backend
+    must survive. A regression to ``any()`` would delete a live-serving route.
+    """
+    import pipeline.deploy as mod
+    calls = []
+    monkeypatch.setattr(mod, "run", _sweep_fake_run(
+        calls, pools_out="qwen-live-router", routes_out=_SWEEP_ROUTES_MIXED))
+
+    mod._sweep_orphaned_httproutes("wl-x-baseline", "kalantar-0")
+
+    assert _deleted_httproutes(calls) == []
+
+
+def test_sweep_warns_when_inferencepool_api_unavailable(monkeypatch, capsys):
+    """When the InferencePool API errors, the sweep no-ops but WARNS — a silent
+    no-op would let the issue-#603 leak recur with zero operator signal."""
+    import pipeline.deploy as mod
+    calls = []
+    monkeypatch.setattr(mod, "run", _sweep_fake_run(
+        calls, pools_rc=1, routes_out=_SWEEP_ROUTES))
+
+    mod._sweep_orphaned_httproutes("wl-x-baseline", "kalantar-0")
+
+    out = capsys.readouterr().out.lower()
+    assert "kalantar-0" in out
+    assert "inferencepool" in out and "skipping" in out
+
+
+def test_reset_pair_done_sweeps_httproutes_in_completed_namespace(monkeypatch):
+    """Primary #603 teardown path: a done pair (namespace already freed, PR name
+    on disk) sweeps orphaned HTTPRoutes in its completed_namespace."""
+    import pipeline.deploy as mod
+    # wl-smoke-baseline IS in _DISCOVERED (pr_name present) -> reaches the
+    # is_done cleanup block, not the (no ns, no pr_name) early branch.
+    entry = {"workload": "wl-smoke", "package": "baseline", "status": "done",
+             "namespace": None, "completed_namespace": "sim2real-0", "retries": 0}
+    calls = []
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        calls.append(cmd)
+        class _R:
+            returncode = 0
+            stdout = ""
+        r = _R()
+        if cmd[:2] == ["helm", "list"]:
+            r.stdout = ""                 # no live releases
+        elif cmd[:3] == ["kubectl", "get", "inferencepool"]:
+            r.stdout = ""                 # no live pools => both pool routes dangle
+        elif cmd[:3] == ["kubectl", "get", "httproute"]:
+            r.stdout = _SWEEP_ROUTES
+        return r
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    mod._reset_pair("wl-smoke-baseline", entry, _DISCOVERED)
+
+    deleted = set(_deleted_httproutes(calls))
+    assert deleted == {"qwen-stale", "qwen-live"}
+    assert "plain-svc-route" not in deleted
+    assert entry["status"] == "pending"
+
+
+def test_reset_pair_done_no_pr_name_still_sweeps_httproutes(monkeypatch):
+    """Done pair reaching the (no ns, no pr_name) early branch — namespace freed
+    and no PipelineRun discovered — must still sweep its completed_namespace
+    (the branch previously did helm cleanup only)."""
+    import pipeline.deploy as mod
+    entry = {"workload": "wl-orphan", "package": "baseline", "status": "done",
+             "namespace": None, "completed_namespace": "sim2real-0", "retries": 0}
+    calls = []
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        calls.append(cmd)
+        class _R:
+            returncode = 0
+            stdout = ""
+        r = _R()
+        if cmd[:2] == ["helm", "list"]:
+            r.stdout = ""
+        elif cmd[:3] == ["kubectl", "get", "inferencepool"]:
+            r.stdout = ""
+        elif cmd[:3] == ["kubectl", "get", "httproute"]:
+            r.stdout = _SWEEP_ROUTES
+        return r
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    # key absent from discovered => pr_name == "" => early (no ns, no pr_name) branch
+    mod._reset_pair("wl-orphan-baseline", entry, {})
+
+    deleted = set(_deleted_httproutes(calls))
+    assert deleted == {"qwen-stale", "qwen-live"}
     assert entry["status"] == "pending"

--- a/pipeline/tests/test_deploy_reset.py
+++ b/pipeline/tests/test_deploy_reset.py
@@ -962,3 +962,117 @@ def test_main_dispatches_reset(tmp_path, monkeypatch):
     run_dir, cluster_config = reset_calls[0]
     assert run_dir.name == "trial-1"
     assert cluster_config == {"namespaces": ["ns-0"]}
+
+
+# ---------------------------------------------------------------------------
+# issue #603: sweep HTTPRoutes orphaned by teardown (not helm-owned, not GC'd)
+# ---------------------------------------------------------------------------
+
+import json as _json
+
+# Three routes: a dangling one (dead InferencePool backend), a live one, and a
+# plain-Service route that has no InferencePool backend at all.
+_SWEEP_ROUTES = _json.dumps({"items": [
+    {"metadata": {"name": "qwen-stale"},
+     "spec": {"rules": [{"backendRefs": [
+         {"group": "inference.networking.x-k8s.io", "kind": "InferencePool",
+          "name": "qwen-stale-router"}]}]}},
+    {"metadata": {"name": "qwen-live"},
+     "spec": {"rules": [{"backendRefs": [
+         {"kind": "InferencePool", "name": "qwen-live-router"}]}]}},
+    {"metadata": {"name": "plain-svc-route"},
+     "spec": {"rules": [{"backendRefs": [
+         {"kind": "Service", "name": "some-svc"}]}]}},
+]})
+
+
+def _sweep_fake_run(calls, *, pools_rc=0, pools_out="", routes_out="{}"):
+    """Fake ``run`` dispatching on the kubectl subcommand the sweep issues."""
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        calls.append(cmd)
+        class _R:
+            returncode = 0
+            stdout = ""
+        r = _R()
+        if cmd[:3] == ["kubectl", "get", "inferencepool"]:
+            r.returncode = pools_rc
+            r.stdout = pools_out       # jsonpath: space-separated pool names
+        elif cmd[:3] == ["kubectl", "get", "httproute"]:
+            r.stdout = routes_out
+        return r
+    return fake_run
+
+
+def _deleted_httproutes(calls):
+    return [c[3] for c in calls if c[:3] == ["kubectl", "delete", "httproute"]]
+
+
+def test_sweep_deletes_only_dangling_httproute(monkeypatch):
+    """Route with a dead InferencePool backend is swept; live + non-pool routes kept."""
+    import pipeline.deploy as mod
+    calls = []
+    monkeypatch.setattr(mod, "run", _sweep_fake_run(
+        calls, pools_out="qwen-live-router", routes_out=_SWEEP_ROUTES))
+
+    mod._sweep_orphaned_httproutes("kalantar-0")
+
+    assert _deleted_httproutes(calls) == ["qwen-stale"]
+
+
+def test_sweep_noop_when_inferencepool_api_unavailable(monkeypatch):
+    """If the InferencePool API errors, sweep does nothing (never over-deletes)."""
+    import pipeline.deploy as mod
+    calls = []
+    monkeypatch.setattr(mod, "run", _sweep_fake_run(
+        calls, pools_rc=1, routes_out=_SWEEP_ROUTES))
+
+    mod._sweep_orphaned_httproutes("kalantar-0")
+
+    assert _deleted_httproutes(calls) == []
+    # must not even enumerate routes once liveness can't be judged
+    assert not any(c[:3] == ["kubectl", "get", "httproute"] for c in calls)
+
+
+def test_sweep_keeps_routes_when_all_backends_live(monkeypatch):
+    """No deletion when every InferencePool backend still exists."""
+    import pipeline.deploy as mod
+    calls = []
+    monkeypatch.setattr(mod, "run", _sweep_fake_run(
+        calls, pools_out="qwen-stale-router qwen-live-router",
+        routes_out=_SWEEP_ROUTES))
+
+    mod._sweep_orphaned_httproutes("kalantar-0")
+
+    assert _deleted_httproutes(calls) == []
+
+
+def test_reset_pair_invokes_sweep_even_with_no_releases(monkeypatch):
+    """_reset_pair sweeps orphaned routes after helm cleanup, even when the
+    namespace has no live releases (debris from prior runs must still be cleared)."""
+    import pipeline.deploy as mod
+    entry = {"workload": "wl-heavy", "package": "baseline", "status": "failed",
+             "namespace": "sim2real-0", "retries": 0}
+    calls = []
+
+    def fake_run(cmd, *, check=True, capture=False, cwd=None):
+        calls.append(cmd)
+        class _R:
+            returncode = 0
+            stdout = ""
+        r = _R()
+        if cmd[:2] == ["helm", "list"]:
+            r.stdout = ""                 # no live releases
+        elif cmd[:3] == ["kubectl", "get", "inferencepool"]:
+            r.stdout = ""                 # no live pools => both pool routes dangle
+        elif cmd[:3] == ["kubectl", "get", "httproute"]:
+            r.stdout = _SWEEP_ROUTES
+        return r
+
+    monkeypatch.setattr(mod, "run", fake_run)
+
+    mod._reset_pair("wl-heavy-baseline", entry, _DISCOVERED)
+
+    deleted = set(_deleted_httproutes(calls))
+    assert deleted == {"qwen-stale", "qwen-live"}   # both InferencePool routes dangle
+    assert "plain-svc-route" not in deleted         # no InferencePool backend
+    assert entry["status"] == "pending"


### PR DESCRIPTION
Closes #603.

## Problem
`deploy.py reset` (and Tekton teardown) leave **orphaned HTTPRoutes** behind. They're rendered by llm-d-benchmark's `08_httproute` template and applied directly — **no helm-release annotation, no ownerReference** — so `helm uninstall` can't remove them (not helm-owned) and k8s GC can't either (no ownerReference to the deleted InferencePool). They strand on the shared gateway with a catch-all `/`; Gateway API resolves `/`-vs-`/` by oldest-wins, so an accumulated stale route eventually routes `/health` (and real traffic) to a dead InferencePool → 500 → the next standup's smoketest health check fails even though the model is healthy.

`_reset_pair`'s cleanup was helm-scoped only, so it could never remove these — orphans accumulated across runs.

## Fix
Add `_sweep_orphaned_httproutes(namespace)`, called after helm cleanup in **both** `_reset_pair` paths (done + non-done):
- Deletes only HTTPRoutes whose backend **InferencePool no longer exists** (dangling) — a route with a live backend is never touched.
- **No-ops if the InferencePool API is unavailable** (never over-deletes).
- Ignores routes with no InferencePool backend.
- Runs even when no live releases remain, to clear prior-run debris.
- Dry-run parity messages added.

## Scope / analysis
HTTPRoute is the only per-run, model-scoped, unowned object that conflicts. Per-model **PodMonitor** (`18_podmonitor`) is the one latent same-class risk (not in current configs, non-conflicting) — see #603. InferencePool/DestinationRule/EnvoyFilter/Deployment/Service/EPP are helm-owned and already cleaned; PVCs/SA/RBAC/harness are intentionally persistent.

The proper upstream fix (out of scope here) is to give `08_httproute` an `ownerReference` to its InferencePool so GC removes it automatically; this PR makes our reset idempotent against the leak in the meantime.

## Tests
`pipeline/tests/test_deploy_reset.py` (+4): dangling-only deletion, API-unavailable no-op, all-live-kept, and `_reset_pair` wiring. **37/37 pass**; existing reset tests unaffected.
