### PR TITLE
fix(bootstrap): validate config.md observe block against blis observe's flag namespace (#602)

### DIFF
--- a/.claude/skills/sim2real-bootstrap/SKILL.md
+++ b/.claude/skills/sim2real-bootstrap/SKILL.md
@@ -337,6 +337,11 @@ Assemble transfer manifest from all prior task outputs.
     5 keys with per-key `# source:` provenance comments; if `config.md` is
     absent or the block is missing, an all-defaults fragment is emitted. Do
     NOT hand-edit the fragment — regenerate by re-running the script.
+    The block is validated against `blis observe`'s flag namespace (issue
+    #602): recognized flags map to their key or `extraArgs`, while replay-only
+    flags (e.g. `--session-mode`) and any non-observe flag are dropped with a
+    `WARNING:` on stderr rather than transcribed. If a dropped flag was in fact
+    intended, add it to `blis_observe.extraArgs` in `transfer.yaml` by hand.
 
 **Output schema:**
 ```yaml

--- a/.claude/skills/sim2real-bootstrap/generate_from_config.py
+++ b/.claude/skills/sim2real-bootstrap/generate_from_config.py
@@ -127,27 +127,41 @@ OBSERVE_PIPELINE_INJECTED_FLAGS = {
     "--total-sessions",
 }
 
-# The complete set of flags `blis observe` accepts, derived from
-# inference-sim cmd/observe_cmd.go @ 583f7195 (PR #1499, corpus-mode). This is
-# the allowlist: a flag in config.md's observe block is written to transfer.yaml
-# only if it appears here (as a first-class OBSERVE_TUNING_FLAGS key, or — for
-# anything without a dedicated key — verbatim in extraArgs). Anything NOT here
-# is dropped, never transcribed (issue #602). Update in lockstep with
-# observe_cmd.go when observe's flags change.
+# The complete set of flags `blis observe` accepts, from inference-sim
+# @ 583f7195 (PR #1499, corpus-mode). This is the allowlist: a flag in
+# config.md's observe block is written to transfer.yaml only if it appears here
+# (as a first-class OBSERVE_TUNING_FLAGS key, or — for anything without a
+# dedicated key — verbatim in extraArgs). Anything NOT here is dropped, never
+# transcribed (issue #602).
+#
+# Two source sites, so both must be regenerated in lockstep when observe's flags
+# change (the second is easy to miss):
+#   1. cmd/observe_cmd.go — flags registered directly on observeCmd. Match EVERY
+#      pflag setter, including Int64Var/Float64Var/DurationVar, not just Int/String.
+#   2. cmd/root.go:registerSaturationFlags(observeCmd) — the --saturation-* /
+#      backlog-drift block, shared with `blis run`/`blis replay` and registered
+#      on observe via that helper call (observe_cmd.go).
 OBSERVE_VALID_FLAGS = {
+    # --- cmd/observe_cmd.go (registered directly on observeCmd) ---
     "--api-format", "--api-key", "--concurrency", "--concurrent-sessions",
-    "--corpus-data", "--corpus-header", "--defaults-filepath", "--itl-output",
-    "--lazy-generation", "--max-concurrency", "--model", "--no-streaming",
-    "--num-requests", "--output-tokens", "--output-tokens-max",
+    "--corpus-data", "--corpus-header", "--defaults-filepath", "--horizon",
+    "--itl-output", "--lazy-generation", "--max-concurrency", "--model",
+    "--no-streaming", "--num-requests", "--output-tokens", "--output-tokens-max",
     "--output-tokens-min", "--output-tokens-stdev", "--post-hoc-detector",
     "--prefix-tokens", "--prewarm-duration", "--prompt-tokens",
     "--prompt-tokens-max", "--prompt-tokens-min", "--prompt-tokens-stdev",
     "--rate", "--record-itl", "--rtt-ms", "--saturation-report",
-    "--saturation-threshold-ms", "--server-type", "--server-url",
+    "--saturation-threshold-ms", "--seed", "--server-type", "--server-url",
     "--session-id-header", "--slo-e2e", "--slo-itl", "--slo-ttft",
     "--think-time-dist", "--think-time-ms", "--timeout", "--total-sessions",
     "--trace-data", "--trace-header", "--unconstrained-output",
     "--warmup-requests", "--workload", "--workload-spec",
+    # --- cmd/root.go:registerSaturationFlags (attached to observeCmd) ---
+    "--saturation-ci", "--saturation-classifier",
+    "--saturation-drain-ratio-saturated", "--saturation-drain-ratio-transient",
+    "--saturation-min-windows", "--saturation-peak-band",
+    "--saturation-peak-ratio", "--saturation-tail-windows",
+    "--saturation-warmup-windows", "--saturation-window",
 }
 
 # Flags that belong to `blis replay` (the simulator's load generator) or to
@@ -691,8 +705,13 @@ def parse_observe_block(config_md_text: str) -> dict[str, str]:
     """Extract flags from the `blis observe \\ ... \\` command in config.md.
 
     Returns a dict keyed by transfer.yaml key. Keys are present only when the
-    block contained the corresponding flag. `extraArgs` collects any unknown
-    non-injected flags (whitespace-joined, source order). Absent block → {}.
+    block contained the corresponding flag. Each flag is validated against
+    `blis observe`'s namespace: modeled tuning flags map to their key, other
+    real observe flags are passed through verbatim in `extraArgs`
+    (whitespace-joined, source order), and flags that are not observe flags
+    (replay-only, sim-world, unknown) are dropped with a stderr warning rather
+    than transcribed (issue #602). Both `--flag value` and `--flag=value` forms
+    are accepted. Absent block → {}.
     """
     # Locate the first line that starts a `blis observe` invocation. We accept
     # optional leading whitespace so the block can live inside a code fence.
@@ -739,29 +758,37 @@ def parse_observe_block(config_md_text: str) -> dict[str, str]:
             # Stray value with no preceding flag — skip.
             i += 1
             continue
-        # Peek at next token; it's a value if it exists and is not a flag.
-        has_value = i + 1 < len(flag_tokens) and not flag_tokens[i + 1].startswith("--")
-        value = flag_tokens[i + 1] if has_value else None
+        # Support both "--flag value" and "--flag=value" forms. Classification
+        # keys on the flag NAME; the value is inline (after '=') or, failing
+        # that, the next token when it is not itself a flag.
+        if "=" in tok:
+            flag_name, inline_value = tok.split("=", 1)
+        else:
+            flag_name, inline_value = tok, None
+        has_next_value = (
+            inline_value is None
+            and i + 1 < len(flag_tokens)
+            and not flag_tokens[i + 1].startswith("--")
+        )
+        # Tokens this flag consumes: itself, plus a separate value token if any.
+        step = 2 if has_next_value else 1
 
-        if tok in OBSERVE_TUNING_FLAGS:
+        if flag_name in OBSERVE_TUNING_FLAGS:
+            value = inline_value if inline_value is not None else (
+                flag_tokens[i + 1] if has_next_value else None
+            )
             if value is not None:
-                parsed[OBSERVE_TUNING_FLAGS[tok]] = value
-                i += 2
-            else:
-                # Tuning flag with no value is malformed; skip.
-                i += 1
-        elif tok in OBSERVE_PIPELINE_INJECTED_FLAGS:
-            # Drop entirely — the Tekton task supplies these.
-            i += 2 if has_value else 1
-        elif tok in OBSERVE_VALID_FLAGS:
+                parsed[OBSERVE_TUNING_FLAGS[flag_name]] = value
+            # else: tuning flag with no value is malformed; skip.
+        elif flag_name in OBSERVE_PIPELINE_INJECTED_FLAGS:
+            pass  # Drop entirely — the Tekton task supplies these.
+        elif flag_name in OBSERVE_VALID_FLAGS:
             # A real blis observe flag with no first-class key — pass it
-            # through verbatim so the operator can tune it in transfer.yaml.
-            if has_value:
-                extra_pieces.extend([tok, value])
-                i += 2
-            else:
-                extra_pieces.append(tok)
-                i += 1
+            # through verbatim (preserving --flag=value vs --flag value) so the
+            # operator can tune it in transfer.yaml.
+            extra_pieces.append(tok)
+            if has_next_value:
+                extra_pieces.append(flag_tokens[i + 1])
         else:
             # Not a blis observe flag. Refuse to transcribe it into extraArgs
             # (it would abort observe at runtime, e.g. the transcribed
@@ -770,15 +797,15 @@ def parse_observe_block(config_md_text: str) -> dict[str, str]:
             # in transfer.yaml if it is legitimate (issue #602).
             reason = (
                 "replay/sim flag with no blis observe equivalent"
-                if tok in OBSERVE_REPLAY_ONLY_FLAGS
+                if flag_name in OBSERVE_REPLAY_ONLY_FLAGS
                 else "not a blis observe flag"
             )
             print(
-                f"WARNING: dropping '{tok}' from the blis observe block "
+                f"WARNING: dropping '{flag_name}' from the blis observe block "
                 f"({reason}); add it to transfer.yaml if intended.",
                 file=sys.stderr,
             )
-            i += 2 if has_value else 1
+        i += step
 
     if extra_pieces:
         parsed["extraArgs"] = " ".join(extra_pieces)

--- a/.claude/skills/sim2real-bootstrap/generate_from_config.py
+++ b/.claude/skills/sim2real-bootstrap/generate_from_config.py
@@ -777,9 +777,20 @@ def parse_observe_block(config_md_text: str) -> dict[str, str]:
             value = inline_value if inline_value is not None else (
                 flag_tokens[i + 1] if has_next_value else None
             )
-            if value is not None:
+            if value:
                 parsed[OBSERVE_TUNING_FLAGS[flag_name]] = value
-            # else: tuning flag with no value is malformed; skip.
+            else:
+                # Recognized tuning flag but no usable value (`--timeout` with
+                # no arg, or `--timeout=`). Drop it and warn — consistent with
+                # the other drop paths — so the sim2real-bootstrap default
+                # applies visibly instead of an empty value leaking into
+                # transfer.yaml tagged as config.md-sourced (issue #602 review).
+                print(
+                    f"WARNING: dropping '{flag_name}' from the blis observe "
+                    f"block (recognized flag with no value); the "
+                    f"sim2real-bootstrap default will apply.",
+                    file=sys.stderr,
+                )
         elif flag_name in OBSERVE_PIPELINE_INJECTED_FLAGS:
             pass  # Drop entirely — the Tekton task supplies these.
         elif flag_name in OBSERVE_VALID_FLAGS:

--- a/.claude/skills/sim2real-bootstrap/generate_from_config.py
+++ b/.claude/skills/sim2real-bootstrap/generate_from_config.py
@@ -110,8 +110,9 @@ OBSERVE_TUNING_FLAGS = {
 # assemble), NOT from config.md. Listing them here keeps a config.md block that
 # spells them out (for readability) from double-injecting them into extraArgs.
 # --trace-header/--trace-data are the OUTPUT flags the task always injects and
-# stay listed. --session-mode is deliberately absent: the task does not inject
-# it (it is invalid for observe), so it is not ours to drop.
+# stay listed. --session-mode is NOT in this set (the task does not inject it):
+# it is not a blis observe flag at all, so it is dropped by the
+# OBSERVE_VALID_FLAGS allowlist guardrail below rather than here (issue #602).
 OBSERVE_PIPELINE_INJECTED_FLAGS = {
     "--server-url",
     "--model",
@@ -124,6 +125,44 @@ OBSERVE_PIPELINE_INJECTED_FLAGS = {
     "--corpus-data",
     "--concurrent-sessions",
     "--total-sessions",
+}
+
+# The complete set of flags `blis observe` accepts, derived from
+# inference-sim cmd/observe_cmd.go @ 583f7195 (PR #1499, corpus-mode). This is
+# the allowlist: a flag in config.md's observe block is written to transfer.yaml
+# only if it appears here (as a first-class OBSERVE_TUNING_FLAGS key, or — for
+# anything without a dedicated key — verbatim in extraArgs). Anything NOT here
+# is dropped, never transcribed (issue #602). Update in lockstep with
+# observe_cmd.go when observe's flags change.
+OBSERVE_VALID_FLAGS = {
+    "--api-format", "--api-key", "--concurrency", "--concurrent-sessions",
+    "--corpus-data", "--corpus-header", "--defaults-filepath", "--itl-output",
+    "--lazy-generation", "--max-concurrency", "--model", "--no-streaming",
+    "--num-requests", "--output-tokens", "--output-tokens-max",
+    "--output-tokens-min", "--output-tokens-stdev", "--post-hoc-detector",
+    "--prefix-tokens", "--prewarm-duration", "--prompt-tokens",
+    "--prompt-tokens-max", "--prompt-tokens-min", "--prompt-tokens-stdev",
+    "--rate", "--record-itl", "--rtt-ms", "--saturation-report",
+    "--saturation-threshold-ms", "--server-type", "--server-url",
+    "--session-id-header", "--slo-e2e", "--slo-itl", "--slo-ttft",
+    "--think-time-dist", "--think-time-ms", "--timeout", "--total-sessions",
+    "--trace-data", "--trace-header", "--unconstrained-output",
+    "--warmup-requests", "--workload", "--workload-spec",
+}
+
+# Flags that belong to `blis replay` (the simulator's load generator) or to
+# `blis run`'s model-of-the-world, and have NO `blis observe` equivalent. An
+# operator hand-authoring config.md by transcribing the sim's `blis replay`
+# invocation will list these; they must be dropped, never transcribed into the
+# observe command (issue #602). --session-mode is the canonical case: observe
+# infers closed-loop from the session pool, so the flag does not exist and
+# `blis observe` aborts with "unknown flag: --session-mode" if it leaks. This
+# set exists only to emit a precise warning — any flag absent from
+# OBSERVE_VALID_FLAGS is dropped regardless of whether it is listed here.
+OBSERVE_REPLAY_ONLY_FLAGS = {
+    "--session-mode", "--results-path", "--trace-output",  # blis replay load/output
+    "--num-instances", "--routing-policy",                 # sim routing
+    "--total-kv-blocks", "--hardware", "--tp",             # sim hardware/model
 }
 
 # Match pipeline/pipeline.yaml:36-50. Update in lockstep if those defaults
@@ -714,14 +753,32 @@ def parse_observe_block(config_md_text: str) -> dict[str, str]:
         elif tok in OBSERVE_PIPELINE_INJECTED_FLAGS:
             # Drop entirely — the Tekton task supplies these.
             i += 2 if has_value else 1
-        else:
-            # Unknown → extraArgs.
+        elif tok in OBSERVE_VALID_FLAGS:
+            # A real blis observe flag with no first-class key — pass it
+            # through verbatim so the operator can tune it in transfer.yaml.
             if has_value:
                 extra_pieces.extend([tok, value])
                 i += 2
             else:
                 extra_pieces.append(tok)
                 i += 1
+        else:
+            # Not a blis observe flag. Refuse to transcribe it into extraArgs
+            # (it would abort observe at runtime, e.g. the transcribed
+            # `blis replay` flag "unknown flag: --session-mode"). Warn and drop
+            # so a valid invocation still emits; the operator can add it back
+            # in transfer.yaml if it is legitimate (issue #602).
+            reason = (
+                "replay/sim flag with no blis observe equivalent"
+                if tok in OBSERVE_REPLAY_ONLY_FLAGS
+                else "not a blis observe flag"
+            )
+            print(
+                f"WARNING: dropping '{tok}' from the blis observe block "
+                f"({reason}); add it to transfer.yaml if intended.",
+                file=sys.stderr,
+            )
+            i += 2 if has_value else 1
 
     if extra_pieces:
         parsed["extraArgs"] = " ".join(extra_pieces)

--- a/.claude/skills/sim2real-bootstrap/tests/test_generate_from_config_observe.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_generate_from_config_observe.py
@@ -1,11 +1,13 @@
 """Tests for parse_observe_block + render_blis_observe_yaml.
 
-Covers acceptance criteria from issue #403:
+Covers acceptance criteria from issues #403 and #602:
   - Full `blis observe \\ ... \\` block → all 4 tuning keys extracted
   - Partial block → only present keys extracted
   - No block in text → empty dict
   - Pipeline-injected flags dropped, not folded into extraArgs
-  - Unknown flags collected into extraArgs (space-joined)
+  - Valid-but-unmodeled observe flags pass through to extraArgs (#602)
+  - Non-observe flags (replay-only, sim-world, unknown) dropped + warned, never
+    transcribed into extraArgs (#602)
   - Rendered YAML has correct provenance for extracted vs defaulted keys
   - Rendered YAML round-trips through PyYAML with expected typing
   - Rendered YAML matches the 5-key schema validated by manifest.py
@@ -119,7 +121,9 @@ blis observe \\
     assert "extraArgs" not in parsed
 
 
-def test_unknown_flags_collected_into_extra_args():
+def test_non_observe_flags_are_dropped_not_extraargs():
+    """Flags that are not in blis observe's namespace are refused, not folded
+    into extraArgs (which would abort observe at runtime). Issue #602."""
     text = """\
 ```bash
 blis observe \\
