### PR TITLE
fix(bootstrap): enable KV transfer whenever a prefill pool is emitted (closes #830)

### DIFF
--- a/.claude/skills/sim2real-bootstrap/SKILL.md
+++ b/.claude/skills/sim2real-bootstrap/SKILL.md
@@ -275,7 +275,7 @@ scenario:
       additionalFlags:
       - "--flag=value"
 
-  # Emitted ONLY when config.md names a prefill pod count (issue #824).
+  # Emitted ONLY when config.md names a prefill pod count (issues #824, #830).
   # Without those rows the output is exactly the single-decode shape above.
   prefill:
     enabled: true                      # required — see note below
@@ -286,6 +286,14 @@ scenario:
     vllm:
       additionalFlags:
       - "--flag=value"                 # shared with decode, not per-role
+
+  # Also emitted with a prefill pool, and only then (issue #830). This is what
+  # makes the pool do anything; see the note below.
+  vllmCommon:
+    kvTransfer:
+      enabled: true
+      connector: NixlConnector
+      role: kv_both
 ```
 
 **Disaggregation (issue #824).** To get a `prefill:` block, `config.md`'s vLLM
@@ -297,6 +305,16 @@ optional per-role accelerator overrides; without them both roles use the shared
 - `enabled: true` is **required**, not decorative. `pipeline/lib/capacity.py`
   defaults prefill to disabled with 0 replicas, so a `prefill:` block lacking it
   reads as disaggregated while planning zero prefill GPUs.
+- **`vllmCommon.kvTransfer` is equally required (issue #830)** — same failure
+  shape, one layer down. `vllmCommon.kvTransfer.enabled` defaults to `false`
+  upstream and vLLM's `--kv-transfer-config` flag is gated on it, so a prefill
+  pool without it gets no KV connector: the prefill pod is never routed to and
+  logs zero requests, while the decode pods prefill their own requests. Nothing
+  errors — the run completes and the results are silently not P/D. Both
+  generators emit it whenever they emit a prefill pool.
+  `role: kv_both` is deprecated for NixlConnector, which wants `kv_producer` on
+  prefill and `kv_consumer` on decode; `vllmCommon` is shared by both roles so
+  per-role values are not expressible today (tracked as #845).
 - `parallelism` and `vllm.additionalFlags` are shared across roles — `config.md`
   has no per-role form for them.
 - **One GPU type per role.** A GPU cell naming several types (`H100, A100`) emits

--- a/.claude/skills/sim2real-bootstrap/generate_from_config.py
+++ b/.claude/skills/sim2real-bootstrap/generate_from_config.py
@@ -833,8 +833,11 @@ def build_scenario(
         # KV transfer is what makes the prefill pool actually do anything (#830).
         # vllmCommon.kvTransfer.enabled defaults to false upstream
         # (llm-d-benchmark config/templates/values/defaults.yaml:725-726) and the
-        # --kv-transfer-config flag is gated on it (_macros.j2:103, emitted at
-        # :110 for decode and :354 for prefill). So a prefill pool WITHOUT this
+        # --kv-transfer-config flag is gated on it: _macros.j2:103 sets
+        # has_kv_transfer inside the single mode-parameterized macro
+        # build_vllm_command(mode) (:83-188), which emits the flag at :111 and
+        # :169 and is invoked for BOTH roles from 13_ms-values.yaml.j2 (:409
+        # decode, :826 prefill). So a prefill pool WITHOUT this
         # block reads as disaggregated and is not: no KV connector is
         # instantiated, the prefill pod is never routed to and logs zero
         # requests, and the decode pods do the prefill work themselves. Nothing

--- a/.claude/skills/sim2real-bootstrap/generate_from_config.py
+++ b/.claude/skills/sim2real-bootstrap/generate_from_config.py
@@ -835,7 +835,7 @@ def build_scenario(
         # (llm-d-benchmark config/templates/values/defaults.yaml:725-726) and the
         # --kv-transfer-config flag is gated on it: _macros.j2:103 sets
         # has_kv_transfer inside the single mode-parameterized macro
-        # build_vllm_command(mode) (:83-188), which emits the flag at :111 and
+        # build_vllm_command(mode) (:83-180), which emits the flag at :111 and
         # :169 and is invoked for BOTH roles from 13_ms-values.yaml.j2 (:409
         # decode, :826 prefill). So a prefill pool WITHOUT this
         # block reads as disaggregated and is not: no KV connector is

--- a/.claude/skills/sim2real-bootstrap/generate_from_config.py
+++ b/.claude/skills/sim2real-bootstrap/generate_from_config.py
@@ -829,6 +829,40 @@ def build_scenario(
         if additional_flags:
             prefill["vllm"] = {"additionalFlags": additional_flags}
         scenario["prefill"] = prefill
+
+        # KV transfer is what makes the prefill pool actually do anything (#830).
+        # vllmCommon.kvTransfer.enabled defaults to false upstream
+        # (llm-d-benchmark config/templates/values/defaults.yaml:725-726) and the
+        # --kv-transfer-config flag is gated on it (_macros.j2:103, emitted at
+        # :110 for decode and :354 for prefill). So a prefill pool WITHOUT this
+        # block reads as disaggregated and is not: no KV connector is
+        # instantiated, the prefill pod is never routed to and logs zero
+        # requests, and the decode pods do the prefill work themselves. Nothing
+        # errors -- observed as 415 requests all served by decode with prefill
+        # idle throughout.
+        #
+        # Same failure class as `enabled: true` above, one layer down: an upstream
+        # default of "off" turning a stated intention into silence. That one is
+        # guarded at the capacity-planning layer; this is the model-server layer.
+        #
+        # connector/role are stated rather than inherited from the upstream
+        # anchors (defaults.yaml:56-57, NixlConnector / kv_both) so the values are
+        # this bundle's decision and not a downstream fallback -- the same
+        # principle the specify skill applies to the `blis observe` block.
+        #
+        # `role: kv_both` is DEPRECATED for NixlConnector, which wants
+        # kv_producer on prefill and kv_consumer on decode. Not expressible today:
+        # vllmCommon is shared by both roles and there is no prefill.kvTransfer.
+        # Tracked as #845; kv_both works and warns until then.
+        #
+        # setdefault, NOT assignment: the enforce_eager override above may already
+        # have created scenario["vllmCommon"], and a plain assignment here would
+        # silently drop it.
+        scenario.setdefault("vllmCommon", {})["kvTransfer"] = {
+            "enabled": True,
+            "connector": "NixlConnector",
+            "role": "kv_both",
+        }
     elif "prefill_hardware" in fields:
         # The row was recognized and stored, then never read, because a prefill
         # accelerator without a prefill pod count describes a pool that does not
@@ -866,6 +900,18 @@ def build_scenario(
         if tp > 1 or dp > 1:
             provenance["prefill.parallelism.tensor"] = tp_source
             provenance["prefill.parallelism.data"] = dp_source
+        # Not from config.md -- implied by stating a prefill pool at all, since a
+        # pool without the transport does nothing (#830).
+        provenance["vllmCommon.kvTransfer.enabled"] = (
+            "implied by prefill pod count; P/D requires a KV transfer backend"
+        )
+        provenance["vllmCommon.kvTransfer.connector"] = (
+            "framework default, stated explicitly (llm-d-benchmark defaults.yaml:56)"
+        )
+        provenance["vllmCommon.kvTransfer.role"] = (
+            "framework default, stated explicitly; kv_both is deprecated for "
+            "NixlConnector but per-role values are not expressible (see #845)"
+        )
 
     return scenario, provenance
 
@@ -892,14 +938,38 @@ def write_provenance_yaml(
     lines.append(f"    blockSize: {scenario['model']['blockSize']}  # {provenance['model.blockSize']}")
     lines.append(f"    gpuMemoryUtilization: {scenario['model']['gpuMemoryUtilization']}  # {provenance['model.gpuMemoryUtilization']}")
 
+    # This emitter is hand-rolled, so every key under vllmCommon needs a branch
+    # here or it is silently dropped from the output no matter what the scenario
+    # dict says. `flags` and `kvTransfer` are independent: enforce_eager sets the
+    # first, a prefill pool sets the second, and either can appear alone.
     if "vllmCommon" in scenario:
-        source = "config.md row \"enforce_eager\""
-        if "enforce_eager" in provenance:
-            source = provenance["enforce_eager"]
         lines.append("")
         lines.append("  vllmCommon:")
-        lines.append("    flags:")
-        lines.append(f"      enforceEager: false  # {source}")
+        if "flags" in scenario["vllmCommon"]:
+            source = "config.md row \"enforce_eager\""
+            if "enforce_eager" in provenance:
+                source = provenance["enforce_eager"]
+            lines.append("    flags:")
+            lines.append(f"      enforceEager: false  # {source}")
+        if "kvTransfer" in scenario["vllmCommon"]:
+            kv = scenario["vllmCommon"]["kvTransfer"]
+            lines.append("    # Required for the prefill pool to do anything: the")
+            lines.append("    # --kv-transfer-config flag is gated on `enabled`, which")
+            lines.append("    # defaults to false, so without this the prefill pod is")
+            lines.append("    # never routed to and decode prefills its own requests.")
+            lines.append("    kvTransfer:")
+            lines.append(
+                f"      enabled: {str(kv['enabled']).lower()}  "
+                f"# {provenance['vllmCommon.kvTransfer.enabled']}"
+            )
+            lines.append(
+                f"      connector: {kv['connector']}  "
+                f"# {provenance['vllmCommon.kvTransfer.connector']}"
+            )
+            lines.append(
+                f"      role: {kv['role']}  "
+                f"# {provenance['vllmCommon.kvTransfer.role']}"
+            )
 
     lines.append("")
     lines.append("  decode:")

--- a/.claude/skills/sim2real-bootstrap/generate_scenarios.py
+++ b/.claude/skills/sim2real-bootstrap/generate_scenarios.py
@@ -271,6 +271,29 @@ def build_scenario(entry: dict, name: str) -> dict:
         if flags:
             prefill["vllm"] = {"additionalFlags": flags}
         scenario["prefill"] = prefill
+
+        # KV transfer is what makes the prefill pool actually do anything (#830).
+        # vllmCommon.kvTransfer.enabled defaults to false upstream
+        # (llm-d-benchmark config/templates/values/defaults.yaml:725-726) and the
+        # --kv-transfer-config flag is gated on it (_macros.j2:103). A prefill pool
+        # without this block reads as disaggregated and is not: no KV connector is
+        # instantiated, the prefill pod is never routed to, and decode prefills its
+        # own requests. Nothing errors.
+        #
+        # Same failure class as `enabled: true` above, one layer down -- that one is
+        # guarded at the capacity-planning layer, this is the model-server layer.
+        #
+        # `role: kv_both` is deprecated for NixlConnector, which wants kv_producer
+        # on prefill and kv_consumer on decode; vllmCommon is shared by both roles
+        # so per-role values are not expressible today. Tracked as #845.
+        #
+        # setdefault, NOT assignment: the enforce_eager override above may already
+        # have created scenario["vllmCommon"].
+        scenario.setdefault("vllmCommon", {})["kvTransfer"] = {
+            "enabled": True,
+            "connector": "NixlConnector",
+            "role": "kv_both",
+        }
     elif workload.get("prefill_hardware"):
         # Declared in KNOWN_FIELDS so check_unknown_fields stays quiet, but unused
         # without a count -- a recognized input silently discarded (issue #824
@@ -301,11 +324,26 @@ def write_commented_yaml(scenario: dict, entry: dict, out_path: str):
     lines.append(f"    blockSize: {scenario['model']['blockSize']}  # from vllm_args.block_size")
     lines.append(f"    gpuMemoryUtilization: {scenario['model']['gpuMemoryUtilization']}  # from vllm_args.gpu_memory_utilization")
 
+    # Hand-rolled emitter: every key under vllmCommon needs a branch here or it is
+    # silently dropped from the output. `flags` and `kvTransfer` are independent --
+    # enforce_eager sets the first, a prefill pool sets the second, and either can
+    # appear alone, so neither may be accessed unconditionally.
     if "vllmCommon" in scenario:
         lines.append("")
         lines.append("  vllmCommon:")
-        lines.append("    flags:")
-        lines.append(f"      enforceEager: {str(scenario['vllmCommon']['flags']['enforceEager']).lower()}  # from vllm_args.enforce_eager")
+        if "flags" in scenario["vllmCommon"]:
+            lines.append("    flags:")
+            lines.append(f"      enforceEager: {str(scenario['vllmCommon']['flags']['enforceEager']).lower()}  # from vllm_args.enforce_eager")
+        if "kvTransfer" in scenario["vllmCommon"]:
+            kv = scenario["vllmCommon"]["kvTransfer"]
+            lines.append("    # Required for the prefill pool to do anything: the")
+            lines.append("    # --kv-transfer-config flag is gated on `enabled`, which")
+            lines.append("    # defaults to false, so without this the prefill pod is")
+            lines.append("    # never routed to and decode prefills its own requests.")
+            lines.append("    kvTransfer:")
+            lines.append(f"      enabled: {str(kv['enabled']).lower()}  # implied by prefill_instances; P/D requires a KV transfer backend")
+            lines.append(f"      connector: {kv['connector']}  # framework default, stated explicitly")
+            lines.append(f"      role: {kv['role']}  # framework default, stated explicitly; kv_both is deprecated for NixlConnector (see #845)")
 
     lines.append("")
     lines.append("  decode:")

--- a/.claude/skills/sim2real-bootstrap/tests/test_generate_from_config_prefill.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_generate_from_config_prefill.py
@@ -471,3 +471,118 @@ def test_emitted_yaml_round_trips_both_roles(tmp_path):
     assert parsed["decode"]["replicas"] == 2
     assert parsed["prefill"]["acceleratorType"]["labelValue"] == "NVIDIA-A100-SXM4-80GB"
     assert parsed["decode"]["acceleratorType"]["labelValue"] == "NVIDIA-H100-80GB-HBM3"
+
+
+# ---------------------------------------------------------------------------
+# KV transfer (issue #830)
+#
+# A prefill pool with no KV transport reads as disaggregated and is not: vLLM's
+# --kv-transfer-config is gated on vllmCommon.kvTransfer.enabled, which defaults
+# to false upstream, so the prefill pod is never routed to and decode prefills
+# its own requests -- silently, with no error.
+#
+# These assert on the EMITTED TEXT (and its parse), never on the intermediate
+# scenario dict alone. Both generators hand-roll their YAML and hardcode which
+# keys under vllmCommon get rendered, so a dict-only assertion passes while the
+# emitter silently drops the key -- the same shape of gap that produced #830.
+# ---------------------------------------------------------------------------
+
+
+def test_prefill_pool_emits_kv_transfer(tmp_path):
+    """Stating a prefill count must turn KV transfer ON in the emitted YAML."""
+    scenario, prov = build([row("Number of prefill pods", "1")])
+    parsed = yaml.safe_load(emit(scenario, prov, tmp_path))["scenario"][0]
+    kv = parsed["vllmCommon"]["kvTransfer"]
+    assert kv["enabled"] is True
+    assert kv["connector"] == "NixlConnector"
+    assert kv["role"] == "kv_both"
+
+
+def test_no_prefill_pool_emits_no_kv_transfer(tmp_path):
+    """Aggregated bundles must regenerate byte-identically — no kvTransfer at all."""
+    scenario, prov = build([])
+    text = emit(scenario, prov, tmp_path)
+    assert "kvTransfer" not in text
+    assert "vllmCommon" not in text
+
+
+def test_stated_zero_prefill_emits_no_kv_transfer(tmp_path):
+    """A stated 0 means aggregated, so it must not enable the transport either."""
+    scenario, prov = build([row("Number of prefill pods", "0")])
+    assert "kvTransfer" not in emit(scenario, prov, tmp_path)
+
+
+def test_kv_transfer_and_enforce_eager_coexist(tmp_path):
+    """Neither vllmCommon subtree may clobber or hide the other.
+
+    `enforce_eager: false` creates scenario["vllmCommon"] before the prefill block
+    runs. A plain assignment in either place drops the other; a hand-rolled emitter
+    rendering only one branch hides the other. Both must survive into the output.
+    """
+    scenario, prov = build(
+        [row("Number of prefill pods", "1"), row("enforce_eager", "false")]
+    )
+    parsed = yaml.safe_load(emit(scenario, prov, tmp_path))["scenario"][0]
+    assert parsed["vllmCommon"]["flags"]["enforceEager"] is False
+    assert parsed["vllmCommon"]["kvTransfer"]["enabled"] is True
+
+
+def test_enforce_eager_alone_still_emits_flags(tmp_path):
+    """The flags-only path must not regress now that the branch is conditional."""
+    scenario, prov = build([row("enforce_eager", "false")])
+    parsed = yaml.safe_load(emit(scenario, prov, tmp_path))["scenario"][0]
+    assert parsed["vllmCommon"]["flags"]["enforceEager"] is False
+    assert "kvTransfer" not in parsed["vllmCommon"]
+
+
+def test_kv_transfer_carries_provenance(tmp_path):
+    """Every emitted key gets a provenance comment; these are no exception."""
+    scenario, prov = build([row("Number of prefill pods", "1")])
+    text = emit(scenario, prov, tmp_path)
+    lines = text.split("\n")
+    start = next(i for i, ln in enumerate(lines) if ln.strip() == "kvTransfer:")
+    block = lines[start + 1 : start + 4]
+    for key in ("enabled:", "connector:", "role:"):
+        line = next(ln for ln in block if key in ln)
+        assert "#" in line, f"{key} emitted without a provenance comment: {line!r}"
+    # kv_both is a known-deprecated value shipped knowingly, so the emitted file
+    # must point at the issue tracking it rather than stay silent about it.
+    assert "#845" in text
+
+
+def test_kv_transfer_agrees_across_both_generators(tmp_path):
+    """generate_scenarios.py has the same prefill block and had the same hole.
+
+    Issue #830 named only generate_from_config.py. Fixing one path and not the
+    other would leave half of bootstrap emitting an inert prefill pool, so the two
+    generators must agree — both that a prefill pool enables the transport, and
+    that no prefill pool leaves it absent.
+    """
+    sys.path.insert(0, str(Path(__file__).parents[1]))
+    import generate_scenarios as gs
+
+    def gs_emit(prefill_instances):
+        entry = {
+            "workload": {"model": "Qwen/Qwen3-14B", "hardware": "H100_SXM_80GB"},
+            "vllm_args": {
+                "num_instances": 2,
+                "prefill_instances": prefill_instances,
+            },
+        }
+        scenario = gs.build_scenario(entry, "cand")
+        out = tmp_path / f"cand-{prefill_instances}.yaml"
+        gs.write_commented_yaml(scenario, entry, str(out))
+        return out.read_text()
+
+    with_prefill = yaml.safe_load(gs_emit(1))["scenario"][0]
+    assert with_prefill["vllmCommon"]["kvTransfer"]["enabled"] is True
+    assert with_prefill["vllmCommon"]["kvTransfer"]["connector"] == "NixlConnector"
+
+    assert "kvTransfer" not in gs_emit(0)
+
+    # The two generators must emit identical transport settings for the same intent.
+    from_config, prov = build([row("Number of prefill pods", "1")])
+    from_config_kv = yaml.safe_load(emit(from_config, prov, tmp_path))["scenario"][0][
+        "vllmCommon"
+    ]["kvTransfer"]
+    assert from_config_kv == with_prefill["vllmCommon"]["kvTransfer"]

--- a/.claude/skills/sim2real-bootstrap/tests/test_generate_scenarios.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_generate_scenarios.py
@@ -226,3 +226,66 @@ def test_emitted_yaml_round_trips_both_roles(tmp_path):
     assert parsed["prefill"]["replicas"] == 1
     assert parsed["decode"]["replicas"] == 2
     assert parsed["prefill"]["parallelism"]["tensor"] == 4
+
+
+# ---------------------------------------------------------------------------
+# KV transfer (issue #830)
+#
+# A prefill pool with no KV transport reads as disaggregated and is not: vLLM's
+# --kv-transfer-config is gated on vllmCommon.kvTransfer.enabled, which defaults
+# to false upstream, so the prefill pod is never routed to and decode prefills
+# its own requests -- silently.
+#
+# `vllmCommon` has TWO independent populators in build_scenario: the enforce_eager
+# override, and the prefill block's kvTransfer. Each of the tests below fails on a
+# specific regression that the code comments warn about but nothing previously
+# caught (both were confirmed to leave the whole suite green when injected):
+#   - plain assignment instead of setdefault in either populator, which drops the
+#     other one
+#   - a hand-rolled emitter branch that renders only one of the two subtrees
+# Assertions are on the EMITTED YAML, never the intermediate dict: the emitter
+# hardcodes which keys it renders, so a dict-only assertion passes while the
+# output silently lacks the key.
+# ---------------------------------------------------------------------------
+
+
+def test_prefill_input_emits_kv_transfer(tmp_path):
+    src = entry(vllm_extra={"prefill_instances": 1})
+    parsed = yaml.safe_load(emit(gs.build_scenario(src, "cand"), src, tmp_path))
+    kv = parsed["scenario"][0]["vllmCommon"]["kvTransfer"]
+    assert kv["enabled"] is True
+    assert kv["connector"] == "NixlConnector"
+    assert kv["role"] == "kv_both"
+
+
+def test_no_prefill_input_emits_no_kv_transfer(tmp_path):
+    src = entry()
+    assert "kvTransfer" not in emit(gs.build_scenario(src, "cand"), src, tmp_path)
+
+
+def test_kv_transfer_and_enforce_eager_coexist(tmp_path):
+    """Both vllmCommon populators must survive together, in the emitted YAML.
+
+    `enforce_eager: false` assigns scenario["vllmCommon"] = {"flags": ...} before
+    the prefill block runs. A plain assignment in the prefill block drops those
+    flags; an emitter that renders only one subtree hides the other. Either
+    regression leaves every other test in this suite passing.
+    """
+    src = entry(vllm_extra={"prefill_instances": 1, "enforce_eager": False})
+    parsed = yaml.safe_load(emit(gs.build_scenario(src, "cand"), src, tmp_path))
+    vc = parsed["scenario"][0]["vllmCommon"]
+    assert vc["flags"]["enforceEager"] is False
+    assert vc["kvTransfer"]["enabled"] is True
+
+
+def test_enforce_eager_alone_still_emits_flags(tmp_path):
+    """The flags-only path must survive the emitter branch becoming conditional.
+
+    Narrowing the `if "flags" in ...` guard to also require kvTransfer would drop
+    enforceEager from every aggregated bundle that sets it.
+    """
+    src = entry(vllm_extra={"enforce_eager": False})
+    parsed = yaml.safe_load(emit(gs.build_scenario(src, "cand"), src, tmp_path))
+    vc = parsed["scenario"][0]["vllmCommon"]
+    assert vc["flags"]["enforceEager"] is False
+    assert "kvTransfer" not in vc


### PR DESCRIPTION
Closes #830. Base: `main`.

A `config.md` naming a prefill pod count produced a scenario that **reads as disaggregated and is not**. `vllmCommon.kvTransfer.enabled` defaults to `false` upstream (`llm-d-benchmark config/templates/values/defaults.yaml:725-726`) and vLLM's `--kv-transfer-config` is gated on it (`_macros.j2:103` sets `has_kv_transfer` inside the single mode-parameterized macro `build_vllm_command(mode)` at `:83-188`, which emits the flag at `:111` and `:169` and is invoked for both roles from `13_ms-values.yaml.j2` — `:409` decode, `:826` prefill). So no KV connector was instantiated: the prefill pod was never routed to and logged zero requests, while the decode pods prefilled their own. Nothing errored — observed on a 1P2D Llama-3.3-70B run as **415 requests all served by decode, prefill idle throughout**.

This is the same failure class as the `enabled: true` the prefill block already carries, one layer down: an upstream default of "off" turning a stated intention into silence. That one is guarded at the capacity-planning layer; this is the model-server layer.

All line references verified against the **pinned** llm-d-benchmark (`76473d0`, per the submodule SHA), not `main`.

## Reviewer attention

**Fixed in BOTH generators — the issue named only one.** `generate_from_config.py` is what #830 cites, but `generate_scenarios.py` (the BLIS-driven path) emits its own prefill block at `:247-273`, carries the *same* "enabled: true is load-bearing" comment, and had `kvTransfer` nowhere either. Fixing one path would have left half of bootstrap emitting an inert prefill pool. A cross-generator test now pins them together.

**The issue's proposed fix was insufficient as written, in both files.** #830 says to merge into `scenario["vllmCommon"]` with `setdefault` — correct as far as it goes, and I did that. But **both generators hand-roll their YAML** rather than dumping it, and both hardcoded the `vllmCommon` subtree to exactly `flags.enforceEager`:

- `generate_from_config.py:895-902`
- `generate_scenarios.py:304-308`

So a `kvTransfer` key added to the dict would have been **silently dropped from the output**. Worse, `generate_scenarios.py:308` accessed `scenario['vllmCommon']['flags']['enforceEager']` unconditionally once `"vllmCommon" in scenario`, so a kvTransfer-only scenario (prefill pool, no `enforce_eager` override) would have raised **KeyError**. Both emitters now branch on each subtree independently, and `test_enforce_eager_alone_still_emits_flags` guards the reverse direction.

**Tests assert on emitted text, not the intermediate dict.** That is deliberate and is the point of the above: a dict-level assertion passes while the emitter drops the key, which is precisely the shape of gap that produced #830. Every new test goes through `emit()` / `write_commented_yaml()` and parses the result.

**`role: kv_both` is knowingly deprecated.** NixlConnector wants `kv_producer` on prefill and `kv_consumer` on decode, but `vllmCommon` is shared by both roles and there is no `prefill.kvTransfer`, so per-role values are not expressible today. Filed as **#845** with the trigger conditions for revisiting, and the emitted provenance comment points at it rather than staying silent.

**`connector`/`role` are stated, not inherited.** Upstream anchors already default them (`defaults.yaml:56-57` → `NixlConnector` / `kv_both`), so emitting them is redundant in effect but deliberate in intent — the same principle the specify skill applies to the `blis observe` block: the values are this bundle's decision, not a downstream fallback.

**Note on the reference scenario.** #830 cites `pd-disaggregation.yaml` as carrying `--kv-transfer-config`. It does — but by hand-writing the raw flag into a command block (`:298`, `:387`), not via the typed `kvTransfer` key. The typed key used here is the better route: a raw flag in `additionalFlags` is a scalar list, so `pipeline/lib/values.py:_merge_lists` Tier 1 has every downstream layer replace it wholesale (the #839 failure class).

## Tests added

Seven, in `test_generate_from_config_prefill.py`:

| Test | Guards |
|---|---|
| `test_prefill_pool_emits_kv_transfer` | the fix itself, in emitted YAML |
| `test_no_prefill_pool_emits_no_kv_transfer` | aggregated bundles regenerate byte-identically |
| `test_stated_zero_prefill_emits_no_kv_transfer` | a stated `0` means aggregated |
| `test_kv_transfer_and_enforce_eager_coexist` | the overwrite trap **and** the emitter-branch trap |
| `test_enforce_eager_alone_still_emits_flags` | no regression on the flags-only path |
| `test_kv_transfer_carries_provenance` | every emitted key has a `#` source comment, and `#845` is referenced |
| `test_kv_transfer_agrees_across_both_generators` | both generators emit identical transport settings |

## Stale-reference sweep

Swept `**/*.md`, `docs/`, `.claude/skills/`, and `README*` for `kvTransfer` / `kv_transfer` / "KV transfer" and for `prefill`. One hit needed updating: `sim2real-bootstrap/SKILL.md` documents the generated scenario shape and the disaggregation rules, and both were now incomplete — the shape block showed a prefill pool with no `vllmCommon.kvTransfer`, and the notes explained why `enabled: true` is load-bearing without the equivalent for the transport. Both updated, with the #845 caveat recorded.

No other doc mentions KV transfer. `pipeline/README.md` is unaffected — this is bootstrap-side generation, not a pipeline stage contract.

## Verification

```
ruff check pipeline/ .claude/skills/ --select F     ->  All checks passed
python -m pytest pipeline/ + all 5 skill test dirs  ->  2359 passed, 1 skipped, 2 xfailed
                                                        coverage 97.68% (fail-under 90)
```

Also rendered a real scenario by hand to confirm `flags` and `kvTransfer` coexist correctly under one `vllmCommon:` with provenance comments on every line.
