### PR TITLE
docs(claude-md): make Project Overview target-agnostic (closes #807)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,8 +2,10 @@
 
 ## Project Overview
 
-sim2real is a pipeline for transferring simulation-discovered routing algorithms from
-inference-sim to production llm-d-inference-scheduler scorer plugins.
+sim2real is a pipeline for taking simulation-discovered algorithms from inference-sim into
+production serving systems. The aim is a general, reproducible process for promoting an algorithm
+found in simulation to a real deployment — it is not tied to any single production target. It is
+currently developed and validated against llm-d-router (as scorer/EPP plugins), the reference target.
 
 ## Repository Structure
 


### PR DESCRIPTION
## What

Rewords the `## Project Overview` in `CLAUDE.md` so sim2real is framed as a general, reproducible process for taking simulation-discovered algorithms to production — with `llm-d-router` as the current reference/tested target, not the definition.

Closes #807.

## Why

The Overview still said "transferring simulation-discovered routing algorithms ... to production **llm-d-inference-scheduler** scorer plugins" — both a stale target name (superseded by `llm-d-router`) and over-narrow framing. This is the same fix already merged for `CONTRIBUTING.md` (#729) and `ROADMAP.md` (#728); this brings CLAUDE.md into line.

## Scope

Only the Overview paragraph (lines 5–6). Line 20 (`e.g. admission-control/llm-d-inference-scheduler/`) names an on-disk directory in experiment repos and is left untouched pending verification of the actual directory name — noted in #807. Line 22 already handles the GAIE→llm-d-router merger correctly.