### PR TITLE
feat(bootstrap): ship three P/D cluster fragments plus preserve-request-id disabled (closes #853)

### DIFF
--- a/.claude/skills/sim2real-bootstrap/SKILL.md
+++ b/.claude/skills/sim2real-bootstrap/SKILL.md
@@ -459,11 +459,27 @@ fragments in place to tweak them for the experiment, or list a fragment
 stem under `defaults.disable` in `transfer.yaml` to opt out entirely.
 
 **Not every fragment is universally correct.** `epponly` is a topology decision,
-`model-pvc-size` is sized for a 70B-class model, `tokenizer-sidecar` matters only
-when the arms declare a `token-producer` plugin, and `preserve-request-id` matches
-nothing under an epponly / externally-managed gateway. Each fragment's header
+`model-pvc-size` is sized for a 70B-class model, and `tokenizer-sidecar` matters
+only when the arms declare a `token-producer` plugin. Each fragment's header
 comment states its own applicability and when to disable it. Making emission
 conditional rather than leaving that to the operator is tracked as #840.
+
+**Fragments that ship disabled (issue #853).** Four are copied but listed in
+`defaults.disable` by Task 5, because none can be a correct always-on default.
+Shipping them anyway means an operator has something to enable rather than
+reinvent; enabling one is deleting its line from `defaults.disable`.
+
+| Fragment | Why it cannot default to on |
+|---|---|
+| `pod-capabilities` | Cannot grant the permission it depends on. On OpenShift the pod will not admit until someone runs `oc adm policy add-scc-to-user privileged` out of band, so enabled-by-default yields unschedulable pods. |
+| `nic-exclusion` | The value is a literal device list for one cluster's cards. A default naming another cluster's devices would exclude the wrong ones — worse than excluding none. |
+| `rdma-device-reservation` | Does not work on the cluster it was written for: the pod netns has no RDMA-capable device, so it reserves an `rdma/roce_gdr` to advertise a capability the pod cannot use. |
+| `preserve-request-id` | An Istio `EnvoyFilter` selecting on a hardcoded gateway name. Under `epponly` + `externallyManaged` no Gateway is deployed, so it matches nothing — and it is the only fragment using `extraObjects`, so it is the only one that can fail at *apply* time rather than being silently inert. |
+
+Note the two bootstrap modes reach the same place by different routes: `--byo`
+already lists **every** stem in `defaults.disable` (`byo.py`'s
+`copy_framework_defaults`), so these four are disabled there without a special
+case. Reconciling that broader BLIS/BYO difference is #840's, not this list's.
 
 ---
 
@@ -548,13 +564,24 @@ context:
   files: <list of context files>
 
 defaults:
-  disable: []
+  # These four ship DISABLED. Each is copied into baselines/defaults/ so an
+  # operator has something to enable rather than reinvent, but none can be a
+  # correct always-on default — see "Fragments that ship disabled" below.
+  # Enabling one is deleting its line.
+  disable:
+    - nic-exclusion
+    - pod-capabilities
+    - preserve-request-id
+    - rdma-device-reservation
   # Available fragments (filename stems in baselines/defaults/):
   #   - epp-verbosity
   #   - epponly
   #   - externally-managed-gateway
   #   - model-pvc-size
-  #   - preserve-request-id
+  #   - nic-exclusion               (ships disabled)
+  #   - pod-capabilities            (ships disabled)
+  #   - preserve-request-id         (ships disabled)
+  #   - rdma-device-reservation     (ships disabled)
   #   - routing-proxy-resources
   #   - tokenizer-sidecar
   #   - vllm-keepalive
@@ -626,7 +653,10 @@ Exit code 0 and all fields printed = success.
       epponly.yaml
       externally-managed-gateway.yaml
       model-pvc-size.yaml
-      preserve-request-id.yaml
+      nic-exclusion.yaml              <- in defaults.disable
+      pod-capabilities.yaml           <- in defaults.disable
+      preserve-request-id.yaml        <- in defaults.disable
+      rdma-device-reservation.yaml    <- in defaults.disable
       routing-proxy-resources.yaml
       tokenizer-sidecar.yaml
       vllm-keepalive.yaml
@@ -786,4 +816,4 @@ This skill ships with supporting files in its directory. Invoke in place — do 
 | `generate_scenarios.README.md` | Coverage map for the JSON-input path. Documents field mappings, omission rules, and gaps. |
 | `pd_plumbing.py` | The P/D and multi-GPU pod plumbing (issue #848): one connector decision in two spellings (`kvTransfer.connector` engine-side, `routing.connector` sidecar-side), the two gate predicates, and one line-emitter per YAML fragment. Imported by both generators — the fragments are identical literal YAML, so a single copy is what keeps the two hand-rolled emitters in agreement. Asserted by `tests/test_pd_plumbing.py` and by the cross-generator check in `tests/test_generate_scenarios.py`. |
 | `byo.py` | Implements the `--byo` branch — argument parsing, YAML validation, path-safe copy operations, `transfer.yaml` emission, batched `sim2real translation register` command generation. Invoked by SKILL.md's dispatch when `--byo` (or any BYO-only flag) is passed. |
-| `templates/defaults/*.yaml` | Framework-owned baseline workaround fragments (request-id, verbosity, sidecar sizing, model-PVC size, topology, tokenizer). Copied into `<experiment-root>/baselines/defaults/` at BLIS task-4b and at BYO run time, so every experiment is self-contained and reproducible. Shape and merge-safety are asserted by `tests/test_defaults_templates.py`. |
+| `templates/defaults/*.yaml` | Framework-owned baseline workaround fragments (request-id, verbosity, sidecar sizing, model-PVC size, topology, tokenizer) plus the P/D cluster-specific ones that ship disabled (pod capabilities, NIC exclusion, RDMA reservation — issue #853). Copied into `<experiment-root>/baselines/defaults/` at BLIS task-4b and at BYO run time, so every experiment is self-contained and reproducible. Shape and merge-safety are asserted by `tests/test_defaults_templates.py`. |

--- a/.claude/skills/sim2real-bootstrap/templates/defaults/nic-exclusion.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/nic-exclusion.yaml
@@ -1,0 +1,46 @@
+# DISABLED BY DEFAULT. Bootstrap lists this stem in transfer.yaml's
+# `defaults.disable`; enabling it is deleting that one line.
+#
+# Excludes specific InfiniBand/RoCE HCAs from NCCL, and caps UCX RMA rails.
+#
+# WHY OFF BY DEFAULT: the value is a literal device list for ONE cluster's cards.
+# A shipped default naming another cluster's devices would exclude the wrong ones,
+# which is worse than excluding none -- NCCL would skip working HCAs and fall back
+# to a slower transport, silently. THE LIST BELOW IS AN EXAMPLE, NOT A DEFAULT:
+# replace it with your own `ibv_devinfo` output before enabling.
+#
+# `mlxl5_7` IS CARRIED VERBATIM AND IS ALMOST CERTAINLY A TYPO for mlx5_7, which
+# would mean that device is NOT actually excluded. Kept as-is because it is what
+# ran in the configuration this was lifted from; fix it deliberately, together with
+# replacing the rest of the list, rather than by assuming the correction is safe.
+#
+# Duplicated across decode and prefill because `extraEnvVars` is a per-role key
+# with no vllmCommon equivalent. Keep the two copies in sync.
+#
+# SAFE TO COEXIST with vllm-keepalive.yaml, which also sets `prefill.extraEnvVars`:
+# the list is all-dicts with a common `name` field, so pipeline/lib/values.py
+# `_merge_lists` Tier 2b merges the two lists BY NAME rather than replacing. Both
+# fragments' variables reach the rendered pod. The same is true of the
+# NIXL/NCCL/NVSHMEM variables `sim2real assemble` emits from config.md (issue
+# #848) -- this fragment adds to them rather than displacing them.
+#
+# Provenance: llm-d guides/pd-disaggregation/modelserver/gpu/vllm/base/
+# patch-{decode,prefill}.yaml. NCCL_EXCLUDE_IB_HCA appears in 2 of the 9 shipped
+# upstream guide scenarios and UCX_MAX_RMA_RAILS in 1 -- it is cluster-tuning, not
+# framework boilerplate, which is the other half of why it ships off.
+#
+# scenario[0].name is realigned to the experiment baseline at merge time.
+scenario:
+- name: defaults
+  decode:
+    extraEnvVars:
+      - name: NCCL_EXCLUDE_IB_HCA
+        value: "mlx5_0,mlx5_2,mlx5_4,mlx5_8,mlxl5_7,mlx5_10,mlx5_12,mlx5_14,mlx5_16"
+      - name: UCX_MAX_RMA_RAILS
+        value: "1"
+  prefill:
+    extraEnvVars:
+      - name: NCCL_EXCLUDE_IB_HCA
+        value: "mlx5_0,mlx5_2,mlx5_4,mlx5_8,mlxl5_7,mlx5_10,mlx5_12,mlx5_14,mlx5_16"
+      - name: UCX_MAX_RMA_RAILS
+        value: "1"

--- a/.claude/skills/sim2real-bootstrap/templates/defaults/pod-capabilities.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/pod-capabilities.yaml
@@ -1,0 +1,60 @@
+# DISABLED BY DEFAULT. Bootstrap lists this stem in transfer.yaml's
+# `defaults.disable`; enabling it is deleting that one line.
+#
+# Elevated pod capabilities for NIXL memory registration.
+#
+# WHY OFF BY DEFAULT: this fragment cannot grant the permission it depends on. On
+# OpenShift the pod will not admit until someone runs, out of band,
+#   oc adm policy add-scc-to-user privileged -z <serviceaccount> -n <namespace>
+# so shipping it enabled would produce unschedulable pods on any cluster whose SCC
+# has not been widened. That is a worse failure than not asking for the capability.
+#
+# ONLY `IPC_LOCK` HAS A P/D JUSTIFICATION -- mlock / ibv_reg_mr for NIXL memory
+# registration. The other three are carried because they are what ran, not because
+# they were shown to be needed:
+#   SYS_RAWIO  gated on NCCL_ACS_DISABLE=1, which nothing in the pipeline sets.
+#   NET_ADMIN  applies only on multi-NIC nodes with same-subnet IPs.
+#   NET_RAW    only if the fping smoketest runs.
+# Trimming to IPC_LOCK alone would also shrink the SCC grant this fragment needs,
+# removing a real deployment obstacle. Worth testing; not yet tested.
+#
+# The keys land on the vLLM container (extraContainerConfig), not the pod, and are
+# duplicated across decode and prefill because both are per-role keys with no
+# vllmCommon equivalent. Keep the two copies in sync.
+#
+# `capabilities.add` is a list of SCALARS, so pipeline/lib/values.py `_merge_lists`
+# Tier 1 has any downstream layer REPLACE it wholesale rather than merge into it.
+# The defaults overlay is the first layer in resolve_baseline's chain, so if your
+# baseline or treatment overlay sets the same key it takes the whole list. Set the
+# capabilities HERE or set them entirely in your baseline; never split them.
+# (Allowlisted in tests/test_defaults_templates.py::_ALLOWED_SCALAR_LISTS.)
+#
+# Provenance: llm-d guides/pd-disaggregation/modelserver/gpu/vllm/base/
+# patch-{decode,prefill}.yaml. Upstream's shipped guides carry IPC_LOCK and
+# SYS_RAWIO in 8 of 9 scenarios; NET_ADMIN and NET_RAW in 4 of 9.
+#
+# scenario[0].name is realigned to the experiment baseline at merge time.
+scenario:
+- name: defaults
+  decode:
+    extraContainerConfig:
+      securityContext:
+        capabilities:
+          add:
+            - "IPC_LOCK"
+            - "SYS_RAWIO"
+            - "NET_ADMIN"
+            - "NET_RAW"
+        runAsGroup: 0
+        runAsUser: 0
+  prefill:
+    extraContainerConfig:
+      securityContext:
+        capabilities:
+          add:
+            - "IPC_LOCK"
+            - "SYS_RAWIO"
+            - "NET_ADMIN"
+            - "NET_RAW"
+        runAsGroup: 0
+        runAsUser: 0

--- a/.claude/skills/sim2real-bootstrap/templates/defaults/preserve-request-id.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/preserve-request-id.yaml
@@ -1,5 +1,21 @@
+# DISABLED BY DEFAULT. Bootstrap lists this stem in transfer.yaml's
+# `defaults.disable`; enabling it is deleting that one line.
+#
 # Workaround: preserve external request-id so requests can be correlated to pods/nodes.
 # See docs/troubleshooting.md "Correlate requests with pods (and hence nodes)".
+#
+# WHY OFF BY DEFAULT (issue #853): the `workloadSelector` below names a Kubernetes
+# Gateway by label. Under this bundle's default topology — `gateway.className:
+# epponly` (epponly.yaml) with `externallyManaged: true`
+# (externally-managed-gateway.yaml) — no Gateway is deployed at all; the EPP's Envoy
+# sidecar is the whole data plane, so the filter matches nothing. It also requires
+# Istio CRDs to be present.
+#
+# It is additionally the ONLY fragment using `extraObjects` (free-form Kubernetes
+# manifests), which makes it the only one that can fail at *apply* time rather than
+# being silently inert. Enable it only under an Istio-managed Gateway whose name
+# matches the selector below.
+#
 # scenario[0].name is realigned to the experiment baseline at merge time.
 scenario:
 - name: defaults

--- a/.claude/skills/sim2real-bootstrap/templates/defaults/rdma-device-reservation.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/rdma-device-reservation.yaml
@@ -1,0 +1,36 @@
+# DISABLED BY DEFAULT. Bootstrap lists this stem in transfer.yaml's
+# `defaults.disable`; enabling it is deleting that one line.
+#
+# Reserves an RDMA device on every model-server pod.
+#
+# WHY OFF BY DEFAULT: it did not work on the cluster it was written for. RoCE
+# derives its GIDs from the associated netdev's IP address, and the pod's network
+# namespace holds only `eth0` (OVN overlay) and `lo` -- so the `mlx5_*` GID tables
+# read all zeros from inside the pod, and adding `rc` to `ucxTls` fails NIXL
+# backend creation outright:
+#   uct_iface_open(rc_verbs/mlx5_0:1) failed: Address not valid
+# In that state these two keys reserve an allocatable `rdma/roce_gdr` device to
+# advertise a capability the pod cannot use, so the reservation is pure cost: the
+# scheduler is asked for a resource that changes nothing.
+#
+# BEFORE ENABLING, confirm your cluster gives the pod a usable RDMA path. Using
+# RoCE requires either hostNetwork or an RDMA-capable CNI (e.g. macvlan +
+# rdma-cni) that places a VF and its GID in the pod's netns. Without one of those,
+# leave this disabled and expect KV transfer over TCP-on-overlay -- which is
+# functional but materially slower, so measure `vllm:nixl_xfer_time_seconds`
+# rather than assuming a simulated transfer bandwidth.
+#
+# Both keys are required together: llm-d-benchmark adds the reservation to pod
+# specs only when `networkResource` AND `networkNr` are both non-empty
+# (config/templates/values/defaults.yaml:781-784). They default to "" upstream,
+# which is why this fragment is the thing that turns the reservation on at all.
+#
+# Provenance: llm-d's pd-disaggregation guide, which sets both keys; 3 of the 9
+# shipped upstream guide scenarios carry `networkResource`.
+#
+# scenario[0].name is realigned to the experiment baseline at merge time.
+scenario:
+- name: defaults
+  vllmCommon:
+    networkResource: "auto"
+    networkNr: "1"

--- a/.claude/skills/sim2real-bootstrap/tests/test_defaults_templates.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_defaults_templates.py
@@ -14,6 +14,7 @@ them. The `additionalFlags` guard below is the narrow, statically-decidable slic
 #841 — it catches keys that provably cannot survive the merge chain, rather than
 comparing resolved scenarios, which is what #841 tracks.
 """
+import itertools
 from pathlib import Path
 
 import pytest
@@ -113,6 +114,18 @@ _ALLOWED_SCALAR_LISTS = {
     # itself takes the whole list and keeps the fragment's CPU limit, breaking the
     # coupling silently. epponly.yaml's header says so.
     "epponly": {"router.proxy.args"},
+    # Linux capabilities to add to the vLLM container, per role. `capabilities.add`
+    # has no key field to merge on — it is a bare list of capability names — so
+    # Tier 1 applies and a baseline setting the same key takes the whole list. The
+    # fragment is the right home anyway: the capability set is inseparable from the
+    # SCC grant its header documents, and splitting it across two files would let
+    # the two drift the way epponly's coupling did. Ships DISABLED, so it reaches a
+    # rendered pod only when an operator has enabled it deliberately.
+    # pod-capabilities.yaml's header says so.
+    "pod-capabilities": {
+        "decode.extraContainerConfig.securityContext.capabilities.add",
+        "prefill.extraContainerConfig.securityContext.capabilities.add",
+    },
 }
 
 
@@ -193,33 +206,157 @@ def test_all_fragments_merge_without_error(deep_merge):
     assert merged["scenario"][0]["name"] == "defaults"
 
 
-def test_no_two_fragments_set_the_same_leaf_key(deep_merge):
-    """Two fragments writing the same leaf make one of them silently order-dependent.
+def test_no_fragment_contribution_is_lost_to_another_fragment(deep_merge):
+    """A fragment's value must survive the merge with every other fragment.
 
-    Merge order is filename-sorted (`load_defaults_overlay`), so the later stem wins
-    and the earlier fragment's value never reaches the output — the inert-fragment
-    failure mode of #839, in its within-layer form. Distinct leaves are fine; this
-    only fires on a genuine collision.
+    Merge order is filename-sorted (`load_defaults_overlay`), so when two fragments
+    write the same leaf the later stem can silently displace the earlier one — the
+    inert-fragment failure mode of #839, in its within-layer form.
+
+    Sharing a leaf key is NOT sufficient for that to happen, which is why this
+    asserts on the merged result rather than on key overlap. `_merge_lists` keeps
+    both sides for a list of dicts with a common key field (Tier 2b, merge by key)
+    and for Kubernetes manifest lists (Tier 2a, merge by identity); it discards the
+    base only for scalar lists (Tier 1, wholesale replace) and for plain scalars
+    (later dict value wins). `prefill.extraEnvVars` is the real case: nic-exclusion
+    and vllm-keepalive both set it and all of their variables reach the pod, because
+    the entries are keyed by `name`.
+
+    So: merge each pair, then check that every leaf value each fragment contributed
+    is still present. That tests the property the guard exists for — nothing goes
+    inert — instead of a proxy for it that forbids a working combination.
     """
-    seen: dict[str, str] = {}
-    collisions = []
-
-    def walk(node, trail, stem):
+    def leaves(node, trail=()):
+        """Flatten to {dotted path: value}, treating lists as leaf values."""
+        out = {}
         if isinstance(node, dict):
             for key, value in node.items():
-                walk(value, trail + [str(key)], stem)
-            return
-        path_key = ".".join(trail)
-        if path_key in seen and seen[path_key] != stem:
-            collisions.append(f"{path_key} (set by {seen[path_key]} and {stem})")
+                out.update(leaves(value, trail + (str(key),)))
         else:
-            seen[path_key] = stem
+            out[".".join(trail)] = node
+        return out
 
-    for path in _fragments():
-        entry = yaml.safe_load(path.read_text())["scenario"][0]
-        walk({k: v for k, v in entry.items() if k != "name"}, [], path.stem)
+    def survives(contributed, merged_value):
+        """Is `contributed` still recoverable from the merged value?"""
+        if isinstance(contributed, list):
+            # Every contributed element must still appear somewhere in the result.
+            if not isinstance(merged_value, list):
+                return False
+            return all(item in merged_value for item in contributed)
+        return contributed == merged_value
 
-    assert not collisions, (
-        "fragments set overlapping leaf keys; filename-sorted merge order decides "
-        f"the winner and the loser is inert: {collisions}"
+    entries = {
+        path.stem: yaml.safe_load(path.read_text())["scenario"][0]
+        for path in _fragments()
+    }
+    losses = []
+
+    for a, b in itertools.combinations(sorted(entries), 2):
+        body_a = {k: v for k, v in entries[a].items() if k != "name"}
+        body_b = {k: v for k, v in entries[b].items() if k != "name"}
+        shared = set(leaves(body_a)) & set(leaves(body_b))
+        if not shared:
+            continue
+        # Filename-sorted order is what load_defaults_overlay applies.
+        merged = deep_merge(deep_merge({}, body_a), body_b)
+        merged_leaves = leaves(merged)
+        for path_key in sorted(shared):
+            for stem, body in ((a, body_a), (b, body_b)):
+                contributed = leaves(body)[path_key]
+                if not survives(contributed, merged_leaves.get(path_key)):
+                    losses.append(
+                        f"{path_key}: {stem}'s value is discarded when "
+                        f"{a} and {b} merge"
+                    )
+
+    assert not losses, (
+        "a fragment's contribution does not survive merging with another fragment, "
+        "so it is inert whenever both are enabled: " + "; ".join(losses)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fragments that ship disabled (issue #853)
+# ---------------------------------------------------------------------------
+# Four fragments are copied into baselines/defaults/ but listed in transfer.yaml's
+# `defaults.disable`, because none can be a correct always-on default. The list
+# lives in SKILL.md's Task 5 template (BLIS mode writes transfer.yaml from it), and
+# each fragment declares its own status with a `DISABLED BY DEFAULT` header line.
+#
+# Two places holding the same fact is exactly how #550 happened -- SKILL.md
+# documented an `llm-d-rbac.yaml` fragment that templates/defaults/ never shipped.
+# These tests pin the two against each other so neither can drift alone.
+
+_DISABLED_MARKER = "DISABLED BY DEFAULT"
+_SKILL_MD = _SKILL_DIR / "SKILL.md"
+
+
+def _fragments_marked_disabled() -> set[str]:
+    return {p.stem for p in _fragments() if _DISABLED_MARKER in p.read_text()}
+
+
+def _skill_md_disable_list() -> list[str]:
+    """Read the `disable:` list items out of SKILL.md's Task 5 transfer.yaml block.
+
+    Line-oriented rather than a YAML parse because the surrounding template holds
+    placeholders (`<derived summary>`) that are not valid YAML values.
+    """
+    lines = _SKILL_MD.read_text().splitlines()
+    stems: list[str] = []
+    for i, line in enumerate(lines):
+        if line.rstrip() != "  disable:":
+            continue
+        for follow in lines[i + 1:]:
+            stripped = follow.strip()
+            if stripped.startswith("- "):
+                stems.append(stripped[2:].strip())
+            elif stripped.startswith("#"):
+                continue  # the "Available fragments" comment block
+            else:
+                break
+        break
+    return stems
+
+
+def test_skill_md_disable_list_matches_the_marked_fragments():
+    """SKILL.md's `defaults.disable` must name exactly the self-declared ones."""
+    in_skill_md = set(_skill_md_disable_list())
+    marked = _fragments_marked_disabled()
+    assert in_skill_md == marked, (
+        "SKILL.md's defaults.disable and the fragments' own "
+        f"'{_DISABLED_MARKER}' headers disagree — "
+        f"only in SKILL.md: {sorted(in_skill_md - marked)}; "
+        f"only in fragment headers: {sorted(marked - in_skill_md)}"
+    )
+
+
+def test_skill_md_disable_list_is_non_empty_and_sorted():
+    """Sorted so a new entry lands deterministically rather than wherever."""
+    stems = _skill_md_disable_list()
+    assert stems, "SKILL.md's defaults.disable is empty — the #853 list is missing"
+    assert stems == sorted(stems), f"defaults.disable is not sorted: {stems}"
+
+
+def test_every_disable_entry_names_a_real_fragment():
+    """A stem that matches no file is a silent no-op in load_defaults_overlay."""
+    all_stems = {p.stem for p in _fragments()}
+    unknown = [s for s in _skill_md_disable_list() if s not in all_stems]
+    assert not unknown, (
+        f"defaults.disable names stems with no fragment file: {unknown} "
+        "(load_defaults_overlay skips by stem, so these disable nothing)"
+    )
+
+
+@pytest.mark.parametrize("path", _fragments(), ids=_fragment_ids())
+def test_disabled_fragment_says_why_in_its_header(path):
+    """A disabled default is only useful if the operator can tell when to enable it."""
+    text = path.read_text()
+    if _DISABLED_MARKER not in text:
+        pytest.skip("fragment ships enabled")
+    header = "\n".join(
+        ln for ln in text.splitlines() if ln.startswith("#")
+    )
+    assert "WHY OFF BY DEFAULT" in header, (
+        f"{path.name}: marked disabled but its header never says why, so an "
+        "operator cannot judge whether their cluster is the exception"
     )


### PR DESCRIPTION
Closes #853

Migrates three sections of `pd-infocomm-2/baselines/baseline.yaml` into
`templates/defaults/` fragments, and adds them plus `preserve-request-id` to the
`defaults.disable` list that Task 5 writes into `transfer.yaml` — previously `[]`.

| Fragment | Source | Content |
|---|---|---|
| `pod-capabilities` | `baseline.yaml:195-204` / `265-274` (byte-identical across roles) | `extraContainerConfig.securityContext`: `capabilities.add: [IPC_LOCK, SYS_RAWIO, NET_ADMIN, NET_RAW]`, `runAsGroup/User: 0` |
| `nic-exclusion` | `baseline.yaml:176-186` / `253-262` | `NCCL_EXCLUDE_IB_HCA` + `UCX_MAX_RMA_RAILS` |
| `rdma-device-reservation` | `baseline.yaml:82-83` | `vllmCommon.networkResource: "auto"`, `networkNr: "1"` |

The source's `extraEnvVars` block holds five variables; only the two NIC keys are
here. The other three (`NVSHMEM_DEBUG`, `NCCL_DEBUG`, `NIXL_LOG_LEVEL`) come from
`config.md` via #848 and would be duplicated if the fragment carried them.

No new mechanism: bootstrap already writes both the fragment file and
`transfer.yaml`. The `defaults` block accepts only `disable`
(`pipeline/lib/manifest.py:139-160`), and nothing needed to change there.

## Two forced changes to existing tests

**`test_no_two_fragments_set_the_same_leaf_key` had a false premise.** It flagged
`prefill.extraEnvVars`, shared by `nic-exclusion` and `vllm-keepalive`, on the
grounds that "the later stem wins and the loser is inert." That is true for scalar
lists and plain scalars, and false for keyed dict-lists: `_merge_lists` Tier 2b
merges `extraEnvVars` **by `name`**, so all three variables reach the pod. The
source baseline's own comment at `:245-251` states this independently, and the
end-to-end check below confirms it. So the guard would have blocked a combination
that works.

Rewritten as `test_no_fragment_contribution_is_lost_to_another_fragment`: it merges
each pair of fragments and asserts each side's contributions survive, testing the
property the guard exists for rather than a proxy that over-rejects. **Still has
teeth** — a scalar-list clash and a plain-scalar clash both fail it, while the
keyed-list union passes.

**`capabilities.add` is a bare scalar list**, so it needs `_ALLOWED_SCALAR_LISTS`
entries. Per that allowlist's own doctrine each entry is "a standing fragility, not
an endorsement", so the fragility is documented in both the allowlist and the
fragment header.

## New drift guards

The BLIS-mode list lives in SKILL.md prose, which no test covered — the exact shape
of #550, where SKILL.md documented an `llm-d-rbac.yaml` fragment that
`templates/defaults/` never shipped. Each disabled fragment now carries a
`DISABLED BY DEFAULT` header marker, and four guards pin the two representations
together: the sets must match, the list must be sorted and non-empty, every stem
must name a real file (a stem that matches nothing disables nothing), and every
marked fragment must explain *why* under `WHY OFF BY DEFAULT` — a disabled default
is only useful if an operator can judge whether their cluster is the exception.

## Verification

- **End-to-end through the real loader**, not just the shape tests: with the four
  stems disabled, none of their keys appear in `load_defaults_overlay`'s output, and
  the eight enabled fragments still apply; with `disable=[]` all four land. 10/10.
- **Fault injection, 5/5 caught**: dropping a stem, adding one that names no file,
  unsorting the list, removing a fragment's marker, removing its rationale.
- **Fault injection on the rewritten guard, 3/3 correct**: scalar-list clash fails,
  plain-scalar clash fails, keyed-list union passes.
- **CI**: `ruff --select F` clean; 2419 passed, 9 skipped, 2 xfailed; coverage
  97.68%. (The 9 skips are `test_disabled_fragment_says_why_in_its_header`
  skipping the 8 enabled fragments, plus one pre-existing skip.)

## Reviewer attention

**The `mlxl5_7` device name is carried verbatim and is almost certainly a typo** for
`mlx5_7` — meaning that device is *not* actually excluded. Kept because it is what
ran, flagged in the fragment header, and the entire list is cluster-specific and
must be replaced before enabling. Say so if you would rather ship the corrected
spelling.

**`pod-capabilities` ships a set its own header argues is too broad.** Only
`IPC_LOCK` has a P/D justification (mlock / `ibv_reg_mr` for NIXL memory
registration). `SYS_RAWIO` is gated on `NCCL_ACS_DISABLE`, which nothing in the
pipeline sets; `NET_ADMIN` needs multi-NIC same-subnet nodes; `NET_RAW` only if the
fping smoketest runs. Carried whole because that is the configuration observed
working; trimming to `IPC_LOCK` would also shrink the SCC grant it depends on and
remove a real deployment obstacle. Upstream's shipped guides carry `IPC_LOCK` and
`SYS_RAWIO` in 8 of 9 scenarios and `NET_ADMIN`/`NET_RAW` in 4 of 9.

**Scope kept narrow deliberately.** #840 owns making existing fragments'
*emission* conditional, and also owns the broader BLIS/BYO difference (`--byo`
already disables every stem via `copy_framework_defaults`; BLIS disabled none).
This PR does not touch that difference — it only stops these four from being on by
default. SKILL.md's new section says so explicitly so the boundary is not
re-litigated later.

**Out of scope but worth a separate issue:** the working baseline sets
`NVSHMEM_DEBUG: "none"` and `NCCL_DEBUG: "WARN"`, while #848 emits `INFO` for both.
Since #848's own comment documents `NVSHMEM_DEBUG != "none"` as load-bearing (it
gates `NVSHMEM_HCA_LIST` into the generated env file), that default contradicts the
configuration actually observed working. Not folded in here.
