### PR TITLE
Add /sim2real-specify: generate bundle inputs with a gated algorithm specification (closes #821)

### DIFF
--- a/.claude/skills/sim2real-specify/SKILL.md
+++ b/.claude/skills/sim2real-specify/SKILL.md
@@ -156,7 +156,9 @@ results will not be attributable.
 
 ## Phase 5 — Specify
 
-Write `algorithms/<arm>.go` per arm, plus `config.md`.
+Write `algorithms/<arm>.go` per arm, plus `README.md` and `config.md`. All three
+have stated contracts below; `config.md`'s is the one most easily lost, because
+its first part is consumed by a machine rather than a reader.
 
 The specification layer:
 
@@ -216,6 +218,57 @@ where the policy did NOT win, the pre-registered expectation, the pins table, an
 the layout. If Phase 1 found no results, write the expectation as a hypothesis with
 no margin attached and say that no measurement backs it.
 
+### What `config.md` must contain
+
+`config.md` states the deployment the transfer targets and every knob the arms
+read. Five parts, in this order:
+
+1. **vLLM pod configuration** — a table headed `## vLLM Pod Configuration`. This
+   table is MACHINE-READ: `/sim2real-bootstrap` Task 3 derives
+   `baselines/baseline.yaml` from it and HALTS without it. `Model` and `GPU` are
+   mandatory. Include `max_model_len` whenever the model is absent from
+   bootstrap's `MODEL_METADATA`, because that pair is what makes the omission
+   fatal rather than merely warned.
+2. **Simulation → deployment mapping** — each simulator flag beside the vLLM
+   parameter it calibrates, so a reader can audit that the two agree.
+3. **Simulator-only knobs** — flags with no deployment equivalent.
+4. **`blis observe` invocation** — a fenced bash block. Emit it even when every
+   value equals the pipeline default, so the values are this bundle's decision
+   and not a downstream fallback.
+5. **Per-arm settings** — the flags distinguishing each arm.
+
+Add a **`## Fleet topology`** section whenever the fleet is not one homogeneous
+pool: state the layout, and state plainly if it is not expressible in the
+scenario schema the target deploys with. Give the operator the options and what
+each costs. Do not let a topology the schema cannot represent reach bootstrap
+undocumented.
+
+Parts 1 and 2 are a PROJECTION of what Phase 1 already read from the campaign
+runner into the dialect the target deploys in. You are not discovering new facts;
+you are restating known ones in the consumer's vocabulary. The simulator dialect
+alone is not enough: a bundle that records `--max-num-running-reqs 256` and stops
+has stated the fact and still fails bootstrap, because the consumer reads
+`max_num_seqs`.
+
+Do not restate bootstrap's field list here — it lives in that skill's
+`PARAMETER_ALIASES` and `VLLM_SECTION_KEYWORDS`, and the Phase 6 consumer check
+verifies agreement mechanically. Duplicating it invites drift.
+
+### Deployment values the simulation cannot supply
+
+Some vLLM parameters are properties of the target cluster, not of the simulation.
+`gpu_memory_utilization` is the common case; `max_model_len` and
+`enable_prefix_caching` are often fixed by no campaign flag.
+
+Do NOT infer them, and do NOT omit the row. Ask the operator. If the operator
+does not know, write the row's value as `**CONFIRM**` and say in the notes column
+what depends on it.
+
+An omitted row becomes a silent downstream default. `CONFIRM` fails loudly.
+Prefer the loud failure. `enable_prefix_caching` earns particular care: bootstrap
+interprets silence as ON rather than flagging it, so a bundle that needs it OFF
+and stays silent gets the opposite of what it meant.
+
 ## Phase 6 — Gate
 
 ### Placeholder substitution
@@ -261,6 +314,27 @@ prompt uses a name absent here, or if a name here is used by no prompt.
    Pass a `--tree` for every checkout the bundle cites, including the inference
    engine if its metrics are cited. A citation into an unpassed tree reports
    `unresolved-path`, which is the tool refusing to guess rather than a defect.
+4. **Consumer check.** The one contract `config.md` has is that
+   `/sim2real-bootstrap` can parse it. Verify with the real consumer rather than
+   by inspection, so the two skills cannot drift and the field list stays
+   single-sourced in bootstrap:
+
+   ```bash
+   python3 .claude/skills/sim2real-bootstrap/generate_from_config.py \
+     <experiment-root>/config.md -o "$(mktemp -d)"
+   python3 .claude/skills/sim2real-bootstrap/generate_from_config.py \
+     <experiment-root>/config.md --emit-observe-yaml
+   ```
+
+   The first must exit 0 — a temp `-o` makes it a dry run, so no bundle file is
+   written. The second must report `# source: config.md` on every key the bundle
+   intends to set; `# source: sim2real-bootstrap default` means part 4 of
+   `config.md` is missing or unparsed.
+
+   Read the warnings, not just the exit code. `model '<x>' not in MODEL_METADATA`
+   and `hardware '<x>' not in HARDWARE_LABELS` are both non-fatal, and both mean
+   bootstrap will need a lookup-table entry before Task 3 produces a usable
+   baseline. Say so in `config.md` where the operator will see it.
 
 ### Reconcile
 
@@ -285,12 +359,16 @@ prompt uses a name absent here, or if a name here is used by no prompt.
   states its top-level score and leaves every operand unimplemented.
 - Every lint failure: correct the citation, or add `lint-skip` on that line if the
   reference is illustrative rather than a citation.
+- Consumer-check failure: fix `config.md`, never the consumer. If the check cannot
+  be made to pass because the fleet is not expressible in the scenario schema,
+  that is a `## Fleet topology` disclosure plus an operator decision — not a
+  reason to ship a `config.md` bootstrap cannot read.
 
 ### Pass condition
 
 Zero `UNSUPPORTED` claims remain, every `BRIDGE` finding has a non-null
-`declared_at`, the lint exits 0, and every re-derivation divergence is resolved or
-declared.
+`declared_at`, the lint exits 0, the consumer check exits 0 with no unintended
+defaults, and every re-derivation divergence is resolved or declared.
 
 If `UNSUPPORTED` findings survive three fix rounds, STOP. Report what remains
 unresolved. Do not describe the bundle as audited.

--- a/.claude/skills/sim2real-specify/SKILL.md
+++ b/.claude/skills/sim2real-specify/SKILL.md
@@ -1,0 +1,254 @@
+---
+name: sim2real-specify
+description: |
+  Turn arbitrary upstream provenance (a BLIS commit, a Nous campaign, a paper
+  plus code) into the canonical sim2real bundle inputs: algorithms/<arm>.go as a
+  cited specification layer, README.md, config.md, workloads/, inputs/, and
+  sim_results/ with checksums. Establishes the five properties that make an
+  algorithm worth transferring -- causal mechanism, required structural shape,
+  observability, isolation, and named threats to validity -- then gates the
+  specification with an independent citation audit, a blind re-derivation of the
+  focal arm, and a mechanical citation lint. Run BEFORE /sim2real-bootstrap.
+argument-hint: "<experiment-root> [--focal ARM]"
+user-invocable: true
+allowed-tools:
+  - Agent
+  - SendMessage
+  - TaskCreate
+  - TaskUpdate
+  - TaskList
+  - AskUserQuestion
+  - Bash(python3 *)
+  - Bash(.venv/bin/python *)
+  - Bash(git *)
+  - Bash(test *)
+  - Bash(shasum *)
+  - Bash(cp *)
+  - Bash(mkdir *)
+  - Glob
+  - Grep
+  - Read
+  - Write
+  - Edit
+---
+
+# sim2real-specify
+
+Produce a bundle whose algorithm specification is worth transferring. This runs
+before `/sim2real-bootstrap`, which consumes `algorithms/` and `workloads/` as
+pre-existing inputs.
+
+The product is a MEANINGFUL algorithm specification. Correctness of the algebra is
+necessary but not sufficient; an algorithm that is unimplementable on the target,
+or indistinguishable from the baseline, is not worth transferring even when its
+arithmetic is perfect.
+
+## What this skill does NOT do
+
+- Does not create `transfer.yaml` or `baselines/` — `/sim2real-bootstrap`.
+- Does not wire submodules — bootstrap Task 1 derives the ref, Task 2 adds it.
+- Does not produce compiling code — `/sim2real-translate`. The specification layer
+  is non-compiling by design and its adapters stay declared unknowns.
+- Does not build images or touch cluster config.
+- Does not emit a limitations register or signal reference document. Degradations
+  are declared in the specification layer's own header.
+
+## Output contract
+
+Produce exactly these paths under `<experiment-root>`:
+
+| path | authored or copied |
+|---|---|
+| `algorithms/<arm>.go` | authored |
+| `README.md` | authored |
+| `config.md` | authored |
+| `workloads/` | copied verbatim |
+| `inputs/` | copied verbatim |
+| `sim_results/` + `CHECKSUMS.sha256` | copied verbatim |
+| `.gitignore` | generated |
+
+Do NOT create `LIMITATIONS.md`, `docs/`, or `scripts/`.
+
+**Verbatim-copy principle.** Anything that already exists upstream is copied, never
+re-expressed: workloads, coefficients, results, patches. Re-authoring is reserved
+for the specification layer, the one artifact that must change form. Re-authored
+algebra is where defects come from; copied artifacts have never been a defect
+source.
+
+## Phase 0 — Ground
+
+Obtain and verify two readable checkouts. Ask the operator for whichever is not
+already present:
+
+- the simulation source at a specific commit;
+- the target component at a specific ref.
+
+Record both pins. Every later claim is a citation against these two trees.
+
+HALT if either is unreadable at its stated pin. Say which one and stop — nothing
+downstream can be substantiated.
+
+## Phase 1 — Mechanism
+
+Establish, by interview plus source reading:
+
+- the decision rule, and where it lives in the simulation source;
+- the CAUSAL story: not that it wins, but why. Name the quantity that differs
+  between conditions and the mechanism that exploits it.
+- the cited evidence that it wins: which cells, what margin, against what
+  baseline.
+
+Copy the results artifacts verbatim into `sim_results/` and write
+`CHECKSUMS.sha256` over them with `shasum -a 256`.
+
+HALT if the results do not match their own checksums, or if the commit that
+produced them is not the pin from Phase 0. A disagreement here invalidates every
+cited margin.
+
+## Phase 2 — Shape
+
+Determine the structural form the decision takes: per-endpoint score, joint argmin
+over a cross product, admission gate, dispatch ceiling, or something else. Then
+read the target checkout and find an extension point that can express it.
+
+Compare against the target's NATURAL decomposition. Where the natural
+decomposition is weaker, quantify what would be lost, using the simulation's own
+ablation rather than an estimate.
+
+HALT if no extension point can express the required shape. The hazard is silent
+fallback to the weaker natural decomposition, which transfers a different
+algorithm while resembling success. Say so loudly instead.
+
+## Phase 3 — Observability
+
+Enumerate every quantity the decision rule reads. Classify each:
+
+| status | meaning |
+|---|---|
+| direct | an existing target or engine value with the same definition |
+| derivable | computable from existing values; record the derivation |
+| degraded | an approximation is available; record the direction of bias |
+| unobtainable | no real signal exists |
+
+Every row carries a citation to the value that supplies it. This is a
+classification pass, not a reference document — keep it to a table.
+
+If a quantity carrying the CORE mechanism is `unobtainable`, stop and put the case
+to the operator with `AskUserQuestion`. Degraded may be acceptable with reasoning,
+but that judgment is the operator's, not yours.
+
+## Phase 4 — Isolation
+
+Identify the comparator arms and ablations that isolate the mechanism, each with
+cited simulation evidence. A comparator that shares the machinery and differs only
+in the objective is worth more than a weaker baseline, because it attributes the
+effect to the mechanism rather than to the machinery.
+
+If nothing isolates the mechanism, say so: the transfer may proceed but its
+results will not be attributable.
+
+## Phase 5 — Specify
+
+Write `algorithms/<arm>.go` per arm, plus `config.md`.
+
+The specification layer:
+
+- states the policy against REAL target interface names;
+- leaves adapters as declared unknowns rather than guesses, so a wrong guess fails
+  loudly rather than mis-scoring silently;
+- carries an upstream `path:line` citation on every non-obvious expression;
+- declares each Phase 3 degradation in its header WITH the direction of bias;
+- invents no in-source marker conventions.
+
+One rule governs references to other pipeline stages:
+
+> A specification may REQUEST things of downstream stages. It may never ASSERT
+> what they do.
+
+"Confirm X against the pinned checkout" is a legitimate request. "Stage Y resolves
+X" asserts another component's behavior and is forbidden unless that component's
+source says so.
+
+`README.md` states the mechanism, the required shape, the honest status including
+where the policy did NOT win, the pre-registered expectation, the pins table, and
+the layout. If Phase 1 found no results, write the expectation as a hypothesis with
+no margin attached and say that no measurement backs it.
+
+## Phase 6 — Gate
+
+### Placeholder substitution
+
+Read `prompts/audit.md` and `prompts/rederive.md` and substitute each braced name
+below. This list is the contract: `tests/test_skill_substitution.py` fails if a
+prompt uses a name absent here, or if a name here is used by no prompt.
+
+- `{BUNDLE_ROOT}` → the absolute experiment root
+- `{ARM_FILE}` → absolute path to the arm under audit
+- `{ARM_NAME}` → the arm's name, matching its filename stem
+- `{SIM_TREE}` → absolute path to the simulation checkout
+- `{SIM_PIN}` → the simulation commit recorded in Phase 0
+- `{TARGET_TREE}` → absolute path to the target checkout
+- `{TARGET_PIN}` → the target ref recorded in Phase 0
+- `{VERDICT_PATH}` → `/tmp/specify-verdict-<arm>.json`
+- `{POLICY_ENTRY_POINTS}` → newline-separated `path:symbol` entry points from Phase 1
+- `{DERIVATION_PATH}` → `/tmp/specify-derivation-<arm>.json`
+- `{MAIN_SESSION_NAME}` → `"main"`
+
+### Run the three components
+
+1. **Citation audit, every arm.** Spawn one agent per arm in a single tool-call
+   message: `Agent(name="audit-<arm>", run_in_background=true,
+   subagent_type=general-purpose, model="opus", prompt=<substituted audit.md>)`.
+2. **Blind re-derivation, focal arm only.** Spawn
+   `Agent(name="rederive", run_in_background=true, subagent_type=general-purpose,
+   model="opus", prompt=<substituted rederive.md>)`. Scoped to the focal arm
+   because that is where the algebra carrying the claim lives.
+3. **Citation lint.** Run:
+
+   ```bash
+   .venv/bin/python .claude/skills/sim2real-specify/scripts/lint_citations.py \
+     --bundle <experiment-root> --tree <sim-tree> --tree <target-tree>
+   ```
+
+   Pass a `--tree` for every checkout the bundle cites, including the inference
+   engine if its metrics are cited. A citation into an unpassed tree reports
+   `unresolved-path`, which is the tool refusing to guess rather than a defect.
+
+### Reconcile
+
+- Every `WRONG` finding: fix the specification. Cite the `settled_by` path in the
+  fix.
+- Every `UNSUPPORTED` finding: delete the claim, or convert it to a stated open
+  question in `README.md` owned by the bundle.
+- Every `BRIDGE` finding with `declared_at: null`: write the declaration into the
+  specification header, naming the degradation AND the direction of the resulting
+  bias. Do NOT delete the code — absence of a simulation counterpart is that
+  code's expected property. This is prose in the header; do not introduce a marker
+  convention for it.
+- Every `BRIDGE` finding whose assumptions the auditor found wrong against the
+  target or engine checkout: fix as for `WRONG`.
+- Every re-derivation term absent from the specification: either add it, or
+  declare its omission in the header with the direction of bias. A silent omission
+  is a defect even when the omission is defensible.
+- Every lint failure: correct the citation, or add `lint-skip` on that line if the
+  reference is illustrative rather than a citation.
+
+### Pass condition
+
+Zero `UNSUPPORTED` claims remain, every `BRIDGE` finding has a non-null
+`declared_at`, the lint exits 0, and every re-derivation divergence is resolved or
+declared.
+
+If `UNSUPPORTED` findings survive three fix rounds, STOP. Report what remains
+unresolved. Do not describe the bundle as audited.
+
+## After specify
+
+Tell the operator:
+
+```
+Specification complete at <experiment-root>. Gate: <n> arms audited,
+<n> re-derivation divergences declared, lint clean.
+
+Next: /sim2real-bootstrap <experiment-root>
+```

--- a/.claude/skills/sim2real-specify/SKILL.md
+++ b/.claude/skills/sim2real-specify/SKILL.md
@@ -133,34 +133,13 @@ Enumerate every quantity the decision rule reads. Classify each:
 Every row carries a citation to the value that supplies it. This is a
 classification pass, not a reference document — keep it to a table.
 
-### Resolve first, ask last
-
-Do NOT ask the operator how to source a signal. Work it out, then ask only about
-what genuinely remains. In order:
-
-1. **Apply the established pattern.** Per-request state that the target exposes
-   only in aggregate is reconstructed by an EPP-side SHADOW TABLE populated from
-   the request lifecycle the EPP already observes — the post-schedule observer,
-   the first-token/streaming hook, and the completion hook. Routing instant, first
-   token, and input length are EXACT this way. Remaining steps are a censored
-   estimate (N̂_out minus tokens streamed); check whether the simulation censors
-   too, in which case the degradation is like-for-like rather than new. This is a
-   solved problem — derive it, cite the hooks, declare the bias.
-2. **Prefer an aggregate correction where one exists.** A shadow table misses
-   requests this replica did not place, so cross-check any count the target
-   reports directly and prefer it. State which quantities remain shadow-only.
-3. **Flag the replication hazard.** A replicated EPP splits a shadow table and
-   systematically under-prices contention. Record it.
-4. **Then batch ONE decision** for whatever is still open.
-
-Ask the operator in a SINGLE `AskUserQuestion` at the end of this phase,
-presenting the whole classification table at once. Never one question per signal.
-Include only signals where you cannot resolve the mapping yourself AND the
-degradation could change the comparison the experiment exists to make — for those,
-give the options you found in the target checkout and your recommendation, not an
-open-ended question. Everything else is a declared degradation and needs no ask.
-
-If nothing meets that bar, do not ask at all. Proceed and declare.
+If a quantity carrying the CORE mechanism is `unobtainable`, you MUST put the case
+to the operator with `AskUserQuestion` before proceeding to Phase 5. This is
+mandatory and blocking, not advisory. Present the quantity, what the target can
+supply instead, and the direction of the resulting bias — then let the operator
+decide. Writing a well-reasoned degradation note is NOT a substitute for asking:
+accepting a degradation that weakens the mechanism under test is the operator's
+call, however good your reasoning is.
 
 This classification governs runtime observability ONLY. It does not license
 omitting anything from the specification — see the firewall in Phase 5.

--- a/.claude/skills/sim2real-specify/SKILL.md
+++ b/.claude/skills/sim2real-specify/SKILL.md
@@ -133,13 +133,34 @@ Enumerate every quantity the decision rule reads. Classify each:
 Every row carries a citation to the value that supplies it. This is a
 classification pass, not a reference document — keep it to a table.
 
-If a quantity carrying the CORE mechanism is `unobtainable`, you MUST put the case
-to the operator with `AskUserQuestion` before proceeding to Phase 5. This is
-mandatory and blocking, not advisory. Present the quantity, what the target can
-supply instead, and the direction of the resulting bias — then let the operator
-decide. Writing a well-reasoned degradation note is NOT a substitute for asking:
-accepting a degradation that weakens the mechanism under test is the operator's
-call, however good your reasoning is.
+### Resolve first, ask last
+
+Do NOT ask the operator how to source a signal. Work it out, then ask only about
+what genuinely remains. In order:
+
+1. **Apply the established pattern.** Per-request state that the target exposes
+   only in aggregate is reconstructed by an EPP-side SHADOW TABLE populated from
+   the request lifecycle the EPP already observes — the post-schedule observer,
+   the first-token/streaming hook, and the completion hook. Routing instant, first
+   token, and input length are EXACT this way. Remaining steps are a censored
+   estimate (N̂_out minus tokens streamed); check whether the simulation censors
+   too, in which case the degradation is like-for-like rather than new. This is a
+   solved problem — derive it, cite the hooks, declare the bias.
+2. **Prefer an aggregate correction where one exists.** A shadow table misses
+   requests this replica did not place, so cross-check any count the target
+   reports directly and prefer it. State which quantities remain shadow-only.
+3. **Flag the replication hazard.** A replicated EPP splits a shadow table and
+   systematically under-prices contention. Record it.
+4. **Then batch ONE decision** for whatever is still open.
+
+Ask the operator in a SINGLE `AskUserQuestion` at the end of this phase,
+presenting the whole classification table at once. Never one question per signal.
+Include only signals where you cannot resolve the mapping yourself AND the
+degradation could change the comparison the experiment exists to make — for those,
+give the options you found in the target checkout and your recommendation, not an
+open-ended question. Everything else is a declared degradation and needs no ask.
+
+If nothing meets that bar, do not ask at all. Proceed and declare.
 
 This classification governs runtime observability ONLY. It does not license
 omitting anything from the specification — see the firewall in Phase 5.

--- a/.claude/skills/sim2real-specify/SKILL.md
+++ b/.claude/skills/sim2real-specify/SKILL.md
@@ -221,7 +221,11 @@ no margin attached and say that no measurement backs it.
 ### What `config.md` must contain
 
 `config.md` states the deployment the transfer targets and every knob the arms
-read. Five parts, in this order:
+read. Five parts. All five must be PRESENT; their order is presentational, and
+the numbering below is a reading order rather than a requirement. The parser
+locates the table by its heading, not its position
+(`generate_from_config.py:300-322`) — so the only ordering rule is not to author
+a SECOND table whose heading also matches, because the first match wins.
 
 1. **vLLM pod configuration** — a table headed `## vLLM Pod Configuration`. This
    table is MACHINE-READ: `/sim2real-bootstrap` Task 3 derives
@@ -253,6 +257,16 @@ has stated the fact and still fails bootstrap, because the consumer reads
 Do not restate bootstrap's field list here — it lives in that skill's
 `PARAMETER_ALIASES` and `VLLM_SECTION_KEYWORDS`, and the Phase 6 consumer check
 verifies agreement mechanically. Duplicating it invites drift.
+
+**Adding these parts to an EXISTING `config.md` — do not renumber its sections.**
+The specification layer cites `config.md` by section number (`§2`, `§4`, `§5`),
+and those citations are silent when broken: the reference still reads plausibly
+and now points at the wrong section. Insert the new parts around the established
+numbering instead, and check what cites them first:
+
+```bash
+grep -noE "config\.md[^ ]*|§[0-9]+" <experiment-root>/algorithms/*.go
+```
 
 ### Deployment values the simulation cannot supply
 

--- a/.claude/skills/sim2real-specify/SKILL.md
+++ b/.claude/skills/sim2real-specify/SKILL.md
@@ -133,9 +133,16 @@ Enumerate every quantity the decision rule reads. Classify each:
 Every row carries a citation to the value that supplies it. This is a
 classification pass, not a reference document — keep it to a table.
 
-If a quantity carrying the CORE mechanism is `unobtainable`, stop and put the case
-to the operator with `AskUserQuestion`. Degraded may be acceptable with reasoning,
-but that judgment is the operator's, not yours.
+If a quantity carrying the CORE mechanism is `unobtainable`, you MUST put the case
+to the operator with `AskUserQuestion` before proceeding to Phase 5. This is
+mandatory and blocking, not advisory. Present the quantity, what the target can
+supply instead, and the direction of the resulting bias — then let the operator
+decide. Writing a well-reasoned degradation note is NOT a substitute for asking:
+accepting a degradation that weakens the mechanism under test is the operator's
+call, however good your reasoning is.
+
+This classification governs runtime observability ONLY. It does not license
+omitting anything from the specification — see the firewall in Phase 5.
 
 ## Phase 4 — Isolation
 
@@ -153,12 +160,47 @@ Write `algorithms/<arm>.go` per arm, plus `config.md`.
 
 The specification layer:
 
+- states the COMPLETE computation — see the completeness rule below;
 - states the policy against REAL target interface names;
-- leaves adapters as declared unknowns rather than guesses, so a wrong guess fails
-  loudly rather than mis-scoring silently;
+- leaves TARGET-API ADAPTERS as declared unknowns rather than guesses, so a wrong
+  guess fails loudly rather than mis-scoring silently;
 - carries an upstream `path:line` citation on every non-obvious expression;
 - declares each Phase 3 degradation in its header WITH the direction of bias;
 - invents no in-source marker conventions.
+
+### Completeness, and the Phase 3 firewall
+
+READ THIS TWICE. It is the failure mode this skill is most prone to.
+
+The specification must state the whole computation: every term the simulation
+sums, every coefficient, every rounding, every guard that skips a term. Nothing
+downstream re-derives the algebra — `/sim2real-translate` treats this file as
+authoritative for the science, so an omission here is carried faithfully into the
+plugin and never questioned again.
+
+A function with NO BODY is legitimate in exactly one case: a target-API adapter
+whose exact accessor must be confirmed against the pinned checkout. It is never
+legitimate for a quantity the simulation computes.
+
+> Phase 3 tells you what the port can OBSERVE AT RUNTIME. It never tells you what
+> the specification may leave UNSTATED.
+
+An `unobtainable` or `degraded` INPUT does not license omitting the algebra that
+consumes it. Those are independent facts and both must be recorded:
+
+- the computation, stated in full, cited to the simulation source;
+- the input's observability status, declared as a degradation with its direction
+  of bias.
+
+Worked example of getting this WRONG. The rollout admission estimate depends on
+per-resident remaining steps, which the target cannot observe. The wrong response
+is a bodiless `estimateAdmissionDelay` marked UNKNOWN. The right response is to
+port the roll-forward estimator in full from the simulation, and separately
+declare that its per-resident input is degraded — approximated from EPP-side
+bookkeeping — and that the resulting bias understates contention.
+
+If you find yourself writing a bodiless function for anything other than an
+accessor, you are omitting science. Write the algebra.
 
 One rule governs references to other pipeline stages:
 
@@ -199,10 +241,16 @@ prompt uses a name absent here, or if a name here is used by no prompt.
 1. **Citation audit, every arm.** Spawn one agent per arm in a single tool-call
    message: `Agent(name="audit-<arm>", run_in_background=true,
    subagent_type=general-purpose, model="opus", prompt=<substituted audit.md>)`.
-2. **Blind re-derivation, focal arm only.** Spawn
-   `Agent(name="rederive", run_in_background=true, subagent_type=general-purpose,
-   model="opus", prompt=<substituted rederive.md>)`. Scoped to the focal arm
-   because that is where the algebra carrying the claim lives.
+2. **Blind re-derivation, EVERY arm.** Spawn one per arm:
+   `Agent(name="rederive-<arm>", run_in_background=true,
+   subagent_type=general-purpose, model="opus",
+   prompt=<substituted rederive.md>)`.
+
+   Every arm, not just the focal one, because this is the gate's ONLY omission
+   detector. The audit does correspondence discovery over expressions that are
+   present; a term that was never written has no expression to audit. Since
+   omission is this skill's most likely failure, the detector cannot be scoped to
+   one file.
 3. **Citation lint.** Run:
 
    ```bash
@@ -227,9 +275,14 @@ prompt uses a name absent here, or if a name here is used by no prompt.
   convention for it.
 - Every `BRIDGE` finding whose assumptions the auditor found wrong against the
   target or engine checkout: fix as for `WRONG`.
-- Every re-derivation term absent from the specification: either add it, or
-  declare its omission in the header with the direction of bias. A silent omission
-  is a defect even when the omission is defensible.
+- Every re-derivation term absent from the specification: ADD IT. The default is
+  to write the algebra, not to declare it missing. Declaring an omission is
+  permitted only when the term cannot be stated at all — not merely when its
+  inputs are unobservable, which is a Phase 3 degradation and does not license
+  omission. A silent omission is a defect even when defensible.
+- Any bodiless function that is NOT a target-API accessor: write its algebra from
+  the simulation source. This is the check that catches a specification which
+  states its top-level score and leaves every operand unimplemented.
 - Every lint failure: correct the citation, or add `lint-skip` on that line if the
   reference is illustrative rather than a citation.
 

--- a/.claude/skills/sim2real-specify/prompts/audit.md
+++ b/.claude/skills/sim2real-specify/prompts/audit.md
@@ -1,0 +1,118 @@
+# Independent specification audit
+
+You are auditing ONE algorithm specification in a sim2real bundle. You have no
+generation transcript and must not ask for one. Your only sources of truth are the
+two checkouts named below. Treat the bundle as a claim to be tested.
+
+## Inputs
+
+- Bundle root: `{BUNDLE_ROOT}`
+- Specification under audit: `{ARM_FILE}` (arm name: `{ARM_NAME}`)
+- Simulation checkout: `{SIM_TREE}` pinned at `{SIM_PIN}`
+- Target component checkout: `{TARGET_TREE}` pinned at `{TARGET_PIN}`
+- Write your verdict to: `{VERDICT_PATH}`
+
+## Method: correspondence discovery
+
+Do NOT assume the specification's citations are complete. Citation density is an
+audit OUTPUT, not an input.
+
+For every non-trivial ported expression in `{ARM_FILE}` -- every arithmetic
+formula, every unit conversion, every rounding decision, every loop bound, every
+guard that skips or censors a term -- do this:
+
+1. Locate the upstream counterpart. If the expression carries a citation, use it
+   as a hint and verify it points where it claims. If it carries none, SEARCH the
+   simulation checkout for the corresponding code by symbol name, by formula
+   shape, and by the surrounding concept. Report `UNSUPPORTED` only after
+   searching, never merely because a citation was absent.
+2. Compare term by term. Enumerate the upstream terms and the ported terms and
+   check the sets match. A missing additive term is the most common defect and
+   the easiest to overlook, because the remaining terms look correct.
+3. Check units explicitly. A name is not a unit. If the upstream reads a metric,
+   find that metric's definition in the target or engine checkout and confirm the
+   scale factor. Never trust a prose mapping document over source.
+4. Check rounding and boundary handling. Whether a quantity is truncated,
+   floored, or ceiled changes results and is invisible in aggregate.
+5. Check quantities recomputed per call site upstream. If upstream derives a
+   value locally at each use (for example a per-request budget clamped to a
+   request-specific size), a ported constant is a defect even when an algebraically
+   equivalent downstream quantity hides it.
+6. Decide whether the code is PORTED or BRIDGE, and audit it accordingly.
+   - PORTED: the simulation computes this quantity, so a counterpart exists.
+     Compare against it. This includes quantities the simulation reads directly
+     from its own state -- if the simulation knows the value exactly and the port
+     obtains it some other way, the counterpart still exists and the acquisition
+     is what you are checking. A unit error here is `WRONG`, not `BRIDGE`.
+   - BRIDGE: the code exists ONLY because the target lacks the simulation's
+     state, so no counterpart exists and none should. Do not report it
+     `UNSUPPORTED` -- absence of a counterpart is the expected finding. Instead
+     verify its assumptions against the target or engine checkout, and check that
+     the specification header declares the degradation AND the direction of the
+     resulting bias. Record that header line in `declared_at`. If no declaration
+     exists, emit the finding with `declared_at: null`.
+
+Then audit the prose. For each non-obvious claim in `{BUNDLE_ROOT}/README.md` and
+`{BUNDLE_ROOT}/config.md`, resolve it against a checkout. Apply one rule:
+
+> A specification may REQUEST things of downstream stages. It may never ASSERT
+> what they do.
+
+A sentence asserting the behavior of another pipeline stage, tool, or agent is
+`UNSUPPORTED` unless that component's own source says so. Verify against the
+component's source, including any section declaring what it does not do.
+
+## Verdicts
+
+Emit one finding per checked claim, using exactly these kinds:
+
+- `CONFIRMED` -- the port matches upstream, or the prose claim is substantiated.
+- `WRONG` -- a counterpart exists and the port disagrees with it. State the
+  correct form.
+- `UNSUPPORTED` -- no counterpart could be found after searching, AND the claim
+  purports to describe one. The claim rests on nothing.
+- `BRIDGE` -- no counterpart by construction, per method step 6. Set
+  `declared_at` to the specification-header line declaring the degradation and its
+  direction of bias, or `null` if no such declaration exists.
+
+Do NOT use `UNSUPPORTED` for bridge code. Absence of a counterpart is that code's
+expected property, not evidence against it.
+
+Every finding MUST carry `settled_by`: the `path:line` in a checkout that settles
+it. For `BRIDGE`, that is the target or engine line establishing what the code can
+actually observe. A finding without `settled_by` is not a finding.
+
+Be specific about consequence. "Units are wrong" is not useful; "the divisor
+under-counts by 100x, collapsing the term that carries hardware heterogeneity" is.
+
+## Output
+
+Write JSON to `{VERDICT_PATH}`:
+
+```json
+{
+  "arm": "{ARM_NAME}",
+  "findings": [
+    {
+      "kind": "WRONG",
+      "file": "algorithms/example.go",
+      "line": 335,
+      "symbol": "enclosingFunctionName",
+      "claim": "what the specification says or computes",
+      "upstream": "sim/example.go:168",
+      "settled_by": "vllm/v1/metrics/loggers.py:563",
+      "declared_at": null,
+      "detail": "what is wrong and what the correct form is, with consequence"
+    }
+  ]
+}
+```
+
+`file` is the bundle-relative path. `line` is the line in `{ARM_FILE}`, or in the
+prose file for a prose claim. `declared_at` is required on `BRIDGE` findings and
+null elsewhere.
+
+When done, send one message to `{MAIN_SESSION_NAME}`:
+`audit-complete: {ARM_NAME} <n> CONFIRMED, <n> WRONG, <n> UNSUPPORTED, <n> BRIDGE`
+
+Do not edit any file other than `{VERDICT_PATH}`. Fixing is not your job.

--- a/.claude/skills/sim2real-specify/prompts/rederive.md
+++ b/.claude/skills/sim2real-specify/prompts/rederive.md
@@ -1,0 +1,67 @@
+# Blind re-derivation
+
+Derive an algorithm's decision rule from simulation source alone. You will NOT be
+shown any existing port, and you must not look for one. If you encounter a file
+that appears to be a port of this policy, stop reading it and continue from the
+simulation source.
+
+## Inputs
+
+- Simulation checkout: `{SIM_TREE}` pinned at `{SIM_PIN}`
+- Entry points for the policy: `{POLICY_ENTRY_POINTS}`
+- Arm name: `{ARM_NAME}`
+- Write your derivation to: `{DERIVATION_PATH}`
+
+## Method
+
+Read the entry points and follow every call they make that contributes to the
+decision. Then write down, as a flat list of named terms, the complete
+computation: what is summed, multiplied, compared, rounded, skipped, and returned.
+
+For each term record:
+
+- `name` -- a short identifier you choose
+- `expression` -- the algebra, in terms of other names you have defined
+- `upstream` -- the `path:line` in `{SIM_TREE}` it comes from
+- `units` -- microseconds, tokens, requests, dimensionless
+- `notes` -- anything a reimplementation would get wrong
+
+Rules that matter for this comparison:
+
+1. Be exhaustive about ADDITIVE terms. If the upstream sums four contributions,
+   list four. Omission is the defect class this exercise exists to catch.
+2. Record every rounding operation as its own note. Floor, ceil, and truncate are
+   not interchangeable.
+3. Record any quantity the upstream recomputes at each call site, and say what it
+   is clamped to. Do not summarize it as a constant.
+4. Record guards that skip a term -- censoring, sentinel values, early
+   `continue` -- and what the skipped contribution would have been.
+5. Where the upstream selects between branches by a flag, follow the branch this
+   policy actually forces and say which flag forces it. Ignore unreachable
+   branches, and note that you ignored them.
+6. Note every quantity that comes from simulator-internal state with no
+   real-cluster analogue. Do not invent a substitute.
+
+## Output
+
+Write JSON to `{DERIVATION_PATH}`:
+
+```json
+{
+  "arm": "{ARM_NAME}",
+  "terms": [
+    {
+      "name": "decodeIterationTime",
+      "expression": "alpha + c0*batchSize + c1*kvTokens + cPf*prefillTokens",
+      "upstream": "sim/example_coeffs.go:41",
+      "units": "microseconds",
+      "notes": "recomputed per candidate under that candidate's own coefficients"
+    }
+  ]
+}
+```
+
+When done, send one message to `{MAIN_SESSION_NAME}`:
+`rederive-complete: {ARM_NAME} <n> terms`
+
+Do not edit any file other than `{DERIVATION_PATH}`.

--- a/.claude/skills/sim2real-specify/scripts/acceptance.py
+++ b/.claude/skills/sim2real-specify/scripts/acceptance.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Score a sim2real-specify audit against the ead56ea labeled fixture.
+
+Sensitivity: the four defects that commit found in the focal arm at 08203b4.
+Specificity: the two comparator arms it found clean and left unchanged.
+
+The agent run itself is manual and nondeterministic; only the scoring here is
+deterministic, and only the scoring is unit-tested.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ARM_FILES = {
+    "causal_slo_externality": "algorithms/causal_slo_externality.go",
+    "least_ttft_joint": "algorithms/least_ttft_joint.go",
+    "kairos_paper": "algorithms/kairos_paper.go",
+}
+
+PROSE_FILES = ("README.md", "config.md")
+
+CLEAN_ARMS = ("least_ttft_joint", "kairos_paper")
+
+DEFECT_KINDS = ("WRONG", "UNSUPPORTED")
+
+
+def load_labels(path: Path) -> list[dict]:
+    return json.loads(path.read_text())["labels"]
+
+
+def match(finding: dict, label: dict, tolerance: int = 6) -> bool:
+    """Does a finding correspond to a labeled defect?
+
+    Symbol match wins outright, so a finding that names the right function is
+    credited even if its line drifted. Otherwise fall back to line proximity --
+    an auditor may anchor a few lines off the exact expression.
+    """
+    if finding.get("file") != label["file"]:
+        return False
+    if finding.get("symbol") and finding["symbol"] == label["symbol"]:
+        return True
+    line = finding.get("line")
+    if line is None:
+        return False
+    return any(abs(line - n) <= tolerance for n in label["lines"])
+
+
+def undeclared_bridges(verdicts: list[dict]) -> list[dict]:
+    """BRIDGE findings with no declared degradation. These block the gate.
+
+    BRIDGE means no simulation counterpart exists BY CONSTRUCTION -- the code is
+    there because the target lacks the simulator's state. That is not a defect and
+    not a false claim; what makes it acceptable is a declared direction of bias in
+    the specification header. A missing or null `declared_at` is the failure.
+    """
+    return [
+        f
+        for v in verdicts
+        for f in v["findings"]
+        if f.get("kind") == "BRIDGE" and not f.get("declared_at")
+    ]
+
+
+def score(verdicts: list[dict], labels: list[dict]) -> dict:
+    # BRIDGE is deliberately excluded: it is neither a defect nor a false
+    # positive, and is gated separately by undeclared_bridges().
+    defects = [
+        f for v in verdicts for f in v["findings"] if f.get("kind") in DEFECT_KINDS
+    ]
+    found = [
+        label["id"] for label in labels if any(match(f, label) for f in defects)
+    ]
+    missed = [label["id"] for label in labels if label["id"] not in found]
+
+    false_positives: dict[str, int] = {}
+    for verdict in verdicts:
+        arm = verdict["arm"]
+        if arm not in CLEAN_ARMS:
+            continue
+        count = sum(1 for f in verdict["findings"] if f.get("kind") in DEFECT_KINDS)
+        if count:
+            false_positives[arm] = count
+
+    return {
+        "found": sorted(found),
+        "missed": sorted(missed),
+        "false_positive_arms": false_positives,
+        "recall": (len(found) / len(labels)) if labels else 0.0,
+    }
+
+
+def materialize(repo: Path, commit: str, dest: Path) -> None:
+    """Extract the three arm files plus prose at `commit` into `dest`."""
+    (dest / "algorithms").mkdir(parents=True, exist_ok=True)
+    for rel in [*ARM_FILES.values(), *PROSE_FILES]:
+        blob = subprocess.run(
+            ["git", "-C", str(repo), "show", f"{commit}:{rel}"],
+            capture_output=True,
+            check=True,
+            text=True,
+        ).stdout
+        (dest / rel).write_text(blob)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    m = sub.add_parser("materialize", help="extract the fixture bundle")
+    m.add_argument("--repo", required=True, type=Path)
+    m.add_argument("--commit", default="08203b4")
+    m.add_argument("--dest", required=True, type=Path)
+
+    s = sub.add_parser("score", help="score verdict JSONs against the labels")
+    s.add_argument("--labels", required=True, type=Path)
+    s.add_argument("--verdict", action="append", required=True, type=Path)
+    s.add_argument("--component", default="audit", choices=["audit", "rederive"])
+
+    args = ap.parse_args(argv)
+
+    if args.cmd == "materialize":
+        materialize(args.repo, args.commit, args.dest)
+        print(f"fixture at {args.dest} from {args.commit}")
+        return 0
+
+    labels = [
+        label
+        for label in load_labels(args.labels)
+        if args.component in label["found_by"]
+    ]
+    verdicts = [json.loads(p.read_text()) for p in args.verdict]
+    result = score(verdicts, labels)
+    undeclared = undeclared_bridges(verdicts)
+    result["undeclared_bridges"] = [
+        f"{f.get('symbol')} at {f.get('file')}:{f.get('line')}" for f in undeclared
+    ]
+    print(json.dumps(result, indent=2))
+    if result["missed"] or result["false_positive_arms"] or undeclared:
+        print("ACCEPTANCE FAILED", file=sys.stderr)
+        return 1
+    print("ACCEPTANCE PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/sim2real-specify/scripts/lint_citations.py
+++ b/.claude/skills/sim2real-specify/scripts/lint_citations.py
@@ -8,8 +8,11 @@ attached to a wrong transcription -- that is the audit agent's job.
 
 from __future__ import annotations
 
+import argparse
 import re
+import sys
 from dataclasses import dataclass
+from pathlib import Path
 
 SOURCE_EXTS = ("go", "py", "md", "yaml", "yml", "json")
 
@@ -52,3 +55,128 @@ def parse_citations(text: str) -> list[Citation]:
                 Citation(path=path, lines=parse_line_spec(spec), source_line=lineno)
             )
     return out
+
+
+@dataclass(frozen=True)
+class Failure:
+    file: str
+    source_line: int
+    citation: str
+    kind: str
+    detail: str
+
+
+def index_tree(root: Path) -> dict[str, list[Path]]:
+    """Map basename -> files, skipping dot-directories."""
+    index: dict[str, list[Path]] = {}
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        if any(part.startswith(".") for part in path.relative_to(root).parts[:-1]):
+            continue
+        index.setdefault(path.name, []).append(path)
+    return index
+
+
+def _candidates(cit: Citation, indexes: list[dict[str, list[Path]]]) -> list[Path]:
+    """Files whose path ends with the cited path.
+
+    Suffix matching is required because real citations range from a rooted
+    `sim/edpp_var.go` to a bare `extractor.go`. Ambiguity is reported rather than
+    guessed, which pushes authors toward more specific citations.
+    """
+    basename = cit.path.rsplit("/", 1)[-1]
+    out: list[Path] = []
+    for index in indexes:
+        for path in index.get(basename, []):
+            if path.as_posix().endswith(cit.path):
+                out.append(path)
+    return out
+
+
+def resolve(cit: Citation, indexes: list[dict[str, list[Path]]]) -> Failure | None:
+    matches = _candidates(cit, indexes)
+    if not matches:
+        return Failure(
+            "", cit.source_line, str(cit), "unresolved-path",
+            "no file in any pinned tree ends with this path",
+        )
+    if len(set(matches)) > 1:
+        shown = ", ".join(sorted(p.as_posix() for p in set(matches))[:4])
+        return Failure(
+            "", cit.source_line, str(cit), "ambiguous-path",
+            f"matches {len(set(matches))} files: {shown}",
+        )
+    target = matches[0]
+    nlines = len(target.read_text(errors="replace").splitlines())
+    over = [n for n in cit.lines if n > nlines or n < 1]
+    if over:
+        return Failure(
+            "", cit.source_line, str(cit), "line-out-of-range",
+            f"{target.name} has {nlines} lines; cited {over}",
+        )
+    return None
+
+
+def lint_bundle(
+    bundle: Path, trees: list[Path], exts: tuple[str, ...]
+) -> list[Failure]:
+    # The bundle indexes itself so intra-bundle references (README.md:22) resolve
+    # without being reported as dangling.
+    indexes = [index_tree(t) for t in [*trees, bundle]]
+    failures: list[Failure] = []
+    for path in sorted(bundle.rglob("*")):
+        if not path.is_file() or path.suffix not in exts:
+            continue
+        if any(part.startswith(".") for part in path.relative_to(bundle).parts[:-1]):
+            continue
+        text = path.read_text(errors="replace")
+        for cit in parse_citations(text):
+            failure = resolve(cit, indexes)
+            if failure is not None:
+                rel = path.relative_to(bundle).as_posix()
+                failures.append(
+                    Failure(
+                        rel, failure.source_line, failure.citation,
+                        failure.kind, failure.detail,
+                    )
+                )
+    return failures
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Lint path:line citations in a sim2real bundle."
+    )
+    ap.add_argument("--bundle", required=True, type=Path)
+    ap.add_argument(
+        "--tree", action="append", default=[], type=Path,
+        help="pinned checkout root; repeatable",
+    )
+    ap.add_argument(
+        "--ext", default=".go,.md",
+        help="comma-separated file extensions to scan",
+    )
+    args = ap.parse_args(argv)
+
+    if not args.bundle.is_dir():
+        print(f"usage error: --bundle {args.bundle} is not a directory", file=sys.stderr)
+        return 2
+    for tree in args.tree:
+        if not tree.is_dir():
+            print(f"usage error: --tree {tree} is not a directory", file=sys.stderr)
+            return 2
+
+    exts = tuple(e if e.startswith(".") else f".{e}" for e in args.ext.split(","))
+    failures = lint_bundle(args.bundle, args.tree, exts)
+    for f in failures:
+        print(
+            f"FAIL {f.kind} {f.file}:{f.source_line} "
+            f"cite={f.citation} -- {f.detail}"
+        )
+    print(f"{len(failures)} citation failure(s)")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/sim2real-specify/scripts/lint_citations.py
+++ b/.claude/skills/sim2real-specify/scripts/lint_citations.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Resolve `path:line` citations in a sim2real bundle against pinned checkouts.
+
+Mechanical only: verifies that a cited path exists in exactly one pinned tree and
+that the cited line numbers are within that file. Cannot detect a correct citation
+attached to a wrong transcription -- that is the audit agent's job.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+SOURCE_EXTS = ("go", "py", "md", "yaml", "yml", "json")
+
+CITATION_RE = re.compile(
+    r"(?<![\w/.-])"                                    # not mid-token
+    r"([A-Za-z0-9_][\w./-]*\.(?:" + "|".join(SOURCE_EXTS) + r"))"
+    r":(\d+(?:[-,]\d+)*)"                              # 12 | 12-20 | 12,20
+    r"(?!\d)"                                          # whole number only
+)
+# NOTE: do not add `.` to that final lookahead. Citations frequently end a
+# sentence -- `sim/edpp.go:1707.` -- and excluding a trailing period silently
+# drops every one of them. Version-like noise is already excluded by requiring a
+# known source extension in the path group.
+
+SKIP_MARKER = "lint-skip"
+
+
+@dataclass(frozen=True)
+class Citation:
+    path: str
+    lines: tuple[int, ...]
+    source_line: int
+
+    def __str__(self) -> str:
+        return f"{self.path}:{','.join(str(n) for n in self.lines)}"
+
+
+def parse_line_spec(spec: str) -> tuple[int, ...]:
+    """'168' -> (168,); '144-157' -> (144, 157); '33,153' -> (33, 153)."""
+    return tuple(int(part) for part in re.split(r"[-,]", spec) if part)
+
+
+def parse_citations(text: str) -> list[Citation]:
+    out: list[Citation] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if SKIP_MARKER in line:
+            continue
+        for path, spec in CITATION_RE.findall(line):
+            out.append(
+                Citation(path=path, lines=parse_line_spec(spec), source_line=lineno)
+            )
+    return out

--- a/.claude/skills/sim2real-specify/tests/fixtures/ead56ea_labels.json
+++ b/.claude/skills/sim2real-specify/tests/fixtures/ead56ea_labels.json
@@ -1,0 +1,52 @@
+{
+  "fixture": {
+    "repo_hint": "pd-infocomm",
+    "commit": "08203b4",
+    "focal_arm": "causal_slo_externality",
+    "clean_arms": ["least_ttft_joint", "kairos_paper"],
+    "authority": "pd-infocomm commit ead56ea",
+    "note": "Line numbers are in algorithms/causal_slo_externality.go at 08203b4 (773 lines), NOT the current post-fix file."
+  },
+  "labels": [
+    {
+      "id": "missing-prefill-attention-charge",
+      "file": "algorithms/causal_slo_externality.go",
+      "lines": [483],
+      "symbol": "cLocalAfter",
+      "found_by": ["audit", "rederive"],
+      "detail": "overlap*tIterOverlap replaces the baseline rate plus the arrival's exact marginal prefill work; the causal prefill-attention term is absent. Upstream charges it in both branches of varReTiming.cLocalAfter and the focal arm force-selects the exact one."
+    },
+    {
+      "id": "kv-usage-fraction-not-percent",
+      "file": "algorithms/causal_slo_externality.go",
+      "lines": [335],
+      "symbol": "kvTokensFor",
+      "found_by": ["audit"],
+      "detail": "spurious /100.0 -- KVCacheUsagePercent is a fraction in [0,1] despite its name, so KV is under-counted 100x, collapsing the C1*KV term that carries hardware heterogeneity. PORTED, not BRIDGE: the summed-context quantity exists upstream and the unit error is settled against the target checkout."
+    },
+    {
+      "id": "admission-steps-not-ceiled",
+      "file": "algorithms/causal_slo_externality.go",
+      "lines": [567, 589],
+      "symbol": "Score",
+      "found_by": ["audit", "rederive"],
+      "detail": "admissionSteps and arrivalSteps must be math.Ceil -- admission lands on an iteration boundary, so the wait is a whole number of baseline decode steps."
+    },
+    {
+      "id": "chunk-not-clamped-to-uncached-suffix",
+      "file": "algorithms/causal_slo_externality.go",
+      "lines": [718],
+      "symbol": "chunkTerms",
+      "found_by": ["audit", "rederive"],
+      "detail": "chunk = ChunkTokens where upstream recomputes min(ap, ChunkTokens) at every call site. Hides because nChunks is algebraically identical either way; only the token count differs."
+    },
+    {
+      "id": "undeclared-colloc-prefill-omission",
+      "file": "algorithms/causal_slo_externality.go",
+      "lines": [500],
+      "symbol": "externality",
+      "found_by": ["rederive"],
+      "detail": "upstream externality is a three-way breakdown and the focal arm enables all three; this port returns only the decode component and declares neither omission. Findable only by re-derivation -- there is no claim to audit."
+    }
+  ]
+}

--- a/.claude/skills/sim2real-specify/tests/test_acceptance.py
+++ b/.claude/skills/sim2real-specify/tests/test_acceptance.py
@@ -1,0 +1,162 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+SKILL = Path(__file__).resolve().parents[1]
+LABELS = SKILL / "tests" / "fixtures" / "ead56ea_labels.json"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "acceptance", SKILL / "scripts" / "acceptance.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+acc = _load()
+
+
+def test_labels_fixture_is_wellformed():
+    data = json.loads(LABELS.read_text())
+    assert data["fixture"]["commit"] == "08203b4"
+    ids = [label["id"] for label in data["labels"]]
+    assert len(ids) == len(set(ids))
+    audit_findable = [label for label in data["labels"] if "audit" in label["found_by"]]
+    assert len(audit_findable) == 4, "ead56ea established four audit-findable defects"
+
+
+def test_match_by_line_within_tolerance():
+    label = {"file": "a.go", "lines": [483], "symbol": "cLocalAfter"}
+    assert acc.match({"file": "a.go", "line": 485, "symbol": "other"}, label)
+    assert not acc.match({"file": "a.go", "line": 600, "symbol": "other"}, label)
+
+
+def test_match_by_symbol_when_line_drifts():
+    label = {"file": "a.go", "lines": [483], "symbol": "cLocalAfter"}
+    assert acc.match({"file": "a.go", "line": 999, "symbol": "cLocalAfter"}, label)
+
+
+def test_match_requires_same_file():
+    label = {"file": "a.go", "lines": [483], "symbol": "cLocalAfter"}
+    assert not acc.match({"file": "b.go", "line": 483, "symbol": "cLocalAfter"}, label)
+
+
+def test_score_reports_recall_and_false_positives():
+    labels = acc.load_labels(LABELS)
+    audit_labels = [label for label in labels if "audit" in label["found_by"]]
+    verdicts = [
+        {
+            "arm": "causal_slo_externality",
+            "findings": [
+                {
+                    "kind": "WRONG",
+                    "file": "algorithms/causal_slo_externality.go",
+                    "line": 335,
+                    "symbol": "kvTokensFor",
+                },
+                {
+                    "kind": "WRONG",
+                    "file": "algorithms/causal_slo_externality.go",
+                    "line": 483,
+                    "symbol": "cLocalAfter",
+                },
+            ],
+        },
+        {
+            "arm": "least_ttft_joint",
+            "findings": [
+                {
+                    "kind": "WRONG",
+                    "file": "algorithms/least_ttft_joint.go",
+                    "line": 12,
+                    "symbol": "somethingElse",
+                },
+            ],
+        },
+    ]
+    result = acc.score(verdicts, audit_labels)
+    assert set(result["found"]) == {
+        "kv-usage-fraction-not-percent",
+        "missing-prefill-attention-charge",
+    }
+    assert set(result["missed"]) == {
+        "admission-steps-not-ceiled",
+        "chunk-not-clamped-to-uncached-suffix",
+    }
+    assert result["recall"] == 0.5
+    assert result["false_positive_arms"] == {"least_ttft_joint": 1}
+
+
+def test_confirmed_and_bridge_are_not_counted_as_false_positives():
+    labels = [
+        label for label in acc.load_labels(LABELS) if "audit" in label["found_by"]
+    ]
+    verdicts = [
+        {
+            "arm": "kairos_paper",
+            "findings": [
+                {
+                    "kind": "CONFIRMED",
+                    "file": "algorithms/kairos_paper.go",
+                    "line": 5,
+                    "symbol": "x",
+                },
+                {
+                    "kind": "BRIDGE",
+                    "file": "algorithms/kairos_paper.go",
+                    "line": 9,
+                    "symbol": "sPfFor",
+                    "declared_at": "algorithms/kairos_paper.go:44",
+                },
+            ],
+        }
+    ]
+    assert acc.score(verdicts, labels)["false_positive_arms"] == {}
+
+
+def test_undeclared_bridge_findings_are_reported():
+    verdicts = [
+        {
+            "arm": "causal_slo_externality",
+            "findings": [
+                {
+                    "kind": "BRIDGE",
+                    "file": "algorithms/causal_slo_externality.go",
+                    "line": 362,
+                    "symbol": "sPfFor",
+                    "declared_at": None,
+                },
+                {
+                    "kind": "BRIDGE",
+                    "file": "algorithms/causal_slo_externality.go",
+                    "line": 231,
+                    "symbol": "residentTable",
+                    "declared_at": "algorithms/causal_slo_externality.go:48",
+                },
+                {
+                    "kind": "WRONG",
+                    "file": "algorithms/causal_slo_externality.go",
+                    "line": 335,
+                    "symbol": "kvTokensFor",
+                },
+            ],
+        }
+    ]
+    undeclared = acc.undeclared_bridges(verdicts)
+    assert [f["symbol"] for f in undeclared] == ["sPfFor"]
+
+
+def test_missing_declared_at_key_counts_as_undeclared():
+    verdicts = [
+        {
+            "arm": "a",
+            "findings": [
+                {"kind": "BRIDGE", "file": "a.go", "line": 1, "symbol": "noKey"},
+            ],
+        }
+    ]
+    assert [f["symbol"] for f in acc.undeclared_bridges(verdicts)] == ["noKey"]

--- a/.claude/skills/sim2real-specify/tests/test_config_contract.py
+++ b/.claude/skills/sim2real-specify/tests/test_config_contract.py
@@ -1,0 +1,91 @@
+"""Guard the config.md contract against drift in its downstream consumer.
+
+Phase 5 tells the author which heading to put the vLLM pod configuration table
+under. `/sim2real-bootstrap` decides which headings it will actually look for.
+Those two live in different skills, so nothing but a test keeps them agreeing —
+and when they disagree the bundle parses as "no vLLM configuration table" and
+bootstrap Task 3 halts, which is the regression this test exists to prevent
+(issue #821 amendment).
+
+The field list itself is deliberately NOT duplicated into SKILL.md, so there is
+nothing to check for it here. The heading is the one string SKILL.md must state
+literally, which makes it the one string that can drift.
+"""
+
+import importlib.util
+import re
+from pathlib import Path
+
+import pytest
+
+SKILL_DIR = Path(__file__).resolve().parents[1]
+BOOTSTRAP_GENERATOR = (
+    SKILL_DIR.parent / "sim2real-bootstrap" / "generate_from_config.py"
+)
+
+
+def _bootstrap_module():
+    """Load bootstrap's generator as a module, or skip if it is not checked out."""
+    if not BOOTSTRAP_GENERATOR.exists():
+        pytest.skip(f"bootstrap generator not present at {BOOTSTRAP_GENERATOR}")
+    spec = importlib.util.spec_from_file_location(
+        "_bootstrap_generate_from_config", BOOTSTRAP_GENERATOR
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _config_contract_section() -> str:
+    text = (SKILL_DIR / "SKILL.md").read_text()
+    start = text.index("### What `config.md` must contain")
+    return text[start : text.index("### Deployment values", start)]
+
+
+def test_prescribed_heading_is_one_bootstrap_recognizes():
+    keywords = [k.lower() for k in _bootstrap_module().VLLM_SECTION_KEYWORDS]
+    section = _config_contract_section()
+
+    headings = re.findall(r"`(##+ [^`]+)`", section)
+    assert headings, "SKILL.md's config.md contract names no heading in backticks"
+
+    for heading in headings:
+        title = heading.lstrip("#").strip().lower()
+        if any(keyword in title for keyword in keywords):
+            return
+    pytest.fail(
+        f"none of the headings SKILL.md prescribes {headings} contains a "
+        f"keyword bootstrap searches for {keywords}"
+    )
+
+
+def test_contract_names_the_mandatory_fields():
+    """`Model` and `GPU` are bootstrap's only hard requirements — say so."""
+    section = _config_contract_section()
+    assert "`Model`" in section and "`GPU`" in section, (
+        "the contract must name the two fields bootstrap treats as mandatory"
+    )
+
+
+def test_mandatory_fields_are_still_the_ones_bootstrap_requires():
+    """If bootstrap's required set changes, the prose above goes stale."""
+    source = BOOTSTRAP_GENERATOR.read_text() if BOOTSTRAP_GENERATOR.exists() else ""
+    if not source:
+        pytest.skip("bootstrap generator not present")
+    required = set(re.findall(r"required field '(\w+)'", source))
+    assert required == {"model", "hardware"}, (
+        f"bootstrap's required fields changed to {sorted(required)}; update the "
+        "config.md contract in SKILL.md to match"
+    )
+
+
+def test_confirm_sentinel_is_the_documented_convention():
+    """`08203b4` used `**CONFIRM**`; a second marker convention would fork it."""
+    text = (SKILL_DIR / "SKILL.md").read_text()
+    start = text.index("### Deployment values the simulation cannot supply")
+    section = text[start : text.index("## Phase 6", start)]
+    assert "**CONFIRM**" in section
+    for invented in ("TBD-OPERATOR", "TODO-OPERATOR", "FIXME"):
+        assert invented not in section, (
+            f"{invented} competes with the CONFIRM convention already in use"
+        )

--- a/.claude/skills/sim2real-specify/tests/test_lint_citations.py
+++ b/.claude/skills/sim2real-specify/tests/test_lint_citations.py
@@ -2,6 +2,8 @@ import importlib.util
 import sys
 from pathlib import Path
 
+import pytest
+
 SKILL = Path(__file__).resolve().parents[1]
 
 
@@ -60,3 +62,83 @@ def test_citation_at_end_of_sentence_is_not_dropped():
     cites = lint.parse_citations("forced at sim/edpp.go:1707.")
     assert cites[0].path == "sim/edpp.go"
     assert cites[0].lines == (1707,)
+
+
+@pytest.fixture
+def tree(tmp_path):
+    """A fake pinned checkout with two files, one of them shadowed by name."""
+    root = tmp_path / "checkout"
+    (root / "sim").mkdir(parents=True)
+    (root / "sim" / "edpp_var.go").write_text(
+        "\n".join(f"line{i}" for i in range(1, 201))
+    )
+    (root / "pkg" / "a").mkdir(parents=True)
+    (root / "pkg" / "a" / "dup.go").write_text("x\ny\n")
+    (root / "pkg" / "b").mkdir(parents=True)
+    (root / "pkg" / "b" / "dup.go").write_text("x\ny\n")
+    (root / ".git").mkdir()
+    (root / ".git" / "edpp_var.go").write_text("noise\n")
+    return root
+
+
+@pytest.fixture
+def bundle(tmp_path):
+    root = tmp_path / "bundle"
+    (root / "algorithms").mkdir(parents=True)
+    return root
+
+
+def test_resolves_valid_citation(bundle, tree):
+    (bundle / "algorithms" / "a.go").write_text("// ported from sim/edpp_var.go:168\n")
+    assert lint.lint_bundle(bundle, [tree], (".go", ".md")) == []
+
+
+def test_flags_unresolved_path(bundle, tree):
+    (bundle / "README.md").write_text("see sim/nope.go:5\n")
+    fails = lint.lint_bundle(bundle, [tree], (".go", ".md"))
+    assert [f.kind for f in fails] == ["unresolved-path"]
+
+
+def test_flags_line_out_of_range(bundle, tree):
+    (bundle / "README.md").write_text("see sim/edpp_var.go:5000\n")
+    fails = lint.lint_bundle(bundle, [tree], (".go", ".md"))
+    assert [f.kind for f in fails] == ["line-out-of-range"]
+    assert "200" in fails[0].detail
+
+
+def test_flags_ambiguous_path(bundle, tree):
+    (bundle / "README.md").write_text("see dup.go:1\n")
+    fails = lint.lint_bundle(bundle, [tree], (".go", ".md"))
+    assert [f.kind for f in fails] == ["ambiguous-path"]
+
+
+def test_ignores_dot_directories(bundle, tree):
+    """.git/edpp_var.go must not create ambiguity with sim/edpp_var.go."""
+    (bundle / "README.md").write_text("see edpp_var.go:1\n")
+    assert lint.lint_bundle(bundle, [tree], (".go", ".md")) == []
+
+
+def test_bundle_is_its_own_tree(bundle, tree):
+    """A self-reference like README.md:2 resolves against the bundle itself."""
+    (bundle / "README.md").write_text("first\nsee README.md:2\n")
+    assert lint.lint_bundle(bundle, [tree], (".go", ".md")) == []
+
+
+def test_failure_records_the_bundle_file_it_came_from(bundle, tree):
+    (bundle / "algorithms" / "a.go").write_text("bad sim/nope.go:5\n")
+    fails = lint.lint_bundle(bundle, [tree], (".go", ".md"))
+    assert fails[0].file == "algorithms/a.go"
+    assert fails[0].source_line == 1
+
+
+def test_main_exit_codes(bundle, tree, capsys):
+    (bundle / "README.md").write_text("see sim/nope.go:5\n")
+    rc = lint.main(["--bundle", str(bundle), "--tree", str(tree)])
+    assert rc == 1
+    assert "unresolved-path" in capsys.readouterr().out
+    (bundle / "README.md").write_text("see sim/edpp_var.go:168\n")
+    assert lint.main(["--bundle", str(bundle), "--tree", str(tree)]) == 0
+
+
+def test_main_usage_error_on_bad_bundle(tmp_path):
+    assert lint.main(["--bundle", str(tmp_path / "nonexistent")]) == 2

--- a/.claude/skills/sim2real-specify/tests/test_lint_citations.py
+++ b/.claude/skills/sim2real-specify/tests/test_lint_citations.py
@@ -1,0 +1,62 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+SKILL = Path(__file__).resolve().parents[1]
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "lint_citations", SKILL / "scripts" / "lint_citations.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    # Register before exec: `from __future__ import annotations` makes dataclass
+    # field annotations strings, and @dataclass resolves them via
+    # sys.modules[cls.__module__].__dict__. An unregistered module makes that None.
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+lint = _load()
+
+
+def test_parses_simple_citation():
+    cites = lint.parse_citations("see sim/edpp_var.go:168 for the charge")
+    assert len(cites) == 1
+    assert cites[0].path == "sim/edpp_var.go"
+    assert cites[0].lines == (168,)
+    assert cites[0].source_line == 1
+
+
+def test_parses_range_and_comma_specs():
+    cites = lint.parse_citations(
+        "a sim/edpp_var.go:144-157 b\nc utilization/config.go:33,153 d"
+    )
+    assert cites[0].lines == (144, 157)
+    assert cites[0].source_line == 1
+    assert cites[1].lines == (33, 153)
+    assert cites[1].source_line == 2
+
+
+def test_parses_bare_basename():
+    cites = lint.parse_citations("llm-d-router passes it through (extractor.go:127)")
+    assert cites[0].path == "extractor.go"
+    assert cites[0].lines == (127,)
+
+
+def test_ignores_non_citation_noise():
+    text = "priced 1.6x more; pinned v0.9.0 at 871b169b; ratio 0.554:0.906"
+    assert lint.parse_citations(text) == []
+
+
+def test_ignores_lint_skip_lines():
+    text = "an example like foo/bar.go:12 is illustrative  # lint-skip"
+    assert lint.parse_citations(text) == []
+
+
+def test_citation_at_end_of_sentence_is_not_dropped():
+    """A trailing period must not defeat the line-spec match."""
+    cites = lint.parse_citations("forced at sim/edpp.go:1707.")
+    assert cites[0].path == "sim/edpp.go"
+    assert cites[0].lines == (1707,)

--- a/.claude/skills/sim2real-specify/tests/test_skill_substitution.py
+++ b/.claude/skills/sim2real-specify/tests/test_skill_substitution.py
@@ -1,0 +1,67 @@
+"""Guard the prompt/SKILL.md placeholder contract.
+
+A prompt placeholder that SKILL.md forgets to substitute reaches the agent as a
+literal `{BRACE}` string, which the agent then treats as a path. The failure is
+silent, so it is worth a mechanical check.
+"""
+
+import re
+from pathlib import Path
+
+SKILL_DIR = Path(__file__).resolve().parents[1]
+PLACEHOLDER = re.compile(r"\{([A-Z][A-Z0-9_]*)\}")
+
+
+def _documented() -> set[str]:
+    text = (SKILL_DIR / "SKILL.md").read_text()
+    start = text.index("### Placeholder substitution")
+    section = text[start : text.index("### Run the three components", start)]
+    return set(PLACEHOLDER.findall(section))
+
+
+def _used() -> dict[str, set[str]]:
+    return {
+        p.name: set(PLACEHOLDER.findall(p.read_text()))
+        for p in sorted((SKILL_DIR / "prompts").glob("*.md"))
+    }
+
+
+def test_every_prompt_placeholder_is_documented():
+    documented = _documented()
+    for name, used in _used().items():
+        missing = used - documented
+        assert not missing, f"{name} uses undocumented placeholders: {sorted(missing)}"
+
+
+def test_no_documented_placeholder_is_unused():
+    all_used = set().union(*_used().values())
+    unused = _documented() - all_used
+    assert not unused, f"SKILL.md documents unused placeholders: {sorted(unused)}"
+
+
+def test_expected_placeholder_sets():
+    used = _used()
+    assert used["audit.md"] == {
+        "ARM_FILE",
+        "ARM_NAME",
+        "BUNDLE_ROOT",
+        "MAIN_SESSION_NAME",
+        "SIM_PIN",
+        "SIM_TREE",
+        "TARGET_PIN",
+        "TARGET_TREE",
+        "VERDICT_PATH",
+    }
+    assert used["rederive.md"] == {
+        "ARM_NAME",
+        "DERIVATION_PATH",
+        "MAIN_SESSION_NAME",
+        "POLICY_ENTRY_POINTS",
+        "SIM_PIN",
+        "SIM_TREE",
+    }
+
+
+def test_both_prompts_are_present():
+    """A renamed or deleted prompt must fail loudly, not silently shrink coverage."""
+    assert set(_used()) == {"audit.md", "rederive.md"}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,7 @@ jobs:
           python -m pytest pipeline/ \
             .claude/skills/sim2real-analyze/tests/ \
             .claude/skills/sim2real-bootstrap/tests/ \
+            .claude/skills/sim2real-specify/tests/ \
             .claude/skills/sim2real-translate/tests/ \
             .claude/skills/sim2real-check/tests/ \
             --cov=pipeline \

--- a/docs/superpowers/plans/2026-08-10-sim2real-specify.md
+++ b/docs/superpowers/plans/2026-08-10-sim2real-specify.md
@@ -1,0 +1,1345 @@
+# sim2real-specify Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the `sim2real-specify` skill — bundle generation from arbitrary provenance, with the algorithm specification gated by an independent citation audit, a blind re-derivation, and a mechanical citation lint.
+
+**Architecture:** A skill directory mirroring `sim2real-translate`: one `SKILL.md` carrying phases 0–6 as prose instructions, two agent prompts substituted with `{PLACEHOLDER}` variables, and one Python script. The only production code is the lint plus an acceptance scorer; everything else is prompts. The gate's agents are spawned `subagent_type=general-purpose`, `model="opus"`, `run_in_background=true`, reporting to `main` — the same mechanics `sim2real-translate` Step 2 uses.
+
+**Tech Stack:** Python 3.11 (stdlib only), pytest, Markdown + YAML frontmatter for skills.
+
+## Global Constraints
+
+- Work on branch `design/sim2real-specify` in the `sim2real` repo. The design spec is `docs/superpowers/specs/2026-08-10-sim2real-specify-design.md`.
+- Python: use the repo-local venv. All commands run as `.venv/bin/python` / `.venv/bin/pytest` from the repo root. Never system Python.
+- `scripts/lint_citations.py` and `scripts/acceptance.py` use **stdlib only** — no new entries in `requirements.txt`.
+- Skill lives at `.claude/skills/sim2real-specify/`. Frontmatter keys, in this order: `name`, `description` (block scalar), `argument-hint`, `user-invocable`, `allowed-tools`.
+- The skill's `name` is exactly `sim2real-specify`; invocation is `/sim2real-specify <experiment-root>`.
+- Prompts use `{PLACEHOLDER}` substitution. Every placeholder appearing in a prompt file MUST be listed in SKILL.md's substitution table — Task 6 enforces this mechanically.
+- Output contract is fixed by the spec: `algorithms/<arm>.go`, `README.md`, `config.md`, `workloads/`, `inputs/`, `sim_results/` + `CHECKSUMS.sha256`, `.gitignore`. **No `LIMITATIONS.md`.**
+- The specification layer invents no in-source marker conventions. A specification may request things of downstream stages; it may never assert what they do.
+- Line numbers cited below for the fixture refer to `algorithms/causal_slo_externality.go` as it exists at commit `08203b4` in the `pd-infocomm` repo (773 lines). Do not confuse them with the current, post-`ead56ea` file.
+
+## File Structure
+
+```
+.claude/skills/sim2real-specify/
+  SKILL.md                        # Task 5 — phases 0-6, interview, output contract
+  prompts/audit.md                # Task 3 — independent citation audit
+  prompts/rederive.md             # Task 4 — blind re-derivation, focal arm
+  scripts/lint_citations.py       # Tasks 1-2 — mechanical path:line resolution
+  scripts/acceptance.py           # Task 7 — fixture materialization + verdict scoring
+  tests/__init__.py               # Task 1
+  tests/test_lint_citations.py    # Tasks 1-2
+  tests/test_skill_substitution.py# Task 6
+  tests/test_acceptance.py        # Task 7
+  tests/fixtures/ead56ea_labels.json   # Task 7 — the four labeled defects
+```
+
+Responsibilities: `lint_citations.py` resolves `path:line` tokens against pinned trees and knows nothing about bundles' meaning. `acceptance.py` materializes the labeled fixture and scores a verdict JSON; it knows nothing about how the verdict was produced. `SKILL.md` orchestrates. The two prompts are independently runnable against any bundle.
+
+---
+
+### Task 1: Citation extraction
+
+Parsing only — no filesystem access. A citation is a path with a known source extension followed by `:` and a line spec.
+
+**Files:**
+- Create: `.claude/skills/sim2real-specify/scripts/lint_citations.py`
+- Create: `.claude/skills/sim2real-specify/tests/__init__.py` (empty)
+- Test: `.claude/skills/sim2real-specify/tests/test_lint_citations.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `Citation` dataclass with fields `path: str`, `lines: tuple[int, ...]`, `source_line: int`; `parse_citations(text: str) -> list[Citation]`; `parse_line_spec(spec: str) -> tuple[int, ...]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `.claude/skills/sim2real-specify/tests/__init__.py` as an empty file, then write `.claude/skills/sim2real-specify/tests/test_lint_citations.py`:
+
+```python
+import importlib.util
+from pathlib import Path
+
+SKILL = Path(__file__).resolve().parents[1]
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "lint_citations", SKILL / "scripts" / "lint_citations.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+lint = _load()
+
+
+def test_parses_simple_citation():
+    cites = lint.parse_citations("see sim/edpp_var.go:168 for the charge")
+    assert len(cites) == 1
+    assert cites[0].path == "sim/edpp_var.go"
+    assert cites[0].lines == (168,)
+    assert cites[0].source_line == 1
+
+
+def test_parses_range_and_comma_specs():
+    cites = lint.parse_citations(
+        "a sim/edpp_var.go:144-157 b\nc utilization/config.go:33,153 d"
+    )
+    assert cites[0].lines == (144, 157)
+    assert cites[0].source_line == 1
+    assert cites[1].lines == (33, 153)
+    assert cites[1].source_line == 2
+
+
+def test_parses_bare_basename():
+    cites = lint.parse_citations("llm-d-router passes it through (extractor.go:127)")
+    assert cites[0].path == "extractor.go"
+    assert cites[0].lines == (127,)
+
+
+def test_ignores_non_citation_noise():
+    text = "priced 1.6x more; pinned v0.9.0 at 871b169b; ratio 0.554:0.906"
+    assert lint.parse_citations(text) == []
+
+
+def test_ignores_lint_skip_lines():
+    text = "an example like foo/bar.go:12 is illustrative  # lint-skip"
+    assert lint.parse_citations(text) == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest .claude/skills/sim2real-specify/tests/test_lint_citations.py -v`
+Expected: FAIL — collection error, `scripts/lint_citations.py` does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `.claude/skills/sim2real-specify/scripts/lint_citations.py`:
+
+```python
+#!/usr/bin/env python3
+"""Resolve `path:line` citations in a sim2real bundle against pinned checkouts.
+
+Mechanical only: verifies that a cited path exists in exactly one pinned tree and
+that the cited line numbers are within that file. Cannot detect a correct citation
+attached to a wrong transcription -- that is the audit agent's job.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+SOURCE_EXTS = ("go", "py", "md", "yaml", "yml", "json")
+
+CITATION_RE = re.compile(
+    r"(?<![\w/.-])"                                    # not mid-token
+    r"([A-Za-z0-9_][\w./-]*\.(?:" + "|".join(SOURCE_EXTS) + r"))"
+    r":(\d+(?:[-,]\d+)*)"                              # 12 | 12-20 | 12,20
+    r"(?!\d)"                                          # whole number only
+)
+# NOTE: do not add `.` to that final lookahead. Citations frequently end a
+# sentence -- `sim/edpp.go:1707.` -- and excluding a trailing period silently
+# drops every one of them. Version-like noise is already excluded by requiring a
+# known source extension in the path group.
+
+SKIP_MARKER = "lint-skip"
+
+
+@dataclass(frozen=True)
+class Citation:
+    path: str
+    lines: tuple[int, ...]
+    source_line: int
+
+    def __str__(self) -> str:
+        return f"{self.path}:{','.join(str(n) for n in self.lines)}"
+
+
+def parse_line_spec(spec: str) -> tuple[int, ...]:
+    """'168' -> (168,); '144-157' -> (144, 157); '33,153' -> (33, 153)."""
+    return tuple(int(part) for part in re.split(r"[-,]", spec) if part)
+
+
+def parse_citations(text: str) -> list[Citation]:
+    out: list[Citation] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if SKIP_MARKER in line:
+            continue
+        for path, spec in CITATION_RE.findall(line):
+            out.append(Citation(path=path, lines=parse_line_spec(spec), source_line=lineno))
+    return out
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest .claude/skills/sim2real-specify/tests/test_lint_citations.py -v`
+Expected: PASS — 5 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .claude/skills/sim2real-specify/scripts/lint_citations.py \
+        .claude/skills/sim2real-specify/tests/__init__.py \
+        .claude/skills/sim2real-specify/tests/test_lint_citations.py
+git commit -m "feat(specify): citation extraction for the bundle lint"
+```
+
+---
+
+### Task 2: Citation resolution and CLI
+
+Resolve each citation by **suffix match** against one or more pinned trees. Suffix matching is required because real citations range from `sim/edpp_var.go` to a bare `extractor.go`. Ambiguity is a failure, not a guess — it forces the author to write a more specific citation.
+
+**Files:**
+- Modify: `.claude/skills/sim2real-specify/scripts/lint_citations.py`
+- Test: `.claude/skills/sim2real-specify/tests/test_lint_citations.py`
+
+**Interfaces:**
+- Consumes: `Citation`, `parse_citations` from Task 1.
+- Produces: `Failure` dataclass with `file: str`, `source_line: int`, `citation: str`, `kind: str`, `detail: str`; `index_tree(root: Path) -> dict[str, list[Path]]`; `resolve(cit, indexes) -> Failure | None`; `lint_bundle(bundle: Path, trees: list[Path], exts: tuple[str, ...]) -> list[Failure]`; `main(argv: list[str] | None = None) -> int`. Failure `kind` is one of `unresolved-path`, `ambiguous-path`, `line-out-of-range`. Exit codes: `0` clean, `1` failures found, `2` usage error.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `.claude/skills/sim2real-specify/tests/test_lint_citations.py`:
+
+```python
+import pytest
+
+
+@pytest.fixture
+def tree(tmp_path):
+    """A fake pinned checkout with two files, one of them shadowed by name."""
+    root = tmp_path / "checkout"
+    (root / "sim").mkdir(parents=True)
+    (root / "sim" / "edpp_var.go").write_text("\n".join(f"line{i}" for i in range(1, 201)))
+    (root / "pkg" / "a").mkdir(parents=True)
+    (root / "pkg" / "a" / "dup.go").write_text("x\ny\n")
+    (root / "pkg" / "b").mkdir(parents=True)
+    (root / "pkg" / "b" / "dup.go").write_text("x\ny\n")
+    (root / ".git").mkdir()
+    (root / ".git" / "edpp_var.go").write_text("noise\n")
+    return root
+
+
+@pytest.fixture
+def bundle(tmp_path):
+    root = tmp_path / "bundle"
+    (root / "algorithms").mkdir(parents=True)
+    return root
+
+
+def test_resolves_valid_citation(bundle, tree):
+    (bundle / "algorithms" / "a.go").write_text("// ported from sim/edpp_var.go:168\n")
+    assert lint.lint_bundle(bundle, [tree], (".go", ".md")) == []
+
+
+def test_flags_unresolved_path(bundle, tree):
+    (bundle / "README.md").write_text("see sim/nope.go:5\n")
+    fails = lint.lint_bundle(bundle, [tree], (".go", ".md"))
+    assert [f.kind for f in fails] == ["unresolved-path"]
+
+
+def test_flags_line_out_of_range(bundle, tree):
+    (bundle / "README.md").write_text("see sim/edpp_var.go:5000\n")
+    fails = lint.lint_bundle(bundle, [tree], (".go", ".md"))
+    assert [f.kind for f in fails] == ["line-out-of-range"]
+    assert "200" in fails[0].detail
+
+
+def test_flags_ambiguous_path(bundle, tree):
+    (bundle / "README.md").write_text("see dup.go:1\n")
+    fails = lint.lint_bundle(bundle, [tree], (".go", ".md"))
+    assert [f.kind for f in fails] == ["ambiguous-path"]
+
+
+def test_ignores_dot_directories(bundle, tree):
+    """.git/edpp_var.go must not create ambiguity with sim/edpp_var.go."""
+    (bundle / "README.md").write_text("see edpp_var.go:1\n")
+    assert lint.lint_bundle(bundle, [tree], (".go", ".md")) == []
+
+
+def test_bundle_is_its_own_tree(bundle, tree):
+    """A self-reference like README.md:2 resolves against the bundle itself."""
+    (bundle / "README.md").write_text("first\nsee README.md:2\n")
+    assert lint.lint_bundle(bundle, [tree], (".go", ".md")) == []
+
+
+def test_main_exit_codes(bundle, tree, capsys):
+    (bundle / "README.md").write_text("see sim/nope.go:5\n")
+    rc = lint.main(["--bundle", str(bundle), "--tree", str(tree)])
+    assert rc == 1
+    assert "unresolved-path" in capsys.readouterr().out
+    (bundle / "README.md").write_text("see sim/edpp_var.go:168\n")
+    assert lint.main(["--bundle", str(bundle), "--tree", str(tree)]) == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest .claude/skills/sim2real-specify/tests/test_lint_citations.py -v`
+Expected: FAIL with `AttributeError: module 'lint_citations' has no attribute 'lint_bundle'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `.claude/skills/sim2real-specify/scripts/lint_citations.py`:
+
+```python
+import argparse
+import sys
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Failure:
+    file: str
+    source_line: int
+    citation: str
+    kind: str
+    detail: str
+
+
+def index_tree(root: Path) -> dict[str, list[Path]]:
+    """Map basename -> files, skipping dot-directories."""
+    index: dict[str, list[Path]] = {}
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        if any(part.startswith(".") for part in path.relative_to(root).parts[:-1]):
+            continue
+        index.setdefault(path.name, []).append(path)
+    return index
+
+
+def _candidates(cit: Citation, indexes: list[dict[str, list[Path]]]) -> list[Path]:
+    basename = cit.path.rsplit("/", 1)[-1]
+    out: list[Path] = []
+    for index in indexes:
+        for path in index.get(basename, []):
+            if path.as_posix().endswith(cit.path):
+                out.append(path)
+    return out
+
+
+def resolve(cit: Citation, indexes: list[dict[str, list[Path]]]) -> Failure | None:
+    matches = _candidates(cit, indexes)
+    if not matches:
+        return Failure("", cit.source_line, str(cit), "unresolved-path",
+                       "no file in any pinned tree ends with this path")
+    if len(set(matches)) > 1:
+        shown = ", ".join(sorted(p.as_posix() for p in set(matches))[:4])
+        return Failure("", cit.source_line, str(cit), "ambiguous-path",
+                       f"matches {len(set(matches))} files: {shown}")
+    target = matches[0]
+    nlines = len(target.read_text(errors="replace").splitlines())
+    over = [n for n in cit.lines if n > nlines or n < 1]
+    if over:
+        return Failure("", cit.source_line, str(cit), "line-out-of-range",
+                       f"{target.name} has {nlines} lines; cited {over}")
+    return None
+
+
+def lint_bundle(bundle: Path, trees: list[Path], exts: tuple[str, ...]) -> list[Failure]:
+    indexes = [index_tree(t) for t in [*trees, bundle]]
+    failures: list[Failure] = []
+    for path in sorted(bundle.rglob("*")):
+        if not path.is_file() or path.suffix not in exts:
+            continue
+        if any(part.startswith(".") for part in path.relative_to(bundle).parts[:-1]):
+            continue
+        text = path.read_text(errors="replace")
+        for cit in parse_citations(text):
+            failure = resolve(cit, indexes)
+            if failure is not None:
+                rel = path.relative_to(bundle).as_posix()
+                failures.append(Failure(rel, failure.source_line, failure.citation,
+                                        failure.kind, failure.detail))
+    return failures
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Lint path:line citations in a sim2real bundle.")
+    ap.add_argument("--bundle", required=True, type=Path)
+    ap.add_argument("--tree", action="append", default=[], type=Path,
+                    help="pinned checkout root; repeatable")
+    ap.add_argument("--ext", default=".go,.md",
+                    help="comma-separated file extensions to scan")
+    args = ap.parse_args(argv)
+
+    if not args.bundle.is_dir():
+        print(f"usage error: --bundle {args.bundle} is not a directory", file=sys.stderr)
+        return 2
+    for tree in args.tree:
+        if not tree.is_dir():
+            print(f"usage error: --tree {tree} is not a directory", file=sys.stderr)
+            return 2
+
+    exts = tuple(e if e.startswith(".") else f".{e}" for e in args.ext.split(","))
+    failures = lint_bundle(args.bundle, args.tree, exts)
+    for f in failures:
+        print(f"FAIL {f.kind} {f.file}:{f.source_line} cite={f.citation} -- {f.detail}")
+    print(f"{len(failures)} citation failure(s)")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest .claude/skills/sim2real-specify/tests/test_lint_citations.py -v`
+Expected: PASS — 12 passed.
+
+- [ ] **Step 5: Smoke-test against the real citation-dense file**
+
+The post-`ead56ea` focal arm is the densest real citation source available. Run it against the BLIS checkout (adjust paths to your machine):
+
+```bash
+mkdir -p /tmp/lintsmoke/algorithms
+cp ../pd-infocomm/algorithms/causal_slo_externality.go /tmp/lintsmoke/algorithms/
+.venv/bin/python .claude/skills/sim2real-specify/scripts/lint_citations.py \
+  --bundle /tmp/lintsmoke --tree inference-sim
+```
+
+Expected: `sim/...` citations resolve. Citations into `llm-d-router` and `vllm` report `unresolved-path` because those trees were not passed — confirming the tool reports rather than guesses. Re-run adding `--tree ../pd-infocomm/llm-d-router --tree ../pd-infocomm/vllm` and confirm the count drops. Record the before/after counts in the commit message.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .claude/skills/sim2real-specify/scripts/lint_citations.py \
+        .claude/skills/sim2real-specify/tests/test_lint_citations.py
+git commit -m "feat(specify): resolve bundle citations against pinned trees"
+```
+
+---
+
+### Task 3: Audit prompt
+
+The independent citation audit, run on every arm. It must perform **correspondence discovery**, not mere citation-checking: the pre-fix fixture carries one citation, so an auditor that only verifies what is already cited returns clean on a file containing four defects.
+
+**Files:**
+- Create: `.claude/skills/sim2real-specify/prompts/audit.md`
+
+**Interfaces:**
+- Consumes: nothing at runtime; SKILL.md substitutes its placeholders.
+- Produces: placeholders `{BUNDLE_ROOT}`, `{ARM_FILE}`, `{ARM_NAME}`, `{SIM_TREE}`, `{SIM_PIN}`, `{TARGET_TREE}`, `{TARGET_PIN}`, `{VERDICT_PATH}`, `{MAIN_SESSION_NAME}`. Writes a verdict JSON to `{VERDICT_PATH}` with schema `{"arm": str, "findings": [{"kind": "CONFIRMED"|"WRONG"|"UNSUPPORTED", "file": str, "line": int, "symbol": str, "claim": str, "upstream": str, "settled_by": str, "detail": str}]}`.
+
+- [ ] **Step 1: Write the prompt**
+
+Create `.claude/skills/sim2real-specify/prompts/audit.md`:
+
+````markdown
+# Independent specification audit
+
+You are auditing ONE algorithm specification in a sim2real bundle. You have no
+generation transcript and must not ask for one. Your only sources of truth are the
+two checkouts named below. Treat the bundle as a claim to be tested.
+
+## Inputs
+
+- Bundle root: `{BUNDLE_ROOT}`
+- Specification under audit: `{ARM_FILE}` (arm name: `{ARM_NAME}`)
+- Simulation checkout: `{SIM_TREE}` pinned at `{SIM_PIN}`
+- Target component checkout: `{TARGET_TREE}` pinned at `{TARGET_PIN}`
+- Write your verdict to: `{VERDICT_PATH}`
+
+## Method: correspondence discovery
+
+Do NOT assume the specification's citations are complete. Citation density is an
+audit OUTPUT, not an input.
+
+For every non-trivial ported expression in `{ARM_FILE}` -- every arithmetic
+formula, every unit conversion, every rounding decision, every loop bound, every
+guard that skips or censors a term -- do this:
+
+1. Locate the upstream counterpart. If the expression carries a citation, use it
+   as a hint and verify it points where it claims. If it carries none, SEARCH the
+   simulation checkout for the corresponding code by symbol name, by formula
+   shape, and by the surrounding concept. Report `UNSUPPORTED` only after
+   searching, never merely because a citation was absent.
+2. Compare term by term. Enumerate the upstream terms and the ported terms and
+   check the sets match. A missing additive term is the most common defect and
+   the easiest to overlook, because the remaining terms look correct.
+3. Check units explicitly. A name is not a unit. If the upstream reads a metric,
+   find that metric's definition in the target or engine checkout and confirm the
+   scale factor. Never trust a prose mapping document over source.
+4. Check rounding and boundary handling. Whether a quantity is truncated,
+   floored, or ceiled changes results and is invisible in aggregate.
+5. Check quantities recomputed per call site upstream. If upstream derives a
+   value locally at each use (for example a per-request budget clamped to a
+   request-specific size), a ported constant is a defect even when an algebraically
+   equivalent downstream quantity hides it.
+
+Then audit the prose. For each non-obvious claim in `{BUNDLE_ROOT}/README.md` and
+`{BUNDLE_ROOT}/config.md`, resolve it against a checkout. Apply one rule:
+
+> A specification may REQUEST things of downstream stages. It may never ASSERT
+> what they do.
+
+A sentence asserting the behavior of another pipeline stage, tool, or agent is
+`UNSUPPORTED` unless that component's own source says so. Verify against the
+component's source, including any section declaring what it does not do.
+
+## Verdicts
+
+Emit one finding per checked claim, using exactly these kinds:
+
+- `CONFIRMED` -- the port matches upstream, or the prose claim is substantiated.
+- `WRONG` -- a counterpart exists and the port disagrees with it. State the
+  correct form.
+- `UNSUPPORTED` -- no upstream counterpart could be found after searching, so the
+  claim rests on nothing.
+
+Every finding MUST carry `settled_by`: the `path:line` in a checkout that settles
+it. A finding without `settled_by` is not a finding.
+
+Be specific about consequence. "Units are wrong" is not useful; "the divisor
+under-counts by 100x, collapsing the term that carries hardware heterogeneity" is.
+
+## Output
+
+Write JSON to `{VERDICT_PATH}`:
+
+```json
+{
+  "arm": "{ARM_NAME}",
+  "findings": [
+    {
+      "kind": "WRONG",
+      "file": "algorithms/example.go",
+      "line": 335,
+      "symbol": "enclosingFunctionName",
+      "claim": "what the specification says or computes",
+      "upstream": "sim/example.go:168",
+      "settled_by": "vllm/v1/metrics/loggers.py:563",
+      "detail": "what is wrong and what the correct form is, with consequence"
+    }
+  ]
+}
+```
+
+When done, send one message to `{MAIN_SESSION_NAME}`:
+`audit-complete: {ARM_NAME} <n> CONFIRMED, <n> WRONG, <n> UNSUPPORTED`
+
+Do not edit any file other than `{VERDICT_PATH}`. Fixing is not your job.
+````
+
+- [ ] **Step 2: Verify the prompt's placeholders are extractable**
+
+Run: `grep -o '{[A-Z_]*}' .claude/skills/sim2real-specify/prompts/audit.md | sort -u`
+Expected: exactly `{ARM_FILE}`, `{ARM_NAME}`, `{BUNDLE_ROOT}`, `{MAIN_SESSION_NAME}`, `{SIM_PIN}`, `{SIM_TREE}`, `{TARGET_PIN}`, `{TARGET_TREE}`, `{VERDICT_PATH}` — nine names, and no stray uppercase braces from the JSON example.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/skills/sim2real-specify/prompts/audit.md
+git commit -m "feat(specify): audit prompt with correspondence discovery"
+```
+
+---
+
+### Task 4: Re-derivation prompt
+
+Blind re-derivation of the focal arm. Justified by anchoring: an auditor reading an existing port rationalizes it. The `chunk = ChunkTokens` defect hid precisely because the derived chunk count is algebraically identical either way — a class a blind writer surfaces and a reviewer talks itself out of. It is also the only component that can find a term omitted *and* undeclared, since there is no claim to audit.
+
+**Files:**
+- Create: `.claude/skills/sim2real-specify/prompts/rederive.md`
+
+**Interfaces:**
+- Consumes: nothing at runtime.
+- Produces: placeholders `{SIM_TREE}`, `{SIM_PIN}`, `{POLICY_ENTRY_POINTS}`, `{ARM_NAME}`, `{DERIVATION_PATH}`, `{MAIN_SESSION_NAME}`. Writes JSON `{"arm": str, "terms": [{"name": str, "expression": str, "upstream": str, "units": str, "notes": str}]}` to `{DERIVATION_PATH}`.
+
+- [ ] **Step 1: Write the prompt**
+
+Create `.claude/skills/sim2real-specify/prompts/rederive.md`:
+
+````markdown
+# Blind re-derivation
+
+Derive an algorithm's decision rule from simulation source alone. You will NOT be
+shown any existing port, and you must not look for one. If you encounter a file
+that appears to be a port of this policy, stop reading it and continue from the
+simulation source.
+
+## Inputs
+
+- Simulation checkout: `{SIM_TREE}` pinned at `{SIM_PIN}`
+- Entry points for the policy: `{POLICY_ENTRY_POINTS}`
+- Arm name: `{ARM_NAME}`
+- Write your derivation to: `{DERIVATION_PATH}`
+
+## Method
+
+Read the entry points and follow every call they make that contributes to the
+decision. Then write down, as a flat list of named terms, the complete
+computation: what is summed, multiplied, compared, rounded, skipped, and returned.
+
+For each term record:
+
+- `name` -- a short identifier you choose
+- `expression` -- the algebra, in terms of other names you have defined
+- `upstream` -- the `path:line` in `{SIM_TREE}` it comes from
+- `units` -- microseconds, tokens, requests, dimensionless
+- `notes` -- anything a reimplementation would get wrong
+
+Rules that matter for this comparison:
+
+1. Be exhaustive about ADDITIVE terms. If the upstream sums four contributions,
+   list four. Omission is the defect class this exercise exists to catch.
+2. Record every rounding operation as its own note. Floor, ceil, and truncate are
+   not interchangeable.
+3. Record any quantity the upstream recomputes at each call site, and say what it
+   is clamped to. Do not summarize it as a constant.
+4. Record guards that skip a term -- censoring, sentinel values, early
+   `continue` -- and what the skipped contribution would have been.
+5. Where the upstream selects between branches by a flag, follow the branch this
+   policy actually forces and say which flag forces it. Ignore unreachable
+   branches, and note that you ignored them.
+6. Note every quantity that comes from simulator-internal state with no
+   real-cluster analogue. Do not invent a substitute.
+
+## Output
+
+Write JSON to `{DERIVATION_PATH}`:
+
+```json
+{
+  "arm": "{ARM_NAME}",
+  "terms": [
+    {
+      "name": "decodeIterationTime",
+      "expression": "alpha + c0*batchSize + c1*kvTokens + cPf*prefillTokens",
+      "upstream": "sim/example_coeffs.go:41",
+      "units": "microseconds",
+      "notes": "recomputed per candidate under that candidate's own coefficients"
+    }
+  ]
+}
+```
+
+When done, send one message to `{MAIN_SESSION_NAME}`:
+`rederive-complete: {ARM_NAME} <n> terms`
+
+Do not edit any file other than `{DERIVATION_PATH}`.
+````
+
+- [ ] **Step 2: Verify the prompt's placeholders are extractable**
+
+Run: `grep -o '{[A-Z_]*}' .claude/skills/sim2real-specify/prompts/rederive.md | sort -u`
+Expected: exactly `{ARM_NAME}`, `{DERIVATION_PATH}`, `{MAIN_SESSION_NAME}`, `{POLICY_ENTRY_POINTS}`, `{SIM_PIN}`, `{SIM_TREE}` — six names.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/skills/sim2real-specify/prompts/rederive.md
+git commit -m "feat(specify): blind re-derivation prompt for the focal arm"
+```
+
+---
+
+### Task 5: SKILL.md
+
+**Files:**
+- Create: `.claude/skills/sim2real-specify/SKILL.md`
+
+**Interfaces:**
+- Consumes: `prompts/audit.md` and `prompts/rederive.md` placeholder sets from Tasks 3–4; `scripts/lint_citations.py` CLI from Task 2.
+- Produces: the substitution table that Task 6's test parses — a Markdown section titled exactly `## Placeholder substitution` containing one list item per placeholder in the form `` - `{NAME}` → ... ``.
+
+- [ ] **Step 1: Write SKILL.md**
+
+Create `.claude/skills/sim2real-specify/SKILL.md`:
+
+````markdown
+---
+name: sim2real-specify
+description: |
+  Turn arbitrary upstream provenance (a BLIS commit, a Nous campaign, a paper
+  plus code) into the canonical sim2real bundle inputs: algorithms/<arm>.go as a
+  cited specification layer, README.md, config.md, workloads/, inputs/, and
+  sim_results/ with checksums. Establishes the five properties that make an
+  algorithm worth transferring -- causal mechanism, required structural shape,
+  observability, isolation, and named threats to validity -- then gates the
+  specification with an independent citation audit, a blind re-derivation of the
+  focal arm, and a mechanical citation lint. Run BEFORE /sim2real-bootstrap.
+argument-hint: "<experiment-root> [--focal ARM]"
+user-invocable: true
+allowed-tools:
+  - Agent
+  - SendMessage
+  - TaskCreate
+  - TaskUpdate
+  - TaskList
+  - AskUserQuestion
+  - Bash(python3 *)
+  - Bash(.venv/bin/python *)
+  - Bash(git *)
+  - Bash(test *)
+  - Bash(shasum *)
+  - Bash(cp *)
+  - Bash(mkdir *)
+  - Glob
+  - Grep
+  - Read
+  - Write
+  - Edit
+---
+
+# sim2real-specify
+
+Produce a bundle whose algorithm specification is worth transferring. This runs
+before `/sim2real-bootstrap`, which consumes `algorithms/` and `workloads/` as
+pre-existing inputs.
+
+The product is a MEANINGFUL algorithm specification. Correctness of the algebra is
+necessary but not sufficient; an algorithm that is unimplementable on the target,
+or indistinguishable from the baseline, is not worth transferring even when its
+arithmetic is perfect.
+
+## What this skill does NOT do
+
+- Does not create `transfer.yaml` or `baselines/` — `/sim2real-bootstrap`.
+- Does not wire submodules — bootstrap Task 1 derives the ref, Task 2 adds it.
+- Does not produce compiling code — `/sim2real-translate`. The specification layer
+  is non-compiling by design and its adapters stay declared unknowns.
+- Does not build images or touch cluster config.
+- Does not emit a limitations register or signal reference document. Degradations
+  are declared in the specification layer's own header.
+
+## Output contract
+
+Produce exactly these paths under `<experiment-root>`:
+
+| path | authored or copied |
+|---|---|
+| `algorithms/<arm>.go` | authored |
+| `README.md` | authored |
+| `config.md` | authored |
+| `workloads/` | copied verbatim |
+| `inputs/` | copied verbatim |
+| `sim_results/` + `CHECKSUMS.sha256` | copied verbatim |
+| `.gitignore` | generated |
+
+Do NOT create `LIMITATIONS.md`, `docs/`, or `scripts/`.
+
+**Verbatim-copy principle.** Anything that already exists upstream is copied, never
+re-expressed: workloads, coefficients, results, patches. Re-authoring is reserved
+for the specification layer, the one artifact that must change form. Re-authored
+algebra is where defects come from; copied artifacts have never been a defect
+source.
+
+## Phase 0 — Ground
+
+Obtain and verify two readable checkouts. Ask the operator for whichever is not
+already present:
+
+- the simulation source at a specific commit;
+- the target component at a specific ref.
+
+Record both pins. Every later claim is a citation against these two trees.
+
+HALT if either is unreadable at its stated pin. Say which one and stop — nothing
+downstream can be substantiated.
+
+## Phase 1 — Mechanism
+
+Establish, by interview plus source reading:
+
+- the decision rule, and where it lives in the simulation source;
+- the CAUSAL story: not that it wins, but why. Name the quantity that differs
+  between conditions and the mechanism that exploits it.
+- the cited evidence that it wins: which cells, what margin, against what
+  baseline.
+
+Copy the results artifacts verbatim into `sim_results/` and write
+`CHECKSUMS.sha256` over them with `shasum -a 256`.
+
+HALT if the results do not match their own checksums, or if the commit that
+produced them is not the pin from Phase 0. A disagreement here invalidates every
+cited margin.
+
+## Phase 2 — Shape
+
+Determine the structural form the decision takes: per-endpoint score, joint argmin
+over a cross product, admission gate, dispatch ceiling, or something else. Then
+read the target checkout and find an extension point that can express it.
+
+Compare against the target's NATURAL decomposition. Where the natural
+decomposition is weaker, quantify what would be lost, using the simulation's own
+ablation rather than an estimate.
+
+HALT if no extension point can express the required shape. The hazard is silent
+fallback to the weaker natural decomposition, which transfers a different
+algorithm while resembling success. Say so loudly instead.
+
+## Phase 3 — Observability
+
+Enumerate every quantity the decision rule reads. Classify each:
+
+| status | meaning |
+|---|---|
+| direct | an existing target or engine value with the same definition |
+| derivable | computable from existing values; record the derivation |
+| degraded | an approximation is available; record the direction of bias |
+| unobtainable | no real signal exists |
+
+Every row carries a citation to the value that supplies it. This is a
+classification pass, not a reference document — keep it to a table.
+
+If a quantity carrying the CORE mechanism is `unobtainable`, stop and put the case
+to the operator with `AskUserQuestion`. Degraded may be acceptable with reasoning,
+but that judgment is the operator's, not yours.
+
+## Phase 4 — Isolation
+
+Identify the comparator arms and ablations that isolate the mechanism, each with
+cited simulation evidence. A comparator that shares the machinery and differs only
+in the objective is worth more than a weaker baseline, because it attributes the
+effect to the mechanism rather than to the machinery.
+
+If nothing isolates the mechanism, say so: the transfer may proceed but its
+results will not be attributable.
+
+## Phase 5 — Specify
+
+Write `algorithms/<arm>.go` per arm, plus `config.md`.
+
+The specification layer:
+
+- states the policy against REAL target interface names;
+- leaves adapters as declared unknowns rather than guesses, so a wrong guess fails
+  loudly rather than mis-scoring silently;
+- carries an upstream `path:line` citation on every non-obvious expression;
+- declares each Phase 3 degradation in its header WITH the direction of bias;
+- invents no in-source marker conventions.
+
+One rule governs references to other pipeline stages:
+
+> A specification may REQUEST things of downstream stages. It may never ASSERT
+> what they do.
+
+"Confirm X against the pinned checkout" is a legitimate request. "Stage Y resolves
+X" asserts another component's behavior and is forbidden unless that component's
+source says so.
+
+`README.md` states the mechanism, the required shape, the honest status including
+where the policy did NOT win, the pre-registered expectation, the pins table, and
+the layout. If Phase 1 found no results, write the expectation as a hypothesis with
+no margin attached and say that no measurement backs it.
+
+## Phase 6 — Gate
+
+### Placeholder substitution
+
+Read `prompts/audit.md` and `prompts/rederive.md` and substitute every
+`{PLACEHOLDER}`:
+
+- `{BUNDLE_ROOT}` → the absolute experiment root
+- `{ARM_FILE}` → absolute path to the arm under audit
+- `{ARM_NAME}` → the arm's name, matching its filename stem
+- `{SIM_TREE}` → absolute path to the simulation checkout
+- `{SIM_PIN}` → the simulation commit recorded in Phase 0
+- `{TARGET_TREE}` → absolute path to the target checkout
+- `{TARGET_PIN}` → the target ref recorded in Phase 0
+- `{VERDICT_PATH}` → `/tmp/specify-verdict-<arm>.json`
+- `{POLICY_ENTRY_POINTS}` → newline-separated `path:symbol` entry points from Phase 1
+- `{DERIVATION_PATH}` → `/tmp/specify-derivation-<arm>.json`
+- `{MAIN_SESSION_NAME}` → `"main"`
+
+### Run the three components
+
+1. **Citation audit, every arm.** Spawn one agent per arm in a single tool-call
+   message: `Agent(name="audit-<arm>", run_in_background=true,
+   subagent_type=general-purpose, model="opus", prompt=<substituted audit.md>)`.
+2. **Blind re-derivation, focal arm only.** Spawn
+   `Agent(name="rederive", run_in_background=true, subagent_type=general-purpose,
+   model="opus", prompt=<substituted rederive.md>)`. Scoped to the focal arm
+   because that is where the algebra carrying the claim lives.
+3. **Citation lint.** Run:
+
+   ```bash
+   .venv/bin/python .claude/skills/sim2real-specify/scripts/lint_citations.py \
+     --bundle <experiment-root> --tree <sim-tree> --tree <target-tree>
+   ```
+
+### Reconcile
+
+- Every `WRONG` finding: fix the specification. Cite the `settled_by` path in the
+  fix.
+- Every `UNSUPPORTED` finding: delete the claim, or convert it to a stated open
+  question in `README.md` owned by the bundle.
+- Every re-derivation term absent from the specification: either add it, or
+  declare its omission in the header with the direction of bias. A silent omission
+  is a defect even when the omission is defensible.
+- Every lint failure: correct the citation, or add `lint-skip` on that line if the
+  reference is illustrative rather than a citation.
+
+### Pass condition
+
+Zero `UNSUPPORTED` claims remain, the lint exits 0, and every re-derivation
+divergence is resolved or declared.
+
+If `UNSUPPORTED` findings survive three fix rounds, STOP. Report what remains
+unresolved. Do not describe the bundle as audited.
+
+## After specify
+
+Tell the operator:
+
+```
+Specification complete at <experiment-root>. Gate: <n> arms audited,
+<n> re-derivation divergences declared, lint clean.
+
+Next: /sim2real-bootstrap <experiment-root>
+```
+````
+
+- [ ] **Step 2: Verify the frontmatter parses**
+
+Run:
+```bash
+.venv/bin/python -c "
+import re, sys, pathlib
+t = pathlib.Path('.claude/skills/sim2real-specify/SKILL.md').read_text()
+m = re.match(r'^---\n(.*?)\n---\n', t, re.S)
+assert m, 'no frontmatter'
+import yaml; fm = yaml.safe_load(m.group(1))
+assert fm['name'] == 'sim2real-specify', fm['name']
+assert fm['user-invocable'] is True
+print('frontmatter ok:', list(fm))
+"
+```
+Expected: `frontmatter ok: ['name', 'description', 'argument-hint', 'user-invocable', 'allowed-tools']`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/skills/sim2real-specify/SKILL.md
+git commit -m "feat(specify): SKILL.md with phases 0-6 and the gate"
+```
+
+---
+
+### Task 6: Placeholder-consistency test
+
+A prompt placeholder that SKILL.md forgets to substitute reaches the agent as a literal `{BRACE}` string, which the agent then treats as a path. This is silent and has bitten the translate skill before. Make it mechanical.
+
+**Files:**
+- Create: `.claude/skills/sim2real-specify/tests/test_skill_substitution.py`
+
+**Interfaces:**
+- Consumes: `SKILL.md`'s `## Placeholder substitution` section and the two prompt files.
+- Produces: nothing.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `.claude/skills/sim2real-specify/tests/test_skill_substitution.py`:
+
+```python
+import re
+from pathlib import Path
+
+SKILL_DIR = Path(__file__).resolve().parents[1]
+PLACEHOLDER = re.compile(r"\{([A-Z][A-Z0-9_]*)\}")
+
+
+def _documented() -> set[str]:
+    text = (SKILL_DIR / "SKILL.md").read_text()
+    start = text.index("### Placeholder substitution")
+    section = text[start : text.index("### Run the three components", start)]
+    return set(PLACEHOLDER.findall(section))
+
+
+def _used() -> dict[str, set[str]]:
+    return {
+        p.name: set(PLACEHOLDER.findall(p.read_text()))
+        for p in sorted((SKILL_DIR / "prompts").glob("*.md"))
+    }
+
+
+def test_every_prompt_placeholder_is_documented():
+    documented = _documented()
+    for name, used in _used().items():
+        missing = used - documented
+        assert not missing, f"{name} uses undocumented placeholders: {sorted(missing)}"
+
+
+def test_no_documented_placeholder_is_unused():
+    all_used = set().union(*_used().values())
+    unused = _documented() - all_used
+    assert not unused, f"SKILL.md documents unused placeholders: {sorted(unused)}"
+
+
+def test_expected_placeholder_sets():
+    used = _used()
+    assert used["audit.md"] == {
+        "ARM_FILE", "ARM_NAME", "BUNDLE_ROOT", "MAIN_SESSION_NAME",
+        "SIM_PIN", "SIM_TREE", "TARGET_PIN", "TARGET_TREE", "VERDICT_PATH",
+    }
+    assert used["rederive.md"] == {
+        "ARM_NAME", "DERIVATION_PATH", "MAIN_SESSION_NAME",
+        "POLICY_ENTRY_POINTS", "SIM_PIN", "SIM_TREE",
+    }
+```
+
+- [ ] **Step 2: Run test to verify it passes or reveals a real gap**
+
+Run: `.venv/bin/pytest .claude/skills/sim2real-specify/tests/test_skill_substitution.py -v`
+Expected: PASS — 3 passed. If it fails, the failure is real: SKILL.md's substitution list and the prompts disagree. Fix SKILL.md's list, not the test.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/skills/sim2real-specify/tests/test_skill_substitution.py
+git commit -m "test(specify): enforce prompt/SKILL.md placeholder agreement"
+```
+
+---
+
+### Task 7: Labeled-fixture acceptance harness
+
+Score the audit against ground truth established independently and by hand in `pd-infocomm` commit `ead56ea`. Sensitivity: four known defects in the focal arm at `08203b4`. Specificity: two comparator arms at the same commit that `ead56ea` found clean and left unchanged.
+
+**Files:**
+- Create: `.claude/skills/sim2real-specify/tests/fixtures/ead56ea_labels.json`
+- Create: `.claude/skills/sim2real-specify/scripts/acceptance.py`
+- Test: `.claude/skills/sim2real-specify/tests/test_acceptance.py`
+
+**Interfaces:**
+- Consumes: `Failure`-free; independent of `lint_citations.py`.
+- Produces: `load_labels(path: Path) -> list[dict]`; `match(finding: dict, label: dict, tolerance: int = 6) -> bool`; `score(verdicts: list[dict], labels: list[dict]) -> dict` returning `{"found": [ids], "missed": [ids], "false_positive_arms": {arm: count}, "recall": float}`; `materialize(repo: Path, commit: str, dest: Path) -> None`; `main(argv) -> int`.
+
+- [ ] **Step 1: Write the labels fixture**
+
+Create `.claude/skills/sim2real-specify/tests/fixtures/ead56ea_labels.json`. Line numbers are in `algorithms/causal_slo_externality.go` at `08203b4`, verified against that blob:
+
+```json
+{
+  "fixture": {
+    "repo_hint": "pd-infocomm",
+    "commit": "08203b4",
+    "focal_arm": "causal_slo_externality",
+    "clean_arms": ["least_ttft_joint", "kairos_paper"],
+    "authority": "pd-infocomm commit ead56ea"
+  },
+  "labels": [
+    {
+      "id": "missing-prefill-attention-charge",
+      "file": "algorithms/causal_slo_externality.go",
+      "lines": [483],
+      "symbol": "cLocalAfter",
+      "found_by": ["audit", "rederive"],
+      "detail": "overlap*tIterOverlap replaces the baseline rate plus the arrival's exact marginal prefill work; the causal prefill-attention term is absent. Upstream charges it in both branches of varReTiming.cLocalAfter and the focal arm force-selects the exact one."
+    },
+    {
+      "id": "kv-usage-fraction-not-percent",
+      "file": "algorithms/causal_slo_externality.go",
+      "lines": [335],
+      "symbol": "kvTokensFor",
+      "found_by": ["audit"],
+      "detail": "spurious /100.0 -- KVCacheUsagePercent is a fraction in [0,1] despite its name, so KV is under-counted 100x, collapsing the C1*KV term that carries hardware heterogeneity."
+    },
+    {
+      "id": "admission-steps-not-ceiled",
+      "file": "algorithms/causal_slo_externality.go",
+      "lines": [567, 589],
+      "symbol": "Score",
+      "found_by": ["audit", "rederive"],
+      "detail": "admissionSteps and arrivalSteps must be math.Ceil -- admission lands on an iteration boundary, so the wait is a whole number of baseline decode steps."
+    },
+    {
+      "id": "chunk-not-clamped-to-uncached-suffix",
+      "file": "algorithms/causal_slo_externality.go",
+      "lines": [718],
+      "symbol": "chunkTerms",
+      "found_by": ["audit", "rederive"],
+      "detail": "chunk = ChunkTokens where upstream recomputes min(ap, ChunkTokens) at every call site. Hides because nChunks is algebraically identical either way; only the token count differs."
+    },
+    {
+      "id": "undeclared-colloc-prefill-omission",
+      "file": "algorithms/causal_slo_externality.go",
+      "lines": [500],
+      "symbol": "externality",
+      "found_by": ["rederive"],
+      "detail": "upstream externality is a three-way breakdown and the focal arm enables all three; this port returns only the decode component and declares neither omission. Findable only by re-derivation -- there is no claim to audit."
+    }
+  ]
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `.claude/skills/sim2real-specify/tests/test_acceptance.py`:
+
+```python
+import importlib.util
+import json
+from pathlib import Path
+
+SKILL = Path(__file__).resolve().parents[1]
+LABELS = SKILL / "tests" / "fixtures" / "ead56ea_labels.json"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "acceptance", SKILL / "scripts" / "acceptance.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+acc = _load()
+
+
+def test_labels_fixture_is_wellformed():
+    data = json.loads(LABELS.read_text())
+    assert data["fixture"]["commit"] == "08203b4"
+    ids = [l["id"] for l in data["labels"]]
+    assert len(ids) == len(set(ids))
+    audit_findable = [l for l in data["labels"] if "audit" in l["found_by"]]
+    assert len(audit_findable) == 4, "ead56ea established four audit-findable defects"
+
+
+def test_match_by_line_within_tolerance():
+    label = {"file": "a.go", "lines": [483], "symbol": "cLocalAfter"}
+    assert acc.match({"file": "a.go", "line": 485, "symbol": "other"}, label)
+    assert not acc.match({"file": "a.go", "line": 600, "symbol": "other"}, label)
+
+
+def test_match_by_symbol_when_line_drifts():
+    label = {"file": "a.go", "lines": [483], "symbol": "cLocalAfter"}
+    assert acc.match({"file": "a.go", "line": 999, "symbol": "cLocalAfter"}, label)
+
+
+def test_score_reports_recall_and_false_positives():
+    labels = acc.load_labels(LABELS)
+    audit_labels = [l for l in labels if "audit" in l["found_by"]]
+    verdicts = [
+        {"arm": "causal_slo_externality", "findings": [
+            {"kind": "WRONG", "file": "algorithms/causal_slo_externality.go",
+             "line": 335, "symbol": "kvTokensFor"},
+            {"kind": "WRONG", "file": "algorithms/causal_slo_externality.go",
+             "line": 483, "symbol": "cLocalAfter"},
+        ]},
+        {"arm": "least_ttft_joint", "findings": [
+            {"kind": "WRONG", "file": "algorithms/least_ttft_joint.go",
+             "line": 12, "symbol": "somethingElse"},
+        ]},
+    ]
+    result = acc.score(verdicts, audit_labels)
+    assert set(result["found"]) == {
+        "kv-usage-fraction-not-percent", "missing-prefill-attention-charge"}
+    assert set(result["missed"]) == {
+        "admission-steps-not-ceiled", "chunk-not-clamped-to-uncached-suffix"}
+    assert result["recall"] == 0.5
+    assert result["false_positive_arms"] == {"least_ttft_joint": 1}
+
+
+def test_confirmed_findings_are_not_counted_as_false_positives():
+    labels = [l for l in acc.load_labels(LABELS) if "audit" in l["found_by"]]
+    verdicts = [{"arm": "kairos_paper", "findings": [
+        {"kind": "CONFIRMED", "file": "algorithms/kairos_paper.go",
+         "line": 5, "symbol": "x"},
+    ]}]
+    assert acc.score(verdicts, labels)["false_positive_arms"] == {}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `.venv/bin/pytest .claude/skills/sim2real-specify/tests/test_acceptance.py -v`
+Expected: FAIL — collection error, `scripts/acceptance.py` does not exist.
+
+- [ ] **Step 4: Write minimal implementation**
+
+Create `.claude/skills/sim2real-specify/scripts/acceptance.py`:
+
+```python
+#!/usr/bin/env python3
+"""Score a sim2real-specify audit against the ead56ea labeled fixture.
+
+Sensitivity: the four defects that commit found in the focal arm at 08203b4.
+Specificity: the two comparator arms it found clean and left unchanged.
+
+The agent run itself is manual and nondeterministic; only the scoring here is
+deterministic, and only the scoring is unit-tested.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ARM_FILES = {
+    "causal_slo_externality": "algorithms/causal_slo_externality.go",
+    "least_ttft_joint": "algorithms/least_ttft_joint.go",
+    "kairos_paper": "algorithms/kairos_paper.go",
+}
+
+
+def load_labels(path: Path) -> list[dict]:
+    return json.loads(path.read_text())["labels"]
+
+
+def match(finding: dict, label: dict, tolerance: int = 6) -> bool:
+    if finding.get("file") != label["file"]:
+        return False
+    if finding.get("symbol") and finding["symbol"] == label["symbol"]:
+        return True
+    line = finding.get("line")
+    if line is None:
+        return False
+    return any(abs(line - n) <= tolerance for n in label["lines"])
+
+
+def score(verdicts: list[dict], labels: list[dict]) -> dict:
+    defects = [f for v in verdicts for f in v["findings"]
+               if f.get("kind") in ("WRONG", "UNSUPPORTED")]
+    found = [l["id"] for l in labels if any(match(f, l) for f in defects)]
+    missed = [l["id"] for l in labels if l["id"] not in found]
+
+    false_positives: dict[str, int] = {}
+    for verdict in verdicts:
+        arm = verdict["arm"]
+        if arm not in ("least_ttft_joint", "kairos_paper"):
+            continue
+        count = sum(1 for f in verdict["findings"]
+                    if f.get("kind") in ("WRONG", "UNSUPPORTED"))
+        if count:
+            false_positives[arm] = count
+
+    return {
+        "found": sorted(found),
+        "missed": sorted(missed),
+        "false_positive_arms": false_positives,
+        "recall": (len(found) / len(labels)) if labels else 0.0,
+    }
+
+
+def materialize(repo: Path, commit: str, dest: Path) -> None:
+    """Extract the three arm files at `commit` into `dest` as a bundle skeleton."""
+    (dest / "algorithms").mkdir(parents=True, exist_ok=True)
+    for rel in ARM_FILES.values():
+        blob = subprocess.run(
+            ["git", "-C", str(repo), "show", f"{commit}:{rel}"],
+            capture_output=True, check=True, text=True,
+        ).stdout
+        (dest / rel).write_text(blob)
+    for rel in ("README.md", "config.md"):
+        blob = subprocess.run(
+            ["git", "-C", str(repo), "show", f"{commit}:{rel}"],
+            capture_output=True, check=True, text=True,
+        ).stdout
+        (dest / rel).write_text(blob)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    m = sub.add_parser("materialize", help="extract the fixture bundle")
+    m.add_argument("--repo", required=True, type=Path)
+    m.add_argument("--commit", default="08203b4")
+    m.add_argument("--dest", required=True, type=Path)
+
+    s = sub.add_parser("score", help="score verdict JSONs against the labels")
+    s.add_argument("--labels", required=True, type=Path)
+    s.add_argument("--verdict", action="append", required=True, type=Path)
+    s.add_argument("--component", default="audit", choices=["audit", "rederive"])
+
+    args = ap.parse_args(argv)
+
+    if args.cmd == "materialize":
+        materialize(args.repo, args.commit, args.dest)
+        print(f"fixture at {args.dest} from {args.commit}")
+        return 0
+
+    labels = [l for l in load_labels(args.labels) if args.component in l["found_by"]]
+    verdicts = [json.loads(p.read_text()) for p in args.verdict]
+    result = score(verdicts, labels)
+    print(json.dumps(result, indent=2))
+    if result["missed"] or result["false_positive_arms"]:
+        print("ACCEPTANCE FAILED", file=sys.stderr)
+        return 1
+    print("ACCEPTANCE PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `.venv/bin/pytest .claude/skills/sim2real-specify/tests/test_acceptance.py -v`
+Expected: PASS — 5 passed.
+
+- [ ] **Step 6: Run the whole skill's test suite**
+
+Run: `.venv/bin/pytest .claude/skills/sim2real-specify/ -v`
+Expected: PASS — 20 passed (5 + 7 from lint, 3 substitution, 5 acceptance).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add .claude/skills/sim2real-specify/scripts/acceptance.py \
+        .claude/skills/sim2real-specify/tests/test_acceptance.py \
+        .claude/skills/sim2real-specify/tests/fixtures/ead56ea_labels.json
+git commit -m "test(specify): acceptance harness scored against the ead56ea fixture"
+```
+
+- [ ] **Step 8: Execute the acceptance run for real**
+
+This step runs agents and is not automated. Materialize the fixture, run the audit prompt against it, and score.
+
+```bash
+.venv/bin/python .claude/skills/sim2real-specify/scripts/acceptance.py \
+  materialize --repo ../pd-infocomm --commit 08203b4 --dest /tmp/specify-fixture
+```
+
+Then, for each of the three arms, substitute `prompts/audit.md` with
+`{BUNDLE_ROOT}=/tmp/specify-fixture`, `{ARM_FILE}=/tmp/specify-fixture/algorithms/<arm>.go`,
+`{SIM_TREE}=inference-sim`, `{SIM_PIN}=871b169b`,
+`{TARGET_TREE}=../pd-infocomm/llm-d-router`, `{TARGET_PIN}=v0.9.0`,
+`{VERDICT_PATH}=/tmp/specify-verdict-<arm>.json`, and spawn one background
+`general-purpose` agent per arm on `model="opus"`. Then:
+
+```bash
+.venv/bin/python .claude/skills/sim2real-specify/scripts/acceptance.py \
+  score --labels .claude/skills/sim2real-specify/tests/fixtures/ead56ea_labels.json \
+  --verdict /tmp/specify-verdict-causal_slo_externality.json \
+  --verdict /tmp/specify-verdict-least_ttft_joint.json \
+  --verdict /tmp/specify-verdict-kairos_paper.json \
+  --component audit
+```
+
+Expected: `recall` 1.0 with empty `missed` and empty `false_positive_arms`.
+
+If recall is below 1.0, the audit prompt is too weak — strengthen the specific
+`Method` clause corresponding to each missed label (for example, a missed
+`chunk-not-clamped-to-uncached-suffix` means clause 5 on per-call-site recomputation
+needs sharpening) and re-run. Do NOT weaken the labels. If `false_positive_arms`
+is non-empty, the prompt is over-flagging; tighten the requirement that every
+finding carry a `settled_by` line that actually contradicts the port.
+
+Record the final scores in the commit message.
+
+- [ ] **Step 9: Commit any prompt strengthening**
+
+```bash
+git add .claude/skills/sim2real-specify/prompts/audit.md
+git commit -m "fix(specify): strengthen audit prompt to reach full recall on the fixture"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** Five properties → SKILL.md Phases 1–5 (Task 5). Placement and non-goals → Task 5's "What this skill does NOT do". Output contract incl. no `LIMITATIONS.md` → Task 5. Verbatim-copy principle → Task 5. Request-vs-assert rule → Tasks 3 and 5. Gate's three components → Tasks 3, 4, 2 respectively, orchestrated in Task 5 Phase 6. Correspondence discovery → Task 3. Failure modes: HALTs → Phases 0–2; operator decisions → Phases 3–4 via `AskUserQuestion`; degraded output → Phase 5; gate non-convergence → Phase 6 three-round bound. Structure → File Structure section. Testing: sensitivity/specificity → Task 7; lint units → Tasks 1–2; lint on the citation-dense post-fix file → Task 2 Step 5; placeholder consistency → Task 6. Deferred items (`provenance.yaml`, bootstrap pin check) are correctly absent from all tasks.
+
+**Known gap, deliberate.** The spec's acceptance criterion "regenerate the bundle from the same provenance and confirm the four defects never appear" is a full end-to-end run of an interview-driven skill. It is not scriptable and is not a task here; Task 7 Step 8 covers the gate half of it, which is where the four defects are caught. Run the end-to-end regeneration once manually after this plan completes.
+
+**Type consistency.** `Citation(path, lines, source_line)` and `Failure(file, source_line, citation, kind, detail)` are used identically in Tasks 1–2. `lint_bundle(bundle, trees, exts)` matches its call in Task 2's tests and Task 5's CLI invocation. Verdict JSON keys (`arm`, `findings`, `kind`, `file`, `line`, `symbol`, `claim`, `upstream`, `settled_by`, `detail`) are identical in Task 3's prompt, Task 7's scorer, and Task 7's tests. `found_by` values `audit`/`rederive` match `--component` choices. Placeholder sets in Task 6's `test_expected_placeholder_sets` match Tasks 3 and 4 exactly and Task 5's substitution list.

--- a/docs/superpowers/plans/2026-08-10-sim2real-specify.md
+++ b/docs/superpowers/plans/2026-08-10-sim2real-specify.md
@@ -423,7 +423,7 @@ The independent citation audit, run on every arm. It must perform **corresponden
 
 **Interfaces:**
 - Consumes: nothing at runtime; SKILL.md substitutes its placeholders.
-- Produces: placeholders `{BUNDLE_ROOT}`, `{ARM_FILE}`, `{ARM_NAME}`, `{SIM_TREE}`, `{SIM_PIN}`, `{TARGET_TREE}`, `{TARGET_PIN}`, `{VERDICT_PATH}`, `{MAIN_SESSION_NAME}`. Writes a verdict JSON to `{VERDICT_PATH}` with schema `{"arm": str, "findings": [{"kind": "CONFIRMED"|"WRONG"|"UNSUPPORTED", "file": str, "line": int, "symbol": str, "claim": str, "upstream": str, "settled_by": str, "detail": str}]}`.
+- Produces: placeholders `{BUNDLE_ROOT}`, `{ARM_FILE}`, `{ARM_NAME}`, `{SIM_TREE}`, `{SIM_PIN}`, `{TARGET_TREE}`, `{TARGET_PIN}`, `{VERDICT_PATH}`, `{MAIN_SESSION_NAME}`. Writes a verdict JSON to `{VERDICT_PATH}` with schema `{"arm": str, "findings": [{"kind": "CONFIRMED"|"WRONG"|"UNSUPPORTED"|"BRIDGE", "file": str, "line": int, "symbol": str, "claim": str, "upstream": str, "settled_by": str, "declared_at": str | null, "detail": str}]}`. `declared_at` is required on `BRIDGE` findings and null elsewhere.
 
 - [ ] **Step 1: Write the prompt**
 
@@ -470,6 +470,19 @@ guard that skips or censors a term -- do this:
    value locally at each use (for example a per-request budget clamped to a
    request-specific size), a ported constant is a defect even when an algebraically
    equivalent downstream quantity hides it.
+6. Decide whether the code is PORTED or BRIDGE, and audit it accordingly.
+   - PORTED: the simulation computes this quantity, so a counterpart exists.
+     Compare against it. This includes quantities the simulation reads directly
+     from its own state — if the simulation knows the value exactly and the port
+     obtains it some other way, the counterpart still exists and the acquisition
+     is what you are checking. A unit error here is `WRONG`, not `BRIDGE`.
+   - BRIDGE: the code exists ONLY because the target lacks the simulation's
+     state, so no counterpart exists and none should. Do not report it
+     `UNSUPPORTED` — absence of a counterpart is the expected finding. Instead
+     verify its assumptions against the target or engine checkout, and check that
+     the specification header declares the degradation AND the direction of the
+     resulting bias. Record that header line in `declared_at`. If no declaration
+     exists, emit the finding with `declared_at: null`.
 
 Then audit the prose. For each non-obvious claim in `{BUNDLE_ROOT}/README.md` and
 `{BUNDLE_ROOT}/config.md`, resolve it against a checkout. Apply one rule:
@@ -488,11 +501,18 @@ Emit one finding per checked claim, using exactly these kinds:
 - `CONFIRMED` -- the port matches upstream, or the prose claim is substantiated.
 - `WRONG` -- a counterpart exists and the port disagrees with it. State the
   correct form.
-- `UNSUPPORTED` -- no upstream counterpart could be found after searching, so the
-  claim rests on nothing.
+- `UNSUPPORTED` -- no counterpart could be found after searching, AND the claim
+  purports to describe one. The claim rests on nothing.
+- `BRIDGE` -- no counterpart by construction, per method step 6. Set
+  `declared_at` to the specification-header line declaring the degradation and its
+  direction of bias, or `null` if no such declaration exists.
+
+Do NOT use `UNSUPPORTED` for bridge code. Absence of a counterpart is that code's
+expected property, not evidence against it.
 
 Every finding MUST carry `settled_by`: the `path:line` in a checkout that settles
-it. A finding without `settled_by` is not a finding.
+it. For `BRIDGE`, that is the target or engine line establishing what the code can
+actually observe. A finding without `settled_by` is not a finding.
 
 Be specific about consequence. "Units are wrong" is not useful; "the divisor
 under-counts by 100x, collapsing the term that carries hardware heterogeneity" is.
@@ -513,6 +533,7 @@ Write JSON to `{VERDICT_PATH}`:
       "claim": "what the specification says or computes",
       "upstream": "sim/example.go:168",
       "settled_by": "vllm/v1/metrics/loggers.py:563",
+      "declared_at": null,
       "detail": "what is wrong and what the correct form is, with consequence"
     }
   ]
@@ -869,6 +890,13 @@ Read `prompts/audit.md` and `prompts/rederive.md` and substitute every
   fix.
 - Every `UNSUPPORTED` finding: delete the claim, or convert it to a stated open
   question in `README.md` owned by the bundle.
+- Every `BRIDGE` finding with `declared_at: null`: write the declaration into the
+  specification header, naming the degradation AND the direction of the resulting
+  bias. Do NOT delete the code — absence of a simulation counterpart is that
+  code's expected property. This is prose in the header; do not introduce a marker
+  convention for it.
+- Every `BRIDGE` finding whose assumptions the auditor found wrong against the
+  target or engine checkout: fix as for `WRONG`.
 - Every re-derivation term absent from the specification: either add it, or
   declare its omission in the header with the direction of bias. A silent omission
   is a defect even when the omission is defensible.
@@ -877,8 +905,9 @@ Read `prompts/audit.md` and `prompts/rederive.md` and substitute every
 
 ### Pass condition
 
-Zero `UNSUPPORTED` claims remain, the lint exits 0, and every re-derivation
-divergence is resolved or declared.
+Zero `UNSUPPORTED` claims remain, every `BRIDGE` finding has a non-null
+`declared_at`, the lint exits 0, and every re-derivation divergence is resolved or
+declared.
 
 If `UNSUPPORTED` findings survive three fix rounds, STOP. Report what remains
 unresolved. Do not describe the bundle as audited.
@@ -1008,7 +1037,7 @@ Score the audit against ground truth established independently and by hand in `p
 
 **Interfaces:**
 - Consumes: `Failure`-free; independent of `lint_citations.py`.
-- Produces: `load_labels(path: Path) -> list[dict]`; `match(finding: dict, label: dict, tolerance: int = 6) -> bool`; `score(verdicts: list[dict], labels: list[dict]) -> dict` returning `{"found": [ids], "missed": [ids], "false_positive_arms": {arm: count}, "recall": float}`; `materialize(repo: Path, commit: str, dest: Path) -> None`; `main(argv) -> int`.
+- Produces: `load_labels(path: Path) -> list[dict]`; `match(finding: dict, label: dict, tolerance: int = 6) -> bool`; `score(verdicts: list[dict], labels: list[dict]) -> dict` returning `{"found": [ids], "missed": [ids], "false_positive_arms": {arm: count}, "recall": float}`; `undeclared_bridges(verdicts: list[dict]) -> list[dict]`; `materialize(repo: Path, commit: str, dest: Path) -> None`; `main(argv) -> int`. `BRIDGE` is neither a defect nor a false positive; it is gated separately by `undeclared_bridges`.
 
 - [ ] **Step 1: Write the labels fixture**
 
@@ -1136,13 +1165,36 @@ def test_score_reports_recall_and_false_positives():
     assert result["false_positive_arms"] == {"least_ttft_joint": 1}
 
 
-def test_confirmed_findings_are_not_counted_as_false_positives():
+def test_confirmed_and_bridge_are_not_counted_as_false_positives():
     labels = [l for l in acc.load_labels(LABELS) if "audit" in l["found_by"]]
     verdicts = [{"arm": "kairos_paper", "findings": [
         {"kind": "CONFIRMED", "file": "algorithms/kairos_paper.go",
          "line": 5, "symbol": "x"},
+        {"kind": "BRIDGE", "file": "algorithms/kairos_paper.go",
+         "line": 9, "symbol": "sPfFor", "declared_at": "algorithms/kairos_paper.go:44"},
     ]}]
     assert acc.score(verdicts, labels)["false_positive_arms"] == {}
+
+
+def test_undeclared_bridge_findings_are_reported():
+    verdicts = [{"arm": "causal_slo_externality", "findings": [
+        {"kind": "BRIDGE", "file": "algorithms/causal_slo_externality.go",
+         "line": 362, "symbol": "sPfFor", "declared_at": None},
+        {"kind": "BRIDGE", "file": "algorithms/causal_slo_externality.go",
+         "line": 231, "symbol": "residentTable",
+         "declared_at": "algorithms/causal_slo_externality.go:48"},
+        {"kind": "WRONG", "file": "algorithms/causal_slo_externality.go",
+         "line": 335, "symbol": "kvTokensFor"},
+    ]}]
+    undeclared = acc.undeclared_bridges(verdicts)
+    assert [f["symbol"] for f in undeclared] == ["sPfFor"]
+
+
+def test_missing_declared_at_key_counts_as_undeclared():
+    verdicts = [{"arm": "a", "findings": [
+        {"kind": "BRIDGE", "file": "a.go", "line": 1, "symbol": "noKey"},
+    ]}]
+    assert [f["symbol"] for f in acc.undeclared_bridges(verdicts)] == ["noKey"]
 ```
 
 - [ ] **Step 3: Run test to verify it fails**
@@ -1195,7 +1247,21 @@ def match(finding: dict, label: dict, tolerance: int = 6) -> bool:
     return any(abs(line - n) <= tolerance for n in label["lines"])
 
 
+def undeclared_bridges(verdicts: list[dict]) -> list[dict]:
+    """BRIDGE findings with no declared degradation. These block the gate.
+
+    BRIDGE means no simulation counterpart exists BY CONSTRUCTION -- the code is
+    there because the target lacks the simulator's state. That is not a defect and
+    not a false claim; what makes it acceptable is a declared direction of bias in
+    the specification header. A missing or null `declared_at` is the failure.
+    """
+    return [f for v in verdicts for f in v["findings"]
+            if f.get("kind") == "BRIDGE" and not f.get("declared_at")]
+
+
 def score(verdicts: list[dict], labels: list[dict]) -> dict:
+    # BRIDGE is deliberately excluded: it is neither a defect nor a false
+    # positive, and is gated separately by undeclared_bridges().
     defects = [f for v in verdicts for f in v["findings"]
                if f.get("kind") in ("WRONG", "UNSUPPORTED")]
     found = [l["id"] for l in labels if any(match(f, l) for f in defects)]
@@ -1260,8 +1326,12 @@ def main(argv: list[str] | None = None) -> int:
     labels = [l for l in load_labels(args.labels) if args.component in l["found_by"]]
     verdicts = [json.loads(p.read_text()) for p in args.verdict]
     result = score(verdicts, labels)
+    undeclared = undeclared_bridges(verdicts)
+    result["undeclared_bridges"] = [
+        f"{f.get('symbol')} at {f.get('file')}:{f.get('line')}" for f in undeclared
+    ]
     print(json.dumps(result, indent=2))
-    if result["missed"] or result["false_positive_arms"]:
+    if result["missed"] or result["false_positive_arms"] or undeclared:
         print("ACCEPTANCE FAILED", file=sys.stderr)
         return 1
     print("ACCEPTANCE PASSED")
@@ -1275,12 +1345,12 @@ if __name__ == "__main__":
 - [ ] **Step 5: Run test to verify it passes**
 
 Run: `.venv/bin/pytest .claude/skills/sim2real-specify/tests/test_acceptance.py -v`
-Expected: PASS — 5 passed.
+Expected: PASS — 7 passed.
 
 - [ ] **Step 6: Run the whole skill's test suite**
 
 Run: `.venv/bin/pytest .claude/skills/sim2real-specify/ -v`
-Expected: PASS — 20 passed (5 + 7 from lint, 3 substitution, 5 acceptance).
+Expected: PASS — 22 passed (5 + 7 from lint, 3 substitution, 7 acceptance).
 
 - [ ] **Step 7: Commit**
 
@@ -1342,4 +1412,6 @@ git commit -m "fix(specify): strengthen audit prompt to reach full recall on the
 
 **Known gap, deliberate.** The spec's acceptance criterion "regenerate the bundle from the same provenance and confirm the four defects never appear" is a full end-to-end run of an interview-driven skill. It is not scriptable and is not a task here; Task 7 Step 8 covers the gate half of it, which is where the four defects are caught. Run the end-to-end regeneration once manually after this plan completes.
 
-**Type consistency.** `Citation(path, lines, source_line)` and `Failure(file, source_line, citation, kind, detail)` are used identically in Tasks 1–2. `lint_bundle(bundle, trees, exts)` matches its call in Task 2's tests and Task 5's CLI invocation. Verdict JSON keys (`arm`, `findings`, `kind`, `file`, `line`, `symbol`, `claim`, `upstream`, `settled_by`, `detail`) are identical in Task 3's prompt, Task 7's scorer, and Task 7's tests. `found_by` values `audit`/`rederive` match `--component` choices. Placeholder sets in Task 6's `test_expected_placeholder_sets` match Tasks 3 and 4 exactly and Task 5's substitution list.
+**Type consistency.** `Citation(path, lines, source_line)` and `Failure(file, source_line, citation, kind, detail)` are used identically in Tasks 1–2. `lint_bundle(bundle, trees, exts)` matches its call in Task 2's tests and Task 5's CLI invocation. Verdict JSON keys (`arm`, `findings`, `kind`, `file`, `line`, `symbol`, `claim`, `upstream`, `settled_by`, `declared_at`, `detail`) are identical in Task 3's prompt, Task 7's scorer, and Task 7's tests. The four verdict kinds `CONFIRMED`/`WRONG`/`UNSUPPORTED`/`BRIDGE` appear consistently in Task 3's prompt, Task 5's reconcile rules and pass condition, and Task 7's `score` / `undeclared_bridges`. `found_by` values `audit`/`rederive` match `--component` choices. Placeholder sets in Task 6's `test_expected_placeholder_sets` match Tasks 3 and 4 exactly and Task 5's substitution list — the `BRIDGE` change adds no placeholders.
+
+**BRIDGE coverage.** Spec's four-verdict table → Task 3 method step 6 and the verdict list. Spec's `declared_at` requirement → Task 3's schema, Task 5's reconcile rule, and Task 7's `undeclared_bridges` plus three tests. Spec's `kvTokensFor`-is-`WRONG`-not-`BRIDGE` boundary → Task 3 method step 6's PORTED clause, and the `kv-usage-fraction-not-percent` label remaining `found_by: ["audit"]` so the fixture still demands it be caught as a defect.

--- a/docs/superpowers/plans/2026-08-10-sim2real-specify.md
+++ b/docs/superpowers/plans/2026-08-10-sim2real-specify.md
@@ -1350,7 +1350,9 @@ Expected: PASS — 7 passed.
 - [ ] **Step 6: Run the whole skill's test suite**
 
 Run: `.venv/bin/pytest .claude/skills/sim2real-specify/ -v`
-Expected: PASS — 22 passed (5 + 7 from lint, 3 substitution, 7 acceptance).
+Expected: PASS — 27 passed (15 lint, 4 substitution, 8 acceptance). See
+"Implementation notes" below for the three extra tests added during execution;
+the originally planned figure was 22.
 
 - [ ] **Step 7: Commit**
 
@@ -1411,6 +1413,49 @@ git commit -m "fix(specify): strengthen audit prompt to reach full recall on the
 **Spec coverage.** Five properties → SKILL.md Phases 1–5 (Task 5). Placement and non-goals → Task 5's "What this skill does NOT do". Output contract incl. no `LIMITATIONS.md` → Task 5. Verbatim-copy principle → Task 5. Request-vs-assert rule → Tasks 3 and 5. Gate's three components → Tasks 3, 4, 2 respectively, orchestrated in Task 5 Phase 6. Correspondence discovery → Task 3. Failure modes: HALTs → Phases 0–2; operator decisions → Phases 3–4 via `AskUserQuestion`; degraded output → Phase 5; gate non-convergence → Phase 6 three-round bound. Structure → File Structure section. Testing: sensitivity/specificity → Task 7; lint units → Tasks 1–2; lint on the citation-dense post-fix file → Task 2 Step 5; placeholder consistency → Task 6. Deferred items (`provenance.yaml`, bootstrap pin check) are correctly absent from all tasks.
 
 **Known gap, deliberate.** The spec's acceptance criterion "regenerate the bundle from the same provenance and confirm the four defects never appear" is a full end-to-end run of an interview-driven skill. It is not scriptable and is not a task here; Task 7 Step 8 covers the gate half of it, which is where the four defects are caught. Run the end-to-end regeneration once manually after this plan completes.
+
+## Implementation notes — deviations from this plan
+
+Recorded during execution. The plan above is the intent; this section is what
+actually shipped, so a reviewer diffing the two does not have to guess.
+
+**Test loader bug in the plan (fixed).** `_load()` as written fails at import:
+`from __future__ import annotations` makes dataclass field annotations strings, and
+`@dataclass` resolves them via `sys.modules[cls.__module__].__dict__`, which is
+`None` for a module built with `module_from_spec` but never registered. Both test
+files now register the module before `exec_module`.
+
+**Prose defect in the planned SKILL.md (fixed).** The substitution section said
+"substitute every `{PLACEHOLDER}`". That literal is itself extracted as a
+placeholder, so `test_no_documented_placeholder_is_unused` failed on its first
+run — the check catching its own first defect. Reworded to name the list as the
+tested contract rather than using a fake placeholder.
+
+**Test counts are higher than planned:** 27 total, not 22.
+
+| file | planned | shipped | added |
+|---|---|---|---|
+| `test_lint_citations.py` | 12 | 15 | citation at end of sentence; failure records its bundle file; `main` usage error |
+| `test_skill_substitution.py` | 3 | 4 | both prompts present (a rename must fail loudly) |
+| `test_acceptance.py` | 7 | 8 | `match` requires same file |
+
+The end-of-sentence test locks in the regex lookahead fence noted in Task 1 — it
+is the one guard whose absence would silently drop most real citations.
+
+**Environment deviations.** The worktree has no `.venv` and no checked-out
+submodules, so commands use the parent repo's `.venv/bin/pytest` (pytest 9.0.3) by
+absolute path, and the smoke test and acceptance run point at the parent's
+`inference-sim` checkout — already at exactly the `871b169b` pin — plus
+`pd-infocomm/llm-d-router` and `pd-infocomm/vllm` for target and engine citations.
+
+**Task 2's smoke test found two real defects** in the post-`ead56ea`
+`causal_slo_externality.go`, a file that had already been hand-audited:
+`vllm/v1/metrics/loggers.go:563` is unresolvable (no `loggers.go` exists anywhere
+in vLLM; it is a typo for `loggers.py`, and the comment carries both spellings),
+and `extractor.go:127` is ambiguous across three files in `llm-d-router`. Both are
+in `kalantar-msb/pd-infocomm`, not this repo, so neither is fixed here.
+
+## Self-Review
 
 **Type consistency.** `Citation(path, lines, source_line)` and `Failure(file, source_line, citation, kind, detail)` are used identically in Tasks 1–2. `lint_bundle(bundle, trees, exts)` matches its call in Task 2's tests and Task 5's CLI invocation. Verdict JSON keys (`arm`, `findings`, `kind`, `file`, `line`, `symbol`, `claim`, `upstream`, `settled_by`, `declared_at`, `detail`) are identical in Task 3's prompt, Task 7's scorer, and Task 7's tests. The four verdict kinds `CONFIRMED`/`WRONG`/`UNSUPPORTED`/`BRIDGE` appear consistently in Task 3's prompt, Task 5's reconcile rules and pass condition, and Task 7's `score` / `undeclared_bridges`. `found_by` values `audit`/`rederive` match `--component` choices. Placeholder sets in Task 6's `test_expected_placeholder_sets` match Tasks 3 and 4 exactly and Task 5's substitution list — the `BRIDGE` change adds no placeholders.
 

--- a/docs/superpowers/specs/2026-08-10-sim2real-specify-design.md
+++ b/docs/superpowers/specs/2026-08-10-sim2real-specify-design.md
@@ -182,11 +182,21 @@ unciteable unless that component's source says so.
 Three components, run in Phase 6 against the pinned checkouts.
 
 **Citation audit — all arms.** A fresh agent receives only the bundle and the two
-checkouts, with no generation transcript. For each cited expression and each
-non-obvious prose claim it resolves the citation and returns `CONFIRMED`,
-`WRONG`, or `UNSUPPORTED`, with the file and line that settles it. `WRONG` is
-fixed. `UNSUPPORTED` is deleted or converted to a stated open question. The
-verdict format is the one `pd-infocomm/docs/signal-analysis.md` already uses.
+checkouts, with no generation transcript. It performs **correspondence
+discovery**: for every non-trivial ported expression and every non-obvious prose
+claim, it locates the upstream counterpart — using an existing citation as a hint
+where one is present, and searching the pinned tree where none is — then returns
+`CONFIRMED`, `WRONG`, or `UNSUPPORTED` with the file and line that settles it.
+`WRONG` is fixed. `UNSUPPORTED` is deleted or converted to a stated open
+question. The verdict format is the one `pd-infocomm/docs/signal-analysis.md`
+already uses.
+
+Correspondence discovery rather than mere citation-checking, because citation
+density is itself an audit output, not an input: the pre-fix
+`causal_slo_externality.go` at `08203b4` carried exactly one citation
+(`pd_profile_handler.go:186`), and every citation in today's file was added by
+`ead56ea`. An auditor that only verifies existing citations would have returned
+clean on the file containing all four defects.
 
 **Blind re-derivation — focal arm only.** A second agent reads only the sim source
 at the pin and writes its own statement of the same policy, without seeing the
@@ -267,7 +277,10 @@ missing `math.Ceil`, and `ChunkTokens` versus `min(ap, ChunkTokens)`.
 `kairos_paper.go` at `08203b4`. Both must come back clean, per `ead56ea`.
 
 **Lint unit tests.** Fixture bundles covering a valid citation, a dangling path,
-an out-of-range line number, and a path outside the recorded pins.
+an out-of-range line number, and a path outside the recorded pins. The lint is
+exercised on synthetic fixtures plus the *post*-fix `causal_slo_externality.go`,
+which is citation-dense; the pre-fix file cannot serve as a lint fixture because
+it carries only one citation.
 
 **Acceptance run.** Regenerate the `pd-infocomm` bundle from the same provenance
 (`INFOCOM_REPRODUCIBILITY.md` plus BLIS `871b169b`) and compare against

--- a/docs/superpowers/specs/2026-08-10-sim2real-specify-design.md
+++ b/docs/superpowers/specs/2026-08-10-sim2real-specify-design.md
@@ -1,0 +1,285 @@
+# sim2real-specify — design
+
+A skill that turns arbitrary upstream provenance into the canonical sim2real
+bundle inputs, with the algorithm specification gated for correctness.
+
+Runs before `sim2real-bootstrap`. Date: 2026-08-10.
+
+## Problem
+
+Bundle creation is the only stage of the sim2real flow with no skill. It has been
+done by ad-hoc, unversioned prompts — `~/Downloads/create-sim2real-bundle.md` for
+Nous-campaign provenance, and a separate one-off prompt for BLIS-commit
+provenance. Three consequences, all observed:
+
+1. **The specification layer has no correctness gate.** `pd-infocomm`'s
+   `algorithms/causal_slo_externality.go` was generated at `08203b4` and audited
+   a day later at `ead56ea`, which found four defects in the ported algebra plus
+   one undeclared fidelity gap. Per that commit's own verification note, the only
+   automated check that had run on the algebra was `gofmt`.
+
+   The most damaging defect was a spurious `/100.0` in `kvTokensFor`:
+   `KVCacheUsagePercent` is a fraction in `[0,1]` despite its name, so the
+   divisor under-counted KV by 100×, collapsing the `C1·KV` term that carries
+   hardware heterogeneity — the mechanism the study's central claim rests on. Its
+   cause was trusting a prose mapping artifact over the source.
+
+   The other three were transcription errors invisible without line-by-line
+   comparison against the cited upstream: a dropped causal prefill-attention
+   charge in `cLocalAfter`, a missing `math.Ceil` on admission/arrival steps, and
+   `chunk = ChunkTokens` where upstream recomputes `min(ap, ChunkTokens)`. The
+   last one hid because `nChunks` is algebraically identical either way.
+
+2. **Required analysis is discovered reactively.** `pd-infocomm/docs/` now holds
+   3,713 lines of analysis written *after* the bundle: `required-signals.md`
+   (1050), `signal-analysis.md` (611), `epp-flow.md` (434),
+   `shared-pool-heterogeneity.md` (1618). `signal-analysis.md` states the
+   protocol that should have applied during generation — "Every claim in §C was
+   checked against source; every number was recomputed. Findings are stated as
+   verdicts with the file and line that settles them."
+
+3. **Unciteable prose ships as fact.** `create-sim2real-bundle.md` grounds four
+   enumerated claim classes (campaign artifacts, target API, measured results,
+   bundle shape) and nothing else. It is a whitelist, so any claim class it does
+   not anticipate is unguarded by construction, and it has no pass that re-reads
+   what it wrote. Its own closing "Key Lessons" section models unattributed
+   assertion as acceptable output.
+
+## Objective
+
+The product is a **meaningful algorithm specification**. Citation discipline and
+the correctness gate are means; they matter only because an algorithm that is
+wrong, unimplementable, or indistinguishable from the baseline is not worth
+transferring.
+
+Five properties define "meaningful". The skill must establish each before the
+bundle is complete.
+
+| # | property | fails if |
+|---|---|---|
+| 1 | the mechanism, causally stated | code is ported with no causal story — nothing to falsify |
+| 2 | the structural shape the decision requires | the target's natural decomposition silently replaces the policy |
+| 3 | observability — every quantity read has a real source | the specification is fiction on a real cluster |
+| 4 | isolation — a comparator that attributes the effect | improvement cannot be attributed to the mechanism |
+| 5 | named threats to validity, with direction of bias | results are uninterpretable |
+
+`pd-infocomm`'s focal-arm header already demonstrates all five, and none of that
+content comes from reading code — it comes from analysis. The Go file is a
+carrier for it. The skill is therefore an elicitation-and-analysis process, not
+a transcription process.
+
+Port correctness — the gate in this design — serves properties 1 and 2. It is one
+row of five.
+
+## Non-goals
+
+Mirroring `sim2real-translate`'s own negative-scope section:
+
+- Does not create `transfer.yaml` or `baselines/` — `bootstrap`'s job.
+- Does not wire submodules — `bootstrap` Task 1 derives the ref, Task 2 adds it.
+- Does not produce compiling code — `translate`'s job. The specification layer is
+  non-compiling by design; its adapters remain declared unknowns.
+- Does not build images or touch cluster config.
+- Does not emit the deep analyses of `pd-infocomm/docs/`. Property 3 is
+  established as a thin classification (below), not as a signal reference doc.
+
+## Placement and scope
+
+Invoked `/sim2real-specify <experiment-root>` from the sim2real repo, before
+`bootstrap`.
+
+One ordering constraint is deliberate. The skill must cite against readable sim
+*and* target checkouts, but `bootstrap` is what derives the target ref and adds
+the submodule, and its Final File Tree lists `algorithms/<algorithm>.go` as
+pre-existing. So `specify` resolves its own pins, records them in README's
+provenance table, and cites against whatever readable checkouts it was given.
+
+## Process
+
+**Phase 0 — Ground.** Obtain a readable sim checkout at a specific commit and a
+readable target checkout at a specific ref. Verify both. Record the pins. Every
+later claim is a citation against these two trees.
+
+**Phase 1 — Mechanism (property 1).** Interview plus source reading to establish
+the causal story, the decision rule, and the cited evidence that it wins: which
+cells, what margin, against what baseline. Results artifacts are copied verbatim.
+
+**Phase 2 — Shape (property 2).** Determine the structural form the decision
+takes — per-endpoint score, joint argmin over a cross product, admission gate,
+dispatch ceiling — and confirm the target has an extension point that can express
+it. Compare explicitly against the target's *natural* decomposition; where that
+decomposition is weaker, quantify what would be lost using the simulation's own
+ablation.
+
+**Phase 3 — Observability (property 3), thin.** Enumerate every quantity the
+decision rule reads. Classify each as direct, derivable, degraded, or
+unobtainable, each with a citation to the target or engine metric that supplies
+it. This is a classification pass, not a reference document.
+
+**Phase 4 — Isolation (property 4).** Identify the comparator arms and ablations
+that isolate the mechanism, each with cited simulation evidence. Emit their
+specification files.
+
+**Phase 5 — Specify (property 5).** Write the specification layer and
+`config.md`. Each degradation identified in Phase 3 is declared in the
+specification layer's header with its direction of bias.
+
+**Phase 6 — Gate.** Run the three gate components below. The bundle is not
+complete until the gate passes.
+
+## Output contract
+
+Exactly what `08203b4` produced. The contract is observed, not invented.
+
+| path | content | authored or copied |
+|---|---|---|
+| `algorithms/<arm>.go` | cited specification layer, one per arm; non-compiling by design | authored |
+| `README.md` | mechanism, shape, honest status, pre-registered expectation, pins table, layout | authored |
+| `config.md` | plugin parameters, engine flags, SLO targets | authored |
+| `workloads/` | workload specifications | copied verbatim |
+| `inputs/` | latency-law coefficients, fleet definitions | copied verbatim |
+| `sim_results/` | the results the claims cite, plus `CHECKSUMS.sha256` | copied verbatim |
+| `.gitignore` | standard ignores | generated |
+
+`LIMITATIONS.md` is **not** an output. It arrived at `78df621`, after generation,
+as post-hoc analysis. Property-5 content lives in the specification layer's
+header, which is where `08203b4` put it: the "Honest status" and "Fidelity gap"
+sections and the per-field `DEVIATION:` notes.
+
+### Verbatim-copy principle
+
+Anything that already exists upstream is copied, never re-expressed: workloads,
+coefficients, results, and any patch carrying the validated change. Re-authoring
+is reserved for the specification layer alone — the one artifact that genuinely
+must change form.
+
+This generalizes an observed asymmetry. In `create-sim2real-bundle.md`,
+`scripts/treatment.patch` is copied verbatim from the winning campaign iteration
+and checked with `git apply --check`; it has never been a defect source. The
+re-authored plugin file has no such device, and re-authored algebra is where all
+four `ead56ea` defects were.
+
+### Specification layer
+
+States the policy against real target interface names. Leaves adapters as
+declared unknowns. Carries an upstream `file:line` citation on every non-obvious
+expression. Declares its own degradations with direction of bias.
+
+It invents no in-source marker conventions. Unresolved contract questions are
+stated as questions in the README, owned by the bundle.
+
+One rule governs how it may refer to other pipeline stages:
+
+> A specification may **request** things of downstream stages. It may never
+> **assert** what they do.
+
+"Confirm X against the pinned checkout" is a legitimate request. "Stage Y
+resolves X" is an assertion about another component's behavior, and is
+unciteable unless that component's source says so.
+
+## Gate mechanics
+
+Three components, run in Phase 6 against the pinned checkouts.
+
+**Citation audit — all arms.** A fresh agent receives only the bundle and the two
+checkouts, with no generation transcript. For each cited expression and each
+non-obvious prose claim it resolves the citation and returns `CONFIRMED`,
+`WRONG`, or `UNSUPPORTED`, with the file and line that settles it. `WRONG` is
+fixed. `UNSUPPORTED` is deleted or converted to a stated open question. The
+verdict format is the one `pd-infocomm/docs/signal-analysis.md` already uses.
+
+**Blind re-derivation — focal arm only.** A second agent reads only the sim source
+at the pin and writes its own statement of the same policy, without seeing the
+port. The two statements are diffed and every divergence adjudicated against
+source. Scoped to the focal arm because that is where every observed defect was;
+`ead56ea` established that both comparator arms audited clean and were unchanged.
+
+Rationale for including this beyond the audit: an auditor reading an existing port
+anchors on it. Defect 4 — which hid because `nChunks` is algebraically identical
+either way — is the class a blind re-derivation surfaces and a review pass talks
+itself out of.
+
+**Citation lint — mechanical.** Extracts `path:line` patterns from the bundle and
+resolves each against the checkout paths passed in at runtime, failing on paths
+or line numbers that do not exist. Deterministic and cheap; catches drift on
+regeneration. It cannot catch misreading — a correct citation attached to a wrong
+transcription resolves fine. That is the audit's job.
+
+**Pass condition.** Zero `UNSUPPORTED` claims remain, and every re-derivation
+divergence is either resolved or recorded as a stated open question.
+
+## Failure modes
+
+**Hard HALT — nothing downstream is trustworthy.**
+
+- Phase 0: sim or target checkout unreadable at the stated pin.
+- Provenance disagreement: `sim_results/` do not match their checksums, or the
+  sim commit is not the one that produced them. Called out explicitly because
+  evidence bases are vendored from forks; if the pin and the results disagree,
+  every cited margin is wrong.
+- Phase 2: no extension point on the target can express the required shape. The
+  specific hazard is silent fallback to the target's weaker natural
+  decomposition, which transfers a different algorithm while resembling success.
+
+**Operator decision — the skill states the case and does not decide.**
+
+- Phase 3: a quantity carrying the core mechanism is unobtainable. Degraded may
+  be acceptable with reasoning; `pd-infocomm` accepted its `S_pf` gap on the
+  argument that the decode-side asymmetry dominates. That is a legitimate call
+  but not the skill's to make.
+- Phase 4: no comparator isolates the mechanism. The transfer may proceed; its
+  results will not be attributable. Say so rather than proceeding quietly.
+
+**Degraded output.** Partial provenance — a paper with no code, or code with no
+results. A specification can still be produced, but with no results the skill
+must refuse to write cited performance claims, and the pre-registered expectation
+becomes a stated hypothesis with no margin attached.
+
+**Gate non-convergence.** If `UNSUPPORTED` claims survive a bounded number of fix
+iterations, stop and report them. Do not ship a bundle that claims to have been
+audited.
+
+## Structure
+
+Mirrors `sim2real-translate`: one script, prompts, one SKILL.md. The three gate
+components are independently invocable and independently testable. The lint is
+the only code; everything else is prompts.
+
+```
+.claude/skills/sim2real-specify/
+  SKILL.md                    # phases 0-6, interview, output contract
+  prompts/audit.md            # independent citation audit
+  prompts/rederive.md         # blind re-derivation, focal arm
+  scripts/lint_citations.py   # mechanical path:line resolution
+```
+
+## Testing
+
+A labeled regression fixture already exists, with ground truth established
+independently and by hand.
+
+**Sensitivity.** Run the audit on `pd-infocomm/algorithms/causal_slo_externality.go`
+at `08203b4` against BLIS `871b169b`. It must find the four defects `ead56ea`
+found: the dropped causal prefill-attention charge, the spurious `/100.0`, the
+missing `math.Ceil`, and `ChunkTokens` versus `min(ap, ChunkTokens)`.
+
+**Specificity.** Run the same audit on `least_ttft_joint.go` and
+`kairos_paper.go` at `08203b4`. Both must come back clean, per `ead56ea`.
+
+**Lint unit tests.** Fixture bundles covering a valid citation, a dangling path,
+an out-of-range line number, and a path outside the recorded pins.
+
+**Acceptance run.** Regenerate the `pd-infocomm` bundle from the same provenance
+(`INFOCOM_REPRODUCIBILITY.md` plus BLIS `871b169b`) and compare against
+`08203b4` + `ead56ea`. Success is that the four defects never appear.
+
+## Deferred
+
+Both were raised during design and cut to keep v1 minimal.
+
+- **Machine-readable `provenance.yaml`.** Pins live in README's provenance table,
+  as observed practice. The lint takes checkout paths at runtime instead.
+- **`bootstrap` pin-mismatch check** — verifying that bootstrap's submodule ref
+  equals the pin the bundle cited against. Worth revisiting: `pd-infocomm/README.md:22`
+  records exactly this drift, noting the sim2real superproject index still points
+  at `583f7195` while the working checkout is `871b169b`.

--- a/docs/superpowers/specs/2026-08-10-sim2real-specify-design.md
+++ b/docs/superpowers/specs/2026-08-10-sim2real-specify-design.md
@@ -186,10 +186,34 @@ checkouts, with no generation transcript. It performs **correspondence
 discovery**: for every non-trivial ported expression and every non-obvious prose
 claim, it locates the upstream counterpart — using an existing citation as a hint
 where one is present, and searching the pinned tree where none is — then returns
-`CONFIRMED`, `WRONG`, or `UNSUPPORTED` with the file and line that settles it.
-`WRONG` is fixed. `UNSUPPORTED` is deleted or converted to a stated open
-question. The verdict format is the one `pd-infocomm/docs/signal-analysis.md`
-already uses.
+one of four verdicts with the file and line that settles it. The verdict format is
+the one `pd-infocomm/docs/signal-analysis.md` already uses.
+
+| verdict | meaning | reconcile action |
+|---|---|---|
+| `CONFIRMED` | matches upstream, or the prose claim is substantiated | none |
+| `WRONG` | a counterpart exists and the port disagrees with it | fix, citing what settles it |
+| `UNSUPPORTED` | no counterpart, and the claim purports to describe one | delete, or convert to a stated open question |
+| `BRIDGE` | no counterpart **by construction** — the code exists because the target lacks the simulator's state | verify assumptions against the target/engine checkout; require a declared direction of bias |
+
+`BRIDGE` exists because `UNSUPPORTED` otherwise conflates two unrelated
+situations. `sPfFor` approximates resident prefill tokens from residents whose
+first token has not arrived; the simulator simply reads the true value, so no
+counterpart exists and none should. An auditor searching for one correctly finds
+nothing — but deleting the code is not the remedy, and the code is not a false
+claim. What justifies it is a declared degradation.
+
+Note the boundary. Where a quantity HAS a simulator definition but a different
+acquisition path on the target, that is not `BRIDGE` — the counterpart exists and
+the audit checks it normally. `kvTokensFor`'s `/100.0` is `WRONG`, not `BRIDGE`:
+the summed-context quantity exists upstream, and the unit error is settled against
+the target checkout.
+
+Every `BRIDGE` finding carries `declared_at`, the specification-header line
+declaring the degradation and its direction of bias. A `BRIDGE` finding with
+`declared_at: null` blocks the gate until the declaration is written. This is a
+field in the audit's output, not an in-source annotation — the skill introduces no
+marker vocabulary.
 
 Correspondence discovery rather than mere citation-checking, because citation
 density is itself an audit output, not an input: the pre-fix
@@ -215,8 +239,9 @@ or line numbers that do not exist. Deterministic and cheap; catches drift on
 regeneration. It cannot catch misreading — a correct citation attached to a wrong
 transcription resolves fine. That is the audit's job.
 
-**Pass condition.** Zero `UNSUPPORTED` claims remain, and every re-derivation
-divergence is either resolved or recorded as a stated open question.
+**Pass condition.** Zero `UNSUPPORTED` claims remain, every `BRIDGE` finding has a
+non-null `declared_at`, and every re-derivation divergence is either resolved or
+recorded as a stated open question.
 
 ## Failure modes
 

--- a/docs/superpowers/specs/2026-08-10-sim2real-specify-design.md
+++ b/docs/superpowers/specs/2026-08-10-sim2real-specify-design.md
@@ -71,6 +71,37 @@ a transcription process.
 Port correctness — the gate in this design — serves properties 1 and 2. It is one
 row of five.
 
+### Completeness is a precondition, not a sixth property
+
+All five properties above are epistemic, and a citation-dense ABSTRACT of an
+algorithm scores well on every one of them while stating none of the algebra. That
+is not a hypothetical: the first real run of this skill produced a focal arm with
+159 citations across four arms — against 11 in the hand-written bundle — and
+declared its two top-level operands bodiless with `UNKNOWN`. The latency law, the
+SLO kernel, the shadow resident table, and the re-timing model were absent
+entirely (`Coeffs`: 27 occurrences by hand, 0 generated).
+
+So the rubric needs a precondition the five properties do not imply:
+
+> The specification states the COMPLETE computation. A bodiless function is
+> legitimate only for a target-API adapter, never for a quantity the simulation
+> computes.
+
+Its cause was a coupling between Phase 3 and Phase 5. The run correctly classified
+per-resident state as unobtainable on the target, then treated that as licence not
+to specify the algebra consuming it — a bodiless `estimateAdmissionDelay` because
+"the rollout model is UNOBTAINABLE." But the rollout model is fully specified in
+the simulator; whether the target can feed it at runtime is an independent fact,
+and one the same analysis had already recorded. Hence the firewall:
+
+> Phase 3 governs what the port can OBSERVE AT RUNTIME. It never governs what the
+> specification may leave UNSTATED.
+
+Note this is the mirror image of the `BRIDGE` verdict below. `BRIDGE` covers code
+with no upstream counterpart; this covers an upstream counterpart with no code.
+Both are failures of correspondence, in opposite directions, and the gate needs a
+detector for each.
+
 ## Non-goals
 
 Mirroring `sim2real-translate`'s own negative-scope section:
@@ -222,11 +253,16 @@ density is itself an audit output, not an input: the pre-fix
 `ead56ea`. An auditor that only verifies existing citations would have returned
 clean on the file containing all four defects.
 
-**Blind re-derivation — focal arm only.** A second agent reads only the sim source
-at the pin and writes its own statement of the same policy, without seeing the
-port. The two statements are diffed and every divergence adjudicated against
-source. Scoped to the focal arm because that is where every observed defect was;
-`ead56ea` established that both comparator arms audited clean and were unchanged.
+**Blind re-derivation — every arm.** A second agent reads only the sim source at
+the pin and writes its own statement of the same policy, without seeing the port.
+The two statements are diffed and every divergence adjudicated against source.
+
+Originally scoped to the focal arm, on the evidence that `ead56ea` found every
+defect there and both comparators audited clean. The first real run overturned
+that: it is the gate's ONLY omission detector, because the audit does
+correspondence discovery over expressions that are present and a term never
+written has no expression to audit. With omission established as this skill's
+dominant failure mode, the detector cannot be scoped to one file.
 
 Rationale for including this beyond the audit: an auditor reading an existing port
 anchors on it. Defect 4 — which hid because `nChunks` is algebraically identical


### PR DESCRIPTION
Closes #821.

## What this adds

`/sim2real-specify`, the bundle-creation stage that runs **before** `/sim2real-bootstrap`. Turns arbitrary upstream provenance (a BLIS commit, a Nous campaign, a paper plus code) into the canonical bundle inputs, and gates the result.

- `SKILL.md` — phases 0-6, HALT conditions, output contract
- `prompts/audit.md` — correspondence-discovery citation audit, one agent per arm
- `prompts/rederive.md` — blind re-derivation, every arm (the only omission detector)
- `scripts/lint_citations.py` — resolves `path:line` tokens against pinned trees
- `scripts/acceptance.py` — fixture materialization + verdict scoring
- `tests/` — lint units, placeholder-contract guard, acceptance harness, config.md contract

## The config.md contract

Found by running the skill's output through `/sim2real-bootstrap`: the produced bundle dropped the `## vLLM Pod Configuration` table that bootstrap Task 3 reads, and bootstrap halted with `could not find vLLM configuration table in config.md`.

That was a regression against this issue's own output contract, which is declared by reference to `pd-infocomm@08203b4` rather than in words — and that commit's `config.md` has the table at `:11` plus `## Fleet topology` at `:35`. Phase 5 never transcribed what the pointer contained, so the implementation lost it.

Fixed by stating the contract (five parts, plus a Fleet topology section when the fleet is not one homogeneous pool), adopting `08203b4`'s existing `**CONFIRM**` marker rather than inventing a second convention, and gating it in Phase 6 with the **real consumer** — `generate_from_config.py -o "$(mktemp -d)"` as a dry run — so the two skills cannot drift and the field list stays single-sourced in bootstrap.

`test_config_contract.py` binds the heading Phase 5 prescribes to bootstrap's `VLLM_SECTION_KEYWORDS`, and the mandatory-field prose to the fields bootstrap actually requires. Both assertions mutation-tested.

## CI

The specify suite was never wired into the workflow, so it was passing only locally. Now added. Doing so surfaced a `tests`-package name collision with `sim2real-translate`, fixed by dropping specify's empty `__init__.py` (aligning with analyze/bootstrap/check, which are plain dirs).

Verified with the exact CI invocation on Python 3.13 with `requirements.txt` installed: **ruff clean, 2232 passed, 1 skipped, 2 xfailed, coverage 97.68%** against the 90% floor.

## Merged main in

`origin/main` was 2 commits ahead (#820, #826). Merged rather than rebased, which also restores the `detect-secrets` CI pin that #826 added — merging the branch as it stood would have reverted it and silently skipped #822's secret-scan tests.

## Follow-ups filed

- **#824** — `generate_from_config.py` emits no `prefill:` block and drops prefill rows silently
- **#825** — bootstrap does not refuse `CONFIRM`/`TBD` sentinel rows, and reads observe flags only from fenced blocks