### PR TITLE
ci(orchestrator-image): push from buildkit to fix flaky `unknown blob` (#661)

### DIFF
--- a/.github/workflows/orchestrator-image.yml
+++ b/.github/workflows/orchestrator-image.yml
@@ -44,7 +44,7 @@ jobs:
             type=raw,value=${{ github.sha }}
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Build
+      - name: Build (load for smoke test)
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -72,8 +72,20 @@ jobs:
           print('OK: all pipeline.lib modules imported')
           "
 
+      # Push from buildkit rather than the docker daemon. A separate
+      # `docker push` of the loaded image intermittently fails with
+      # `unknown blob`: layers restored from the type=gha cache are
+      # manifest-present but blob-absent in the daemon store (issue #661).
+      # This step is a warm cache hit from the build above, so it rebuilds
+      # nothing and streams the (guaranteed-present) blobs straight to ghcr.
       - name: Push
-        run: docker push --all-tags ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
 
       - name: Notify on failure
         if: failure() && github.event_name == 'push'


### PR DESCRIPTION
## Summary

Fixes the flaky `unknown blob` failure in the **Build Orchestrator Image** workflow (issue #661, run [30535337655](https://github.com/inference-sim/sim2real/actions/runs/30535337655)).

## Root cause

The job built the image with `docker/build-push-action@v6` using `push: false` + `load: true` + `cache-from: type=gha`, smoke-tested the loaded image, then pushed it with a **separate** `docker push --all-tags`.

When layers are restored from the `type=gha` cache, buildx loads the image *manifest* into the docker daemon, but the actual layer **blob content** for cache-hit layers isn't always materialized in the daemon's content store. The subsequent classic-client `docker push` then tries to upload a layer whose bytes aren't present locally, and the registry rejects it as `unknown blob`. It's cache-state dependent, hence intermittent — the failing run's freshly-built layers pushed fine, then a cache-sourced layer failed. (The next push, run 30542718590, succeeded with the identical image, which is why main went green again on its own.)

## Fix

Replace the separate `docker push` with a second `docker/build-push-action@v6` step (`push: true`). Because the first step wrote `cache-to: type=gha,mode=max`, this step is a warm cache hit — it rebuilds nothing and streams the blobs **straight from buildkit's store**, where every referenced blob is guaranteed present. That eliminates the daemon missing-blob path entirely.

- Build → smoke test → push **order is unchanged**, so the smoke test still gates the push.
- No `cache-to` on the push step (cache is already written by the build step).
- Applies the OCI `labels` from `docker/metadata-action` to the pushed manifest as a minor bonus (the old `docker push --all-tags` did not).
- Renamed the first step to `Build (load for smoke test)` for clarity.

Workflow-only change — Dockerfile and `pipeline/` are untouched, so no `pipeline/` tests are affected.

## Verification

- YAML parses (`yaml.safe_load`).
- Stale-ref sweep: no docs/skills/README referenced `docker push --all-tags`; the only remaining mention is the new explanatory comment.
- Full verification is the workflow running on merge to `main` (it triggers on `.github/workflows/orchestrator-image.yml` changes), which exercises the new push path end-to-end.

Fixes #661
