### PR TITLE
fix(security): redact credentials inlined as plain config fields (#819)

### DIFF
--- a/pipeline/lib/redact.py
+++ b/pipeline/lib/redact.py
@@ -1,15 +1,29 @@
 """YAML redaction for collected plan files.
 
-Stubs out sensitive field values in Kubernetes objects whose `kind`
-matches a denylist, so collected plan YAMLs do not carry credentials
-into developer laptops or shared run dirs.
+Stubs out sensitive field values so collected plan YAMLs do not carry
+credentials into developer laptops or shared run dirs. Two independent
+mechanisms run over every file (defense in depth):
+
+  1. **Kind-based** — for Kubernetes objects whose `kind` matches a
+     denylist (default: ``Secret``), every value under `data` /
+     `stringData` is replaced with ``REDACTED``.
+  2. **Key-name-based** — for *any* document regardless of `kind`, a
+     recursive walk replaces values whose key names a credential
+     (``token``, ``password``, ``apiKey`` … — see ``SENSITIVE_KEYS``).
+     This catches credentials inlined as ordinary config fields, e.g.
+     an llm-d-benchmark harness plan's ``huggingface.token`` (issue
+     #819), which is neither a ``Secret`` nor under `data`/`stringData`.
 
 Behavior:
-  - `data` and `stringData` values in matching docs are replaced with
-    the literal string ``REDACTED``. Key names are preserved.
-  - Multi-doc YAML files are processed per-document; non-matching docs
-    pass through unchanged.
-  - Files without any matching docs are not rewritten.
+  - Matching values are replaced with the literal string ``REDACTED``.
+    Key names are always preserved.
+  - Reference/name fields that merely point at a secret (``secretName``,
+    ``tokenKey``, ``contextSecretName``) are NOT credentials and are left
+    intact — key matching is exact (case-insensitive), not substring.
+  - Multi-doc YAML files are processed per-document. A document is
+    counted once if either mechanism changed it; documents with no
+    `kind` are labelled ``document`` in the summary header.
+  - Files with no changes are not rewritten.
   - Unreadable / unparseable files are left untouched (warning logged).
   - Writes go through a sibling tmp file + atomic ``os.replace`` so a
     process crash mid-write cannot leave a half-redacted file on disk.
@@ -27,6 +41,51 @@ from pipeline.lib.log import warn
 REDACTED = "REDACTED"
 
 DEFAULT_REDACT_KINDS: frozenset[str] = frozenset({"Secret"})
+
+# Key names (matched case-insensitively, exact — not substring) whose
+# values are credentials and must be stubbed wherever they appear, in any
+# document. Stored lowercased; compared against ``key.lower()``.
+#
+# Deliberately excluded — these reference or name a secret but are not
+# themselves secret: ``secretName``, ``tokenKey``, ``contextSecretName``.
+SENSITIVE_KEYS: frozenset[str] = frozenset({
+    "token",
+    "tokenbase64",
+    "password",
+    "apikey",
+    "api_key",
+    "accesskey",
+    "secretaccesskey",
+    "authorization",
+    "bearertoken",
+})
+
+
+def _stub_sensitive_keys(node: object) -> bool:
+    """Recursively stub values under sensitive keys, in-place.
+
+    Walks nested dicts and lists. A value is replaced with ``REDACTED``
+    when its key is in ``SENSITIVE_KEYS`` (case-insensitive exact match);
+    the sensitive value is stubbed wholesale and not descended into.
+    Recursion continues through every other container value.
+
+    Already-redacted values are left as-is (so a re-run over a scrubbed
+    file reports no change). Returns True if any value was changed.
+    """
+    changed = False
+    if isinstance(node, dict):
+        for key, value in list(node.items()):
+            if isinstance(key, str) and key.lower() in SENSITIVE_KEYS:
+                if value != REDACTED:
+                    node[key] = REDACTED
+                    changed = True
+            elif _stub_sensitive_keys(value):
+                changed = True
+    elif isinstance(node, list):
+        for item in node:
+            if _stub_sensitive_keys(item):
+                changed = True
+    return changed
 
 
 def _stub_data_fields(doc: dict) -> bool:
@@ -82,8 +141,12 @@ def redact_yaml_file(path: Path, kinds: Iterable[str] | None = None) -> int:
         if not isinstance(doc, dict):
             continue
         kind = doc.get("kind")
-        if kind in redact_set and _stub_data_fields(doc):
-            counts[kind] += 1
+        changed = kind in redact_set and _stub_data_fields(doc)
+        # Key-name scrub runs on every document, regardless of kind.
+        changed = _stub_sensitive_keys(doc) or changed
+        if changed:
+            label = kind if isinstance(kind, str) else "document"
+            counts[label] += 1
 
     total = sum(counts.values())
     if total == 0:

--- a/pipeline/lib/redact.py
+++ b/pipeline/lib/redact.py
@@ -42,18 +42,22 @@ REDACTED = "REDACTED"
 
 DEFAULT_REDACT_KINDS: frozenset[str] = frozenset({"Secret"})
 
-# Key names (matched case-insensitively, exact — not substring) whose
-# values are credentials and must be stubbed wherever they appear, in any
-# document. Stored lowercased; compared against ``key.lower()``.
+# Key names whose values are credentials and must be stubbed wherever they
+# appear, in any document. Matching is exact against a normalized form of
+# the key: lowercased with ``_`` / ``-`` separators stripped (see
+# ``_normalize_key``), so ``accessKey``, ``access_key``, ``access-key`` and
+# ``ACCESSKEY`` all match the single entry ``accesskey``. Entries here are
+# therefore stored in that same separator-free lowercase form.
 #
-# Deliberately excluded — these reference or name a secret but are not
-# themselves secret: ``secretName``, ``tokenKey``, ``contextSecretName``.
+# Deliberately NOT matched — these reference or name a secret but are not
+# themselves secret; none normalizes to an entry below: ``secretName``
+# (→ ``secretname``), ``tokenKey`` (→ ``tokenkey``), ``contextSecretName``
+# (→ ``contextsecretname``).
 SENSITIVE_KEYS: frozenset[str] = frozenset({
     "token",
     "tokenbase64",
     "password",
     "apikey",
-    "api_key",
     "accesskey",
     "secretaccesskey",
     "authorization",
@@ -61,13 +65,26 @@ SENSITIVE_KEYS: frozenset[str] = frozenset({
 })
 
 
+def _normalize_key(key: str) -> str:
+    """Lowercase and strip ``_`` / ``-`` so separator style doesn't matter.
+
+    ``accessKey``, ``access_key``, ``access-key`` and ``ACCESSKEY`` all
+    normalize to ``accesskey``. This keeps the denylist a single entry per
+    key while catching every common YAML spelling — without it, camelCase
+    and snake_case forms of the same field would need separate entries and
+    a missing one would silently bypass redaction (the class of bug in #819).
+    """
+    return key.lower().replace("_", "").replace("-", "")
+
+
 def _stub_sensitive_keys(node: object) -> bool:
     """Recursively stub values under sensitive keys, in-place.
 
     Walks nested dicts and lists. A value is replaced with ``REDACTED``
-    when its key is in ``SENSITIVE_KEYS`` (case-insensitive exact match);
-    the sensitive value is stubbed wholesale and not descended into.
-    Recursion continues through every other container value.
+    when its key matches ``SENSITIVE_KEYS`` after normalization (see
+    ``_normalize_key`` — case- and separator-insensitive exact match); the
+    sensitive value is stubbed wholesale and not descended into. Recursion
+    continues through every other container value.
 
     Already-redacted values are left as-is (so a re-run over a scrubbed
     file reports no change). Returns True if any value was changed.
@@ -75,7 +92,7 @@ def _stub_sensitive_keys(node: object) -> bool:
     changed = False
     if isinstance(node, dict):
         for key, value in list(node.items()):
-            if isinstance(key, str) and key.lower() in SENSITIVE_KEYS:
+            if isinstance(key, str) and _normalize_key(key) in SENSITIVE_KEYS:
                 if value != REDACTED:
                     node[key] = REDACTED
                     changed = True
@@ -116,11 +133,16 @@ def _format_header(counts: Counter) -> str:
 
 
 def redact_yaml_file(path: Path, kinds: Iterable[str] | None = None) -> int:
-    """Redact data/stringData values for kind-matching docs in `path`.
+    """Redact credentials in `path`, in place.
 
-    Returns the count of docs that were redacted. Returns 0 (without
-    rewriting the file) for: files with no matching docs, files that
-    aren't valid YAML, or files that can't be read.
+    Two mechanisms run per document (see the module docstring): the
+    kind-based `data`/`stringData` scrub for docs whose `kind` is in
+    `kinds`, and the key-name scrub (`_stub_sensitive_keys`) on every doc
+    regardless of `kind`.
+
+    Returns the count of docs changed by either mechanism. Returns 0
+    (without rewriting the file) for: files with nothing to redact, files
+    that aren't valid YAML, or files that can't be read.
     """
     redact_set = frozenset(kinds) if kinds is not None else DEFAULT_REDACT_KINDS
 

--- a/pipeline/tests/test_redact.py
+++ b/pipeline/tests/test_redact.py
@@ -194,12 +194,13 @@ def test_multi_kind_header_combines_counts(tmp_path: Path):
 
 
 def test_default_kind_set_is_secret_only(tmp_path: Path):
-    """ConfigMap is NOT in the default redact set; default-call leaves it alone."""
+    """ConfigMap is NOT in the default redact set; a ConfigMap carrying only
+    non-sensitive keys is not wholesale-stubbed the way a Secret would be."""
     src = (
         "apiVersion: v1\n"
         "kind: ConfigMap\n"
         "metadata: {name: cm}\n"
-        "data: {token: hf_abc}\n"
+        "data: {greeting: hello}\n"
     )
     p = tmp_path / "cm.yaml"
     p.write_text(src)
@@ -246,6 +247,123 @@ def test_tree_on_empty_or_missing_dir(tmp_path: Path):
 
     missing = tmp_path / "does-not-exist"
     assert redact_yaml_tree(missing) == 0
+
+
+# ── Sensitive-key scrub in non-Secret documents (issue #819) ─────────
+
+
+def test_redacts_sensitive_keys_in_plain_config(tmp_path: Path):
+    """A non-Secret harness config with an inlined HF token is scrubbed.
+
+    This is the issue #819 case: an llm-d-benchmark plan config.yaml whose
+    top-level document has no `kind:` and carries the credential as an
+    ordinary field (`huggingface.token` / `huggingface.tokenBase64`).
+    """
+    # Fixture values are deliberately fake and do not match any real
+    # credential pattern — the test only asserts they become REDACTED.
+    src = (
+        "huggingface:\n"
+        "  enabled: true\n"
+        "  secretName: hf-secret\n"
+        "  token: fake-example-token-not-real\n"
+        "  tokenBase64: ZmFrZS1leGFtcGxlLXRva2Vu\n"
+        "  tokenKey: HF_TOKEN\n"
+        "contextSecretName: llmdbench-context\n"
+    )
+    p = tmp_path / "config.yaml"
+    p.write_text(src)
+    assert redact_yaml_file(p) == 1
+    out = p.read_text()
+    assert out.startswith("# REDACTED by sim2real collect: 1 document stubbed\n")
+    d = list(yaml.safe_load_all(out))[0]
+    hf = d["huggingface"]
+    # Credentials scrubbed …
+    assert hf["token"] == REDACTED
+    assert hf["tokenBase64"] == REDACTED
+    # … reference / name fields preserved.
+    assert hf["enabled"] is True
+    assert hf["secretName"] == "hf-secret"
+    assert hf["tokenKey"] == "HF_TOKEN"
+    assert d["contextSecretName"] == "llmdbench-context"
+
+
+def test_sensitive_key_scrub_recurses_into_lists(tmp_path: Path):
+    """Sensitive keys nested inside list items (e.g. extraObjects) are found."""
+    src = (
+        "extraObjects:\n"
+        "- apiVersion: v1\n"
+        "  kind: Custom\n"
+        "  spec:\n"
+        "    password: hunter2\n"
+        "- name: keep-me\n"
+    )
+    p = tmp_path / "plan.yaml"
+    p.write_text(src)
+    assert redact_yaml_file(p) == 1
+    d = list(yaml.safe_load_all(p.read_text()))[0]
+    assert d["extraObjects"][0]["spec"]["password"] == REDACTED
+    assert d["extraObjects"][1]["name"] == "keep-me"
+
+
+def test_sensitive_key_scrub_case_insensitive_and_variants(tmp_path: Path):
+    """Case variants and the underscore form of key names are all caught."""
+    src = (
+        "auth:\n"
+        "  Token: abc\n"
+        "  API_KEY: def\n"
+        "  apiKey: ghi\n"
+        "  bearerToken: jkl\n"
+        "  authorization: Bearer xyz\n"
+    )
+    p = tmp_path / "auth.yaml"
+    p.write_text(src)
+    assert redact_yaml_file(p) == 1
+    auth = list(yaml.safe_load_all(p.read_text()))[0]["auth"]
+    assert all(v == REDACTED for v in auth.values())
+
+
+def test_sensitive_key_in_non_secret_kind_is_redacted(tmp_path: Path):
+    """A `token` key in a ConfigMap (not in the kind denylist) is scrubbed."""
+    src = (
+        "apiVersion: v1\n"
+        "kind: ConfigMap\n"
+        "metadata: {name: cm}\n"
+        "data: {token: hf_abc, greeting: hello}\n"
+    )
+    p = tmp_path / "cm.yaml"
+    p.write_text(src)
+    assert redact_yaml_file(p) == 1
+    d = list(yaml.safe_load_all(p.read_text()))[0]
+    assert d["data"]["token"] == REDACTED
+    assert d["data"]["greeting"] == "hello"
+
+
+def test_sensitive_key_scrub_idempotent(tmp_path: Path):
+    """Re-running over an already-scrubbed plain config is a no-op."""
+    src = (
+        "huggingface:\n"
+        "  token: hf_secret\n"
+        "  tokenBase64: YWJj\n"
+    )
+    p = tmp_path / "config.yaml"
+    p.write_text(src)
+    assert redact_yaml_file(p) == 1
+    after_first = p.read_text()
+    assert redact_yaml_file(p) == 0
+    assert p.read_text() == after_first
+
+
+def test_reference_keys_never_redacted(tmp_path: Path):
+    """Keys that name/reference secrets are not themselves secrets."""
+    src = (
+        "secretName: hf-secret\n"
+        "contextSecretName: llmdbench-context\n"
+        "tokenKey: HF_TOKEN\n"
+    )
+    p = tmp_path / "refs.yaml"
+    p.write_text(src)
+    assert redact_yaml_file(p) == 0
+    assert p.read_text() == src
 
 
 # ── Additional edge-case coverage (quality agent) ────────────────────

--- a/pipeline/tests/test_redact.py
+++ b/pipeline/tests/test_redact.py
@@ -306,14 +306,26 @@ def test_sensitive_key_scrub_recurses_into_lists(tmp_path: Path):
 
 
 def test_sensitive_key_scrub_case_insensitive_and_variants(tmp_path: Path):
-    """Case variants and the underscore form of key names are all caught."""
+    """Every case/separator spelling of a sensitive key is caught.
+
+    Covers camelCase, snake_case, SCREAMING_CASE and no-separator forms —
+    including the AWS-style access-key names and the base64/bearer keys
+    whose snake_case spellings would bypass an exact-lowercase match.
+    """
     src = (
         "auth:\n"
-        "  Token: abc\n"
-        "  API_KEY: def\n"
-        "  apiKey: ghi\n"
-        "  bearerToken: jkl\n"
+        "  Token: a\n"
+        "  API_KEY: b\n"
+        "  apiKey: c\n"
+        "  bearerToken: d\n"
+        "  bearer_token: e\n"
         "  authorization: Bearer xyz\n"
+        "  accessKey: f\n"
+        "  access_key: g\n"
+        "  secretAccessKey: h\n"
+        "  secret_access_key: i\n"
+        "  tokenBase64: j\n"
+        "  token_base64: k\n"
     )
     p = tmp_path / "auth.yaml"
     p.write_text(src)


### PR DESCRIPTION
Closes #819

## Problem

`deploy.py collect` redacts collected plan YAMLs via `pipeline/lib/redact.py`, but the redactor only scrubbed Kubernetes `Secret` objects and only their `data`/`stringData` values. An llm-d-benchmark harness plan `config.yaml` inlines the HF token as an ordinary field:

```yaml
huggingface:
  token: hf_…          # leaked
  tokenBase64: …       # leaked
```

That document has no `kind:`, so it slipped through unredacted on two independent counts (wrong kind-gate, wrong field-gate).

## Change

- Add `_stub_sensitive_keys` — a recursive walk (dicts **and lists**) that stubs values whose key is in a new `SENSITIVE_KEYS` denylist (`token`, `tokenBase64`, `password`, `apiKey`/`api_key`, `accessKey`, `secretAccessKey`, `authorization`, `bearerToken`).
- Runs on **every** document regardless of `kind`; the existing Secret/`data` scrub is kept as defense in depth. A doc is counted once if either mechanism changed it; kind-less docs are labelled `document` in the summary header.
- Matching is **case-insensitive exact** on the key name, so reference/name fields in the same file (`secretName`, `tokenKey`, `contextSecretName`) are deliberately preserved.
- Both collect call sites (`deploy.py:1304` tree pass, `:1496` per-plan-file) funnel through `redact_yaml_file`, so both are covered by this one change.

## Reviewer attention

- **Contract change:** `test_default_kind_set_is_secret_only` was updated — a `token` key in a ConfigMap is now (correctly) scrubbed by the key-path, which conflicts with the old test's expectation. The test was rewritten to use a non-sensitive key and keep its original intent (ConfigMap not wholesale-stubbed).
- The recursive scrub is idempotent (skips values already `== REDACTED`), preserving the no-rewrite-if-unchanged behavior on re-collect.

## Tests

Added coverage for: the `huggingface.token`/`tokenBase64` config case, list recursion (extraObjects-style), case/underscore key variants, a sensitive key in a non-Secret kind, idempotency, and reference-key preservation. Full suite: `1977 passed, 2 xfailed`; `ruff --select F` clean.

## Docs sweep

Grepped `**/*.md`, `README*`, `.claude/skills/` for `redact` — the only hits (`pipeline/README.md`, `CLAUDE.md` module tables) describe redact.py as "stubs sensitive fields before writing to results/", which remains accurate. No doc updates needed.

## Out of scope (flagged, not fixed here)

The originally-leaked token is live. This change protects **future** collects only — already-collected files still carry the credential, so the token must be rotated and existing trees re-scrubbed.