@@ -129,11 +133,11 @@ blis observe \\
 ```
 """
     parsed = gfc.parse_observe_block(text)
-    assert parsed["maxConcurrency"] == "100"
-    assert parsed["extraArgs"] == "--new-flag foo --another-flag bar"
+    assert parsed == {"maxConcurrency": "100"}
+    assert "extraArgs" not in parsed
 
 
-def test_bare_unknown_flag_collected_into_extra_args():
+def test_bare_non_observe_flag_is_dropped_not_extraargs():
     text = """\
 ```bash
 blis observe \\
@@ -142,8 +146,84 @@ blis observe \\
 ```
 """
     parsed = gfc.parse_observe_block(text)
+    assert parsed == {"timeout": "60"}
+    assert "extraArgs" not in parsed
+
+
+def test_session_mode_is_dropped_not_extraargs():
+    """The documented failure (#602): a transcribed `blis replay` closed-loop
+    invocation carries --session-mode (+ pool flags). --session-mode has no
+    observe equivalent and must be dropped, not transcribed — otherwise observe
+    aborts with `unknown flag: --session-mode`."""
+    text = """\
+```bash
+blis observe \\
+  --session-mode closed-loop \\
+  --concurrent-sessions 128 \\
+  --total-sessions 192 \\
+  --max-concurrency 10000
+```
+"""
+    parsed = gfc.parse_observe_block(text)
+    # --session-mode dropped (replay-only); pool flags dropped (task-injected);
+    # only the modeled tuning flag survives.
+    assert parsed == {"maxConcurrency": "10000"}
+    assert "extraArgs" not in parsed
+
+
+def test_sim_world_flags_are_dropped_not_extraargs():
+    """Simulator model-of-the-world flags (routing/hardware/instances) are
+    realized by the real deployment + EPP; they must never reach observe."""
+    text = """\
+```bash
+blis observe \\
+  --num-instances 4 \\
+  --routing-policy least-loaded \\
+  --total-kv-blocks 8192 \\
+  --hardware H100 \\
+  --tp 2 \\
+  --timeout 60
+```
+"""
+    parsed = gfc.parse_observe_block(text)
+    assert parsed == {"timeout": "60"}
+    assert "extraArgs" not in parsed
+
+
+def test_valid_but_unmodeled_observe_flags_pass_through_to_extraargs():
+    """Real blis observe flags without a first-class key survive into extraArgs
+    so the operator can tune them in transfer.yaml. Issue #602 choice (a)."""
+    text = """\
+```bash
+blis observe \\
+  --rate 50 \\
+  --num-requests 1000 \\
+  --no-streaming \\
+  --timeout 60
+```
+"""
+    parsed = gfc.parse_observe_block(text)
     assert parsed["timeout"] == "60"
-    assert parsed["extraArgs"] == "--verbose"
+    assert parsed["extraArgs"] == "--rate 50 --num-requests 1000 --no-streaming"
+
+
+def test_dropped_flag_emits_warning_to_stderr(capsys):
+    """Refusing a flag is surfaced, not silent, so the operator can re-add a
+    legitimate flag in transfer.yaml. Issue #602."""
+    text = """\
+```bash
+blis observe \\
+  --session-mode closed-loop \\
+  --frobnicate x \\
+  --timeout 60
+```
+"""
+    gfc.parse_observe_block(text)
+    err = capsys.readouterr().err
+    assert "--session-mode" in err
+    assert "replay/sim flag with no blis observe equivalent" in err
+    assert "--frobnicate" in err
+    assert "not a blis observe flag" in err
 
 
 def test_block_without_backslash_continuation_still_parses():
@@ -211,10 +291,10 @@ def test_render_output_parses_as_yaml_with_expected_types():
 
 
 def test_render_extra_args_from_config_stays_a_string():
-    parsed = {"extraArgs": "--verbose --dry-run"}
+    parsed = {"extraArgs": "--rate 50 --no-streaming"}
     out = gfc.render_blis_observe_yaml(parsed)
     loaded = yaml.safe_load(out)
-    assert loaded["blis_observe"]["extraArgs"] == "--verbose --dry-run"
+    assert loaded["blis_observe"]["extraArgs"] == "--rate 50 --no-streaming"
 
 
 def test_render_key_order_is_canonical():

--- a/.claude/skills/sim2real-bootstrap/tests/test_generate_from_config_observe.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_generate_from_config_observe.py
@@ -207,6 +207,44 @@ blis observe \\
     assert parsed["extraArgs"] == "--rate 50 --num-requests 1000 --no-streaming"
 
 
+def test_seed_and_saturation_flags_pass_through_to_extraargs():
+    """Regression for the review of #602: --seed (Int64Var, missed by the first
+    allowlist regex) and the --saturation-* backlog-drift flags (registered on
+    observeCmd via registerSaturationFlags, not inline) are real observe flags
+    and must survive into extraArgs, not be dropped."""
+    text = """\
+```bash
+blis observe \\
+  --seed 42 \\
+  --saturation-window 5s \\
+  --saturation-classifier composite \\
+  --timeout 60
+```
+"""
+    parsed = gfc.parse_observe_block(text)
+    assert parsed["timeout"] == "60"
+    assert parsed["extraArgs"] == (
+        "--seed 42 --saturation-window 5s --saturation-classifier composite"
+    )
+
+
+def test_equals_form_flags_are_handled():
+    """--flag=value must classify on the flag name: a modeled tuning flag maps
+    to its key, a valid-but-unmodeled flag passes through verbatim, and a
+    non-observe flag is still dropped."""
+    text = """\
+```bash
+blis observe \\
+  --timeout=900 \\
+  --rate=50 \\
+  --session-mode=closed-loop
+```
+"""
+    parsed = gfc.parse_observe_block(text)
+    assert parsed["timeout"] == "900"
+    assert parsed["extraArgs"] == "--rate=50"
+
+
 def test_dropped_flag_emits_warning_to_stderr(capsys):
     """Refusing a flag is surfaced, not silent, so the operator can re-add a
     legitimate flag in transfer.yaml. Issue #602."""

--- a/.claude/skills/sim2real-bootstrap/tests/test_generate_from_config_observe.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_generate_from_config_observe.py
@@ -245,6 +245,30 @@ blis observe \\
     assert parsed["extraArgs"] == "--rate=50"
 
 
+def test_tuning_flag_with_no_value_is_dropped_and_warned(capsys):
+    """A recognized tuning flag with no usable value (`--timeout` with no arg,
+    or the `=`-form `--timeout=`) is malformed: drop it and warn so the
+    bootstrap default applies, rather than leak an empty value into
+    transfer.yaml tagged as config.md-sourced. Issue #602 review."""
+    text = """\
+```bash
+blis observe \\
+  --timeout= \\
+  --max-concurrency \\
+  --rate 50
+```
+"""
+    parsed = gfc.parse_observe_block(text)
+    # Neither malformed tuning flag lands a key; only the valid unmodeled flag.
+    assert "timeout" not in parsed
+    assert "maxConcurrency" not in parsed
+    assert parsed["extraArgs"] == "--rate 50"
+    err = capsys.readouterr().err
+    assert "--timeout" in err
+    assert "--max-concurrency" in err
+    assert "recognized flag with no value" in err
+
+
 def test_dropped_flag_emits_warning_to_stderr(capsys):
     """Refusing a flag is surfaced, not silent, so the operator can re-add a
     legitimate flag in transfer.yaml. Issue #602."""


### PR DESCRIPTION
Closes #602.

## Problem

`sim2real-bootstrap` parses the `blis observe` block in `config.md` and routed
any flag it didn't recognize straight into `blis_observe.extraArgs`. Because the
operator hand-authors `config.md` — often by transcribing the simulation's
`blis replay` invocation — replay-only flags fell through into `extraArgs` and
`blis observe` aborted at runtime:

```
blis_observe.extraArgs: "--session-mode closed-loop --concurrent-sessions 128 --total-sessions 192"
→ blis observe: unknown flag: --session-mode
```

## Fix

Treat the observe block as a statement of **observe intent** and validate each
flag against `blis observe`'s real flag namespace. Classification (order):

| Flag category | Action |
|---|---|
| Modeled tuning (`--max-concurrency`, `--timeout`, `--warmup-requests`, `--prewarm-duration`) | first-class key |
| Task-injected (`--server-url`, `--corpus-*`, `--concurrent-sessions`, `--total-sessions`, …) | drop (task supplies) |
| Valid observe flag, unmodeled (`--rate`, `--num-requests`, `--no-streaming`, …) | pass through to `extraArgs` |
| Not an observe flag (replay-only `--session-mode`, sim-world `--num-instances`/`--routing-policy`/`--hardware`/`--tp`, or unknown) | **warn on stderr + drop** |

`extraArgs` stays, but only as a **validated passthrough** of real-but-unmodeled
observe flags — never a catch-all again. Dropped flags are surfaced with a
`WARNING:` so the operator can re-add a legitimate one in `transfer.yaml`
(consistent with the config.md → transfer.yaml intent/edit split).

The allowlist (`OBSERVE_VALID_FLAGS`) is derived from `inference-sim
cmd/observe_cmd.go @ 583f7195` (PR #1499, corpus-mode) — the same commit the
submodule gitlink points at — with a lockstep comment matching the existing
`OBSERVE_DEFAULTS` convention.

## Reviewer attention

- **`OBSERVE_VALID_FLAGS` is hand-maintained** and must track `observe_cmd.go`.
  Chose a hardcoded set with a lockstep comment over querying `blis observe
  --help` at runtime (which would add a binary dependency to the skill). This
  matches how `OBSERVE_DEFAULTS` already mirrors `pipeline.yaml`.
- **Warn-and-drop, not hard-fail** — a single stray flag shouldn't block the
  whole bootstrap; the operator adjusts `transfer.yaml`. Both satisfy the "never
  place unrecognized flags into extraArgs" acceptance criterion.
- **Two prior tests flipped** (`test_unknown_flags_collected_into_extra_args`,
  `test_bare_unknown_flag_collected_into_extra_args`) — they asserted the old
  catch-all behavior, which is exactly what this PR reverses.
- **`OBSERVE_REPLAY_ONLY_FLAGS`** exists only to produce a precise warning
  message; the functional guardrail is the allowlist, so a flag not listed there
  is still dropped.

## Tests

Added: `--session-mode` dropped, sim-world flags dropped, valid-but-unmodeled
passthrough survives, warning emitted to stderr (capsys). Full suite green:
`2079 passed, 1 skipped, 2 xfailed`; `ruff check ... --select F` clean.

## Stale-reference sweep

Grepped `**/*.md`, `docs/`, `.claude/skills/`, `README*` for `extraArgs` /
unknown-flag references. Updated: `SKILL.md` step 10 (documents the new
validation/drop-with-warning behavior). Left as-is: `docs/superpowers/plans/
2026-07-08-issue-403-...md` (historical plan artifact recording #403's original
behavior, not live docs); `pipeline/README.md` / `docs/epics/` mentions of the
`extraArgs` key (still accurate — the key is unchanged).

No `pipeline/` changes; CI already covers `.claude/skills/sim2real-bootstrap/tests/`.
