### PR TITLE
fix(bootstrap): emit parallelism.workers=1, not tensor_parallel_size (closes #831)

### DIFF
--- a/.claude/skills/sim2real-bootstrap/generate_from_config.py
+++ b/.claude/skills/sim2real-bootstrap/generate_from_config.py
@@ -339,6 +339,12 @@ _COUNT_NOUN_TAIL_RE = re.compile(r"\b(?:pods?|instances?|replicas?|nodes?)(?:\s+
 # malformed replica counts would reject config.md files that work on main.
 _RATIO_LABEL_RE = re.compile(r"\b(?:per|each)\s+\S+$")
 
+# `parallelism.workers` is the LeaderWorkerSet group size -- pods per replica --
+# not a parallelism degree. Nothing in config.md states it today, so it is a
+# stated default rather than a derived value (#831). A config.md input for
+# multi-pod model instances is tracked by #843.
+_WORKERS_PROVENANCE = "single-node default (LWS pods per replica, not a parallelism degree)"
+
 
 def is_unrecognized_replica_label(raw: str) -> bool:
     """True when a vLLM-table parameter label names a replica count we cannot map.
@@ -351,9 +357,11 @@ def is_unrecognized_replica_label(raw: str) -> bool:
       size. Erroring on them would both break working inputs and offer advice
       ("use `number of pods`") that is wrong for the row.
 
-    "workers" is deliberately NOT a counted noun here: it collides with
-    `parallelism.workers`, which derives from tensor_parallel_size rather than a
-    replica count, so flagging it would emit the same misleading guidance.
+    "workers" is deliberately NOT in `_COUNT_NOUN_TAIL_RE`. It *is* a pod count --
+    `parallelism.workers` is the LeaderWorkerSet group size -- but this generator
+    has no input field for it, so a `workers` row cannot be resolved and the
+    "use `number of pods`" advice this function offers would be wrong for it.
+    #843 adds the input field; flagging the label belongs with that change.
     """
     cleaned = normalize_cell(raw).lower().strip()
     if not cleaned or cleaned.startswith("-"):
@@ -777,7 +785,10 @@ def build_scenario(
             "data": dp,
             "dataLocal": dp,
             "tensor": tp,
-            "workers": tp,
+            # LWS group size (pods per replica), NOT a parallelism degree. A
+            # single pod holding `tensor` GPUs is workers: 1. Multi-pod model
+            # instances need a config.md input that does not exist yet (#843).
+            "workers": 1,
         }
 
     additional_flags = build_additional_flags(fields)
@@ -824,7 +835,7 @@ def build_scenario(
                 "data": dp,
                 "dataLocal": dp,
                 "tensor": tp,
-                "workers": tp,
+                "workers": 1,
             }
         if additional_flags:
             prefill["vllm"] = {"additionalFlags": additional_flags}
@@ -859,6 +870,7 @@ def build_scenario(
     if tp > 1 or dp > 1:
         provenance["decode.parallelism.tensor"] = tp_source
         provenance["decode.parallelism.data"] = dp_source
+        provenance["decode.parallelism.workers"] = _WORKERS_PROVENANCE
 
     if "prefill" in scenario:
         provenance["prefill.replicas"] = fields["prefill_replicas"].source
@@ -866,6 +878,7 @@ def build_scenario(
         if tp > 1 or dp > 1:
             provenance["prefill.parallelism.tensor"] = tp_source
             provenance["prefill.parallelism.data"] = dp_source
+            provenance["prefill.parallelism.workers"] = _WORKERS_PROVENANCE
 
     return scenario, provenance
 
@@ -914,7 +927,7 @@ def write_provenance_yaml(
         lines.append(f"      data: {p['data']}  # {provenance['decode.parallelism.data']}")
         lines.append(f"      dataLocal: {p['dataLocal']}  # {provenance['decode.parallelism.data']}")
         lines.append(f"      tensor: {p['tensor']}  # {provenance['decode.parallelism.tensor']}")
-        lines.append(f"      workers: {p['workers']}  # {provenance['decode.parallelism.tensor']}")
+        lines.append(f"      workers: {p['workers']}  # {provenance['decode.parallelism.workers']}")
 
     if "vllm" in scenario["decode"]:
         lines.append("    vllm:")
@@ -945,7 +958,7 @@ def write_provenance_yaml(
             lines.append(f"      data: {pp['data']}  # {provenance['prefill.parallelism.data']}")
             lines.append(f"      dataLocal: {pp['dataLocal']}  # {provenance['prefill.parallelism.data']}")
             lines.append(f"      tensor: {pp['tensor']}  # {provenance['prefill.parallelism.tensor']}")
-            lines.append(f"      workers: {pp['workers']}  # {provenance['prefill.parallelism.tensor']}")
+            lines.append(f"      workers: {pp['workers']}  # {provenance['prefill.parallelism.workers']}")
         if "vllm" in p_role:
             lines.append("    vllm:")
             lines.append("      additionalFlags:")

--- a/.claude/skills/sim2real-bootstrap/generate_scenarios.README.md
+++ b/.claude/skills/sim2real-bootstrap/generate_scenarios.README.md
@@ -67,8 +67,9 @@ Maps simulation hardware identifiers → Kubernetes node selector label values.
 | `workload.prefill_hardware` | `prefill.acceleratorType.labelValue` (optional; falls back to `workload.hardware`) |
 | `vllm_args.num_instances` | `decode.replicas` |
 | `vllm_args.prefill_instances` | `prefill.replicas` (optional; omitted or `0` produces no `prefill:` block) |
-| `vllm_args.tensor_parallel_size` | `decode.parallelism.tensor`, `decode.parallelism.workers` |
+| `vllm_args.tensor_parallel_size` | `decode.parallelism.tensor` |
 | `vllm_args.data_parallel_size` | `decode.parallelism.data`, `decode.parallelism.dataLocal` |
+| _(no input)_ | `decode.parallelism.workers` — always `1`; LWS pods per replica, not a parallelism degree (#831). Multi-pod model instances tracked by #843 |
 | `vllm_args.block_size` | `model.blockSize` |
 | `vllm_args.gpu_memory_utilization` | `model.gpuMemoryUtilization` |
 | `vllm_args.enforce_eager` | `vllmCommon.flags.enforceEager` |

--- a/.claude/skills/sim2real-bootstrap/generate_scenarios.py
+++ b/.claude/skills/sim2real-bootstrap/generate_scenarios.py
@@ -14,6 +14,10 @@ import re
 import sys
 from pathlib import Path
 
+# See #831: `workers` is the LeaderWorkerSet group size (pods per replica), not a
+# parallelism degree, and no input field states it -- so it is a stated default.
+_WORKERS_COMMENT = "single-node default (LWS pods per replica, not a parallelism degree)"
+
 # ---------------------------------------------------------------------------
 # Lookup tables
 # ---------------------------------------------------------------------------
@@ -229,7 +233,10 @@ def build_scenario(entry: dict, name: str) -> dict:
             "data": dp,
             "dataLocal": dp,
             "tensor": tp,
-            "workers": tp,
+            # LWS group size (pods per replica), NOT a parallelism degree. A
+            # single pod holding `tensor` GPUs is workers: 1. Multi-pod model
+            # instances need an input field that does not exist yet (#843).
+            "workers": 1,
         }
 
     flags = build_additional_flags(vllm_args)
@@ -266,7 +273,7 @@ def build_scenario(entry: dict, name: str) -> dict:
                 "data": dp,
                 "dataLocal": dp,
                 "tensor": tp,
-                "workers": tp,
+                "workers": 1,
             }
         if flags:
             prefill["vllm"] = {"additionalFlags": flags}
@@ -322,7 +329,7 @@ def write_commented_yaml(scenario: dict, entry: dict, out_path: str):
         lines.append(f"      data: {p['data']}  # from vllm_args.data_parallel_size")
         lines.append(f"      dataLocal: {p['dataLocal']}  # from vllm_args.data_parallel_size")
         lines.append(f"      tensor: {p['tensor']}  # from vllm_args.tensor_parallel_size")
-        lines.append(f"      workers: {p['workers']}  # from vllm_args.tensor_parallel_size")
+        lines.append(f"      workers: {p['workers']}  # {_WORKERS_COMMENT}")
 
     if "vllm" in scenario["decode"]:
         lines.append("    vllm:")
@@ -364,7 +371,7 @@ def write_commented_yaml(scenario: dict, entry: dict, out_path: str):
             lines.append(f"      data: {pp['data']}  # from vllm_args.data_parallel_size")
             lines.append(f"      dataLocal: {pp['dataLocal']}  # from vllm_args.data_parallel_size")
             lines.append(f"      tensor: {pp['tensor']}  # from vllm_args.tensor_parallel_size")
-            lines.append(f"      workers: {pp['workers']}  # from vllm_args.tensor_parallel_size")
+            lines.append(f"      workers: {pp['workers']}  # {_WORKERS_COMMENT}")
         if "vllm" in p_role:
             lines.append("    vllm:")
             lines.append("      additionalFlags:")

--- a/.claude/skills/sim2real-bootstrap/tests/test_generate_from_config_prefill.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_generate_from_config_prefill.py
@@ -516,3 +516,39 @@ def test_dp_only_still_emits_workers_one():
     p = scenario["decode"]["parallelism"]
     assert p["tensor"] == 1
     assert p["workers"] == 1
+
+
+def test_prefill_workers_comment_also_avoids_tensor_parallel_size(tmp_path):
+    """The prefill emit line is a separate code path from decode's.
+
+    A transposed provenance key would raise KeyError and be caught by the
+    existing round-trip test, but citing `tp_source` instead of the workers
+    string would emit silently-wrong text that nothing else asserts.
+    """
+    scenario, prov = build([
+        row("Number of decode pods", "2"),
+        row("Number of prefill pods", "1"),
+        row("tensor_parallel_size", "4"),
+    ])
+    text = emit(scenario, prov, tmp_path)
+    workers_lines = [ln for ln in text.splitlines() if ln.strip().startswith("workers:")]
+    assert len(workers_lines) == 2, "expected one workers line per role"
+    for line in workers_lines:
+        assert "tensor_parallel_size" not in line
+        assert "pods per replica" in line
+    parsed = yaml.safe_load(text)["scenario"][0]
+    assert parsed["prefill"]["parallelism"]["workers"] == 1
+    assert parsed["decode"]["parallelism"]["workers"] == 1
+
+
+def test_workers_is_one_when_both_tp_and_dp_exceed_one():
+    """The gate is `tp > 1 or dp > 1`; the AND case is the one a future
+    formula-based derivation would break first."""
+    scenario, _ = build([
+        row("Number of pods", "2"),
+        row("tensor_parallel_size", "4"),
+        row("data_parallel_size", "2"),
+    ])
+    p = scenario["decode"]["parallelism"]
+    assert (p["tensor"], p["data"], p["dataLocal"]) == (4, 2, 2)
+    assert p["workers"] == 1

--- a/.claude/skills/sim2real-bootstrap/tests/test_generate_from_config_prefill.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_generate_from_config_prefill.py
@@ -242,9 +242,9 @@ def test_ratio_row_in_vllm_table_does_not_abort(tmp_path):
 
 
 def test_workers_label_is_left_alone():
-    """`workers` collides with parallelism.workers, which derives from
-    tensor_parallel_size rather than a replica count, so flagging it would emit
-    the same misleading guidance the ratio exclusion exists to prevent."""
+    """`workers` is a pod count -- parallelism.workers is the LWS group size --
+    but no input field resolves it yet (#843), so the "use `number of pods`"
+    advice this check offers would be wrong for it; left unflagged (#831)."""
     assert gfc.is_unrecognized_replica_label("Prefill workers") is False
 
 
@@ -471,3 +471,48 @@ def test_emitted_yaml_round_trips_both_roles(tmp_path):
     assert parsed["decode"]["replicas"] == 2
     assert parsed["prefill"]["acceleratorType"]["labelValue"] == "NVIDIA-A100-SXM4-80GB"
     assert parsed["decode"]["acceleratorType"]["labelValue"] == "NVIDIA-H100-80GB-HBM3"
+
+
+# ---------------------------------------------------------------------------
+# parallelism.workers (issue #831)
+# ---------------------------------------------------------------------------
+
+def test_workers_is_one_not_tensor_parallel_size():
+    """`workers` is the LWS pods-per-replica count, not a parallelism degree.
+
+    A single pod holding 4 GPUs at TP=4 is `tensor: 4, workers: 1`. Emitting
+    `workers: 4` claims four pods per replica.
+    """
+    scenario, _ = build([row("Number of pods", "2"), row("tensor_parallel_size", "4")])
+    p = scenario["decode"]["parallelism"]
+    assert p["tensor"] == 4
+    assert p["workers"] == 1
+
+
+def test_prefill_workers_is_one():
+    scenario, _ = build([
+        row("Number of pods", "2"),
+        row("Number of prefill pods", "1"),
+        row("tensor_parallel_size", "4"),
+    ])
+    assert scenario["prefill"]["parallelism"]["tensor"] == 4
+    assert scenario["prefill"]["parallelism"]["workers"] == 1
+
+
+def test_workers_provenance_does_not_cite_tensor_parallel_size(tmp_path):
+    """The emitted comment must not claim `workers` came from TP."""
+    scenario, prov = build([row("Number of pods", "2"), row("tensor_parallel_size", "4")])
+    text = emit(scenario, prov, tmp_path)
+    workers_lines = [ln for ln in text.splitlines() if ln.strip().startswith("workers:")]
+    assert len(workers_lines) == 1
+    assert "tensor_parallel_size" not in workers_lines[0]
+    assert "pods per replica" in workers_lines[0]
+    assert yaml.safe_load(text)["scenario"][0]["decode"]["parallelism"]["workers"] == 1
+
+
+def test_dp_only_still_emits_workers_one():
+    """dp>1 with tp==1 already produced workers: 1; guard against regression."""
+    scenario, _ = build([row("Number of pods", "2"), row("data_parallel_size", "2")])
+    p = scenario["decode"]["parallelism"]
+    assert p["tensor"] == 1
+    assert p["workers"] == 1

--- a/.claude/skills/sim2real-bootstrap/tests/test_generate_scenarios.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_generate_scenarios.py
@@ -226,3 +226,40 @@ def test_emitted_yaml_round_trips_both_roles(tmp_path):
     assert parsed["prefill"]["replicas"] == 1
     assert parsed["decode"]["replicas"] == 2
     assert parsed["prefill"]["parallelism"]["tensor"] == 4
+
+
+# ---------------------------------------------------------------------------
+# parallelism.workers (issue #831)
+# ---------------------------------------------------------------------------
+
+def test_workers_is_one_not_tensor_parallel_size():
+    """`workers` is the LWS pods-per-replica count, not a parallelism degree."""
+    scenario = gs.build_scenario(entry(vllm_extra={"tensor_parallel_size": 4}), "cand")
+    p = scenario["decode"]["parallelism"]
+    assert p["tensor"] == 4
+    assert p["workers"] == 1
+
+
+def test_prefill_workers_is_one():
+    src = entry(vllm_extra={"prefill_instances": 1, "tensor_parallel_size": 4})
+    scenario = gs.build_scenario(src, "cand")
+    assert scenario["prefill"]["parallelism"]["tensor"] == 4
+    assert scenario["prefill"]["parallelism"]["workers"] == 1
+
+
+def test_workers_comment_does_not_cite_tensor_parallel_size(tmp_path):
+    src = entry(vllm_extra={"tensor_parallel_size": 4})
+    scenario = gs.build_scenario(src, "cand")
+    text = emit(scenario, src, tmp_path)
+    workers_lines = [ln for ln in text.splitlines() if ln.strip().startswith("workers:")]
+    assert len(workers_lines) == 1
+    assert "tensor_parallel_size" not in workers_lines[0]
+    assert "pods per replica" in workers_lines[0]
+    assert yaml.safe_load(text)["scenario"][0]["decode"]["parallelism"]["workers"] == 1
+
+
+def test_dp_only_still_emits_workers_one():
+    scenario = gs.build_scenario(entry(vllm_extra={"data_parallel_size": 2}), "cand")
+    p = scenario["decode"]["parallelism"]
+    assert p["tensor"] == 1
+    assert p["workers"] == 1

--- a/.claude/skills/sim2real-bootstrap/tests/test_generate_scenarios.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_generate_scenarios.py
@@ -263,3 +263,28 @@ def test_dp_only_still_emits_workers_one():
     p = scenario["decode"]["parallelism"]
     assert p["tensor"] == 1
     assert p["workers"] == 1
+
+
+def test_prefill_workers_comment_also_avoids_tensor_parallel_size(tmp_path):
+    """The prefill emit line is a separate code path from decode's."""
+    src = entry(vllm_extra={"prefill_instances": 1, "tensor_parallel_size": 4})
+    scenario = gs.build_scenario(src, "cand")
+    text = emit(scenario, src, tmp_path)
+    workers_lines = [ln for ln in text.splitlines() if ln.strip().startswith("workers:")]
+    assert len(workers_lines) == 2, "expected one workers line per role"
+    for line in workers_lines:
+        assert "tensor_parallel_size" not in line
+        assert "pods per replica" in line
+    parsed = yaml.safe_load(text)["scenario"][0]
+    assert parsed["prefill"]["parallelism"]["workers"] == 1
+    assert parsed["decode"]["parallelism"]["workers"] == 1
+
+
+def test_workers_is_one_when_both_tp_and_dp_exceed_one():
+    """The gate is `tp > 1 or dp > 1`; cover the AND case too."""
+    scenario = gs.build_scenario(
+        entry(vllm_extra={"tensor_parallel_size": 4, "data_parallel_size": 2}), "cand"
+    )
+    p = scenario["decode"]["parallelism"]
+    assert (p["tensor"], p["data"], p["dataLocal"]) == (4, 2, 2)
+    assert p["workers"] == 1

--- a/docs/superpowers/plans/2026-08-24-issue-831-parallelism-workers.md
+++ b/docs/superpowers/plans/2026-08-24-issue-831-parallelism-workers.md
@@ -1,0 +1,438 @@
+# parallelism.workers Correction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the bootstrap generators from writing `parallelism.workers = tensor_parallel_size`; emit `workers: 1` with provenance that states what the key actually means.
+
+**Architecture:** `workers` is the LeaderWorkerSet group size (pods per replica), not a parallelism degree. Both bootstrap generators currently set it from `tensor_parallel_size`. Fix the constant in all four dict-construction sites, give `workers` its own provenance entry instead of borrowing the tensor source, and correct the two prose sites that encode the wrong belief.
+
+**Tech Stack:** Python 3.10+, pytest, PyYAML
+
+**Spec:** GitHub issue #831 (`gh issue view 831`)
+
+## Global Constraints
+
+- `workers: 1` is emitted **explicitly**, never omitted. The issue offers omission as an alternative; it is rejected — see "Rejected alternative" below.
+- The two generators stay independent modules. No shared helper is introduced in this PR — see "Rejected alternative" below.
+- Behaviour change is confined to `tp > 1`. At `tp == 1` the old code already emitted `workers: 1`; at `tp == 1, dp == 1` the `if tp > 1 or dp > 1` gate emits no `parallelism` block at all. Existing bundles with `tp == 1` must regenerate byte-identically.
+- `is_unrecognized_replica_label` keeps its current behaviour. `workers` stays absent from `_COUNT_NOUN_TAIL_RE`; making it a recognized input field belongs to #843.
+- No change to the `if tp > 1 or dp > 1` gates. Widening them for `workers > 1` belongs to #843.
+- Provenance source strings follow the existing register in this file: short lowercase phrases, e.g. `config.md row "tensor_parallel_size"`, `default (not in config.md)`, `lookup: HARDWARE_LABELS["..."]`.
+
+## Rejected alternatives (record for reviewers)
+
+**Omitting the key.** Verified safe today but rejected. `render_plans.py:284-299` `deep_merge` recurses, so an absent `workers` inherits `1` from `defaults.yaml:845` (decode) / `:991` (prefill), both `*parallelism_single`. However `defaults.yaml:200,209,222,231` — the `large`/`xlarge` resource presets — carry `*parallelism_4gpu`/`*parallelism_8gpu` containing `workers: 4`/`workers: 8`, and `_apply_resource_preset` (`render_plans.py:302-325`) passes the preset as the *override* argument, so a preset wins over the scenario. `resourcePreset` is currently set nowhere (not in sim2real, not in any experiment repo, not in any `config/scenarios/` file), so omission is presently safe — but it makes the correct value depend on an upstream default staying put. Explicit `1` does not.
+
+**Lifting a shared helper across the two generators.** Rejected for this PR. `generate_from_config.py` and `generate_scenarios.py` are independent entry-point scripts with no cross-imports and no shared module in the skill directory. The duplicated surface is a four-key dict literal and four f-string emit lines; extracting a module for a constant is not worth the structural change. #843 adds real logic here (a `pods_per_replica` input field, paired `multinode` emission, widened gates) — that is the right moment to lift a helper.
+
+---
+
+### Task 1: `generate_from_config.py` — the config.md input path
+
+**Files:**
+- Modify: `.claude/skills/sim2real-bootstrap/generate_from_config.py:775-781` (decode dict), `:822-829` (prefill dict), `:859-868` (provenance), `:917` and `:948` (emit lines), `:354-356` (rationale comment)
+- Test: `.claude/skills/sim2real-bootstrap/tests/test_generate_from_config_prefill.py`
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces: provenance keys `decode.parallelism.workers` and `prefill.parallelism.workers`, both holding the string `single-node default (LWS pods per replica, not a parallelism degree)`. Task 2 mirrors this wording as an inline literal.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_generate_from_config_prefill.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# parallelism.workers (issue #831)
+# ---------------------------------------------------------------------------
+
+def test_workers_is_one_not_tensor_parallel_size():
+    """`workers` is the LWS pods-per-replica count, not a parallelism degree.
+
+    A single pod holding 4 GPUs at TP=4 is `tensor: 4, workers: 1`. Emitting
+    `workers: 4` claims four pods per replica.
+    """
+    scenario, _ = build([row("Number of pods", "2"), row("tensor_parallel_size", "4")])
+    p = scenario["decode"]["parallelism"]
+    assert p["tensor"] == 4
+    assert p["workers"] == 1
+
+
+def test_prefill_workers_is_one():
+    scenario, _ = build([
+        row("Number of pods", "2"),
+        row("Number of prefill pods", "1"),
+        row("tensor_parallel_size", "4"),
+    ])
+    assert scenario["prefill"]["parallelism"]["tensor"] == 4
+    assert scenario["prefill"]["parallelism"]["workers"] == 1
+
+
+def test_workers_provenance_does_not_cite_tensor_parallel_size(tmp_path):
+    """The emitted comment must not claim `workers` came from TP."""
+    scenario, prov = build([row("Number of pods", "2"), row("tensor_parallel_size", "4")])
+    text = emit(scenario, prov, tmp_path)
+    workers_lines = [ln for ln in text.splitlines() if ln.strip().startswith("workers:")]
+    assert len(workers_lines) == 1
+    assert "tensor_parallel_size" not in workers_lines[0]
+    assert "pods per replica" in workers_lines[0]
+    assert yaml.safe_load(text)["scenario"][0]["decode"]["parallelism"]["workers"] == 1
+
+
+def test_dp_only_still_emits_workers_one():
+    """dp>1 with tp==1 already produced workers: 1; guard against regression."""
+    scenario, _ = build([row("Number of pods", "2"), row("data_parallel_size", "2")])
+    p = scenario["decode"]["parallelism"]
+    assert p["tensor"] == 1
+    assert p["workers"] == 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest .claude/skills/sim2real-bootstrap/tests/test_generate_from_config_prefill.py -k workers -v`
+
+Expected: `test_workers_is_one_not_tensor_parallel_size` FAILS with `assert 4 == 1`; `test_prefill_workers_is_one` FAILS the same way; `test_workers_provenance_does_not_cite_tensor_parallel_size` FAILS on `"tensor_parallel_size" not in workers_lines[0]`. `test_dp_only_still_emits_workers_one` PASSES already (it is the regression guard).
+
+- [ ] **Step 3: Fix the two dict-construction sites**
+
+At `:775-781`, change `"workers": tp` to `"workers": 1`:
+
+```python
+    if tp > 1 or dp > 1:
+        decode["parallelism"] = {
+            "data": dp,
+            "dataLocal": dp,
+            "tensor": tp,
+            # LWS group size (pods per replica), NOT a parallelism degree. A
+            # single pod holding `tensor` GPUs is workers: 1. Multi-pod model
+            # instances need a config.md input that does not exist yet (#843).
+            "workers": 1,
+        }
+```
+
+At `:822-829`, the prefill block, make the identical change (no comment — the decode block above carries the explanation):
+
+```python
+        if tp > 1 or dp > 1:
+            prefill["parallelism"] = {
+                "data": dp,
+                "dataLocal": dp,
+                "tensor": tp,
+                "workers": 1,
+            }
+```
+
+- [ ] **Step 4: Add the provenance entries**
+
+At `:859-868`, add a `workers` key alongside the existing `tensor` and `data` entries, for both roles:
+
+```python
+    if tp > 1 or dp > 1:
+        provenance["decode.parallelism.tensor"] = tp_source
+        provenance["decode.parallelism.data"] = dp_source
+        provenance["decode.parallelism.workers"] = _WORKERS_PROVENANCE
+
+    if "prefill" in scenario:
+        provenance["prefill.replicas"] = fields["prefill_replicas"].source
+        provenance["prefill.acceleratorType.labelValue"] = prefill_hw_source
+        if tp > 1 or dp > 1:
+            provenance["prefill.parallelism.tensor"] = tp_source
+            provenance["prefill.parallelism.data"] = dp_source
+            provenance["prefill.parallelism.workers"] = _WORKERS_PROVENANCE
+```
+
+Define the constant at module level, next to the other module constants (after `_RATIO_LABEL_RE` at `:340`):
+
+```python
+# `parallelism.workers` is the LeaderWorkerSet group size -- pods per replica --
+# not a parallelism degree. Nothing in config.md states it today, so it is a
+# stated default rather than a derived value (#831). A config.md input for
+# multi-pod model instances is tracked by #843.
+_WORKERS_PROVENANCE = "single-node default (LWS pods per replica, not a parallelism degree)"
+```
+
+- [ ] **Step 5: Point the emit lines at the new provenance key**
+
+At `:917` (decode) change the provenance lookup:
+
+```python
+        lines.append(f"      workers: {p['workers']}  # {provenance['decode.parallelism.workers']}")
+```
+
+At `:948` (prefill):
+
+```python
+            lines.append(f"      workers: {pp['workers']}  # {provenance['prefill.parallelism.workers']}")
+```
+
+- [ ] **Step 6: Correct the rationale comment**
+
+In the `is_unrecognized_replica_label` docstring at `:354-356`, replace the paragraph that states the wrong derivation. Behaviour is unchanged — `workers` stays out of `_COUNT_NOUN_TAIL_RE` — but the reason is now accurate:
+
+```python
+    "workers" is deliberately NOT in `_COUNT_NOUN_TAIL_RE`. It *is* a pod count --
+    `parallelism.workers` is the LeaderWorkerSet group size -- but this generator
+    has no input field for it, so a `workers` row cannot be resolved and the
+    "use `number of pods`" advice this function offers would be wrong for it.
+    #843 adds the input field; flagging the label belongs with that change.
+```
+
+- [ ] **Step 7: Fix the test docstring that repeats the wrong belief**
+
+At `tests/test_generate_from_config_prefill.py:244-248`, the assertion stays; the docstring is corrected:
+
+```python
+def test_workers_label_is_left_alone():
+    """`workers` is a pod count, but no input field resolves it yet (#843), so
+    the "use `number of pods`" advice would be wrong -- left unflagged (#831).
+    """
+    assert gfc.is_unrecognized_replica_label("Prefill workers") is False
+```
+
+- [ ] **Step 8: Run the tests to verify they pass**
+
+Run: `python -m pytest .claude/skills/sim2real-bootstrap/tests/ -v`
+
+Expected: all PASS. Pay attention to the two pre-existing assertions that must still hold — `test_prefill_inherits_shared_parallelism_and_flags` at `:143-148` asserts `prefill.parallelism == decode.parallelism` and `tensor == 4`; both roles now carry `workers: 1` so equality is preserved.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add .claude/skills/sim2real-bootstrap/generate_from_config.py .claude/skills/sim2real-bootstrap/tests/test_generate_from_config_prefill.py
+git commit -m "fix(bootstrap): emit parallelism.workers=1, not tensor_parallel_size (#831)"
+```
+
+---
+
+### Task 2: `generate_scenarios.py` — the JSON input path
+
+**Files:**
+- Modify: `.claude/skills/sim2real-bootstrap/generate_scenarios.py:227-233` (decode dict), `:264-270` (prefill dict), `:325` and `:367` (emit lines)
+- Modify: `.claude/skills/sim2real-bootstrap/generate_scenarios.README.md:70` (mapping table row)
+- Test: `.claude/skills/sim2real-bootstrap/tests/test_generate_scenarios.py`
+
+**Interfaces:**
+- Consumes: the provenance wording from Task 1, mirrored here as an inline literal (this module has no provenance dict — it writes source comments as f-string literals).
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_generate_scenarios.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# parallelism.workers (issue #831)
+# ---------------------------------------------------------------------------
+
+def test_workers_is_one_not_tensor_parallel_size():
+    """`workers` is the LWS pods-per-replica count, not a parallelism degree."""
+    scenario = gs.build_scenario(entry(vllm_extra={"tensor_parallel_size": 4}), "cand")
+    p = scenario["decode"]["parallelism"]
+    assert p["tensor"] == 4
+    assert p["workers"] == 1
+
+
+def test_prefill_workers_is_one():
+    src = entry(vllm_extra={"prefill_instances": 1, "tensor_parallel_size": 4})
+    scenario = gs.build_scenario(src, "cand")
+    assert scenario["prefill"]["parallelism"]["tensor"] == 4
+    assert scenario["prefill"]["parallelism"]["workers"] == 1
+
+
+def test_workers_comment_does_not_cite_tensor_parallel_size(tmp_path):
+    src = entry(vllm_extra={"tensor_parallel_size": 4})
+    scenario = gs.build_scenario(src, "cand")
+    text = emit(scenario, src, tmp_path)
+    workers_lines = [ln for ln in text.splitlines() if ln.strip().startswith("workers:")]
+    assert len(workers_lines) == 1
+    assert "tensor_parallel_size" not in workers_lines[0]
+    assert "pods per replica" in workers_lines[0]
+    assert yaml.safe_load(text)["scenario"][0]["decode"]["parallelism"]["workers"] == 1
+
+
+def test_dp_only_still_emits_workers_one():
+    scenario = gs.build_scenario(entry(vllm_extra={"data_parallel_size": 2}), "cand")
+    p = scenario["decode"]["parallelism"]
+    assert p["tensor"] == 1
+    assert p["workers"] == 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest .claude/skills/sim2real-bootstrap/tests/test_generate_scenarios.py -k workers -v`
+
+Expected: the first three FAIL (`assert 4 == 1`, then the comment assertion); `test_dp_only_still_emits_workers_one` PASSES as a regression guard.
+
+- [ ] **Step 3: Fix the two dict-construction sites**
+
+At `:227-233`:
+
+```python
+    if tp > 1 or dp > 1:
+        decode["parallelism"] = {
+            "data": dp,
+            "dataLocal": dp,
+            "tensor": tp,
+            # LWS group size (pods per replica), NOT a parallelism degree. A
+            # single pod holding `tensor` GPUs is workers: 1. Multi-pod model
+            # instances need an input field that does not exist yet (#843).
+            "workers": 1,
+        }
+```
+
+At `:264-270`, the prefill block:
+
+```python
+        if tp > 1 or dp > 1:
+            prefill["parallelism"] = {
+                "data": dp,
+                "dataLocal": dp,
+                "tensor": tp,
+                "workers": 1,
+            }
+```
+
+- [ ] **Step 4: Fix the two emit-line source comments**
+
+This module writes source comments as inline literals rather than looking them up in a provenance dict. Define the constant at module level alongside the other module-level constants:
+
+```python
+# See #831: `workers` is the LeaderWorkerSet group size (pods per replica), not a
+# parallelism degree, and no input field states it -- so it is a stated default.
+_WORKERS_COMMENT = "single-node default (LWS pods per replica, not a parallelism degree)"
+```
+
+At `:325` (decode):
+
+```python
+        lines.append(f"      workers: {p['workers']}  # {_WORKERS_COMMENT}")
+```
+
+At `:367` (prefill):
+
+```python
+            lines.append(f"      workers: {pp['workers']}  # {_WORKERS_COMMENT}")
+```
+
+- [ ] **Step 5: Fix the stale mapping row in the README**
+
+`generate_scenarios.README.md:70` currently reads:
+
+```markdown
+| `vllm_args.tensor_parallel_size` | `decode.parallelism.tensor`, `decode.parallelism.workers` |
+```
+
+Replace with a row that no longer claims TP feeds `workers`, and add a row recording where `workers` does come from:
+
+```markdown
+| `vllm_args.tensor_parallel_size` | `decode.parallelism.tensor` |
+| _(no input)_ | `decode.parallelism.workers` — always `1`; LWS pods per replica, not a parallelism degree (#831). Multi-pod instances tracked by #843 |
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `python -m pytest .claude/skills/sim2real-bootstrap/tests/ -v`
+
+Expected: all PASS. `test_prefill_inherits_parallelism_and_flags` at `:97-100` asserts the two roles' parallelism dicts are equal — preserved, both are `workers: 1`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add .claude/skills/sim2real-bootstrap/generate_scenarios.py .claude/skills/sim2real-bootstrap/tests/test_generate_scenarios.py .claude/skills/sim2real-bootstrap/generate_scenarios.README.md
+git commit -m "fix(bootstrap): emit parallelism.workers=1 on the JSON input path (#831)"
+```
+
+---
+
+### Task 3: Full-suite verification and stale-reference sweep
+
+**Files:** none modified unless the sweep finds a hit.
+
+**Interfaces:**
+- Consumes: the completed Task 1 and Task 2 changes.
+- Produces: the verification evidence quoted in the PR body.
+
+- [ ] **Step 1: Run the CI lint gate**
+
+Run: `ruff check pipeline/ .claude/skills/ --select F`
+
+Expected: clean. The new module-level constants must be referenced, or F401/F841 will fire.
+
+- [ ] **Step 2: Run the full CI test command**
+
+Run:
+
+```bash
+python -m pytest pipeline/ \
+  .claude/skills/sim2real-analyze/tests/ \
+  .claude/skills/sim2real-bootstrap/tests/ \
+  .claude/skills/sim2real-translate/tests/ \
+  .claude/skills/sim2real-check/tests/ \
+  --cov=pipeline --cov-report=term-missing --cov-fail-under=90 -q
+```
+
+Expected: all pass, coverage gate satisfied. Coverage is measured on `pipeline/` only and this change touches neither, so the percentage should be unchanged from `main`.
+
+- [ ] **Step 3: Sweep for stale references**
+
+The changed surface is: the literal value of `parallelism.workers` in generated YAML, and the source-comment text attached to it. No file paths, public symbols, or function signatures changed, so a path-grep is not the right instrument — grep for the *claim*:
+
+```bash
+grep -rn "workers" --include="*.md" . | grep -v "^./llm-d-benchmark" | grep -v "^./docs/superpowers/plans"
+grep -rn "parallelism" --include="*.md" . | grep -v "^./llm-d-benchmark"
+```
+
+Expected hits and their disposition:
+- `.claude/skills/sim2real-bootstrap/generate_scenarios.README.md` — updated in Task 2.
+- `docs/superpowers/plans/2026-08-24-issue-831-parallelism-workers.md` — this plan; leave.
+- Anything under `llm-d-benchmark/` — vendored submodule, out of scope.
+
+Record any hit not in that list and decide stale / accurate / unrelated.
+
+- [ ] **Step 4: Confirm no leak into the parent repo**
+
+Run:
+
+```bash
+git status --porcelain
+git -C ../../.. status --porcelain
+```
+
+Expected: the worktree lists only the intended files. The parent repo must show no new modifications beyond the pre-existing untracked entries recorded at session start (`.gitmodules`, `inference-sim`, `docs/blog/`, `docs/proposals/`, `graphify-out/`, `scratch/`).
+
+- [ ] **Step 5: Verify the acceptance criterion end-to-end**
+
+The issue's reproduction is: author a `config.md` with `| tensor_parallel_size | 4 |`, run the generator, inspect `baselines/baseline.yaml`. Reproduce it directly:
+
+```bash
+python - <<'PY'
+import sys; sys.path.insert(0, ".claude/skills/sim2real-bootstrap")
+import generate_from_config as gfc
+rows = [
+    {"Parameter": "Model", "Value": "Qwen/Qwen3-14B", "Notes": ""},
+    {"Parameter": "GPU", "Value": "H100_SXM_80GB", "Notes": ""},
+    {"Parameter": "Number of pods", "Value": "2", "Notes": ""},
+    {"Parameter": "tensor_parallel_size", "Value": "4", "Notes": ""},
+]
+t = gfc.TableSection(heading="vLLM Pod Configuration", rows=rows, line_number=0)
+sc, pv = gfc.build_scenario(gfc.extract_fields(t), "repro")
+gfc.write_provenance_yaml(sc, pv, "/tmp/repro-831.yaml")
+PY
+grep -A5 "parallelism:" /tmp/repro-831.yaml
+```
+
+Expected: `tensor: 4` with `workers: 1`, and the `workers` comment naming pods-per-replica rather than `tensor_parallel_size`.
+
+- [ ] **Step 6: Commit any sweep fixes**
+
+Only if Step 3 found a stale reference. Otherwise skip.
+
+---
+
+## Self-Review
+
+**1. Spec coverage.** Issue #831 asks for: (a) `workers: 1` instead of `tp` — Task 1 Step 3, Task 2 Step 3; (b) the comment at `:354` corrected — Task 1 Step 6. The vet added: (c) the JSON-input path, which the issue omits — Task 2; (d) the provenance plumbing, since `workers` borrowing `tp_source` is the same false claim in machine-readable form — Task 1 Steps 4-5, Task 2 Step 4; (e) the stale README mapping row — Task 2 Step 5; (f) the test docstring repeating the belief — Task 1 Step 7. Explicitly deferred to #843 and recorded in Global Constraints: the `_COUNT_NOUN_TAIL_RE` membership, the `if tp > 1 or dp > 1` gates, `multinode` emission, and any `pods_per_replica` input field.
+
+**2. Placeholder scan.** No TBDs. Every code step carries the literal text to write; every run step carries the command and its expected result.
+
+**3. Type consistency.** `_WORKERS_PROVENANCE` (Task 1, used via the `provenance` dict) and `_WORKERS_COMMENT` (Task 2, used inline) hold the identical string `single-node default (LWS pods per replica, not a parallelism degree)`. They are deliberately separate module-level constants in two independent scripts, per the rejected-alternative note. Both satisfy the `"pods per replica" in workers_lines[0]` assertion the tests in each task make.


### PR DESCRIPTION
## Summary

`parallelism.workers` was set from `tensor_parallel_size` in both bootstrap generators. It is not a parallelism degree — in llm-d-modelservice it is the LeaderWorkerSet **size**, the number of pods per replica. A single pod holding 4 GPUs at TP=4 is `workers: 1`; `workers: 4` claims four pods per replica.

Emits `workers: 1` instead, and gives `workers` its own provenance so the generated YAML stops asserting a source it does not have. Closes #831.

## Changes

**`.claude/skills/sim2real-bootstrap/generate_from_config.py`** (config.md input path)
- Decode and prefill parallelism dicts: `"workers": tp` → `"workers": 1`.
- New module constant `_WORKERS_PROVENANCE`, and provenance entries `decode.parallelism.workers` / `prefill.parallelism.workers`. Previously `workers` borrowed `tp_source`, so the emitted line read `workers: 4  # config.md row "tensor_parallel_size"` — the same false claim in machine-readable form. It now reads `workers: 1  # single-node default (LWS pods per replica, not a parallelism degree)`.
- `is_unrecognized_replica_label` docstring: behaviour unchanged (`workers` stays out of `_COUNT_NOUN_TAIL_RE`), rationale corrected. The old text said `workers` "derives from tensor_parallel_size" — the belief that caused the bug, preserved in a comment. It now says `workers` *is* a pod count but no input field resolves it yet, so the "use `number of pods`" advice this check offers would be wrong for it.

**`.claude/skills/sim2real-bootstrap/generate_scenarios.py`** (JSON input path)
- Same two dict sites, same fix; both emit lines now use `_WORKERS_COMMENT` instead of `# from vllm_args.tensor_parallel_size`.

**`.claude/skills/sim2real-bootstrap/generate_scenarios.README.md`**
- Mapping table no longer claims `tensor_parallel_size` feeds `parallelism.workers`; a new row records `workers` as a stated default with no input.

**Tests** — 8 new (4 per generator): `workers == 1` while `tensor == 4` for both roles, the emitted comment does not cite `tensor_parallel_size`, and a `dp>1, tp==1` regression guard.

## Reviewer attention

**Scope: the JSON path is included, though #831 names only `generate_from_config.py`.** `generate_scenarios.py` had the identical defect at both dict sites and both emit lines. #824 set this precedent — it fixed both generators together because they share the alias vocabulary and fixing one leaves the other silently wrong. Without this, `/sim2real-bootstrap` would be correct from `config.md` and wrong from JSON.

**Scope: the provenance plumbing is included, though #831 mentions only the value.** The issue asks to "also update the comment at :354". The `:354` comment is prose a developer reads; the provenance reuse is the same false statement in the *generated artifact*, which is what an operator reads. Fixing the constant while leaving the comment asserting it came from TP would have been a half-fix.

**Explicit `workers: 1` rather than omitting the key.** #831 offers omission and leans toward it on "don't state values with no source to cite" grounds. I verified omission is safe *today* and still rejected it:

- `render_plans.py:284-299` `deep_merge` recurses, so an absent `workers` inherits `1` from `defaults.yaml:845` (decode) / `:991` (prefill), both `*parallelism_single`.
- But `defaults.yaml:200,209,222,231` — the `large`/`xlarge` resource presets — carry `*parallelism_4gpu`/`*parallelism_8gpu`, which contain `workers: 4`/`workers: 8`. And `_apply_resource_preset` (`render_plans.py:302-325`) passes the preset as the *override* argument, so a preset wins over the scenario.
- `resourcePreset` is currently set nowhere — not in sim2real, not in any experiment repo, not in any `config/scenarios/` file — so omission would work. It would also make the correct value depend on an upstream default staying put. Explicit `1` does not, and it is what carries the semantics comment.

**No shared helper across the two generators.** They are independent entry-point scripts with no cross-imports and no shared module in the skill directory. The duplicated surface is a four-key dict literal; extracting a module for a constant is not worth the structural change. #843 adds real logic here (a `pods_per_replica` input, paired `multinode` emission, widened gates) — that is the right moment to lift a helper.

**Deliberately out of scope, tracked by #843:** adding `workers` to `_COUNT_NOUN_TAIL_RE`, widening the `if tp > 1 or dp > 1` gates, emitting `multinode`, and any `pods_per_replica` input field. #831 is the constant fix; #843 is making a multi-pod topology expressible.

**One claim in #831 I could not verify.** The `data = dataLocal × workers` invariant attributed to the chart — `llm-d-modelservice` is not vendored here. Contrary data point: `wide-ep-lws.yaml:346-350` is `data: 1, dataLocal: 8, workers: 2` (`1 ≠ 16`), the only in-tree violation and the one genuine LWS scenario. The fix does not depend on this claim.

## Blast radius

Behaviour changes only when `tp > 1`. At `tp == 1, dp > 1` the old code already emitted `workers: 1`; at `tp == 1, dp == 1` the gate emits no `parallelism` block at all. The `single_pool_baseline.golden.yaml` fixture is a `tp == 1` case with no `parallelism` block, so it is byte-identical. Two pre-existing assertions that `prefill.parallelism == decode.parallelism` still hold — both roles carry `workers: 1`.

## Sweep for stale references

Grepped `**/*.md` (excluding the vendored `llm-d-benchmark/`) for `parallelism.workers` and `tensor_parallel_size`:

- `generate_scenarios.README.md:70,72` — updated here.
- `generate_scenarios.README.md:28` — "`decode.parallelism` omitted when `tensor_parallel_size == 1` AND `data_parallel_size == 1` … matches the `parallelism_single` default". Still accurate, and now more so: `parallelism_single` is `workers: 1`, which is what the emitted block carries.
- `.claude/skills/sim2real-check/SKILL.md:450` — TP degree in the vLLM server-config parity list. Unrelated; `workers` is a chart value, not a vLLM server arg.
- `tests/fixtures/single_pool_config.md:14` — `tensor_parallel_size = 1` fixture; emits no `parallelism` block.

No hits in `CLAUDE.md`, `pipeline/README.md`, or the bootstrap `SKILL.md`.

## Test plan

- [x] `python -m pytest .claude/skills/sim2real-bootstrap/tests/ -q` — 192 passed, 1 skipped.
- [x] Full CI command (`pipeline/` + all four skill test dirs, `--cov-fail-under=90`) — **2280 passed, 1 skipped, 2 xfailed; coverage 97.68%**.
- [x] `ruff check pipeline/ .claude/skills/ --select F` — clean.
- [x] New tests confirmed failing before the fix (`assert 4 == 1`, and the emitted comment asserting `tensor_parallel_size`), passing after.
- [x] Reproduced #831's acceptance criterion end-to-end — a `config.md` with `tensor_parallel_size = 4` plus prefill and decode pod counts now emits, for both roles:

  ```yaml
      parallelism:
        dataLocal: 1  # default (not in config.md)
        tensor: 4  # config.md row "tensor_parallel_size"
        workers: 1  # single-node default (LWS pods per replica, not a parallelism degree)
  ```

Closes #831
