### PR TITLE
fix(bootstrap): sync baselines/defaults templates; fix two inert fragments (closes #839)

### DIFF
--- a/.claude/skills/sim2real-bootstrap/SKILL.md
+++ b/.claude/skills/sim2real-bootstrap/SKILL.md
@@ -346,10 +346,10 @@ ls "$EXPERIMENT_ROOT"/workloads/*.yaml
 
 **action:** shell
 
-Framework workarounds documented in `docs/troubleshooting.md` (EPP llm-d.ai
-RBAC, request-id preservation, EPP/vLLM verbosity, routing-proxy resource
-requests) are applied automatically by `sim2real assemble` from
-`<experiment-root>/baselines/defaults/`. Copy the framework templates into
+Framework workarounds documented in `docs/troubleshooting.md` (request-id
+preservation, EPP/vLLM verbosity, sidecar resource requests, model-PVC sizing,
+topology and tokenizer wiring) are applied automatically by `sim2real assemble`
+from `<experiment-root>/baselines/defaults/`. Copy the framework templates into
 the experiment so each experiment is self-contained and reproducible.
 
 ```bash
@@ -361,6 +361,13 @@ ls "$EXPERIMENT_ROOT/baselines/defaults/"
 Each fragment is a partial scenario YAML — operators can edit individual
 fragments in place to tweak them for the experiment, or list a fragment
 stem under `defaults.disable` in `transfer.yaml` to opt out entirely.
+
+**Not every fragment is universally correct.** `epponly` is a topology decision,
+`model-pvc-size` is sized for a 70B-class model, `tokenizer-sidecar` matters only
+when the arms declare a `token-producer` plugin, and `preserve-request-id` matches
+nothing under an epponly / externally-managed gateway. Each fragment's header
+comment states its own applicability and when to disable it. Making emission
+conditional rather than leaving that to the operator is tracked as #840.
 
 ---
 
@@ -448,9 +455,13 @@ defaults:
   disable: []
   # Available fragments (filename stems in baselines/defaults/):
   #   - epp-verbosity
+  #   - epponly
   #   - externally-managed-gateway
+  #   - model-pvc-size
   #   - preserve-request-id
   #   - routing-proxy-resources
+  #   - tokenizer-sidecar
+  #   - vllm-keepalive
   #   - vllm-logging
 ```
 
@@ -515,11 +526,15 @@ Exit code 0 and all fields printed = success.
   baselines/
     <name>.yaml                  <- task-3
     defaults/                    <- task-4b
-      preserve-request-id.yaml
       epp-verbosity.yaml
-      vllm-logging.yaml
+      epponly.yaml
       externally-managed-gateway.yaml
+      model-pvc-size.yaml
+      preserve-request-id.yaml
       routing-proxy-resources.yaml
+      tokenizer-sidecar.yaml
+      vllm-keepalive.yaml
+      vllm-logging.yaml
   <component-name>/             <- task-2 (submodule)
   algorithms/
     <algorithm>.go               <- pre-existing
@@ -674,4 +689,4 @@ This skill ships with supporting files in its directory. Invoke in place — do 
 | `generate_scenarios.py` | Converts JSON config (`top3_selection.json`) → scenario YAMLs. Use when JSON input exists (BLIS). |
 | `generate_scenarios.README.md` | Coverage map for the JSON-input path. Documents field mappings, omission rules, and gaps. |
 | `byo.py` | Implements the `--byo` branch — argument parsing, YAML validation, path-safe copy operations, `transfer.yaml` emission, batched `sim2real translation register` command generation. Invoked by SKILL.md's dispatch when `--byo` (or any BYO-only flag) is passed. |
-| `templates/defaults/*.yaml` | Framework-owned baseline workaround fragments (RBAC, request-id, verbosity). Copied into `<experiment-root>/baselines/defaults/` at BLIS task-4b and at BYO run time, so every experiment is self-contained and reproducible. |
+| `templates/defaults/*.yaml` | Framework-owned baseline workaround fragments (request-id, verbosity, sidecar sizing, model-PVC size, topology, tokenizer). Copied into `<experiment-root>/baselines/defaults/` at BLIS task-4b and at BYO run time, so every experiment is self-contained and reproducible. Shape and merge-safety are asserted by `tests/test_defaults_templates.py`. |

--- a/.claude/skills/sim2real-bootstrap/templates/defaults/epp-verbosity.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/epp-verbosity.yaml
@@ -1,8 +1,38 @@
-# Workaround: bump EPP log verbosity for diagnosability.
+# Raise EPP log verbosity above the framework default for diagnosability.
 # See docs/troubleshooting.md "Increasing logging verbosity / EPP".
+#
+# THE SCALE. llm-d-router's EPP logs through named constants, not raw numbers
+# (pkg/common/observability/logging/const.go:20-23, v0.9.0):
+#   DEFAULT = 2    VERBOSE = 3    DEBUG = 4    TRACE = 5
+# llm-d-benchmark defaults `router.epp.verbosity` to "1"
+# (config/templates/values/defaults.yaml:649 at the pinned SHA), i.e. below even
+# DEFAULT, so the EPP is near-silent out of the box.
+#
+# WHY "3" AND NOT "5". DEBUG(4) is by far the largest bucket of call sites in the
+# EPP, and the EPP sits in the request path -- so the logging costs CPU on every
+# request as well as disk. "5" turns on every DEBUG and TRACE site at once, which
+# in practice is more log volume than a run can carry.
+#
+# "3" IS THE FLOOR, NOT A PREFERENCE. /sim2real-check S5c.6 (InferenceObjective
+# resolution at runtime) reads `objectiveKey` and `priority` off `Request handled`
+# lines, which are attached under V(logging.VERBOSE) -- i.e. exactly 3. At "3"
+# that check runs; below "3" it reports INAPPLICABLE and the run loses its
+# objective-resolution evidence. Do not lower this without accepting that.
+#
+# ESCALATING. "3" stops BELOW the level where the P/D decider explains itself
+# (prefix_based_pd_decider.go uses V(logging.DEBUG)), so the escalation for
+# prefill-selection problems is "4" -- which keeps the decider diagnostics and
+# still drops every TRACE site. Reach for "5" only for a specific TRACE-level
+# call site you have already identified.
+#
+# WHY THIS IS A FRAGMENT AND NOT PART OF baselines/<name>.yaml. Verbosity is a
+# diagnostic, not part of the measured mechanism, so nothing in config.md declares
+# it. Keeping it here means `transfer.yaml: defaults.disable` can switch it off
+# for a measurement run; a key in baselines/<name>.yaml has no such switch.
+#
 # scenario[0].name is realigned to the experiment baseline at merge time.
 scenario:
 - name: defaults
   router:
     epp:
-      verbosity: "5"
+      verbosity: "3"

--- a/.claude/skills/sim2real-bootstrap/templates/defaults/epponly.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/epponly.yaml
@@ -1,0 +1,82 @@
+# Standalone router topology: no Kubernetes Gateway is deployed; the EPP runs with
+# an Envoy sidecar that serves HTTP directly. Sizes and configures that sidecar,
+# because under this topology it becomes the WHOLE data plane.
+#
+# THIS FRAGMENT SIZES A DIFFERENT SIDECAR THAN routing-proxy-resources.yaml.
+# The two look like duplicates and are not:
+#   router.proxy   (here)  -> the Envoy sidecar INSIDE THE EPP POD. Maps onto the
+#                             routerlib chart's top-level `proxy:`
+#                             (config/charts/routerlib/values.yaml:76, v0.9.0).
+#   routing.proxy  (there) -> llm-d-benchmark's nixl routing sidecar BESIDE EACH
+#                             MODEL SERVER, the peer of vllmCommon.kvTransfer.
+# They are distinct containers in distinct pods with distinct jobs. Both fragments
+# are intended to coexist; do not "deduplicate" them.
+#
+# THE TWO KEYS BELOW ARE COUPLED, which is why they live in one file:
+# `--concurrency 8` is chosen to match the `limits.cpu: "8"` set immediately below.
+# Change one without the other and you either starve Envoy's workers or
+# oversubscribe them.
+#
+# WARNING -- THE COUPLING CAN BREAK SILENTLY. `args` is a list of SCALARS, so
+# pipeline/lib/values.py `_merge_lists` Tier 1 has any downstream layer REPLACE it
+# wholesale rather than merge into it. The defaults overlay is the first layer in
+# resolve_baseline's chain, so if your `baselines/<name>.yaml` or the registered
+# treatment overlay sets `router.proxy.args` at all, it takes the whole list -- and
+# `--concurrency 8` goes with it -- while `limits.cpu: "8"` below still applies.
+# That is the failure this file was written to prevent, reappearing one layer up.
+# Set the args HERE, or set BOTH keys in your baseline; never split them.
+# (`.claude/skills/sim2real-bootstrap/tests/test_defaults_templates.py` allowlists
+# this one key so a new fragment cannot add another scalar list unnoticed.)
+#
+# THE ARGS BLOCK IS UPSTREAM BOILERPLATE, not a local invention. It appears
+# byte-for-byte -- comment included -- in 8 of the 9 shipped llm-d-benchmark guide
+# scenarios at the pinned SHA (config/scenarios/guides/: optimized-baseline,
+# flow-control, agentic-serving, predicted-latency-routing, tiered-prefix-cache,
+# precise-prefix-cache-routing, pd-disaggregation, wide-ep-lws; only
+# workload-autoscaling omits it). That every shipped scenario overrides the same
+# chart defaults identically is an argument for them being framework defaults
+# instead. Not yet filed upstream against llm-d/llm-d-benchmark -- if you file it,
+# reference it here.
+#
+# WHAT THIS BLOCK ADDS OVER UPSTREAM: `limits.cpu: "8"`. Upstream sets
+# `--concurrency 8` while leaving CPU unlimited, so the 8 there is arbitrary. The
+# limit below is what makes it mean something.
+#
+# CAVEAT ON THE UPSTREAM COMMENT'S CLAIMS. Those guide scenarios justify the block
+# as overriding chart defaults of `--log-level trace` and no `--concurrency`. That
+# is stale as of routerlib v0.9.0, whose envoy preset already passes
+# `--log-level warn` AND `--cpuset-threads`
+# (config/charts/llm-d-router-standalone/values.yaml:253-265). `--cpuset-threads`
+# makes Envoy size its worker pool from the cgroup's CPU allotment, which is
+# strictly more adaptive than a hardcoded `--concurrency 8` -- and copying the
+# upstream block DROPS it. The args are kept as-is here for byte-parity with
+# upstream rather than because that tradeoff was decided; revisit if the sidecar
+# shows CPU trouble.
+#
+# Keys must sit under scenario[0]: llm-d-benchmark's render_plans.py merges
+# "defaults -> shared -> stack", so only `scenario:` and `shared:` are read from a
+# scenario file's top level and any other top-level key is silently ignored.
+#
+# scenario[0].name is realigned to the experiment baseline at merge time.
+scenario:
+- name: defaults
+  gateway:
+    className: epponly
+  router:
+    proxy:
+      resources:
+        requests: {cpu: "4", memory: 8Gi}
+        limits: {cpu: "8", memory: 16Gi}
+      args:
+        - "--service-node"
+        - "envoy-sidecar"
+        - "--log-level"
+        - "warn"
+        - "--concurrency"
+        - "8"
+        - "--drain-strategy"
+        - "immediate"
+        - "--drain-time-s"
+        - "60"
+        - "-c"
+        - "/etc/envoy/envoy.yaml"

--- a/.claude/skills/sim2real-bootstrap/templates/defaults/model-pvc-size.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/model-pvc-size.yaml
@@ -1,0 +1,30 @@
+# Size the model PVC for a large model.
+#
+# The framework defaults `storage.modelPvc.size` to 300Gi
+# (llm-d-benchmark config/templates/values/defaults.yaml:307 at the pinned SHA),
+# which cannot hold a 70B-class model as the download job fetches it: `hf download`
+# takes the WHOLE repo, so e.g. Llama-3.3-70B-Instruct lands as ~132 GiB of
+# safetensors plus ~131 GiB of original/*.pth that vLLM never reads. All nine
+# shipped llm-d-benchmark guide scenarios override this same default to 1Ti.
+#
+# 1Ti IS NOT UNIVERSALLY CORRECT -- it is sized for a 70B-class model and is
+# wasteful for a small one. If your model is small, either lower this value or add
+# `model-pvc-size` to `transfer.yaml: defaults.disable` to fall back to the
+# framework's 300Gi. Deriving the size from the model rather than emitting a
+# constant is tracked as inference-sim/sim2real#840.
+#
+# THIS ONLY SIZES A PVC THAT DOES NOT YET EXIST. An existing model-pvc is never
+# resized: `_check_existing_pvc` (llmdbenchmark/executor/step.py:331) fails standup
+# with "existing PVC is too small" rather than expanding it. Already-provisioned
+# namespaces need `kubectl patch pvc model-pvc` first.
+#
+# Keys must sit under scenario[0]: llm-d-benchmark's render_plans.py merges
+# "defaults -> shared -> stack", so only `scenario:` and `shared:` are read from a
+# scenario file's top level and any other top-level key is silently ignored.
+#
+# scenario[0].name is realigned to the experiment baseline at merge time.
+scenario:
+- name: defaults
+  storage:
+    modelPvc:
+      size: 1Ti

--- a/.claude/skills/sim2real-bootstrap/templates/defaults/routing-proxy-resources.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/routing-proxy-resources.yaml
@@ -2,6 +2,18 @@
 # The chart leaves routing.proxy.resources unset; without requests the proxy
 # can be scheduled with no real CPU/memory budget. See docs/troubleshooting.md
 # "Framework defaults overlay".
+#
+# THIS SIZES A DIFFERENT SIDECAR THAN epponly.yaml. The two look like duplicates
+# and are not:
+#   routing.proxy  (here)  -> llm-d-benchmark's nixl routing sidecar BESIDE EACH
+#                             MODEL SERVER, the peer of vllmCommon.kvTransfer
+#                             (defaults.yaml:691 `routing:` at the pinned SHA).
+#   router.proxy   (there) -> the Envoy sidecar INSIDE THE EPP POD, which under
+#                             the epponly topology is the whole data plane
+#                             (defaults.yaml:627 `router:`).
+# Distinct containers, distinct pods, distinct jobs. Both fragments are intended
+# to coexist; do not "deduplicate" them.
+#
 # scenario[0].name is realigned to the experiment baseline at merge time.
 scenario:
 - name: defaults

--- a/.claude/skills/sim2real-bootstrap/templates/defaults/tokenizer-sidecar.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/tokenizer-sidecar.yaml
@@ -1,0 +1,79 @@
+# Enable the chart's vLLM render sidecar in the EPP pod, so a token-producer
+# plugin's `http://localhost:8000` actually resolves.
+#
+# ONLY NEEDED IF YOUR ARMS USE A token-producer PLUGIN. If no generated
+# `<algo>_config.yaml` declares one, add `tokenizer-sidecar` to
+# `transfer.yaml: defaults.disable` -- this fragment then only costs you a CPU
+# container in the EPP pod. Making the emission conditional on the plugin list is
+# tracked as inference-sim/sim2real#840.
+#
+# WHY IT IS REQUIRED WHEN IT IS REQUIRED, and why the failure is silent. A plugin
+# config that declares
+#   - type: token-producer
+#     parameters: {modelName: ..., vllm: {url: "http://localhost:8000"}}
+# has nothing serving port 8000 inside the EPP pod, because
+# `router.tokenizer.enabled` defaults to false (routerlib values.yaml:78-79,
+# v0.9.0). The consequence is silent rather than loud: with no TokenizedPrompt,
+# `getUserInputLenInTokens` returns 0 WITH NO ERROR, so a P/D decider comparing it
+# against a non-cached-token threshold answers "no disaggregated PD" for EVERY
+# request -- logged only at DEBUG(4), i.e. invisible at the verbosity
+# epp-verbosity.yaml sets. The observable signature is a run with thousands of
+# requests and zero prefill selections.
+#
+# WHAT THIS ADDS: a `vllm-render` container in the EPP pod running
+# `vllm launch render <modelName> --port=8000` from docker.io/vllm/vllm-openai-cpu
+# -- CPU-only, so it consumes no GPU. `modelName` is deliberately left unset;
+# render_plans `_normalize_router_block` fills it from `model.name`.
+#
+# HF_TOKEN OVERRIDE. The chart points this sidecar at secret `llm-d-hf-token`
+# (routerlib values.yaml:89-94). Change the secret name below to whatever your
+# namespace actually has, and note that a gated model repo makes the override
+# mandatory rather than cosmetic -- without a usable token the render container
+# cannot pull the tokenizer.
+#
+# HF_HOME. Set explicitly to a world-writable path, and NOT to the chart's own
+# cache mount. The chart mounts an emptyDir named model-cache at
+# /root/.cache/huggingface (routerlib templates/_deployment.yaml) and never sets
+# HF_HOME, so that path is the HF cache ONLY IF HOME=/root -- i.e. only when the
+# container runs as root. Under an OpenShift SCC that forces a high random
+# runAsUser with runAsNonRoot, that UID has no /etc/passwd entry, HOME resolves to
+# `/`, HuggingFace resolves its cache to /.cache, and the download dies with
+#   OSError: PermissionError at /.cache when downloading <model>.
+# Pointing HF_HOME at the chart's mount does not help either: /root is mode 0700
+# owned by root, so a non-root UID cannot traverse into it, and the error just
+# moves to "PermissionError at /root/.cache". The emptyDir itself is writable (the
+# pod fsGroup applies to it) but the path leading to it is not, so no value of
+# HF_HOME makes that mount usable. The volume is therefore left unused and the
+# cache lands in the container's writable layer -- a few MB of config.json +
+# tokenizer.json, re-fetched on restart. /tmp is mode 1777 and the container sets
+# no readOnlyRootFilesystem, so it is writable by any UID.
+#
+# WHY THIS MATTERS FOR STANDUP, not just for the plugin: with the cache
+# unwritable, vllm-render CrashLoopBackOffs, which holds the EPP below ready and
+# makes standup fail fast with "Inference pool not ready: Pod(s) in terminal
+# failure state" -- so the whole run fails on a sidecar the model servers do not
+# need.
+#
+# PREFLIGHT after deploy:
+#   - `curl -s localhost:8000/v1/models` from inside the EPP pod succeeds
+#   - the EPP log does NOT contain "auto-created default producer" naming
+#     token-producer (which would mean the estimate backend is in the path)
+#
+# KNOWN VERSION SKEW: the sidecar image tag defaults to a vllm-openai-cpu build
+# that may lag the vllm-openai tag the model servers run. Token counts normally
+# agree; pin the sidecar tag to match if that assumption matters for your arms.
+#
+# scenario[0].name is realigned to the experiment baseline at merge time.
+scenario:
+- name: defaults
+  router:
+    tokenizer:
+      enabled: true
+      env:
+        - name: HF_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: hf-secret
+              key: HF_TOKEN
+        - name: HF_HOME
+          value: /tmp/hf

--- a/.claude/skills/sim2real-bootstrap/templates/defaults/vllm-keepalive.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/vllm-keepalive.yaml
@@ -1,0 +1,53 @@
+# Workaround: raise vLLM's HTTP keep-alive above the routing sidecar's idle
+# connection timeout, on the prefill leg.
+#
+# THE MISMATCH, both sides verified in source:
+#   - the routing sidecar holds idle connections for 90s:
+#     `t.IdleConnTimeout = 90 * time.Second` on a cloned http.DefaultTransport with
+#     unlimited idle conns (llm-d-router v0.9.0, pkg/sidecar/proxy/proxy.go:415)
+#   - vLLM closes them after 5s: `VLLM_HTTP_TIMEOUT_KEEP_ALIVE: int = 5` in
+#     vllm/envs.py ("Timeout in seconds for keeping HTTP connections alive in API
+#     server")
+# A Go transport pooling sockets for 90s against a server that drops them at 5s
+# reuses connections the server has already closed, and the reuse fails with a
+# TCP RST.
+#
+# PROVENANCE OF 120. It is llm-d-benchmark's own default, not a number picked here:
+# config/templates/jinja/_macros.j2 emits
+#     - name: VLLM_HTTP_TIMEOUT_KEEP_ALIVE
+#       value: "{{ config.vllm.httpTimeoutKeepAlive | default(120) }}"
+# unconditionally into every model-server container, for both roles. Added in
+# llm-d-benchmark 28cfc06 (#1675).
+#
+# WHY THIS FRAGMENT STILL EXISTS GIVEN THAT MACRO: sim2real's llm-d-benchmark pin
+# predates it. `git grep -i http_timeout_keep_alive` over the pinned tree returns
+# nothing, so on the version that actually renders these pods nothing sets the
+# variable and vLLM's 5s default applies. This fragment is load-bearing today.
+#
+# WHEN TO DELETE IT: once the llm-d-benchmark pin advances past 28cfc06. Tracked
+# with the exact removal conditions as inference-sim/sim2real#838. At that point
+# the macro supplies 120 on both roles and this fragment becomes redundant, and the
+# first-class way to express a NON-default value becomes the per-role key
+# `prefill.vllm.httpTimeoutKeepAlive` rather than an extraEnvVars entry. Setting it
+# via extraEnvVars once the macro exists appends a second env entry for the same
+# name in the rendered container (last one wins) -- harmless but a smell. Do NOT
+# switch to the first-class key before the pin moves: at the pinned version nothing
+# reads it, so the change would silently drop prefill back to 5s.
+#
+# PREFILL ONLY, and why: the decode leg is localhost inside the sidecar's own pod
+# and sees traffic on nearly every request, so its connections rarely idle past 5s,
+# while the prefill connection idles whenever no request disaggregates. Widening
+# this to decode would be defensible and closer to what the macro does.
+#
+# Inert until KV transfer is enabled in baselines/<name>.yaml, and live the moment
+# it is. `extraEnvVars` is a list of dicts carrying `name`, so pipeline/lib/values.py
+# `_merge_lists` merges it by that key (Tier 2b) rather than replacing it -- unlike
+# a scalar list, this key CAN be set from the defaults layer.
+#
+# scenario[0].name is realigned to the experiment baseline at merge time.
+scenario:
+- name: defaults
+  prefill:
+    extraEnvVars:
+      - name: VLLM_HTTP_TIMEOUT_KEEP_ALIVE
+        value: "120"

--- a/.claude/skills/sim2real-bootstrap/templates/defaults/vllm-logging.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/vllm-logging.yaml
@@ -1,10 +1,51 @@
-# Workaround: enable vLLM uvicorn access log + INFO logging for diagnosability.
-# See docs/troubleshooting.md "Increasing logging verbosity / vLLM".
+# Restore vLLM's own default for the uvicorn access log, which llm-d-benchmark
+# inverts.
+#
+# WHAT THE LOG IS. uvicorn is the ASGI server under vLLM's OpenAI-compatible API
+# server; its access log emits one line per HTTP request:
+#   INFO: 10.x.x.x:54321 - "POST /v1/completions HTTP/1.1" 400 Bad Request
+# Without it the engine log still shows an exception but not which requests were
+# rejected, on which pod, or at what rate.
+#
+# THE TWO DEFAULTS, AND THE INVERSION:
+#   vLLM             `disable_uvicorn_access_log: bool = False` on FrontendArgs
+#                    ("Disable uvicorn access log.")             -> log ON
+#   llm-d-benchmark  `vllmCommon.flags.disableUvicornAccessLog: true`
+#                    (config/templates/values/defaults.yaml:789), gated at
+#                    _macros.j2:100 / :364 and emitting
+#                    --disable-uvicorn-access-log at :154 / :397 for BOTH roles
+#                                                                -> log OFF
+# Line refs are against the pinned llm-d-benchmark (see the `llm-d-benchmark`
+# submodule SHA). This fragment puts vLLM back on its own default.
+#
+# USE THE TYPED KEY, NOT additionalFlags. A previous version of this fragment set
+#     decode: {vllm: {additionalFlags: ["--no-disable-uvicorn-access-log"],
+#                     loggingLevel: INFO}}
+# and both keys were inert:
+#   - `additionalFlags` is a list of scalars, so pipeline/lib/values.py
+#     `_merge_lists` Tier 1 has the overlay REPLACE the base. This fragment is
+#     the FIRST layer in resolve_baseline's chain, and both `baselines/<name>.yaml`
+#     and the translate-generated baseline overlay set that same list downstream
+#     -- so the fragment's entry was discarded before it could reach the command.
+#     No scalar-list key can usefully be set from this layer at all.
+#   - `loggingLevel: INFO` is already the framework default twice over
+#     (defaults.yaml:51 `logging_level: &logging_level INFO`, plus a
+#     `default('INFO')` fallback at _macros.j2:230).
+# It was also decode-only, while the framework's suppression covers both roles --
+# so prefill served its requests with no access log at all. The typed
+# `vllmCommon.flags` key below is read per-role by the macro and fixes both.
+#
+# WHY THIS IS A FRAGMENT AND NOT PART OF baselines/<name>.yaml. It is a
+# framework-default override for diagnosability, not part of the measured
+# mechanism, so nothing in config.md declares it. Keeping it here means
+# `transfer.yaml: defaults.disable` can switch it off -- which matters, because
+# per-request logging is not free at high QPS: this is exactly the kind of
+# diagnostic you want during bring-up and may want off for a measurement run.
+# A key in baselines/<name>.yaml has no such switch.
+#
 # scenario[0].name is realigned to the experiment baseline at merge time.
 scenario:
 - name: defaults
-  decode:
-    vllm:
-      additionalFlags:
-      - --no-disable-uvicorn-access-log
-      loggingLevel: INFO
+  vllmCommon:
+    flags:
+      disableUvicornAccessLog: false

--- a/.claude/skills/sim2real-bootstrap/tests/test_defaults_templates.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_defaults_templates.py
@@ -1,0 +1,225 @@
+"""Shape and merge-safety tests for the shipped framework-defaults fragments.
+
+`templates/defaults/*.yaml` is copied verbatim into every bootstrapped experiment
+repo and deep-merged under each baseline by `sim2real assemble`. Nothing else
+validates their *content* — `test_byo.py` only checks that the emitted
+`transfer.yaml` inventory matches the directory listing, which it derives by glob,
+so a fragment with a malformed shape or an unmergeable key would ship silently.
+
+These tests are deliberately glob-driven: adding a fragment requires no test edit,
+but the new fragment must satisfy the same contract as the existing ones.
+
+Issue #839 (two shipped fragments were wrong, five were missing) is what motivated
+them. The `additionalFlags` guard below is the narrow, statically-decidable slice of
+#841 — it catches keys that provably cannot survive the merge chain, rather than
+comparing resolved scenarios, which is what #841 tracks.
+"""
+from pathlib import Path
+
+import pytest
+import yaml
+
+_SKILL_DIR = Path(__file__).resolve().parents[1]
+_TEMPLATE_DIR = _SKILL_DIR / "templates" / "defaults"
+
+# Repo root: .claude/skills/sim2real-bootstrap -> up three.
+_REPO_ROOT = _SKILL_DIR.parents[2]
+
+
+def _fragments():
+    return sorted(_TEMPLATE_DIR.glob("*.yaml"))
+
+
+def _fragment_ids():
+    return [p.stem for p in _fragments()]
+
+
+@pytest.fixture(scope="module")
+def deep_merge():
+    """Import the real merge used by assemble, so these tests track its behavior."""
+    import sys
+
+    if str(_REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(_REPO_ROOT))
+    from pipeline.lib.values import deep_merge as _dm
+
+    return _dm
+
+
+def test_template_dir_is_not_empty():
+    assert _fragments(), f"no fragments found under {_TEMPLATE_DIR}"
+
+
+@pytest.mark.parametrize("path", _fragments(), ids=_fragment_ids())
+def test_fragment_parses_as_mapping(path):
+    data = yaml.safe_load(path.read_text())
+    assert isinstance(data, dict), (
+        f"{path.name}: must be a YAML mapping, got {type(data).__name__}"
+    )
+
+
+@pytest.mark.parametrize("path", _fragments(), ids=_fragment_ids())
+def test_fragment_has_only_scenario_at_top_level(path):
+    """render_plans merges "defaults -> shared -> stack", so only `scenario:` and
+    `shared:` are read from a scenario file's top level. Any other top-level key is
+    silently ignored — an inert fragment by construction."""
+    data = yaml.safe_load(path.read_text())
+    assert set(data) <= {"scenario", "shared"}, (
+        f"{path.name}: unexpected top-level key(s) "
+        f"{sorted(set(data) - {'scenario', 'shared'})} — only `scenario` and `shared` "
+        "are read from a scenario file's top level; anything else is silently ignored"
+    )
+    assert "scenario" in data, f"{path.name}: missing top-level `scenario`"
+
+
+@pytest.mark.parametrize("path", _fragments(), ids=_fragment_ids())
+def test_fragment_scenario_is_single_entry_named_defaults(path):
+    """`_align_overlay_name` realigns scenario[0].name to the bundle's name so both
+    sides collapse into one entry. A fragment with more than one entry, or a name
+    other than `defaults`, produces a phantom scenario (issue #516)."""
+    scenario = yaml.safe_load(path.read_text())["scenario"]
+    assert isinstance(scenario, list), f"{path.name}: `scenario` must be a list"
+    assert len(scenario) == 1, (
+        f"{path.name}: `scenario` must have exactly one entry, got {len(scenario)}"
+    )
+    assert scenario[0].get("name") == "defaults", (
+        f"{path.name}: scenario[0].name must be 'defaults', got "
+        f"{scenario[0].get('name')!r}"
+    )
+
+
+@pytest.mark.parametrize("path", _fragments(), ids=_fragment_ids())
+def test_fragment_sets_something_beyond_its_name(path):
+    """A fragment whose only key is `name` merges to nothing."""
+    entry = yaml.safe_load(path.read_text())["scenario"][0]
+    assert set(entry) - {"name"}, (
+        f"{path.name}: scenario[0] sets nothing beyond `name` — the fragment is inert"
+    )
+
+
+# Scalar-list keys a fragment is knowingly allowed to set, as {stem: {dotted key}}.
+#
+# A scalar list set from the defaults layer only survives if NO downstream layer
+# sets the same key, because `_merge_lists` Tier 1 replaces rather than appends.
+# That makes every entry here a standing fragility, not an endorsement: an
+# experiment whose `baselines/<name>.yaml` sets the same key silently wins, and the
+# fragment's value never reaches the rendered output. Each entry must be justified
+# below and warned about in the fragment's own header comment.
+_ALLOWED_SCALAR_LISTS = {
+    # Envoy sidecar CLI args. Kept here rather than in `baselines/<name>.yaml`
+    # because `--concurrency 8` is only meaningful next to the `limits.cpu: "8"`
+    # the same fragment sets, and splitting them across two files is what let them
+    # drift apart before. The tradeoff: a baseline that sets `router.proxy.args`
+    # itself takes the whole list and keeps the fragment's CPU limit, breaking the
+    # coupling silently. epponly.yaml's header says so.
+    "epponly": {"router.proxy.args"},
+}
+
+
+@pytest.mark.parametrize("path", _fragments(), ids=_fragment_ids())
+def test_fragment_sets_no_unacknowledged_scalar_list_key(path):
+    """Scalar lists set from this layer are fragile, so each one must be deliberate.
+
+    `_merge_lists` Tier 1 replaces (rather than appends) whenever either side holds
+    a non-dict item. The defaults overlay is the FIRST layer in `resolve_baseline`'s
+    chain — `deep_merge(defaults, bundle)` then `deep_merge(..., overlay)` — so a
+    scalar list it sets is discarded the moment any downstream layer sets the same
+    key. `vllm.additionalFlags` is the case that shipped inert for months (#839).
+
+    Rather than forbid scalar lists outright (which would rule out a fragment that
+    legitimately owns a key nothing downstream touches), require that each one be
+    listed in `_ALLOWED_SCALAR_LISTS` with a reason. A new fragment cannot add one
+    by accident, and the allowlist is the inventory of keys to re-check whenever an
+    experiment's baseline grows.
+    """
+    entry = yaml.safe_load(path.read_text())["scenario"][0]
+    found = set()
+
+    def walk(node, trail):
+        if isinstance(node, dict):
+            for key, value in node.items():
+                walk(value, trail + [str(key)])
+        elif isinstance(node, list) and node:
+            if any(not isinstance(item, dict) for item in node):
+                found.add(".".join(trail))
+
+    walk(entry, [])
+    allowed = _ALLOWED_SCALAR_LISTS.get(path.stem, set())
+
+    unacknowledged = sorted(found - allowed)
+    assert not unacknowledged, (
+        f"{path.name}: sets scalar list(s) {unacknowledged} — a list of non-dicts is "
+        "REPLACED by any downstream layer (_merge_lists Tier 1), so a value set here "
+        "cannot be relied on to reach the rendered output. Prefer a typed "
+        "scalar/bool key, or a list of dicts carrying `name` (which merges by key). "
+        "If the key genuinely belongs in this layer, add it to "
+        "_ALLOWED_SCALAR_LISTS with a reason and warn about it in the fragment's "
+        "header comment."
+    )
+
+    stale = sorted(allowed - found)
+    assert not stale, (
+        f"{path.name}: _ALLOWED_SCALAR_LISTS still lists {stale}, but the fragment no "
+        "longer sets it — drop the allowlist entry."
+    )
+
+
+def test_scalar_list_allowlist_has_no_entries_for_missing_fragments():
+    """An allowlist entry for a deleted fragment would silently permit a future
+    fragment that happens to reuse the stem."""
+    stems = set(_fragment_ids())
+    orphans = sorted(set(_ALLOWED_SCALAR_LISTS) - stems)
+    assert not orphans, (
+        f"_ALLOWED_SCALAR_LISTS names fragment(s) that no longer exist: {orphans}"
+    )
+
+
+def test_all_fragments_merge_without_error(deep_merge):
+    """Merging every fragment in filename-sorted order must not raise.
+
+    Mirrors what `load_defaults_overlay` does with nothing disabled. `_merge_lists`
+    raises ValueError on duplicate Kubernetes object identities and on positionally
+    folding manifests with differing markers — so two fragments contributing
+    conflicting `extraObjects` would fail assemble for every bootstrapped
+    experiment. Catch it here instead.
+    """
+    merged: dict = {}
+    for path in _fragments():
+        fragment = yaml.safe_load(path.read_text())
+        try:
+            merged = deep_merge(merged, fragment)
+        except ValueError as exc:  # pragma: no cover - only on a real conflict
+            pytest.fail(f"{path.name} conflicts with an earlier fragment: {exc}")
+    assert merged["scenario"][0]["name"] == "defaults"
+
+
+def test_no_two_fragments_set_the_same_leaf_key(deep_merge):
+    """Two fragments writing the same leaf make one of them silently order-dependent.
+
+    Merge order is filename-sorted (`load_defaults_overlay`), so the later stem wins
+    and the earlier fragment's value never reaches the output — the inert-fragment
+    failure mode of #839, in its within-layer form. Distinct leaves are fine; this
+    only fires on a genuine collision.
+    """
+    seen: dict[str, str] = {}
+    collisions = []
+
+    def walk(node, trail, stem):
+        if isinstance(node, dict):
+            for key, value in node.items():
+                walk(value, trail + [str(key)], stem)
+            return
+        path_key = ".".join(trail)
+        if path_key in seen and seen[path_key] != stem:
+            collisions.append(f"{path_key} (set by {seen[path_key]} and {stem})")
+        else:
+            seen[path_key] = stem
+
+    for path in _fragments():
+        entry = yaml.safe_load(path.read_text())["scenario"][0]
+        walk({k: v for k, v in entry.items() if k != "name"}, [], path.stem)
+
+    assert not collisions, (
+        "fragments set overlapping leaf keys; filename-sorted merge order decides "
+        f"the winner and the loser is inert: {collisions}"
+    )

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,13 +8,21 @@ The workarounds below are applied automatically by `sim2real assemble` via a def
 
 The fragments shipped today:
 
-| Fragment stem | What it adds |
-|---------------|--------------|
-| `epp-verbosity` | `router.epp.verbosity: "5"` |
-| `externally-managed-gateway` | `gateway.externallyManaged: true` — tells the chart to assume the gateway (Istio, AgentGateway, etc.) is managed externally and skip in-chart gateway provisioning |
-| `preserve-request-id` | `EnvoyFilter` that preserves the external request-id |
-| `routing-proxy-resources` | `routing.proxy.resources.requests` set to `memory: 16Gi`, `cpu: 4` (chart leaves it unset) |
-| `vllm-logging` | `vllm.additionalFlags: [--no-disable-uvicorn-access-log]` + `loggingLevel: INFO` |
+| Fragment stem | What it adds | Universally correct? |
+|---------------|--------------|----------------------|
+| `epp-verbosity` | `router.epp.verbosity: "3"` — VERBOSE, the floor for `/sim2real-check` §5c.6 | yes |
+| `epponly` | `gateway.className: epponly` plus sizing and args for the Envoy sidecar **inside the EPP pod** (`router.proxy`) | no — a topology decision |
+| `externally-managed-gateway` | `gateway.externallyManaged: true` — tells the chart to assume the gateway (Istio, AgentGateway, etc.) is managed externally and skip in-chart gateway provisioning | no — topology-dependent |
+| `model-pvc-size` | `storage.modelPvc.size: 1Ti` (framework default 300Gi cannot hold a 70B-class model as `hf download` fetches it) | no — sized for a 70B-class model |
+| `preserve-request-id` | `EnvoyFilter` that preserves the external request-id | no — matches nothing under epponly / externally-managed, and needs Istio CRDs |
+| `routing-proxy-resources` | `routing.proxy.resources.requests` set to `memory: 16Gi`, `cpu: 4` — the nixl routing sidecar **beside each model server** (chart leaves it unset) | yes |
+| `tokenizer-sidecar` | `router.tokenizer.enabled: true` + HF_TOKEN / HF_HOME env, so a `token-producer` plugin's `localhost:8000` resolves | no — only when the arms declare that plugin |
+| `vllm-keepalive` | `VLLM_HTTP_TIMEOUT_KEEP_ALIVE=120` on prefill, above the routing sidecar's 90s idle timeout | yes, until the llm-d-benchmark pin advances (#838) |
+| `vllm-logging` | `vllmCommon.flags.disableUvicornAccessLog: false` — restores vLLM's own default on **both** roles | yes |
+
+`epponly` and `routing-proxy-resources` size **different** sidecars — `router.proxy` is the Envoy inside the EPP pod, `routing.proxy` is the nixl sidecar next to each model server. They are not duplicates. Each fragment's header comment carries the full reasoning and cites.
+
+Making emission conditional for the "no" rows, rather than leaving it to the operator to notice, is tracked as [#840](https://github.com/inference-sim/sim2real/issues/840). Detecting a fragment that has no effect on the resolved scenario is [#841](https://github.com/inference-sim/sim2real/issues/841).
 
 **Opt out** by listing fragment stems under `defaults.disable` in `transfer.yaml`:
 
@@ -121,20 +129,32 @@ Add to the `scenario` in `baselines/*.yaml`:
 ```yaml
 router:
   epp:
-    verbosity: "5"
+    verbosity: "3"
 ```
 
-> **Note:** The `epp-verbosity` framework defaults fragment applies this automatically — it is enabled by default for all bootstrapped experiments. The `/sim2real-check` §4.2 InferenceObjectives check is **INAPPLICABLE** when EPP verbosity is below `-v=3`; `verbosity: "5"` (V(5) = VERBOSE) satisfies this requirement.
+**The scale is named constants, not raw numbers** (`llm-d-router pkg/common/observability/logging/const.go:20-23`, v0.9.0):
+
+| value | constant | when to use it |
+|-------|----------|----------------|
+| `"1"` | — | the llm-d-benchmark default; below `DEFAULT`, so the EPP is near-silent |
+| `"2"` | `DEFAULT` | |
+| `"3"` | `VERBOSE` | **what `epp-verbosity` sets.** The floor for `/sim2real-check` §5c.6 |
+| `"4"` | `DEBUG` | escalation for prefill-selection problems — the P/D decider explains itself here |
+| `"5"` | `TRACE` | only for a specific TRACE call site you have already identified |
+
+> **Note:** The `epp-verbosity` framework defaults fragment applies `"3"` automatically — it is enabled by default for all bootstrapped experiments. `/sim2real-check` §5c.6 (InferenceObjective resolution at runtime) reads `objectiveKey` off `Request handled` lines, which are attached under `V(logging.VERBOSE)` — so `"3"` is exactly the floor at which that check runs, and anything lower makes it **INAPPLICABLE**. Going above `"3"` costs CPU on every request, since the EPP is in the request path; prefer `"4"` over `"5"` when you need more, as it keeps the decider diagnostics while dropping every TRACE site.
 
 ### vLLM
 
-Add to `**.vllm` in `baselines/*.yaml`:
+Add to the `scenario` in `baselines/*.yaml`:
 
 ```yaml
-additionalFlags:
-- --no-disable-uvicorn-access-log
-loggingLevel: INFO
+vllmCommon:
+  flags:
+    disableUvicornAccessLog: false
 ```
+
+> **Note:** Use this typed key, not `**.vllm.additionalFlags: [--no-disable-uvicorn-access-log]`. `additionalFlags` is a list of scalars, so `pipeline/lib/values.py:_merge_lists` has each later layer *replace* it rather than append — a flag set from the defaults overlay is discarded by `baselines/<name>.yaml` and again by the registered overlay. The typed key also applies to **both** roles; `decode.vllm.loggingLevel: INFO` was additionally a no-op, since `INFO` is already the framework default (`defaults.yaml:51`).
 
 ## Correlate requests with pods (and hence nodes)
 


### PR DESCRIPTION
Closes #839. Base: `main`.

`templates/defaults/` shipped 5 fragments; the `pd-infocomm-2` bundle carries 10, and two of the shipped five had diverged from the bundle's corrected copies. A bootstrap re-run today would drop fragments the bundle needs and reinstate two known-bad ones.

## Part 1 — the two fragments that were wrong

**`vllm-logging.yaml` did nothing.** It set `decode.vllm.additionalFlags: ["--no-disable-uvicorn-access-log"]` plus `loggingLevel: INFO`. Both keys were inert:

- `additionalFlags` is a list of scalars, so `pipeline/lib/values.py:_merge_lists` Tier 1 has the overlay *replace* the base. The defaults overlay is the **first** layer in `resolve_baseline`'s chain, and both `baselines/<name>.yaml` and the translate overlay set that same list downstream — so the fragment's entry was discarded before it could reach the rendered command.
- `loggingLevel: INFO` is already the framework default twice over (`defaults.yaml:51`, plus a `default('INFO')` fallback at `_macros.j2:230`).

It was also decode-only, while the framework's suppression (`defaults.yaml:789`, emitted at `_macros.j2:154`/`:397`) covers **both** roles — so prefill served its requests with no access log at all. Now uses the typed `vllmCommon.flags.disableUvicornAccessLog: false`, which the macro reads per-role.

**`epp-verbosity.yaml` was set to an unusable level.** EPP levels are named constants (`llm-d-router pkg/common/observability/logging/const.go:20-23`): `DEFAULT=2, VERBOSE=3, DEBUG=4, TRACE=5`. `"5"` turns on every DEBUG and TRACE site at once, and the EPP is in the request path so it costs CPU as well as disk. Now `"3"`, with the 2/3/4/5 scale documented in the fragment and in `docs/troubleshooting.md`.

`"3"` is the **floor**, not a preference: `/sim2real-check` §5c.6 reads `objectiveKey` off `Request handled` lines, attached under `V(logging.VERBOSE)` — exactly 3. At `"3"` the check runs; below it, INAPPLICABLE. Both the fragment header and the troubleshooting note say so, so the next person to lower it knows the cost.

## Part 2 — four fragments added

`epponly`, `model-pvc-size`, `tokenizer-sidecar`, `vllm-keepalive`. Ported from the bundle's hand-authored copies, with comments trimmed to the mechanism, the source cites, and each fragment's applicability — dropping the bundle-specific correction logs, which are that repo's debugging history rather than something every future experiment repo needs.

`enforce-eager` is **held**, per the issue: it controls CUDA graphs and therefore moves ITL, the metric the arms are compared on, so it is a stated experiment decision rather than a silent default (#832).

## Reviewer attention

**A test caught a real problem mid-implementation.** Nothing previously validated fragment *content* — `test_byo.py` only checks that the emitted inventory matches the directory listing, and it derives that by glob. So a fragment with a malformed shape or an unmergeable key would ship to every bootstrapped experiment silently. The new `tests/test_defaults_templates.py` asserts shape (single `scenario` entry named `defaults`, nothing but `scenario`/`shared` at top level, sets something beyond `name`), merge safety (all nine merge through the real `deep_merge` without a `_merge_lists` ValueError), and no two fragments writing the same leaf key.

Its scalar-list guard immediately failed on `epponly.yaml`: `router.proxy.args` **is itself a scalar list**. So an experiment whose `baselines/<name>.yaml` sets `router.proxy.args` — the natural place, since that's where the upstream guide scenarios put it — silently takes the whole list, dropping `--concurrency 8`, while *keeping* the fragment's `limits.cpu: "8"`. That is precisely the args/CPU-limit coupling the fragment was created to hold together, breaking one layer up.

I did not weaken the guard to green the build. Scalar-list keys are now allowlisted per fragment with a stated reason, the allowlist is checked for staleness in both directions, and `epponly.yaml`'s header carries an explicit warning. If you think the args belong in the baseline instead, that's a live design question — say so and I'll file it.

**`router.proxy` and `routing.proxy` are different components.** `epponly.yaml` sets `router.proxy.{resources,args}` — routerlib's Envoy sidecar *inside the EPP pod* (`config/charts/routerlib/values.yaml:76`). The already-shipped `routing-proxy-resources.yaml` sets `routing.proxy.resources` — llm-d-benchmark's nixl routing sidecar *beside each model server* (`defaults.yaml:627 router:` vs `:691 routing:`). Distinct containers, distinct pods, distinct jobs. Nothing previously distinguished them and the names invite deduplication, so both fragment headers now say which sidecar they size. The resolved overlay shows them coexisting as separate blocks.

**One upstream claim I did not propagate.** The bundle's `epponly.yaml` justified its args block as overriding chart defaults of `--log-level trace` and no `--concurrency` — text inherited verbatim from 8 of the 9 upstream guide scenarios. That is stale as of routerlib v0.9.0, whose envoy preset already passes `--log-level warn` **and** `--cpuset-threads` (`llm-d-router-standalone/values.yaml:253-265`). `--cpuset-threads` sizes Envoy's worker pool from the cgroup, which is strictly more adaptive than a hardcoded `--concurrency 8` — and copying the upstream block drops it. I kept the args at byte-parity with upstream rather than silently deciding that tradeoff, and recorded it in the fragment header as something to revisit.

## Line references

All of the issue's cites verify against the **pinned** llm-d-benchmark (`76473d0`, per the submodule SHA), not `main`: `defaults.yaml:51`/`:307`/`:649`/`:789`, `_macros.j2:100`/`:154`/`:230`/`:364`/`:397`, `step.py:331`. Also confirmed at the pin: `VLLM_HTTP_TIMEOUT_KEEP_ALIVE` appears nowhere, so `vllm-keepalive` is load-bearing today (#838 tracks its removal); all 9 guide scenarios override `modelPvc.size` to 1Ti; 8 of 9 carry the proxy args block. The issue body's note asking to re-derive these was my error from checking the wrong commit — I've since corrected it there.

## Stale-reference sweep

Swept `**/*.md`, `docs/`, `.claude/skills/`, and `README*` for the five old stems, hardcoded fragment counts, `verbosity: "5"`, `--no-disable-uvicorn-access-log`, and `-v=3`. Updated:

- `SKILL.md` — both inventory lists (`transfer.yaml` template comment, generated file tree), the Task 4b prose (which described fragments as "EPP llm-d.ai RBAC, request-id preservation, …" — RBAC was removed from the shipped defaults some time ago), and the templates row in the reference table.
- `docs/troubleshooting.md` — a **third** inventory location the issue didn't mention. Its fragment table is now 9 rows with a "universally correct?" column, and the EPP-verbosity note at what was line 127 said `verbosity: "5"` **(V(5) = VERBOSE)**, which was wrong independently of this PR (V(5) is TRACE), and cited "`/sim2real-check` §4.2" when the section is §5c.6. Both fixed. Its vLLM snippet also still showed the now-known-inert `additionalFlags` form; replaced with the typed key plus a note on why.

Left alone: `pipeline/README.md` and `sim2real-check/SKILL.md` reference the mechanism generically or state the `-v=3` requirement correctly — no stems, no counts, nothing stale.

No CI workflow change needed: the new test file lives in `.claude/skills/sim2real-bootstrap/tests/`, already listed.

## Verification

```
ruff check pipeline/ .claude/skills/ --select F     ->  All checks passed
python -m pytest pipeline/ + all 5 skill test dirs  ->  2352 passed, 1 skipped, 2 xfailed
                                                        coverage 97.68% (fail-under 90)
```

Also ran the real `load_defaults_overlay` over the template directory to confirm all nine merge into one `scenario[0]` named `defaults` with no key loss.

## Out of scope

Split out of #839 during vetting, both filed:

- **#840** — fragments are emitted unconditionally, but `epponly`, `model-pvc-size`, `tokenizer-sidecar`, and `preserve-request-id` are topology-, model-, or plugin-specific. Also needs BLIS and BYO to agree on the default posture — BYO already pre-disables every stem, BLIS enables every stem.
- **#841** — nothing surfaces a fragment with no effect on the resolved scenario. The new tests cover the statically-decidable slice (a key that provably cannot survive the merge chain); the resolve-diff check is #841's.
