### PR TITLE
feat(bootstrap): emit decode/prefill CPU+memory, config.md-stated or generous defaults (closes #850)

### DIFF
--- a/.claude/skills/sim2real-bootstrap/SKILL.md
+++ b/.claude/skills/sim2real-bootstrap/SKILL.md
@@ -416,7 +416,17 @@ optional per-role accelerator overrides; without them both roles use the shared
 
   Values are passed through verbatim as strings — `32`, `500m`, `1.5`, `128Gi`,
   `1536Mi` are all valid Kubernetes quantities and re-serializing risks changing
-  them. Stating only some is fine; the rest take defaults.
+  them. Stating only some is fine; the rest take defaults. A per-role row left
+  **blank** counts as unset and falls through to the shared row, not to the
+  default — writing an empty row is not an instruction to ignore the shared row
+  you did fill in.
+
+  The JSON-input path (`generate_scenarios.py`) takes the same values as
+  `vllm_args` keys — `cpu_limit`, `decode_memory_request`, and so on — with the
+  same precedence, and cites `vllm_args` rather than `config.md` in its warnings
+  and source comments, since it is selected only when no `config.md` exists. Both
+  paths resolve through `pod_resources.resolve_resources`, so the precedence
+  cannot differ between them.
 
   **Defaults when a row is absent** — decode is sized above prefill, which is both
   upstream's own sizing and the observed-working configuration:

--- a/.claude/skills/sim2real-bootstrap/SKILL.md
+++ b/.claude/skills/sim2real-bootstrap/SKILL.md
@@ -398,35 +398,34 @@ optional per-role accelerator overrides; without them both roles use the shared
 - `parallelism` and `vllm.additionalFlags` are shared across roles — `config.md`
   has no per-role form for them.
 - **CPU/memory is always emitted, per role (issue #850).** Bootstrap used to emit
-  none, so bundles inherited the framework default of `limits: {memory: 40Gi,
-  cpu: "4"}` with no `requests` — four CPU for a pod that may hold four GPUs and
-  shares its cgroup with the routing sidecar. That starves vLLM, and the signal
-  (`Reducing Torch parallelism from N threads to 1`) surfaces as ITL noise rather
-  than a failure, so it corrupts the metric the arms are compared on.
+  none, so bundles inherited the framework default — `limits` **and** `requests`
+  both `{memory: 40Gi, cpu: "4"}` for each role (`defaults.yaml:848-858` decode,
+  `:993-1000` prefill). Four CPU for a pod that may hold four GPUs and shares its
+  cgroup with the routing sidecar starves vLLM, and the signal (`Reducing Torch
+  parallelism from N threads to 1`) surfaces as ITL noise rather than a failure, so
+  it corrupts the metric the arms are compared on.
 
-  **Rows `config.md` may state**, each optional, resolved *per-role row → shared
-  row → role default* (the same precedence as `Decode GPU` over `GPU`):
+  **Rows `config.md` may state**, each optional, applied to **both** roles:
 
-  | Shared row | Per-role override |
+  | Row | Also accepted as |
   |---|---|
-  | `cpu limit` | `decode cpu limit`, `prefill cpu limit` |
-  | `memory limit` | `decode memory limit`, `prefill memory limit` |
-  | `cpu request` | `decode cpu request`, `prefill cpu request` |
-  | `memory request` | `decode memory request`, `prefill memory request` |
+  | `cpu limit` | `cpu_limit`, `cpu limits` |
+  | `memory limit` | `memory_limit`, `memory limits` |
+  | `cpu request` | `cpu_request`, `cpu requests` |
+  | `memory request` | `memory_request`, `memory requests` |
 
-  Values are passed through verbatim as strings — `32`, `500m`, `1.5`, `128Gi`,
-  `1536Mi` are all valid Kubernetes quantities and re-serializing risks changing
-  them. Stating only some is fine; the rest take defaults. A per-role row left
-  **blank** counts as unset and falls through to the shared row, not to the
-  default — writing an empty row is not an instruction to ignore the shared row
-  you did fill in.
+  Stating only some is fine; the rest take their per-role default. There are
+  deliberately **no per-role rows** — an operator who needs decode and prefill to
+  differ edits `baselines/baseline.yaml` after bootstrap, as they do for everything
+  else the generator does not model. The JSON-input path takes the same four names
+  as `vllm_args` keys.
 
-  The JSON-input path (`generate_scenarios.py`) takes the same values as
-  `vllm_args` keys — `cpu_limit`, `decode_memory_request`, and so on — with the
-  same precedence, and cites `vllm_args` rather than `config.md` in its warnings
-  and source comments, since it is selected only when no `config.md` exists. Both
-  paths resolve through `pod_resources.resolve_resources`, so the precedence
-  cannot differ between them.
+  Values are emitted verbatim as **quoted** strings — `32`, `500m`, `1.5`, `128Gi`,
+  `1536Mi` are all valid Kubernetes quantities, and an unquoted one is re-typed by
+  any YAML reader (`128` to an int, `yes` to a bool). A value that is **not** a
+  valid quantity — `TBD`, `16 Gi`, `32 cores`, or a bare `-` placeholder — is a hard
+  error at generation, because the cluster would otherwise reject the pod at
+  admission far from the row that caused it.
 
   **Defaults when a row is absent** — decode is sized above prefill, which is both
   upstream's own sizing and the observed-working configuration:
@@ -437,19 +436,21 @@ optional per-role accelerator overrides; without them both roles use the shared
   | prefill | `16Gi` / `8` | `8Gi` / `4` |
 
   Limits come from llm-d's `pd-disaggregation` guide verbatim. Requests are half
-  those limits, and are **emitted explicitly on purpose**: omitting `requests` is
-  not "no reservation" — Kubernetes copies the limit into the request when the
-  request is absent, so limits-only would reserve the whole generous figure on
-  every replica, and a 2-replica decode pool would reserve 256Gi before prefill is
-  scheduled at all.
+  those limits: requests are what the scheduler actually reserves, and reserving the
+  generous ceiling on every replica would make a multi-replica pool unschedulable on
+  a busy cluster. **Both halves are stated** because the framework default sets
+  both, and a scenario is deep-merged over it — emitting only `limits` would leave
+  `requests` at the inherited 40Gi/`"4"`, so a decode pod would ask for 40Gi while
+  permitted 128Gi. That pairing would be implicit and surprising.
 
   **The defaults are not measured.** They come from one cluster, one model, one
   tensor-parallel degree. Whenever any quantity falls back to a default, bootstrap
-  prints a `WARNING` naming the starvation signal, and the emitted YAML carries the
-  same caveat as a comment. State all four rows for a role and both warnings go
-  away, because then the numbers are the operator's. Fixed starting values were
-  chosen over deriving from GPU count deliberately: a wrong fixed number is visible
-  and correctable, a wrong formula looks principled.
+  prints a `WARNING` naming the starvation signal and the quantities that defaulted,
+  and the emitted YAML carries the same caveat plus a per-value source comment.
+  State all four rows and both go quiet, because then the numbers are the
+  operator's. Fixed starting values were chosen over deriving from GPU count
+  deliberately: a wrong fixed number is visible and correctable, a wrong formula
+  looks principled.
 - **One GPU type per role.** A GPU cell naming several types (`H100, A100`) emits
   the first and prints a `WARNING` naming every type found and the one used: a
   role is one Deployment, so it carries one node selector and its replicas cannot

--- a/.claude/skills/sim2real-bootstrap/SKILL.md
+++ b/.claude/skills/sim2real-bootstrap/SKILL.md
@@ -414,11 +414,24 @@ optional per-role accelerator overrides; without them both roles use the shared
   | `cpu request` | `cpu_request`, `cpu requests` |
   | `memory request` | `memory_request`, `memory requests` |
 
-  Stating only some is fine; the rest take their per-role default. There are
-  deliberately **no per-role rows** — an operator who needs decode and prefill to
-  differ edits `baselines/baseline.yaml` after bootstrap, as they do for everything
-  else the generator does not model. The JSON-input path takes the same four names
-  as `vllm_args` keys.
+  There are deliberately **no per-role rows** — an operator who needs decode and
+  prefill to differ edits `baselines/baseline.yaml` after bootstrap, as they do for
+  everything else the generator does not model. The JSON-input path takes the same
+  four names as `vllm_args` keys.
+
+  **The pair is reconciled per role**, which matters because the four rows are shared
+  while the defaults differ 4–8× between roles. Per resource:
+
+  1. the **limit** is the stated value, else that role's default;
+  2. the **request** is the stated value; failing that, half the limit when the limit
+     was stated (the role's default request may not fit a limit you changed), else
+     that role's default request;
+  3. the request is then **clamped to the limit**, with a warning naming the role.
+
+  Step 3 is why stating only some rows is safe. A `cpu request: 20` is sensible for
+  decode (limit 32) and impossible for prefill (limit 8) — the same row feeds both, so
+  prefill's is clamped to 8 rather than emitting a pod Kubernetes would reject at
+  admission. If you want a larger request on prefill, state a `cpu limit` too.
 
   Values are emitted verbatim as **quoted** strings — `32`, `500m`, `1.5`, `128Gi`,
   `1536Mi` are all valid Kubernetes quantities, and an unquoted one is re-typed by
@@ -433,15 +446,28 @@ optional per-role accelerator overrides; without them both roles use the shared
   | Role | limits | requests |
   |---|---|---|
   | decode | `128Gi` / `32` | `64Gi` / `16` |
-  | prefill | `16Gi` / `8` | `8Gi` / `4` |
+  | prefill | `16Gi` / `8` | `16Gi` / `8` |
 
-  Limits come from llm-d's `pd-disaggregation` guide verbatim. Requests are half
-  those limits: requests are what the scheduler actually reserves, and reserving the
-  generous ceiling on every replica would make a multi-replica pool unschedulable on
-  a busy cluster. **Both halves are stated** because the framework default sets
-  both, and a scenario is deep-merged over it — emitting only `limits` would leave
-  `requests` at the inherited 40Gi/`"4"`, so a decode pod would ask for 40Gi while
-  permitted 128Gi. That pairing would be implicit and surprising.
+  Limits come from llm-d's `pd-disaggregation` guide verbatim. Decode's request is
+  half its limit — requests are what the scheduler actually reserves, and reserving
+  the generous ceiling on every replica would make a multi-replica pool
+  unschedulable on a busy cluster.
+
+  **Prefill's request equals its limit**, matching upstream. Issue #848 mounts a
+  `medium: Memory` tmpfs at `/dev/shm` sized `16Gi` in `vllmCommon`, so both roles
+  get it, and tmpfs charges against the pod's memory. A prefill request below that
+  `16Gi` would put the pod above its request as soon as collectives filled
+  `/dev/shm` — an eviction candidate under node pressure, mid-run, on exactly the
+  TP>1 P/D configuration this targets. Guaranteed QoS is what protects it there.
+
+  **Both halves are stated** because the framework default sets both, and a scenario
+  is deep-merged over it — emitting only `limits` would leave `requests` at the
+  inherited 40Gi/`"4"`, so a decode pod would ask for 40Gi while permitted 128Gi.
+  That pairing would be implicit and surprising.
+
+  **Reservations multiply by replicas.** A 4-replica decode pool at the default
+  request reserves 64 CPU and 256Gi before anything else is scheduled. On a busy
+  cluster that is the number to check first if pods stay Pending.
 
   **The defaults are not measured.** They come from one cluster, one model, one
   tensor-parallel degree. Whenever any quantity falls back to a default, bootstrap
@@ -870,7 +896,7 @@ This skill ships with supporting files in its directory. Invoke in place — do 
 | `generate_from_config.py` | Parses `config.md` markdown tables → scenario YAMLs with provenance comments. Preferred for most BLIS experiments. Handles hardware normalization, bare-flag prefix-caching input/output, and unknown model/hardware detection. |
 | `generate_scenarios.py` | Converts JSON config (`top3_selection.json`) → scenario YAMLs. Use when JSON input exists (BLIS). |
 | `generate_scenarios.README.md` | Coverage map for the JSON-input path. Documents field mappings, omission rules, and gaps. |
-| `pod_resources.py` | Per-role CPU/memory for the model-server pods (issue #850): the fixed per-role default table (decode sized above prefill), `resolve_resources` (per-role row → shared row → default, values passed through as strings), and the line emitter including the unmeasured-defaults comment. Imported by both generators so the emitted text cannot drift. Asserted by `tests/test_pod_resources.py` plus the cross-generator check in `tests/test_generate_scenarios.py`. |
+| `pod_resources.py` | CPU/memory for the model-server pods (issue #850): the fixed per-role default table (decode sized above prefill), `resolve_resources` (four shared input keys resolved per role into a coherent limit/request pair — stated value, else derived, else default, with a request clamped to its own role's limit), a Kubernetes quantity validator, and the line emitter. Imported by both generators so the emitted text cannot drift. Asserted by `tests/test_pod_resources.py` plus the cross-generator check in `tests/test_generate_scenarios.py`. |
 | `pd_plumbing.py` | The P/D and multi-GPU pod plumbing (issue #848): one connector decision in two spellings (`kvTransfer.connector` engine-side, `routing.connector` sidecar-side), the two gate predicates, and one line-emitter per YAML fragment. Imported by both generators — the fragments are identical literal YAML, so a single copy is what keeps the two hand-rolled emitters in agreement. Asserted by `tests/test_pd_plumbing.py` and by the cross-generator check in `tests/test_generate_scenarios.py`. |
 | `byo.py` | Implements the `--byo` branch — argument parsing, YAML validation, path-safe copy operations, `transfer.yaml` emission, batched `sim2real translation register` command generation. Invoked by SKILL.md's dispatch when `--byo` (or any BYO-only flag) is passed. |
 | `templates/defaults/*.yaml` | Framework-owned baseline workaround fragments (request-id, verbosity, sidecar sizing, model-PVC size, topology, tokenizer) plus the P/D cluster-specific ones that ship disabled (pod capabilities, NIC exclusion, RDMA reservation — issue #853). Copied into `<experiment-root>/baselines/defaults/` at BLIS task-4b and at BYO run time, so every experiment is self-contained and reproducible. Shape and merge-safety are asserted by `tests/test_defaults_templates.py`. |

--- a/.claude/skills/sim2real-bootstrap/SKILL.md
+++ b/.claude/skills/sim2real-bootstrap/SKILL.md
@@ -207,6 +207,8 @@ Generate llm-d-benchmark scenario YAML(s) for baseline arm(s).
   scenario YAMLs. Use only when a JSON input file exists.
 - `generate_scenarios.README.md` — documents field mappings, lookup tables,
   omission rules, and coverage gaps for the JSON-input path.
+- `pod_resources.py` — per-role CPU/memory: the fixed default table, the
+  stated-value resolver, and the line emitter. Imported by BOTH generators.
 - `pd_plumbing.py` — the P/D and multi-GPU pod fragments (init container,
   `shared-config` / `dshm` volumes, `preprocessScript`, NIXL/NCCL/NVSHMEM env
   vars, `routing.connector`) plus the two gates that decide when they apply.
@@ -395,6 +397,49 @@ optional per-role accelerator overrides; without them both roles use the shared
   device reservation.
 - `parallelism` and `vllm.additionalFlags` are shared across roles — `config.md`
   has no per-role form for them.
+- **CPU/memory is always emitted, per role (issue #850).** Bootstrap used to emit
+  none, so bundles inherited the framework default of `limits: {memory: 40Gi,
+  cpu: "4"}` with no `requests` — four CPU for a pod that may hold four GPUs and
+  shares its cgroup with the routing sidecar. That starves vLLM, and the signal
+  (`Reducing Torch parallelism from N threads to 1`) surfaces as ITL noise rather
+  than a failure, so it corrupts the metric the arms are compared on.
+
+  **Rows `config.md` may state**, each optional, resolved *per-role row → shared
+  row → role default* (the same precedence as `Decode GPU` over `GPU`):
+
+  | Shared row | Per-role override |
+  |---|---|
+  | `cpu limit` | `decode cpu limit`, `prefill cpu limit` |
+  | `memory limit` | `decode memory limit`, `prefill memory limit` |
+  | `cpu request` | `decode cpu request`, `prefill cpu request` |
+  | `memory request` | `decode memory request`, `prefill memory request` |
+
+  Values are passed through verbatim as strings — `32`, `500m`, `1.5`, `128Gi`,
+  `1536Mi` are all valid Kubernetes quantities and re-serializing risks changing
+  them. Stating only some is fine; the rest take defaults.
+
+  **Defaults when a row is absent** — decode is sized above prefill, which is both
+  upstream's own sizing and the observed-working configuration:
+
+  | Role | limits | requests |
+  |---|---|---|
+  | decode | `128Gi` / `32` | `64Gi` / `16` |
+  | prefill | `16Gi` / `8` | `8Gi` / `4` |
+
+  Limits come from llm-d's `pd-disaggregation` guide verbatim. Requests are half
+  those limits, and are **emitted explicitly on purpose**: omitting `requests` is
+  not "no reservation" — Kubernetes copies the limit into the request when the
+  request is absent, so limits-only would reserve the whole generous figure on
+  every replica, and a 2-replica decode pool would reserve 256Gi before prefill is
+  scheduled at all.
+
+  **The defaults are not measured.** They come from one cluster, one model, one
+  tensor-parallel degree. Whenever any quantity falls back to a default, bootstrap
+  prints a `WARNING` naming the starvation signal, and the emitted YAML carries the
+  same caveat as a comment. State all four rows for a role and both warnings go
+  away, because then the numbers are the operator's. Fixed starting values were
+  chosen over deriving from GPU count deliberately: a wrong fixed number is visible
+  and correctable, a wrong formula looks principled.
 - **One GPU type per role.** A GPU cell naming several types (`H100, A100`) emits
   the first and prints a `WARNING` naming every type found and the one used: a
   role is one Deployment, so it carries one node selector and its replicas cannot
@@ -814,6 +859,7 @@ This skill ships with supporting files in its directory. Invoke in place — do 
 | `generate_from_config.py` | Parses `config.md` markdown tables → scenario YAMLs with provenance comments. Preferred for most BLIS experiments. Handles hardware normalization, bare-flag prefix-caching input/output, and unknown model/hardware detection. |
 | `generate_scenarios.py` | Converts JSON config (`top3_selection.json`) → scenario YAMLs. Use when JSON input exists (BLIS). |
 | `generate_scenarios.README.md` | Coverage map for the JSON-input path. Documents field mappings, omission rules, and gaps. |
+| `pod_resources.py` | Per-role CPU/memory for the model-server pods (issue #850): the fixed per-role default table (decode sized above prefill), `resolve_resources` (per-role row → shared row → default, values passed through as strings), and the line emitter including the unmeasured-defaults comment. Imported by both generators so the emitted text cannot drift. Asserted by `tests/test_pod_resources.py` plus the cross-generator check in `tests/test_generate_scenarios.py`. |
 | `pd_plumbing.py` | The P/D and multi-GPU pod plumbing (issue #848): one connector decision in two spellings (`kvTransfer.connector` engine-side, `routing.connector` sidecar-side), the two gate predicates, and one line-emitter per YAML fragment. Imported by both generators — the fragments are identical literal YAML, so a single copy is what keeps the two hand-rolled emitters in agreement. Asserted by `tests/test_pd_plumbing.py` and by the cross-generator check in `tests/test_generate_scenarios.py`. |
 | `byo.py` | Implements the `--byo` branch — argument parsing, YAML validation, path-safe copy operations, `transfer.yaml` emission, batched `sim2real translation register` command generation. Invoked by SKILL.md's dispatch when `--byo` (or any BYO-only flag) is passed. |
 | `templates/defaults/*.yaml` | Framework-owned baseline workaround fragments (request-id, verbosity, sidecar sizing, model-PVC size, topology, tokenizer) plus the P/D cluster-specific ones that ship disabled (pod capabilities, NIC exclusion, RDMA reservation — issue #853). Copied into `<experiment-root>/baselines/defaults/` at BLIS task-4b and at BYO run time, so every experiment is self-contained and reproducible. Shape and merge-safety are asserted by `tests/test_defaults_templates.py`. |

--- a/.claude/skills/sim2real-bootstrap/SKILL.md
+++ b/.claude/skills/sim2real-bootstrap/SKILL.md
@@ -425,7 +425,9 @@ optional per-role accelerator overrides; without them both roles use the shared
   1. the **limit** is the stated value, else that role's default;
   2. the **request** is the stated value; failing that, half the limit when the limit
      was stated (the role's default request may not fit a limit you changed), else
-     that role's default request;
+     that role's default request. **Prefill memory is matched to its limit rather
+     than halved**, for the `/dev/shm` reason below — so raising prefill's memory
+     limit raises its request with it and keeps Guaranteed QoS;
   3. the request is then **clamped to the limit**, with a warning naming the role.
 
   Step 3 is why stating only some rows is safe. A `cpu request: 20` is sensible for

--- a/.claude/skills/sim2real-bootstrap/generate_from_config.py
+++ b/.claude/skills/sim2real-bootstrap/generate_from_config.py
@@ -23,6 +23,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 import pd_plumbing as pdp
+import pod_resources as pres
 
 
 # ---------------------------------------------------------------------------
@@ -98,6 +99,21 @@ PARAMETER_ALIASES = {
     },
     "prefill_hardware": {"prefill gpu", "prefill hardware"},
     "decode_hardware": {"decode gpu", "decode hardware"},
+    # Pod CPU/memory (issue #850). Shared keys with optional per-role overrides,
+    # the same shape as `hardware` / `decode_hardware` / `prefill_hardware` above.
+    # Absent any of these, pod_resources supplies generous per-role defaults.
+    "cpu_limit": {"cpu limit", "cpu_limit", "cpu limits"},
+    "memory_limit": {"memory limit", "memory_limit", "memory limits"},
+    "cpu_request": {"cpu request", "cpu_request", "cpu requests"},
+    "memory_request": {"memory request", "memory_request", "memory requests"},
+    "decode_cpu_limit": {"decode cpu limit", "decode_cpu_limit"},
+    "decode_memory_limit": {"decode memory limit", "decode_memory_limit"},
+    "decode_cpu_request": {"decode cpu request", "decode_cpu_request"},
+    "decode_memory_request": {"decode memory request", "decode_memory_request"},
+    "prefill_cpu_limit": {"prefill cpu limit", "prefill_cpu_limit"},
+    "prefill_memory_limit": {"prefill memory limit", "prefill_memory_limit"},
+    "prefill_cpu_request": {"prefill cpu request", "prefill_cpu_request"},
+    "prefill_memory_request": {"prefill memory request", "prefill_memory_request"},
     "dtype": {"dtype", "--dtype"},
     "pipeline_parallel_size": {"pipeline_parallel_size", "--pipeline-parallel-size"},
     "data_parallel_size": {"data_parallel_size", "--data-parallel-size"},
@@ -895,6 +911,33 @@ def build_scenario(
             file=sys.stderr,
         )
 
+    # --- Pod CPU/memory (issue #850) ---
+    # Bootstrap emitted nothing here, so bundles inherited 4 CPU / 40Gi for a pod
+    # that may hold four GPUs -- which starves vLLM and shows up as ITL noise
+    # rather than a failure. Resolved per role: a `decode cpu limit` row beats a
+    # shared `cpu limit` row beats the role default, matching how `Decode GPU`
+    # beats `GPU`. Values stay strings; see pod_resources.
+    # `provenance` does not exist yet (it is built below), so the per-quantity
+    # sources are collected here and merged into it once it does.
+    resource_provenance: dict[str, str] = {}
+    for role_name in ("decode", "prefill"):
+        if role_name not in scenario:
+            continue
+        stated = {}
+        for key in pres.KEYS:
+            field_obj = fields.get(f"{role_name}_{key}") or fields.get(key)
+            stated[key] = None if field_obj is None else str(field_obj.value)
+        values, res_prov = pres.resolve_resources(role_name, stated)
+        scenario[role_name]["resources"] = values
+        warn = pres.used_any_default(res_prov)
+        if warn:
+            print(pres.starvation_warning(role_name), file=sys.stderr)
+        # Read by the emitter to decide whether to print the unmeasured-defaults
+        # comment. Underscore-prefixed: internal, never emitted.
+        scenario[role_name]["_resources_warn"] = warn
+        for key, src in res_prov.items():
+            resource_provenance[f"{role_name}.resources.{key}"] = src
+
     # --- Pod plumbing (issue #848) ---
     # #846 turns kvTransfer on with a prefill pool. On its own that crashloops the
     # worker during "Initializing NIXL wrapper", because nothing sets up the
@@ -933,6 +976,7 @@ def build_scenario(
 
     # --- Build provenance map ---
     provenance = {
+        **resource_provenance,
         "model.name": fields["model"].source,
         "model.shortName": meta_source + ".shortName" if meta else "derived from model name",
         "model.path": meta_source + ".path" if meta else "derived from model name",
@@ -1068,6 +1112,15 @@ def write_provenance_yaml(
         pdp.extra_env_var_lines(nixl=gates["kv"], multigpu=gates["multigpu"])
     )
 
+    # CPU/memory (#850), also per-role and also with no vllmCommon form.
+    if "resources" in scenario["decode"]:
+        lines.extend(
+            pres.resource_lines(
+                scenario["decode"]["resources"],
+                warn=scenario["decode"].get("_resources_warn", True),
+            )
+        )
+
     # Prefill role, emitted only when config.md named a prefill pod count. Placed
     # after decode so the decode bytes above are untouched when it is absent.
     if "prefill" in scenario:
@@ -1106,6 +1159,14 @@ def write_provenance_yaml(
         lines.extend(
             pdp.extra_env_var_lines(nixl=gates["kv"], multigpu=gates["multigpu"])
         )
+
+        if "resources" in p_role:
+            lines.extend(
+                pres.resource_lines(
+                    p_role["resources"],
+                    warn=p_role.get("_resources_warn", True),
+                )
+            )
 
     # Scenario-level plumbing (#848), last so every block above keeps its bytes.
     if gates["kv"]:

--- a/.claude/skills/sim2real-bootstrap/generate_from_config.py
+++ b/.claude/skills/sim2real-bootstrap/generate_from_config.py
@@ -121,6 +121,28 @@ PARAMETER_ALIASES = {
     "enforce_eager": {"enforce_eager", "--enforce-eager"},
 }
 
+# Canonical fields whose value is free-form text, never a number.
+#
+# Everything NOT listed here is handed to `parse_numeric`, which takes only the
+# FIRST whitespace-delimited token. That silently truncates any value a human
+# might reasonably space out: a Kubernetes quantity typed `16 Gi` becomes `16`
+# -- sixteen BYTES of memory rather than 16Gi -- and because the field then
+# counts as stated, no warning fires. The pod-resource fields are derived from
+# PARAMETER_ALIASES rather than listed by hand so a newly added `*_limit` /
+# `*_request` alias cannot forget to join this set.
+#
+# `prefill_hardware` / `decode_hardware` are here for the same reason. They
+# happen to survive `parse_numeric` today only because a GPU label's first token
+# is not numeric -- accident, not design.
+_STRING_VALUED_FIELDS = frozenset(
+    {"model", "hardware", "prefill_hardware", "decode_hardware", "dtype"}
+    | {
+        name
+        for name in PARAMETER_ALIASES
+        if name.endswith(("_limit", "_request"))
+    }
+)
+
 # Section heading keywords that indicate a vLLM configuration table
 VLLM_SECTION_KEYWORDS = [
     "vllm pod configuration",
@@ -579,7 +601,7 @@ def extract_fields(table: TableSection) -> dict[str, ProvenanceValue]:
             continue
 
         # Parse value based on field type
-        if canonical in ("model", "hardware", "dtype"):
+        if canonical in _STRING_VALUED_FIELDS:
             value = normalize_cell(raw_value)
         elif canonical in ("enable_chunked_prefill", "enforce_eager"):
             value = parse_boolean(raw_value)
@@ -931,10 +953,22 @@ def build_scenario(
         scenario[role_name]["resources"] = values
         warn = pres.used_any_default(res_prov)
         if warn:
-            print(pres.starvation_warning(role_name), file=sys.stderr)
+            print(
+                pres.starvation_warning(role_name, values, res_prov),
+                file=sys.stderr,
+            )
+        for problem in pres.request_exceeds_limit(values):
+            print(
+                f"  WARNING: {role_name} {problem}. Kubernetes rejects that pod "
+                f"at admission. Each quantity resolves independently, so a "
+                f"stated request with an unstated limit takes the default limit "
+                f"-- state both.",
+                file=sys.stderr,
+            )
         # Read by the emitter to decide whether to print the unmeasured-defaults
         # comment. Underscore-prefixed: internal, never emitted.
         scenario[role_name]["_resources_warn"] = warn
+        scenario[role_name]["_resources_provenance"] = res_prov
         for key, src in res_prov.items():
             resource_provenance[f"{role_name}.resources.{key}"] = src
 
@@ -1117,6 +1151,7 @@ def write_provenance_yaml(
         lines.extend(
             pres.resource_lines(
                 scenario["decode"]["resources"],
+                scenario["decode"]["_resources_provenance"],
                 warn=scenario["decode"].get("_resources_warn", True),
             )
         )
@@ -1164,6 +1199,7 @@ def write_provenance_yaml(
             lines.extend(
                 pres.resource_lines(
                     p_role["resources"],
+                    p_role["_resources_provenance"],
                     warn=p_role.get("_resources_warn", True),
                 )
             )

--- a/.claude/skills/sim2real-bootstrap/generate_from_config.py
+++ b/.claude/skills/sim2real-bootstrap/generate_from_config.py
@@ -945,16 +945,26 @@ def build_scenario(
     for role_name in ("decode", "prefill"):
         if role_name not in scenario:
             continue
-        stated = {}
+        # Per-role and shared are handed over SEPARATELY: pod_resources owns the
+        # precedence, so a blank per-role cell falls through to the shared row
+        # rather than skipping straight to the default.
+        per_role = {}
+        shared = {}
         for key in pres.KEYS:
-            field_obj = fields.get(f"{role_name}_{key}") or fields.get(key)
-            stated[key] = None if field_obj is None else str(field_obj.value)
-        values, res_prov = pres.resolve_resources(role_name, stated)
+            role_field = fields.get(f"{role_name}_{key}")
+            shared_field = fields.get(key)
+            per_role[key] = None if role_field is None else str(role_field.value)
+            shared[key] = None if shared_field is None else str(shared_field.value)
+        values, res_prov = pres.resolve_resources(
+            role_name, per_role, shared, pres.CONFIG_MD_INPUT
+        )
         scenario[role_name]["resources"] = values
         warn = pres.used_any_default(res_prov)
         if warn:
             print(
-                pres.starvation_warning(role_name, values, res_prov),
+                pres.starvation_warning(
+                    role_name, values, res_prov, pres.CONFIG_MD_INPUT
+                ),
                 file=sys.stderr,
             )
         for problem in pres.request_exceeds_limit(values):

--- a/.claude/skills/sim2real-bootstrap/generate_from_config.py
+++ b/.claude/skills/sim2real-bootstrap/generate_from_config.py
@@ -99,21 +99,14 @@ PARAMETER_ALIASES = {
     },
     "prefill_hardware": {"prefill gpu", "prefill hardware"},
     "decode_hardware": {"decode gpu", "decode hardware"},
-    # Pod CPU/memory (issue #850). Shared keys with optional per-role overrides,
-    # the same shape as `hardware` / `decode_hardware` / `prefill_hardware` above.
-    # Absent any of these, pod_resources supplies generous per-role defaults.
+    # Pod CPU/memory (issue #850). Four keys, applied to both roles. Per-role
+    # overrides were considered and left out: nothing asked for them, and an
+    # operator who needs decode and prefill to differ edits baselines/baseline.yaml
+    # after bootstrap, as they do for everything else the generator does not model.
     "cpu_limit": {"cpu limit", "cpu_limit", "cpu limits"},
     "memory_limit": {"memory limit", "memory_limit", "memory limits"},
     "cpu_request": {"cpu request", "cpu_request", "cpu requests"},
     "memory_request": {"memory request", "memory_request", "memory requests"},
-    "decode_cpu_limit": {"decode cpu limit", "decode_cpu_limit"},
-    "decode_memory_limit": {"decode memory limit", "decode_memory_limit"},
-    "decode_cpu_request": {"decode cpu request", "decode_cpu_request"},
-    "decode_memory_request": {"decode memory request", "decode_memory_request"},
-    "prefill_cpu_limit": {"prefill cpu limit", "prefill_cpu_limit"},
-    "prefill_memory_limit": {"prefill memory limit", "prefill_memory_limit"},
-    "prefill_cpu_request": {"prefill cpu request", "prefill_cpu_request"},
-    "prefill_memory_request": {"prefill memory request", "prefill_memory_request"},
     "dtype": {"dtype", "--dtype"},
     "pipeline_parallel_size": {"pipeline_parallel_size", "--pipeline-parallel-size"},
     "data_parallel_size": {"data_parallel_size", "--data-parallel-size"},
@@ -935,48 +928,36 @@ def build_scenario(
 
     # --- Pod CPU/memory (issue #850) ---
     # Bootstrap emitted nothing here, so bundles inherited 4 CPU / 40Gi for a pod
-    # that may hold four GPUs -- which starves vLLM and shows up as ITL noise
-    # rather than a failure. Resolved per role: a `decode cpu limit` row beats a
-    # shared `cpu limit` row beats the role default, matching how `Decode GPU`
-    # beats `GPU`. Values stay strings; see pod_resources.
-    # `provenance` does not exist yet (it is built below), so the per-quantity
-    # sources are collected here and merged into it once it does.
+    # that may hold four GPUs -- which starves vLLM and shows up as ITL noise rather
+    # than a failure. `provenance` does not exist yet, so sources are collected here
+    # and merged into it below.
     resource_provenance: dict[str, str] = {}
     for role_name in ("decode", "prefill"):
         if role_name not in scenario:
             continue
-        # Per-role and shared are handed over SEPARATELY: pod_resources owns the
-        # precedence, so a blank per-role cell falls through to the shared row
-        # rather than skipping straight to the default.
-        per_role = {}
-        shared = {}
+        stated = {}
         for key in pres.KEYS:
-            role_field = fields.get(f"{role_name}_{key}")
-            shared_field = fields.get(key)
-            per_role[key] = None if role_field is None else str(role_field.value)
-            shared[key] = None if shared_field is None else str(shared_field.value)
-        values, res_prov = pres.resolve_resources(
-            role_name, per_role, shared, pres.CONFIG_MD_INPUT
-        )
+            field_obj = fields.get(key)
+            stated[key] = None if field_obj is None else str(field_obj.value)
+        values, res_prov = pres.resolve_resources(role_name, stated)
         scenario[role_name]["resources"] = values
-        warn = pres.used_any_default(res_prov)
+        warn = bool(pres.defaulted_keys(res_prov))
         if warn:
+            print(pres.starvation_warning(role_name, values, res_prov),
+                  file=sys.stderr)
+        bad = pres.invalid_quantities(values)
+        if bad:
+            # Hard error, matching the unrecognized-replica-row branch above: an
+            # invalid quantity produces a pod the cluster rejects at admission, far
+            # from the row that caused it, so failing here is the cheap place.
             print(
-                pres.starvation_warning(
-                    role_name, values, res_prov, pres.CONFIG_MD_INPUT
-                ),
+                f"  ERROR: {role_name} has invalid Kubernetes quantities: "
+                f"{', '.join(bad)}. Use e.g. 32, 500m, 128Gi, 1536Mi -- no spaces, "
+                f"no trailing words, no placeholders.",
                 file=sys.stderr,
             )
-        for problem in pres.request_exceeds_limit(values):
-            print(
-                f"  WARNING: {role_name} {problem}. Kubernetes rejects that pod "
-                f"at admission. Each quantity resolves independently, so a "
-                f"stated request with an unstated limit takes the default limit "
-                f"-- state both.",
-                file=sys.stderr,
-            )
-        # Read by the emitter to decide whether to print the unmeasured-defaults
-        # comment. Underscore-prefixed: internal, never emitted.
+            sys.exit(1)
+        # Read by the emitter to decide whether to print the defaults preamble.
         scenario[role_name]["_resources_warn"] = warn
         scenario[role_name]["_resources_provenance"] = res_prov
         for key, src in res_prov.items():

--- a/.claude/skills/sim2real-bootstrap/generate_from_config.py
+++ b/.claude/skills/sim2real-bootstrap/generate_from_config.py
@@ -447,7 +447,13 @@ def warn_role_rows_outside_vllm_table(
 
     Returns the warning lines emitted, for testability.
     """
-    role_fields = {"prefill_replicas", "prefill_hardware", "decode_hardware", "replicas"}
+    role_fields = {
+        "prefill_replicas", "prefill_hardware", "decode_hardware", "replicas",
+        # The #850 CPU/memory rows belong here for the same reason: stated in a
+        # table this parser does not read, they are dropped and the defaults
+        # warning then asserts the operator stated nothing.
+        "cpu_limit", "memory_limit", "cpu_request", "memory_request",
+    }
     satisfied = already_extracted or set()
     emitted = []
     for table in tables:
@@ -929,9 +935,9 @@ def build_scenario(
     # --- Pod CPU/memory (issue #850) ---
     # Bootstrap emitted nothing here, so bundles inherited 4 CPU / 40Gi for a pod
     # that may hold four GPUs -- which starves vLLM and shows up as ITL noise rather
-    # than a failure. `provenance` does not exist yet, so sources are collected here
-    # and merged into it below.
-    resource_provenance: dict[str, str] = {}
+    # than a failure. Per-quantity sources are stashed on the role for the emitter,
+    # which is the only reader -- they are deliberately NOT merged into `provenance`
+    # as well, since two records of the same fact let one of them rot.
     for role_name in ("decode", "prefill"):
         if role_name not in scenario:
             continue
@@ -939,8 +945,10 @@ def build_scenario(
         for key in pres.KEYS:
             field_obj = fields.get(key)
             stated[key] = None if field_obj is None else str(field_obj.value)
-        values, res_prov = pres.resolve_resources(role_name, stated)
+        values, res_prov, notices = pres.resolve_resources(role_name, stated)
         scenario[role_name]["resources"] = values
+        for notice in notices:
+            print(f"  WARNING: {notice}", file=sys.stderr)
         warn = bool(pres.defaulted_keys(res_prov))
         if warn:
             print(pres.starvation_warning(role_name, values, res_prov),
@@ -960,8 +968,6 @@ def build_scenario(
         # Read by the emitter to decide whether to print the defaults preamble.
         scenario[role_name]["_resources_warn"] = warn
         scenario[role_name]["_resources_provenance"] = res_prov
-        for key, src in res_prov.items():
-            resource_provenance[f"{role_name}.resources.{key}"] = src
 
     # --- Pod plumbing (issue #848) ---
     # #846 turns kvTransfer on with a prefill pool. On its own that crashloops the
@@ -1001,7 +1007,6 @@ def build_scenario(
 
     # --- Build provenance map ---
     provenance = {
-        **resource_provenance,
         "model.name": fields["model"].source,
         "model.shortName": meta_source + ".shortName" if meta else "derived from model name",
         "model.path": meta_source + ".path" if meta else "derived from model name",

--- a/.claude/skills/sim2real-bootstrap/generate_scenarios.py
+++ b/.claude/skills/sim2real-bootstrap/generate_scenarios.py
@@ -325,8 +325,10 @@ def build_scenario(entry: dict, name: str) -> dict:
         if role_name not in scenario:
             continue
         stated = {key: vllm_args.get(key) for key in pres.KEYS}
-        values, res_prov = pres.resolve_resources(role_name, stated)
+        values, res_prov, notices = pres.resolve_resources(role_name, stated)
         scenario[role_name]["resources"] = values
+        for notice in notices:
+            print(f"  WARNING: {notice}", file=sys.stderr)
         warn = bool(pres.defaulted_keys(res_prov))
         if warn:
             print(pres.starvation_warning(role_name, values, res_prov),

--- a/.claude/skills/sim2real-bootstrap/generate_scenarios.py
+++ b/.claude/skills/sim2real-bootstrap/generate_scenarios.py
@@ -120,13 +120,8 @@ KNOWN_FIELDS = {
             "enable_chunked_prefill", "block_size",
             "gpu_memory_utilization", "dtype", "kv_cache_dtype",
             "enable_prefix_caching", "enforce_eager", "swap_space",
-            # Pod CPU/memory (issue #850): four shared keys plus per-role
-            # overrides, resolved by pod_resources.
+            # Pod CPU/memory (issue #850), applied to both roles.
             "cpu_limit", "memory_limit", "cpu_request", "memory_request",
-            "decode_cpu_limit", "decode_memory_limit",
-            "decode_cpu_request", "decode_memory_request",
-            "prefill_cpu_limit", "prefill_memory_limit",
-            "prefill_cpu_request", "prefill_memory_request",
         },
         "ignored": set(),
     },
@@ -325,38 +320,26 @@ def build_scenario(entry: dict, name: str) -> dict:
         )
 
     # --- Pod CPU/memory (issue #850) ---
-    # Same resolution order and the same shared module as the config.md path:
-    # per-role key beats shared key beats the role default.
+    # Same four keys and the same resolver as the config.md path.
     for role_name in ("decode", "prefill"):
         if role_name not in scenario:
             continue
-        # Handed over separately so pod_resources applies the precedence. The old
-        # `vllm_args.get(f"{role}_{key}", vllm_args.get(key))` returned None for a
-        # per-role key PRESENT with a JSON null or "", never consulting the shared
-        # key, so a stated shared value was silently replaced by the default.
-        per_role = {key: vllm_args.get(f"{role_name}_{key}") for key in pres.KEYS}
-        shared = {key: vllm_args.get(key) for key in pres.KEYS}
-        values, res_prov = pres.resolve_resources(
-            role_name, per_role, shared, pres.JSON_INPUT
-        )
+        stated = {key: vllm_args.get(key) for key in pres.KEYS}
+        values, res_prov = pres.resolve_resources(role_name, stated)
         scenario[role_name]["resources"] = values
-        warn = pres.used_any_default(res_prov)
+        warn = bool(pres.defaulted_keys(res_prov))
         if warn:
+            print(pres.starvation_warning(role_name, values, res_prov),
+                  file=sys.stderr)
+        bad = pres.invalid_quantities(values)
+        if bad:
             print(
-                pres.starvation_warning(
-                    role_name, values, res_prov, pres.JSON_INPUT
-                ),
+                f"  ERROR: {role_name} has invalid Kubernetes quantities: "
+                f"{', '.join(bad)}. Use e.g. 32, 500m, 128Gi, 1536Mi -- no spaces, "
+                f"no trailing words, no placeholders.",
                 file=sys.stderr,
             )
-        for problem in pres.request_exceeds_limit(values):
-            print(
-                f"  WARNING: {role_name} {problem}. Kubernetes rejects that pod "
-                f"at admission. Each quantity resolves independently, so a "
-                f"stated request with an unstated limit takes the default limit "
-                f"-- state both.",
-                file=sys.stderr,
-            )
-        # Internal, read by the emitter; never printed. See generate_from_config.py.
+            sys.exit(1)
         scenario[role_name]["_resources_warn"] = warn
         scenario[role_name]["_resources_provenance"] = res_prov
 

--- a/.claude/skills/sim2real-bootstrap/generate_scenarios.py
+++ b/.claude/skills/sim2real-bootstrap/generate_scenarios.py
@@ -330,16 +330,22 @@ def build_scenario(entry: dict, name: str) -> dict:
     for role_name in ("decode", "prefill"):
         if role_name not in scenario:
             continue
-        stated = {
-            key: vllm_args.get(f"{role_name}_{key}", vllm_args.get(key))
-            for key in pres.KEYS
-        }
-        values, res_prov = pres.resolve_resources(role_name, stated)
+        # Handed over separately so pod_resources applies the precedence. The old
+        # `vllm_args.get(f"{role}_{key}", vllm_args.get(key))` returned None for a
+        # per-role key PRESENT with a JSON null or "", never consulting the shared
+        # key, so a stated shared value was silently replaced by the default.
+        per_role = {key: vllm_args.get(f"{role_name}_{key}") for key in pres.KEYS}
+        shared = {key: vllm_args.get(key) for key in pres.KEYS}
+        values, res_prov = pres.resolve_resources(
+            role_name, per_role, shared, pres.JSON_INPUT
+        )
         scenario[role_name]["resources"] = values
         warn = pres.used_any_default(res_prov)
         if warn:
             print(
-                pres.starvation_warning(role_name, values, res_prov),
+                pres.starvation_warning(
+                    role_name, values, res_prov, pres.JSON_INPUT
+                ),
                 file=sys.stderr,
             )
         for problem in pres.request_exceeds_limit(values):

--- a/.claude/skills/sim2real-bootstrap/generate_scenarios.py
+++ b/.claude/skills/sim2real-bootstrap/generate_scenarios.py
@@ -338,9 +338,21 @@ def build_scenario(entry: dict, name: str) -> dict:
         scenario[role_name]["resources"] = values
         warn = pres.used_any_default(res_prov)
         if warn:
-            print(pres.starvation_warning(role_name), file=sys.stderr)
+            print(
+                pres.starvation_warning(role_name, values, res_prov),
+                file=sys.stderr,
+            )
+        for problem in pres.request_exceeds_limit(values):
+            print(
+                f"  WARNING: {role_name} {problem}. Kubernetes rejects that pod "
+                f"at admission. Each quantity resolves independently, so a "
+                f"stated request with an unstated limit takes the default limit "
+                f"-- state both.",
+                file=sys.stderr,
+            )
         # Internal, read by the emitter; never printed. See generate_from_config.py.
         scenario[role_name]["_resources_warn"] = warn
+        scenario[role_name]["_resources_provenance"] = res_prov
 
     # --- Pod plumbing (issue #848) ---
     # Same two gates and the same fragments as generate_from_config.py -- see
@@ -461,6 +473,7 @@ def write_commented_yaml(scenario: dict, entry: dict, out_path: str):
         lines.extend(
             pres.resource_lines(
                 scenario["decode"]["resources"],
+                scenario["decode"]["_resources_provenance"],
                 warn=scenario["decode"].get("_resources_warn", True),
             )
         )
@@ -517,6 +530,7 @@ def write_commented_yaml(scenario: dict, entry: dict, out_path: str):
             lines.extend(
                 pres.resource_lines(
                     p_role["resources"],
+                    p_role["_resources_provenance"],
                     warn=p_role.get("_resources_warn", True),
                 )
             )

--- a/.claude/skills/sim2real-bootstrap/generate_scenarios.py
+++ b/.claude/skills/sim2real-bootstrap/generate_scenarios.py
@@ -15,6 +15,7 @@ import sys
 from pathlib import Path
 
 import pd_plumbing as pdp
+import pod_resources as pres
 
 # See #831: `workers` is the LeaderWorkerSet group size (pods per replica), not a
 # parallelism degree, and no input field states it -- so it is a stated default.
@@ -119,6 +120,13 @@ KNOWN_FIELDS = {
             "enable_chunked_prefill", "block_size",
             "gpu_memory_utilization", "dtype", "kv_cache_dtype",
             "enable_prefix_caching", "enforce_eager", "swap_space",
+            # Pod CPU/memory (issue #850): four shared keys plus per-role
+            # overrides, resolved by pod_resources.
+            "cpu_limit", "memory_limit", "cpu_request", "memory_request",
+            "decode_cpu_limit", "decode_memory_limit",
+            "decode_cpu_request", "decode_memory_request",
+            "prefill_cpu_limit", "prefill_memory_limit",
+            "prefill_cpu_request", "prefill_memory_request",
         },
         "ignored": set(),
     },
@@ -316,6 +324,24 @@ def build_scenario(entry: dict, name: str) -> dict:
             file=sys.stderr,
         )
 
+    # --- Pod CPU/memory (issue #850) ---
+    # Same resolution order and the same shared module as the config.md path:
+    # per-role key beats shared key beats the role default.
+    for role_name in ("decode", "prefill"):
+        if role_name not in scenario:
+            continue
+        stated = {
+            key: vllm_args.get(f"{role_name}_{key}", vllm_args.get(key))
+            for key in pres.KEYS
+        }
+        values, res_prov = pres.resolve_resources(role_name, stated)
+        scenario[role_name]["resources"] = values
+        warn = pres.used_any_default(res_prov)
+        if warn:
+            print(pres.starvation_warning(role_name), file=sys.stderr)
+        # Internal, read by the emitter; never printed. See generate_from_config.py.
+        scenario[role_name]["_resources_warn"] = warn
+
     # --- Pod plumbing (issue #848) ---
     # Same two gates and the same fragments as generate_from_config.py -- see
     # pd_plumbing's module docstring for why both generators must agree here.
@@ -430,6 +456,15 @@ def write_commented_yaml(scenario: dict, entry: dict, out_path: str):
         pdp.extra_env_var_lines(nixl=gates["kv"], multigpu=gates["multigpu"])
     )
 
+    # CPU/memory (#850), also per-role.
+    if "resources" in scenario["decode"]:
+        lines.extend(
+            pres.resource_lines(
+                scenario["decode"]["resources"],
+                warn=scenario["decode"].get("_resources_warn", True),
+            )
+        )
+
     # Prefill role, emitted only when the entry named a prefill pod count. Placed
     # after decode so the decode bytes above are untouched when it is absent.
     if "prefill" in scenario:
@@ -477,6 +512,14 @@ def write_commented_yaml(scenario: dict, entry: dict, out_path: str):
         lines.extend(
             pdp.extra_env_var_lines(nixl=gates["kv"], multigpu=gates["multigpu"])
         )
+
+        if "resources" in p_role:
+            lines.extend(
+                pres.resource_lines(
+                    p_role["resources"],
+                    warn=p_role.get("_resources_warn", True),
+                )
+            )
 
     # Scenario-level plumbing (#848), last so every block above keeps its bytes.
     if gates["kv"]:

--- a/.claude/skills/sim2real-bootstrap/pod_resources.py
+++ b/.claude/skills/sim2real-bootstrap/pod_resources.py
@@ -9,34 +9,42 @@ with the routing sidecar that requests four more, starves vLLM. The signal is
 `Reducing Torch parallelism from N threads to 1`, which surfaces as ITL noise --
 corrupting the metric arms are compared on instead of failing loudly.
 
-BOTH HALVES ARE EMITTED, and they differ:
+TWO NUMBERS PER RESOURCE, and Kubernetes requires request <= limit or the pod never
+admits:
 
   limits    generous. Headroom costs nothing unless it is used.
-  requests  below the limit. This is what the scheduler actually reserves, and
-            reserving the full generous ceiling on every replica would make a
-            multi-replica pool unschedulable on a busy cluster.
+  requests  what the scheduler actually reserves.
 
-Emitting both rather than limits alone is deliberate. The framework default sets
-both, and a scenario is deep-merged over it, so emitting only `limits` would leave
-`requests` at the inherited 40Gi/"4" -- a decode pod would end up asking for 40Gi
-while permitted 128Gi. That pairing would be implicit and surprising; stating both
-keeps it visible in one place.
+THE PAIR IS RECONCILED PER ROLE, which is the whole reason this module exists rather
+than four independent lookups. The defaults differ by 4-8x between roles (decode
+32 CPU / 128Gi, prefill 8 / 16Gi), while the input rows are shared and apply to both.
+So a `cpu request: 20` row that is entirely sensible for decode exceeds prefill's
+8-CPU limit. Resolving the four quantities independently emitted exactly that --
+`requests {96Gi, 20}` against `limits {16Gi, 8}` -- an invalid pod spec, under a
+comment claiming requests sit below limits. `resolve_resources` now clamps a request
+to its own role's limit and says so, so an invalid pair cannot be expressed.
 
-WHERE THE NUMBERS COME FROM. The limits are the observed-working figures from
-llm-d's pd-disaggregation guide (config/scenarios/guides/pd-disaggregation.yaml:410-416
-decode, :321-327 prefill), which pd-infocomm-2's baseline also carries. Decode is
-sized above prefill there, matching the operator's constraint. Requests are half
-those limits -- a stated default, not a measurement.
+WHERE THE NUMBERS COME FROM. Limits are the observed-working figures from llm-d's
+pd-disaggregation guide (config/scenarios/guides/pd-disaggregation.yaml:410-416
+decode, :321-327 prefill), which pd-infocomm-2's baseline also carries; decode is
+sized above prefill there, matching the operator's constraint.
+
+Decode's request is half its limit -- headroom without reserving the ceiling on every
+replica. PREFILL'S REQUEST EQUALS ITS LIMIT, matching upstream, because #848 mounts a
+`medium: Memory` tmpfs at /dev/shm sized 16Gi in `vllmCommon` (both roles). tmpfs
+charges against the pod's memory, so a prefill pod whose request was half its 16Gi
+limit would sit above its request as soon as collectives filled /dev/shm, making it
+an eviction candidate under node pressure mid-run. Guaranteed QoS is what upstream
+uses there and is what protects it.
 
 NOTHING HERE IS MEASURED on any cluster but the one the figures came from, at one
-tensor-parallel degree and one model. That is deliberate: fixed starting values were
-chosen over a derived formula, to be revised once there is data. `warn` keeps that
-visible in the emitted YAML rather than letting generous-looking numbers read as
-authoritative.
+tensor-parallel degree and one model. Fixed starting values were chosen over a
+derived formula, to be revised once there is data. `warn` keeps that visible in the
+emitted YAML rather than letting generous-looking numbers read as authoritative.
 
 Values are emitted QUOTED, both memory and cpu. They are opaque Kubernetes quantity
 strings, and an unquoted one is re-typed by any YAML reader: `128` becomes an int,
-`yes` becomes True, `-` becomes a list item that will not parse at all.
+`yes` becomes True, `-` becomes a sequence entry that will not parse at all.
 
 Indentation contract: emitted lines sit INSIDE a role block (`decode:` / `prefill:`)
 that the caller has already printed -- `resources:` at 4 spaces, `limits:`/
@@ -45,12 +53,10 @@ that the caller has already printed -- `resources:` at 4 spaces, `limits:`/
 
 import re
 
-# The four quantities, in emission order within each of limits/requests.
 KEYS = ("cpu_limit", "memory_limit", "cpu_request", "memory_request")
 
-# Per-role fixed defaults. Limits verbatim from the upstream guide; requests half.
-# decode > prefill on every quantity -- the operator's constraint and upstream's own
-# sizing.
+# Per-role fixed defaults. Limits verbatim from the upstream guide. Decode's request
+# is half its limit; prefill's equals its limit -- see the /dev/shm note above.
 DEFAULTS = {
     "decode": {
         "cpu_limit": "32",
@@ -61,66 +67,146 @@ DEFAULTS = {
     "prefill": {
         "cpu_limit": "8",
         "memory_limit": "16Gi",
-        "cpu_request": "4",
-        "memory_request": "8Gi",
+        "cpu_request": "8",
+        "memory_request": "16Gi",
     },
 }
 
 STATED = "operator-stated"
 DEFAULTED = "sim2real-bootstrap default (UNMEASURED)"
+DERIVED = "half the stated limit"
+CLAMPED = "clamped to this role's limit"
 
-# Kubernetes' own quantity grammar (apimachinery/pkg/api/resource). Deliberately not
-# a parser -- just enough to reject what the cluster would reject at admission, so a
-# `TBD`, `N/A`, `32 cores` or `16 Gi` row fails here rather than on the cluster far
-# from the row that caused it.
-_QUANTITY_RE = re.compile(r"^[+-]?[0-9.]+(?:[eE][+-]?[0-9]+)?[EPTGMk]?i?m?$")
+# Kubernetes' quantity grammar (apimachinery/pkg/api/resource): a number with an
+# optional binary (Ki..Ei) or decimal (m, k..E) suffix, OR a bare decimal exponent
+# which cannot be combined with a suffix. Written from the grammar rather than from
+# memory: an earlier version put lowercase `k` in the class but not the uppercase `K`
+# that binary kilo uses, so it hard-rejected a valid `1Ki` while accepting `1ki`,
+# `1.2.3`, `...`, `1e3Gi` and negatives.
+_SUFFIX_MULTIPLIER = {
+    "": 1.0, "m": 1e-3,
+    "k": 1e3, "M": 1e6, "G": 1e9, "T": 1e12, "P": 1e15, "E": 1e18,
+    "Ki": 2 ** 10, "Mi": 2 ** 20, "Gi": 2 ** 30,
+    "Ti": 2 ** 40, "Pi": 2 ** 50, "Ei": 2 ** 60,
+}
+_SUFFIXED_RE = re.compile(
+    r"^(?P<num>[0-9]+(?:\.[0-9]+)?)(?P<suffix>Ki|Mi|Gi|Ti|Pi|Ei|m|k|M|G|T|P|E)?$"
+)
+_EXPONENT_RE = re.compile(r"^[0-9]+(?:\.[0-9]+)?[eE][+-]?[0-9]+$")
 
 
-def resolve_resources(role: str, stated: dict) -> "tuple[dict, dict]":
-    """Resolve one role's four quantities: the stated value, else the role default.
+def _magnitude(quantity: str) -> "float | None":
+    """Numeric value of a Kubernetes quantity, or None if it is not one.
 
-    `stated` maps each of KEYS to what the input declared, or None. Absent, None and
-    whitespace-only all count as unstated. Values pass through as strings and are
-    never parsed -- `32`, `500m`, `1.5`, `128Gi`, `1536Mi` are all valid Kubernetes
-    quantities and re-serializing risks changing them.
-
-    Returns (values, provenance), both keyed by KEYS.
+    Negative values parse per the grammar but are rejected by pod validation
+    (`must be greater than or equal to 0`), so a leading sign is not accepted here.
     """
-    values, provenance = {}, {}
-    for key in KEYS:
-        given = stated.get(key)
-        text = "" if given is None else str(given).strip()
-        if text:
-            values[key], provenance[key] = text, STATED
-        else:
-            values[key], provenance[key] = DEFAULTS[role][key], DEFAULTED
-    return values, provenance
+    text = quantity.strip()
+    match = _SUFFIXED_RE.match(text)
+    if match:
+        return float(match.group("num")) * _SUFFIX_MULTIPLIER[
+            match.group("suffix") or ""]
+    if _EXPONENT_RE.match(text):
+        return float(text)
+    return None
+
+
+def _halve(quantity: str) -> str:
+    """Half a quantity, keeping its suffix. `128Gi` -> `64Gi`, `32` -> `16`."""
+    match = _SUFFIXED_RE.match(quantity.strip())
+    if not match:  # pragma: no cover - callers validate first
+        return quantity
+    halved = float(match.group("num")) / 2
+    number = f"{halved:g}"
+    return f"{number}{match.group('suffix') or ''}"
 
 
 def invalid_quantities(values: dict) -> "list[str]":
-    """Stated values that are not valid Kubernetes quantities.
+    """Values that are not valid Kubernetes quantities.
 
-    Only stated values can be invalid -- the defaults are known-good -- but this
-    checks all four so a bad default could never slip through either.
+    A pod carrying one is rejected at admission, far from the row that caused it, so
+    this is checked at generation time instead.
     """
-    return [
-        f"{key}={values[key]!r}"
-        for key in KEYS
-        if not _QUANTITY_RE.match(values[key])
-    ]
+    return [f"{k}={values[k]!r}" for k in KEYS if _magnitude(values[k]) is None]
+
+
+def resolve_resources(role: str, stated: dict) -> "tuple[dict, dict, list[str]]":
+    """Resolve one role's limits and requests into a coherent pair.
+
+    Per resource: the limit is what the input stated, else the role default. The
+    request is what the input stated; failing that, half the limit when the limit was
+    stated (the role's default request may not fit a limit the operator changed), else
+    the role default request. The request is then clamped to the limit, because the
+    shared input rows apply to both roles and a value sized for decode exceeds
+    prefill's smaller limits.
+
+    Absent, None and whitespace-only all count as unstated. Values pass through as
+    strings and are never reformatted -- `32`, `500m`, `1.5`, `128Gi`, `1536Mi` are
+    all valid quantities and re-serializing risks changing them.
+
+    Returns (values, provenance, notices); notices describe any clamping, for the
+    caller to print.
+    """
+    def clean(key):
+        raw = stated.get(key)
+        text = "" if raw is None else str(raw).strip()
+        return text or None
+
+    values, provenance, notices = {}, {}, []
+    for kind in ("cpu", "memory"):
+        limit_key, request_key = f"{kind}_limit", f"{kind}_request"
+
+        limit = clean(limit_key)
+        if limit:
+            values[limit_key], provenance[limit_key] = limit, STATED
+        else:
+            values[limit_key] = DEFAULTS[role][limit_key]
+            provenance[limit_key] = DEFAULTED
+
+        request = clean(request_key)
+        if request:
+            values[request_key], provenance[request_key] = request, STATED
+        elif limit and _magnitude(values[limit_key]) is not None:
+            # Half the stated limit: the role default request may not fit a limit the
+            # operator changed. Only when that limit is a readable quantity -- halving
+            # an invalid one would propagate it and make the error name two keys
+            # instead of the single bad row.
+            values[request_key] = _halve(values[limit_key])
+            provenance[request_key] = DERIVED
+        else:
+            values[request_key] = DEFAULTS[role][request_key]
+            provenance[request_key] = DEFAULTED
+
+        # Clamp only when both sides are readable quantities; invalid_quantities
+        # reports the unreadable ones and the caller fails on those.
+        req_mag = _magnitude(values[request_key])
+        lim_mag = _magnitude(values[limit_key])
+        if req_mag is not None and lim_mag is not None and req_mag > lim_mag:
+            notices.append(
+                f"{role} {kind} request {values[request_key]} exceeds its limit "
+                f"{values[limit_key]}, so it was clamped to the limit. Kubernetes "
+                f"rejects a pod whose request exceeds its limit. The CPU/memory rows "
+                f"are shared by both roles, and {role}'s limits are "
+                f"{DEFAULTS[role][limit_key]} by default -- state a "
+                f"{kind} limit too if you need a larger request here."
+            )
+            values[request_key] = values[limit_key]
+            provenance[request_key] = CLAMPED
+
+    return values, provenance, notices
 
 
 def defaulted_keys(provenance: dict) -> "list[str]":
-    """Which quantities fell back to a default, in KEYS order."""
+    """Which quantities fell back to a role default, in KEYS order."""
     return [k for k in KEYS if provenance.get(k) == DEFAULTED]
 
 
 def starvation_warning(role: str, values: dict, provenance: dict) -> str:
-    """Generation-time warning naming the quantities that defaulted, and their values.
+    """Generation-time warning naming the quantities that defaulted and their values.
 
-    Reports what was actually emitted. Printing the whole default table would
+    Reports what was actually emitted: printing the whole default table would
     contradict the YAML whenever the operator overrode part of it. Names no input
-    file: both generators share this, and they read different inputs.
+    file, because both generators share this and they read different inputs.
     """
     missing = defaulted_keys(provenance)
     shown = ", ".join(f"{k}={values[k]}" for k in missing)
@@ -138,24 +224,23 @@ def resource_lines(values: dict, provenance: dict, *, warn: bool) -> "list[str]"
     """`resources` for one role block, as YAML lines.
 
     Emitted inside a role block the caller has already printed. Each value carries
-    its own `# source` comment: the four resolve independently, so a single header
-    comment could not say which came from where. `warn` adds the unmeasured-defaults
-    preamble; pass False when every quantity was stated.
+    its own `# source` comment: the four are resolved independently, so a single
+    header comment could not say where each came from. `warn` adds the
+    unmeasured-defaults preamble; pass False when every quantity was stated.
     """
     lines = []
     if warn:
         lines += [
             "    # Some or all of these are GENEROUS DEFAULTS, NOT measured -- see",
             "    # the per-value sources. Defaults' limits come from llm-d's",
-            "    # pd-disaggregation guide; their requests are half that. Watch for",
-            "    # 'Reducing Torch parallelism from N threads to 1' in the pod log:",
-            "    # that is CPU starvation, and it shows up as ITL noise rather than",
-            "    # a failure.",
+            "    # pd-disaggregation guide. Watch for 'Reducing Torch parallelism",
+            "    # from N threads to 1' in the pod log: that is CPU starvation, and",
+            "    # it shows up as ITL noise rather than a failure.",
             "    #",
-            "    # requests sit below limits so the scheduler reserves less than the",
-            "    # ceiling. Both halves are stated because the framework default",
-            "    # sets both, and emitting only limits would leave requests at the",
-            "    # inherited 40Gi/4.",
+            "    # requests never exceed limits -- Kubernetes rejects such a pod.",
+            "    # Both halves are stated because the framework default sets both,",
+            "    # so emitting only limits would leave requests at the inherited",
+            "    # 40Gi/4.",
         ]
     lines.append("    resources:")
     for section, mem_key, cpu_key in (

--- a/.claude/skills/sim2real-bootstrap/pod_resources.py
+++ b/.claude/skills/sim2real-bootstrap/pod_resources.py
@@ -106,35 +106,103 @@ def used_any_default(provenance: dict) -> bool:
     return any(src == _DEFAULT_SOURCE for src in provenance.values())
 
 
-def starvation_warning(role: str) -> str:
-    """The generation-time (stderr) warning text, shared by both generators."""
+def defaulted_keys(provenance: dict) -> "list[str]":
+    """Which quantities fell back to a default, in KEYS order."""
+    return [k for k in KEYS if provenance.get(k) == _DEFAULT_SOURCE]
+
+
+def starvation_warning(role: str, values: dict, provenance: dict) -> str:
+    """The generation-time (stderr) warning, shared by both generators.
+
+    Reports the ACTUAL emitted numbers for the quantities that defaulted, and
+    names only those. Printing the whole default table would contradict the
+    emitted YAML whenever the operator overrode part of it -- e.g. stating only
+    `decode cpu limit: 64` would still have announced "limits 32 CPU", which
+    reads as the override having been ignored.
+    """
+    missing = defaulted_keys(provenance)
+    shown = ", ".join(f"{k}={values[k]}" for k in missing)
     return (
-        f"  WARNING: no CPU/memory rows for {role}, so generous UNMEASURED "
-        f"defaults were emitted (limits "
-        f"{DEFAULTS[role]['cpu_limit']} CPU / {DEFAULTS[role]['memory_limit']}, "
-        f"requests {DEFAULTS[role]['cpu_request']} CPU / "
-        f"{DEFAULTS[role]['memory_request']}). They are headroom, not a "
+        f"  WARNING: {role} has no config.md row for {len(missing)} of "
+        f"{len(KEYS)} CPU/memory quantities, so generous UNMEASURED defaults "
+        f"were emitted for them ({shown}). They are headroom, not a "
         f"measurement. Watch the {role} logs for 'Reducing Torch parallelism "
         f"from N threads to 1' -- that is CPU starvation, and it surfaces as ITL "
-        f"noise rather than a failure. State '{role} cpu limit' and "
-        f"'{role} memory limit' rows in config.md to override."
+        f"noise rather than a failure. Add "
+        f"'{role} <cpu|memory> <limit|request>' rows to config.md to override."
     )
 
 
-def resource_lines(values: dict, *, warn: bool) -> "list[str]":
+def _quantity_exceeds(request: str, limit: str) -> bool:
+    """True when `request` provably exceeds `limit`.
+
+    Deliberately conservative. Kubernetes quantities carry suffixes (`500m`,
+    `1536Mi`, `2Gi`) whose comparison needs a real unit parser, which this module
+    does not have. So it compares only when both values share a form it can read
+    exactly -- bare numbers, or the same suffix -- and returns False otherwise.
+    A False here means "not proven", never "verified fine".
+    """
+    req, lim = request.strip(), limit.strip()
+    try:
+        return float(req) > float(lim)
+    except ValueError:
+        pass
+    for suffix in ("Gi", "Mi", "Ki", "G", "M", "K", "m"):
+        if req.endswith(suffix) and lim.endswith(suffix):
+            try:
+                return float(req[: -len(suffix)]) > float(lim[: -len(suffix)])
+            except ValueError:
+                return False
+    return False
+
+
+def request_exceeds_limit(values: dict) -> "list[str]":
+    """Quantities whose request provably exceeds its limit.
+
+    Kubernetes rejects such a pod at admission, and because each quantity is
+    resolved independently, a config.md stating only `decode cpu request: 40`
+    against the default limit of 32 produces exactly that -- failing on the
+    cluster, far from the row that caused it. Returns the offending pairs so the
+    generator can say so at generation time instead.
+    """
+    bad = []
+    for kind in ("cpu", "memory"):
+        req, lim = values[f"{kind}_request"], values[f"{kind}_limit"]
+        if _quantity_exceeds(req, lim):
+            bad.append(f"{kind}: request {req} > limit {lim}")
+    return bad
+
+
+_SHORT_SOURCE = {
+    _STATED_SOURCE: "config.md row",
+    _DEFAULT_SOURCE: "sim2real-bootstrap default (generous, UNMEASURED)",
+}
+
+
+def resource_lines(values: dict, provenance: dict, *, warn: bool) -> "list[str]":
     """`resources` for one role block, as YAML lines.
 
-    Emitted inside a role block the caller has already printed. `warn` adds the
-    unmeasured-defaults comment; pass False when every quantity was stated.
+    Emitted inside a role block the caller has already printed.
+
+    Every value carries its own `# source` comment, the convention the rest of
+    this generator's output follows. That matters here because the four
+    quantities resolve independently: a header comment claiming the figures come
+    from the upstream guide would be false for whichever ones the operator
+    overrode, so the per-line sources are the only honest way to say which is
+    which.
+
+    `warn` adds the unmeasured-defaults preamble; pass False when every quantity
+    was stated, since then the numbers are the operator's.
     """
     lines: list[str] = []
     if warn:
         lines += [
-            "    # Generous headroom, NOT measured. Limits are the llm-d",
-            "    # pd-disaggregation guide's observed-working figures; requests are",
-            "    # half of them. Watch for 'Reducing Torch parallelism from N",
-            "    # threads to 1' in the pod log -- that is CPU starvation, and it",
-            "    # shows up as ITL noise rather than a failure.",
+            "    # Some or all of the figures below are GENEROUS DEFAULTS, NOT",
+            "    # measured -- see the per-value sources. The defaults' limits come",
+            "    # from llm-d's pd-disaggregation guide; their requests are half",
+            "    # that. Watch for 'Reducing Torch parallelism from N threads to 1'",
+            "    # in the pod log -- that is CPU starvation, and it shows up as ITL",
+            "    # noise rather than a failure.",
             "    #",
             "    # requests are stated explicitly on purpose: omitting them does",
             "    # NOT mean 'no reservation'. Kubernetes copies the limit into the",
@@ -146,13 +214,17 @@ def resource_lines(values: dict, *, warn: bool) -> "list[str]":
             "    # survive. That differs from the scalar lists elsewhere in this",
             "    # skill, which are replaced wholesale.",
         ]
+
+    def src(key: str) -> str:
+        return _SHORT_SOURCE.get(provenance.get(key, ""), "unknown source")
+
     lines += [
         "    resources:",
         "      limits:",
-        f"        memory: {values['memory_limit']}",
-        f"        cpu: '{values['cpu_limit']}'",
+        f"        memory: {values['memory_limit']}  # {src('memory_limit')}",
+        f"        cpu: '{values['cpu_limit']}'  # {src('cpu_limit')}",
         "      requests:",
-        f"        memory: {values['memory_request']}",
-        f"        cpu: '{values['cpu_request']}'",
+        f"        memory: {values['memory_request']}  # {src('memory_request')}",
+        f"        cpu: '{values['cpu_request']}'  # {src('cpu_request')}",
     ]
     return lines

--- a/.claude/skills/sim2real-bootstrap/pod_resources.py
+++ b/.claude/skills/sim2real-bootstrap/pod_resources.py
@@ -41,6 +41,8 @@ Indentation contract: emitted lines sit INSIDE a role block (`decode:` /
 `limits:`/`requests:` at 6, their leaves at 8. Callers own blank-line separation.
 """
 
+from typing import NamedTuple
+
 # The four quantities, in emission order within each of limits/requests.
 KEYS = ("cpu_limit", "memory_limit", "cpu_request", "memory_request")
 
@@ -67,29 +69,90 @@ _DEFAULT_SOURCE = (
     "sim2real-bootstrap default (generous, UNMEASURED; limits from llm-d "
     "pd-disaggregation guide, requests half)"
 )
-_STATED_SOURCE = "config.md row"
+
+
+class InputStyle(NamedTuple):
+    """How to describe this generator's input when citing or advising about it.
+
+    The two generators read different inputs -- `config.md` markdown rows and
+    `top3_selection.json`'s `vllm_args` -- and SKILL.md selects the JSON path
+    precisely when no config.md exists. Hardcoding "config.md row" here therefore
+    printed remediation naming a file that is not the input, and cited a source the
+    JSON path never had. Every other source comment `generate_scenarios.py` emits
+    uses its own "from vllm_args.X" convention; this keeps that consistent.
+    """
+
+    per_role_source: str
+    shared_source: str
+    remediation: str
+
+
+CONFIG_MD_INPUT = InputStyle(
+    per_role_source="config.md per-role row",
+    shared_source="config.md shared row",
+    remediation=(
+        "Add '{role} <cpu|memory> <limit|request>' rows to config.md to override"
+    ),
+)
+
+JSON_INPUT = InputStyle(
+    per_role_source="from vllm_args.{role}_<key>",
+    shared_source="from vllm_args.<key>",
+    remediation=(
+        "Set vllm_args.{role}_cpu_limit / _memory_limit (or the unprefixed "
+        "shared keys) in the input JSON to override"
+    ),
+)
 
 
 def resolve_resources(
-    role: str, stated: "dict[str, str | None]"
+    role: str,
+    per_role: "dict[str, str | None]",
+    shared: "dict[str, str | None] | None" = None,
+    style: InputStyle = CONFIG_MD_INPUT,
 ) -> "tuple[dict, dict]":
-    """Resolve one role's four quantities, preferring stated values.
+    """Resolve one role's four quantities: per-role value, then shared, then default.
 
-    `stated` maps each of KEYS to the value the input declared, or None. Values
-    pass through as strings and are never parsed: `32`, `500m`, `1.5`, `128Gi` and
-    `1536Mi` are all valid Kubernetes quantities, and re-serializing risks
-    changing them.
+    THE PRECEDENCE LIVES HERE, in the one module both generators import, rather
+    than at each call site. It was duplicated before, and the two copies diverged:
+    the JSON path used `vllm_args.get(f"{role}_{key}", vllm_args.get(key))`, which
+    returns None -- never consulting the shared key -- for a per-role key that is
+    PRESENT with a null or empty value. The config.md path had the same hole for a
+    row whose value cell is blank. Either way a stated shared value was silently
+    discarded in favour of the built-in default. One implementation cannot disagree
+    with itself.
+
+    "Empty" means absent, None, or whitespace-only, for both levels. A per-role key
+    present but blank is treated as unset -- the operator wrote a row and left it
+    empty, which is not an instruction to ignore the shared row they did fill in.
+
+    Values pass through as strings and are never parsed: `32`, `500m`, `1.5`,
+    `128Gi` and `1536Mi` are all valid Kubernetes quantities, and re-serializing
+    risks changing them.
 
     Returns (values, provenance), both keyed by KEYS.
     """
+    shared = shared or {}
     defaults = DEFAULTS[role]
     values: dict = {}
     provenance: dict = {}
+
+    def stated(source: dict, key: str) -> "str | None":
+        given = source.get(key)
+        if given is None:
+            return None
+        text = str(given).strip()
+        return text or None
+
     for key in KEYS:
-        given = stated.get(key)
-        if given is not None and str(given).strip():
-            values[key] = str(given).strip()
-            provenance[key] = _STATED_SOURCE
+        role_value = stated(per_role, key)
+        shared_value = stated(shared, key)
+        if role_value is not None:
+            values[key] = role_value
+            provenance[key] = style.per_role_source.format(role=role)
+        elif shared_value is not None:
+            values[key] = shared_value
+            provenance[key] = style.shared_source.format(role=role)
         else:
             values[key] = defaults[key]
             provenance[key] = _DEFAULT_SOURCE
@@ -111,7 +174,12 @@ def defaulted_keys(provenance: dict) -> "list[str]":
     return [k for k in KEYS if provenance.get(k) == _DEFAULT_SOURCE]
 
 
-def starvation_warning(role: str, values: dict, provenance: dict) -> str:
+def starvation_warning(
+    role: str,
+    values: dict,
+    provenance: dict,
+    style: InputStyle = CONFIG_MD_INPUT,
+) -> str:
     """The generation-time (stderr) warning, shared by both generators.
 
     Reports the ACTUAL emitted numbers for the quantities that defaulted, and
@@ -123,13 +191,14 @@ def starvation_warning(role: str, values: dict, provenance: dict) -> str:
     missing = defaulted_keys(provenance)
     shown = ", ".join(f"{k}={values[k]}" for k in missing)
     return (
-        f"  WARNING: {role} has no config.md row for {len(missing)} of "
+        f"  WARNING: {role} has no stated value for {len(missing)} of "
         f"{len(KEYS)} CPU/memory quantities, so generous UNMEASURED defaults "
         f"were emitted for them ({shown}). They are headroom, not a "
         f"measurement. Watch the {role} logs for 'Reducing Torch parallelism "
         f"from N threads to 1' -- that is CPU starvation, and it surfaces as ITL "
-        f"noise rather than a failure. Add "
-        f"'{role} <cpu|memory> <limit|request>' rows to config.md to override."
+        f"noise rather than a failure. "
+        + style.remediation.format(role=role)
+        + "."
     )
 
 
@@ -173,10 +242,9 @@ def request_exceeds_limit(values: dict) -> "list[str]":
     return bad
 
 
-_SHORT_SOURCE = {
-    _STATED_SOURCE: "config.md row",
-    _DEFAULT_SOURCE: "sim2real-bootstrap default (generous, UNMEASURED)",
-}
+# The emitted `# source` comment. Stated sources vary by input style, so they are
+# passed through as-is; only the long default string is shortened for the comment.
+_DEFAULT_COMMENT = "sim2real-bootstrap default (generous, UNMEASURED)"
 
 
 def resource_lines(values: dict, provenance: dict, *, warn: bool) -> "list[str]":
@@ -216,7 +284,8 @@ def resource_lines(values: dict, provenance: dict, *, warn: bool) -> "list[str]"
         ]
 
     def src(key: str) -> str:
-        return _SHORT_SOURCE.get(provenance.get(key, ""), "unknown source")
+        source = provenance.get(key, "unknown source")
+        return _DEFAULT_COMMENT if source == _DEFAULT_SOURCE else source
 
     lines += [
         "    resources:",

--- a/.claude/skills/sim2real-bootstrap/pod_resources.py
+++ b/.claude/skills/sim2real-bootstrap/pod_resources.py
@@ -1,55 +1,56 @@
 #!/usr/bin/env python3
 """CPU/memory for the model-server pods (issue #850).
 
-Bootstrap emitted no `resources` at all, so every bundle inherited the framework
-default -- `limits: {memory: 40Gi, cpu: "4"}` with no `requests`
-(llm-d-benchmark@76473d0 config/templates/values/defaults.yaml:848-851 decode,
-:994-997 prefill). Four CPU for a pod that may hold four GPUs, sharing its cgroup
+Bootstrap emitted no `resources`, so every bundle inherited the framework default:
+`limits` AND `requests` both `{memory: 40Gi, cpu: "4"}` for each role
+(llm-d-benchmark@76473d0 config/templates/values/defaults.yaml:848-858 decode,
+:993-1000 prefill). Four CPU for a pod that may hold four GPUs, sharing its cgroup
 with the routing sidecar that requests four more, starves vLLM. The signal is
 `Reducing Torch parallelism from N threads to 1`, which surfaces as ITL noise --
-so it corrupts the metric arms are compared on instead of failing loudly.
+corrupting the metric arms are compared on instead of failing loudly.
 
-THE limits/requests TRAP. `limits` without `requests` is not "no reservation":
-Kubernetes copies the limit into the request when the request is absent. So a
-decode block carrying `limits: {128Gi, 32}` and no `requests` reserves 128Gi and
-32 CPU per replica before prefill is scheduled at all -- on a busy cluster an
-unschedulable pod, which reads as a capacity problem rather than a config one.
-Both halves are therefore emitted, and they differ:
+BOTH HALVES ARE EMITTED, and they differ:
 
   limits    generous. Headroom costs nothing unless it is used.
-  requests  modest and EXPLICIT. This is what the scheduler actually reserves.
+  requests  below the limit. This is what the scheduler actually reserves, and
+            reserving the full generous ceiling on every replica would make a
+            multi-replica pool unschedulable on a busy cluster.
+
+Emitting both rather than limits alone is deliberate. The framework default sets
+both, and a scenario is deep-merged over it, so emitting only `limits` would leave
+`requests` at the inherited 40Gi/"4" -- a decode pod would end up asking for 40Gi
+while permitted 128Gi. That pairing would be implicit and surprising; stating both
+keeps it visible in one place.
 
 WHERE THE NUMBERS COME FROM. The limits are the observed-working figures from
 llm-d's pd-disaggregation guide (config/scenarios/guides/pd-disaggregation.yaml:410-416
 decode, :321-327 prefill), which pd-infocomm-2's baseline also carries. Decode is
-sized above prefill there, matching the operator's constraint that decode needs
-more. Requests are half those limits -- a stated default, not a measurement.
+sized above prefill there, matching the operator's constraint. Requests are half
+those limits -- a stated default, not a measurement.
 
 NOTHING HERE IS MEASURED on any cluster but the one the figures came from, at one
-tensor-parallel degree and one model. That is deliberate: the operator chose fixed
-starting values over a derived formula, to be revised once there is data. The
-`warn` path exists to keep that visible in the emitted YAML rather than letting
-generous-looking numbers read as authoritative.
+tensor-parallel degree and one model. That is deliberate: fixed starting values were
+chosen over a derived formula, to be revised once there is data. `warn` keeps that
+visible in the emitted YAML rather than letting generous-looking numbers read as
+authoritative.
 
-Deliberately NOT scaled by GPU count. `tensor x dataLocal` was considered and
-rejected for now: it would reproduce one cluster's decode block at TP=4 while
-inventing every other cell of the table. Fixed values are wrong in a way an
-operator can see and correct; a formula is wrong in a way that looks principled.
+Values are emitted QUOTED, both memory and cpu. They are opaque Kubernetes quantity
+strings, and an unquoted one is re-typed by any YAML reader: `128` becomes an int,
+`yes` becomes True, `-` becomes a list item that will not parse at all.
 
-Indentation contract: emitted lines sit INSIDE a role block (`decode:` /
-`prefill:`) that the caller has already printed -- `resources:` at 4 spaces, its
-`limits:`/`requests:` at 6, their leaves at 8. Callers own blank-line separation.
+Indentation contract: emitted lines sit INSIDE a role block (`decode:` / `prefill:`)
+that the caller has already printed -- `resources:` at 4 spaces, `limits:`/
+`requests:` at 6, their leaves at 8. Callers own blank-line separation.
 """
 
-from typing import NamedTuple
+import re
 
 # The four quantities, in emission order within each of limits/requests.
 KEYS = ("cpu_limit", "memory_limit", "cpu_request", "memory_request")
 
 # Per-role fixed defaults. Limits verbatim from the upstream guide; requests half.
-# decode > prefill on every quantity -- the operator's constraint and upstream's
-# own sizing. CPU values are strings: the chart's other cpu values are quoted, and
-# a bare int is a different YAML type.
+# decode > prefill on every quantity -- the operator's constraint and upstream's own
+# sizing.
 DEFAULTS = {
     "decode": {
         "cpu_limit": "32",
@@ -65,235 +66,103 @@ DEFAULTS = {
     },
 }
 
-_DEFAULT_SOURCE = (
-    "sim2real-bootstrap default (generous, UNMEASURED; limits from llm-d "
-    "pd-disaggregation guide, requests half)"
-)
+STATED = "operator-stated"
+DEFAULTED = "sim2real-bootstrap default (UNMEASURED)"
+
+# Kubernetes' own quantity grammar (apimachinery/pkg/api/resource). Deliberately not
+# a parser -- just enough to reject what the cluster would reject at admission, so a
+# `TBD`, `N/A`, `32 cores` or `16 Gi` row fails here rather than on the cluster far
+# from the row that caused it.
+_QUANTITY_RE = re.compile(r"^[+-]?[0-9.]+(?:[eE][+-]?[0-9]+)?[EPTGMk]?i?m?$")
 
 
-class InputStyle(NamedTuple):
-    """How to describe this generator's input when citing or advising about it.
+def resolve_resources(role: str, stated: dict) -> "tuple[dict, dict]":
+    """Resolve one role's four quantities: the stated value, else the role default.
 
-    The two generators read different inputs -- `config.md` markdown rows and
-    `top3_selection.json`'s `vllm_args` -- and SKILL.md selects the JSON path
-    precisely when no config.md exists. Hardcoding "config.md row" here therefore
-    printed remediation naming a file that is not the input, and cited a source the
-    JSON path never had. Every other source comment `generate_scenarios.py` emits
-    uses its own "from vllm_args.X" convention; this keeps that consistent.
-    """
-
-    per_role_source: str
-    shared_source: str
-    remediation: str
-
-
-CONFIG_MD_INPUT = InputStyle(
-    per_role_source="config.md per-role row",
-    shared_source="config.md shared row",
-    remediation=(
-        "Add '{role} <cpu|memory> <limit|request>' rows to config.md to override"
-    ),
-)
-
-JSON_INPUT = InputStyle(
-    per_role_source="from vllm_args.{role}_<key>",
-    shared_source="from vllm_args.<key>",
-    remediation=(
-        "Set vllm_args.{role}_cpu_limit / _memory_limit (or the unprefixed "
-        "shared keys) in the input JSON to override"
-    ),
-)
-
-
-def resolve_resources(
-    role: str,
-    per_role: "dict[str, str | None]",
-    shared: "dict[str, str | None] | None" = None,
-    style: InputStyle = CONFIG_MD_INPUT,
-) -> "tuple[dict, dict]":
-    """Resolve one role's four quantities: per-role value, then shared, then default.
-
-    THE PRECEDENCE LIVES HERE, in the one module both generators import, rather
-    than at each call site. It was duplicated before, and the two copies diverged:
-    the JSON path used `vllm_args.get(f"{role}_{key}", vllm_args.get(key))`, which
-    returns None -- never consulting the shared key -- for a per-role key that is
-    PRESENT with a null or empty value. The config.md path had the same hole for a
-    row whose value cell is blank. Either way a stated shared value was silently
-    discarded in favour of the built-in default. One implementation cannot disagree
-    with itself.
-
-    "Empty" means absent, None, or whitespace-only, for both levels. A per-role key
-    present but blank is treated as unset -- the operator wrote a row and left it
-    empty, which is not an instruction to ignore the shared row they did fill in.
-
-    Values pass through as strings and are never parsed: `32`, `500m`, `1.5`,
-    `128Gi` and `1536Mi` are all valid Kubernetes quantities, and re-serializing
-    risks changing them.
+    `stated` maps each of KEYS to what the input declared, or None. Absent, None and
+    whitespace-only all count as unstated. Values pass through as strings and are
+    never parsed -- `32`, `500m`, `1.5`, `128Gi`, `1536Mi` are all valid Kubernetes
+    quantities and re-serializing risks changing them.
 
     Returns (values, provenance), both keyed by KEYS.
     """
-    shared = shared or {}
-    defaults = DEFAULTS[role]
-    values: dict = {}
-    provenance: dict = {}
-
-    def stated(source: dict, key: str) -> "str | None":
-        given = source.get(key)
-        if given is None:
-            return None
-        text = str(given).strip()
-        return text or None
-
+    values, provenance = {}, {}
     for key in KEYS:
-        role_value = stated(per_role, key)
-        shared_value = stated(shared, key)
-        if role_value is not None:
-            values[key] = role_value
-            provenance[key] = style.per_role_source.format(role=role)
-        elif shared_value is not None:
-            values[key] = shared_value
-            provenance[key] = style.shared_source.format(role=role)
+        given = stated.get(key)
+        text = "" if given is None else str(given).strip()
+        if text:
+            values[key], provenance[key] = text, STATED
         else:
-            values[key] = defaults[key]
-            provenance[key] = _DEFAULT_SOURCE
+            values[key], provenance[key] = DEFAULTS[role][key], DEFAULTED
     return values, provenance
 
 
-def used_any_default(provenance: dict) -> bool:
-    """True when at least one quantity fell back to a default.
+def invalid_quantities(values: dict) -> "list[str]":
+    """Stated values that are not valid Kubernetes quantities.
 
-    Drives both warnings: an input that states all four gets no warning, because
-    then the numbers are the operator's and saying they are unmeasured would be
-    both wrong and noise.
+    Only stated values can be invalid -- the defaults are known-good -- but this
+    checks all four so a bad default could never slip through either.
     """
-    return any(src == _DEFAULT_SOURCE for src in provenance.values())
+    return [
+        f"{key}={values[key]!r}"
+        for key in KEYS
+        if not _QUANTITY_RE.match(values[key])
+    ]
 
 
 def defaulted_keys(provenance: dict) -> "list[str]":
     """Which quantities fell back to a default, in KEYS order."""
-    return [k for k in KEYS if provenance.get(k) == _DEFAULT_SOURCE]
+    return [k for k in KEYS if provenance.get(k) == DEFAULTED]
 
 
-def starvation_warning(
-    role: str,
-    values: dict,
-    provenance: dict,
-    style: InputStyle = CONFIG_MD_INPUT,
-) -> str:
-    """The generation-time (stderr) warning, shared by both generators.
+def starvation_warning(role: str, values: dict, provenance: dict) -> str:
+    """Generation-time warning naming the quantities that defaulted, and their values.
 
-    Reports the ACTUAL emitted numbers for the quantities that defaulted, and
-    names only those. Printing the whole default table would contradict the
-    emitted YAML whenever the operator overrode part of it -- e.g. stating only
-    `decode cpu limit: 64` would still have announced "limits 32 CPU", which
-    reads as the override having been ignored.
+    Reports what was actually emitted. Printing the whole default table would
+    contradict the YAML whenever the operator overrode part of it. Names no input
+    file: both generators share this, and they read different inputs.
     """
     missing = defaulted_keys(provenance)
     shown = ", ".join(f"{k}={values[k]}" for k in missing)
     return (
-        f"  WARNING: {role} has no stated value for {len(missing)} of "
-        f"{len(KEYS)} CPU/memory quantities, so generous UNMEASURED defaults "
-        f"were emitted for them ({shown}). They are headroom, not a "
-        f"measurement. Watch the {role} logs for 'Reducing Torch parallelism "
-        f"from N threads to 1' -- that is CPU starvation, and it surfaces as ITL "
-        f"noise rather than a failure. "
-        + style.remediation.format(role=role)
-        + "."
+        f"  WARNING: {role} has no stated value for {len(missing)} of {len(KEYS)} "
+        f"CPU/memory quantities, so generous UNMEASURED defaults were emitted for "
+        f"them ({shown}). They are headroom, not a measurement. Watch the {role} "
+        f"logs for 'Reducing Torch parallelism from N threads to 1' -- that is CPU "
+        f"starvation, and it surfaces as ITL noise rather than a failure. State "
+        f"cpu/memory limit and request values in the bootstrap input to override."
     )
-
-
-def _quantity_exceeds(request: str, limit: str) -> bool:
-    """True when `request` provably exceeds `limit`.
-
-    Deliberately conservative. Kubernetes quantities carry suffixes (`500m`,
-    `1536Mi`, `2Gi`) whose comparison needs a real unit parser, which this module
-    does not have. So it compares only when both values share a form it can read
-    exactly -- bare numbers, or the same suffix -- and returns False otherwise.
-    A False here means "not proven", never "verified fine".
-    """
-    req, lim = request.strip(), limit.strip()
-    try:
-        return float(req) > float(lim)
-    except ValueError:
-        pass
-    for suffix in ("Gi", "Mi", "Ki", "G", "M", "K", "m"):
-        if req.endswith(suffix) and lim.endswith(suffix):
-            try:
-                return float(req[: -len(suffix)]) > float(lim[: -len(suffix)])
-            except ValueError:
-                return False
-    return False
-
-
-def request_exceeds_limit(values: dict) -> "list[str]":
-    """Quantities whose request provably exceeds its limit.
-
-    Kubernetes rejects such a pod at admission, and because each quantity is
-    resolved independently, a config.md stating only `decode cpu request: 40`
-    against the default limit of 32 produces exactly that -- failing on the
-    cluster, far from the row that caused it. Returns the offending pairs so the
-    generator can say so at generation time instead.
-    """
-    bad = []
-    for kind in ("cpu", "memory"):
-        req, lim = values[f"{kind}_request"], values[f"{kind}_limit"]
-        if _quantity_exceeds(req, lim):
-            bad.append(f"{kind}: request {req} > limit {lim}")
-    return bad
-
-
-# The emitted `# source` comment. Stated sources vary by input style, so they are
-# passed through as-is; only the long default string is shortened for the comment.
-_DEFAULT_COMMENT = "sim2real-bootstrap default (generous, UNMEASURED)"
 
 
 def resource_lines(values: dict, provenance: dict, *, warn: bool) -> "list[str]":
     """`resources` for one role block, as YAML lines.
 
-    Emitted inside a role block the caller has already printed.
-
-    Every value carries its own `# source` comment, the convention the rest of
-    this generator's output follows. That matters here because the four
-    quantities resolve independently: a header comment claiming the figures come
-    from the upstream guide would be false for whichever ones the operator
-    overrode, so the per-line sources are the only honest way to say which is
-    which.
-
-    `warn` adds the unmeasured-defaults preamble; pass False when every quantity
-    was stated, since then the numbers are the operator's.
+    Emitted inside a role block the caller has already printed. Each value carries
+    its own `# source` comment: the four resolve independently, so a single header
+    comment could not say which came from where. `warn` adds the unmeasured-defaults
+    preamble; pass False when every quantity was stated.
     """
-    lines: list[str] = []
+    lines = []
     if warn:
         lines += [
-            "    # Some or all of the figures below are GENEROUS DEFAULTS, NOT",
-            "    # measured -- see the per-value sources. The defaults' limits come",
-            "    # from llm-d's pd-disaggregation guide; their requests are half",
-            "    # that. Watch for 'Reducing Torch parallelism from N threads to 1'",
-            "    # in the pod log -- that is CPU starvation, and it shows up as ITL",
-            "    # noise rather than a failure.",
+            "    # Some or all of these are GENEROUS DEFAULTS, NOT measured -- see",
+            "    # the per-value sources. Defaults' limits come from llm-d's",
+            "    # pd-disaggregation guide; their requests are half that. Watch for",
+            "    # 'Reducing Torch parallelism from N threads to 1' in the pod log:",
+            "    # that is CPU starvation, and it shows up as ITL noise rather than",
+            "    # a failure.",
             "    #",
-            "    # requests are stated explicitly on purpose: omitting them does",
-            "    # NOT mean 'no reservation'. Kubernetes copies the limit into the",
-            "    # request when the request is absent, so limits-only would reserve",
-            "    # the whole generous figure on every replica.",
-            "    #",
-            "    # `resources` is a mapping, so a downstream baseline overriding",
-            "    # e.g. limits.cpu deep-merges key by key -- the requests below",
-            "    # survive. That differs from the scalar lists elsewhere in this",
-            "    # skill, which are replaced wholesale.",
+            "    # requests sit below limits so the scheduler reserves less than the",
+            "    # ceiling. Both halves are stated because the framework default",
+            "    # sets both, and emitting only limits would leave requests at the",
+            "    # inherited 40Gi/4.",
         ]
-
-    def src(key: str) -> str:
-        source = provenance.get(key, "unknown source")
-        return _DEFAULT_COMMENT if source == _DEFAULT_SOURCE else source
-
-    lines += [
-        "    resources:",
-        "      limits:",
-        f"        memory: {values['memory_limit']}  # {src('memory_limit')}",
-        f"        cpu: '{values['cpu_limit']}'  # {src('cpu_limit')}",
-        "      requests:",
-        f"        memory: {values['memory_request']}  # {src('memory_request')}",
-        f"        cpu: '{values['cpu_request']}'  # {src('cpu_request')}",
-    ]
+    lines.append("    resources:")
+    for section, mem_key, cpu_key in (
+        ("limits", "memory_limit", "cpu_limit"),
+        ("requests", "memory_request", "cpu_request"),
+    ):
+        lines.append(f"      {section}:")
+        lines.append(f"        memory: '{values[mem_key]}'  # {provenance[mem_key]}")
+        lines.append(f"        cpu: '{values[cpu_key]}'  # {provenance[cpu_key]}")
     return lines

--- a/.claude/skills/sim2real-bootstrap/pod_resources.py
+++ b/.claude/skills/sim2real-bootstrap/pod_resources.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""CPU/memory for the model-server pods (issue #850).
+
+Bootstrap emitted no `resources` at all, so every bundle inherited the framework
+default -- `limits: {memory: 40Gi, cpu: "4"}` with no `requests`
+(llm-d-benchmark@76473d0 config/templates/values/defaults.yaml:848-851 decode,
+:994-997 prefill). Four CPU for a pod that may hold four GPUs, sharing its cgroup
+with the routing sidecar that requests four more, starves vLLM. The signal is
+`Reducing Torch parallelism from N threads to 1`, which surfaces as ITL noise --
+so it corrupts the metric arms are compared on instead of failing loudly.
+
+THE limits/requests TRAP. `limits` without `requests` is not "no reservation":
+Kubernetes copies the limit into the request when the request is absent. So a
+decode block carrying `limits: {128Gi, 32}` and no `requests` reserves 128Gi and
+32 CPU per replica before prefill is scheduled at all -- on a busy cluster an
+unschedulable pod, which reads as a capacity problem rather than a config one.
+Both halves are therefore emitted, and they differ:
+
+  limits    generous. Headroom costs nothing unless it is used.
+  requests  modest and EXPLICIT. This is what the scheduler actually reserves.
+
+WHERE THE NUMBERS COME FROM. The limits are the observed-working figures from
+llm-d's pd-disaggregation guide (config/scenarios/guides/pd-disaggregation.yaml:410-416
+decode, :321-327 prefill), which pd-infocomm-2's baseline also carries. Decode is
+sized above prefill there, matching the operator's constraint that decode needs
+more. Requests are half those limits -- a stated default, not a measurement.
+
+NOTHING HERE IS MEASURED on any cluster but the one the figures came from, at one
+tensor-parallel degree and one model. That is deliberate: the operator chose fixed
+starting values over a derived formula, to be revised once there is data. The
+`warn` path exists to keep that visible in the emitted YAML rather than letting
+generous-looking numbers read as authoritative.
+
+Deliberately NOT scaled by GPU count. `tensor x dataLocal` was considered and
+rejected for now: it would reproduce one cluster's decode block at TP=4 while
+inventing every other cell of the table. Fixed values are wrong in a way an
+operator can see and correct; a formula is wrong in a way that looks principled.
+
+Indentation contract: emitted lines sit INSIDE a role block (`decode:` /
+`prefill:`) that the caller has already printed -- `resources:` at 4 spaces, its
+`limits:`/`requests:` at 6, their leaves at 8. Callers own blank-line separation.
+"""
+
+# The four quantities, in emission order within each of limits/requests.
+KEYS = ("cpu_limit", "memory_limit", "cpu_request", "memory_request")
+
+# Per-role fixed defaults. Limits verbatim from the upstream guide; requests half.
+# decode > prefill on every quantity -- the operator's constraint and upstream's
+# own sizing. CPU values are strings: the chart's other cpu values are quoted, and
+# a bare int is a different YAML type.
+DEFAULTS = {
+    "decode": {
+        "cpu_limit": "32",
+        "memory_limit": "128Gi",
+        "cpu_request": "16",
+        "memory_request": "64Gi",
+    },
+    "prefill": {
+        "cpu_limit": "8",
+        "memory_limit": "16Gi",
+        "cpu_request": "4",
+        "memory_request": "8Gi",
+    },
+}
+
+_DEFAULT_SOURCE = (
+    "sim2real-bootstrap default (generous, UNMEASURED; limits from llm-d "
+    "pd-disaggregation guide, requests half)"
+)
+_STATED_SOURCE = "config.md row"
+
+
+def resolve_resources(
+    role: str, stated: "dict[str, str | None]"
+) -> "tuple[dict, dict]":
+    """Resolve one role's four quantities, preferring stated values.
+
+    `stated` maps each of KEYS to the value the input declared, or None. Values
+    pass through as strings and are never parsed: `32`, `500m`, `1.5`, `128Gi` and
+    `1536Mi` are all valid Kubernetes quantities, and re-serializing risks
+    changing them.
+
+    Returns (values, provenance), both keyed by KEYS.
+    """
+    defaults = DEFAULTS[role]
+    values: dict = {}
+    provenance: dict = {}
+    for key in KEYS:
+        given = stated.get(key)
+        if given is not None and str(given).strip():
+            values[key] = str(given).strip()
+            provenance[key] = _STATED_SOURCE
+        else:
+            values[key] = defaults[key]
+            provenance[key] = _DEFAULT_SOURCE
+    return values, provenance
+
+
+def used_any_default(provenance: dict) -> bool:
+    """True when at least one quantity fell back to a default.
+
+    Drives both warnings: an input that states all four gets no warning, because
+    then the numbers are the operator's and saying they are unmeasured would be
+    both wrong and noise.
+    """
+    return any(src == _DEFAULT_SOURCE for src in provenance.values())
+
+
+def starvation_warning(role: str) -> str:
+    """The generation-time (stderr) warning text, shared by both generators."""
+    return (
+        f"  WARNING: no CPU/memory rows for {role}, so generous UNMEASURED "
+        f"defaults were emitted (limits "
+        f"{DEFAULTS[role]['cpu_limit']} CPU / {DEFAULTS[role]['memory_limit']}, "
+        f"requests {DEFAULTS[role]['cpu_request']} CPU / "
+        f"{DEFAULTS[role]['memory_request']}). They are headroom, not a "
+        f"measurement. Watch the {role} logs for 'Reducing Torch parallelism "
+        f"from N threads to 1' -- that is CPU starvation, and it surfaces as ITL "
+        f"noise rather than a failure. State '{role} cpu limit' and "
+        f"'{role} memory limit' rows in config.md to override."
+    )
+
+
+def resource_lines(values: dict, *, warn: bool) -> "list[str]":
+    """`resources` for one role block, as YAML lines.
+
+    Emitted inside a role block the caller has already printed. `warn` adds the
+    unmeasured-defaults comment; pass False when every quantity was stated.
+    """
+    lines: list[str] = []
+    if warn:
+        lines += [
+            "    # Generous headroom, NOT measured. Limits are the llm-d",
+            "    # pd-disaggregation guide's observed-working figures; requests are",
+            "    # half of them. Watch for 'Reducing Torch parallelism from N",
+            "    # threads to 1' in the pod log -- that is CPU starvation, and it",
+            "    # shows up as ITL noise rather than a failure.",
+            "    #",
+            "    # requests are stated explicitly on purpose: omitting them does",
+            "    # NOT mean 'no reservation'. Kubernetes copies the limit into the",
+            "    # request when the request is absent, so limits-only would reserve",
+            "    # the whole generous figure on every replica.",
+            "    #",
+            "    # `resources` is a mapping, so a downstream baseline overriding",
+            "    # e.g. limits.cpu deep-merges key by key -- the requests below",
+            "    # survive. That differs from the scalar lists elsewhere in this",
+            "    # skill, which are replaced wholesale.",
+        ]
+    lines += [
+        "    resources:",
+        "      limits:",
+        f"        memory: {values['memory_limit']}",
+        f"        cpu: '{values['cpu_limit']}'",
+        "      requests:",
+        f"        memory: {values['memory_request']}",
+        f"        cpu: '{values['cpu_request']}'",
+    ]
+    return lines

--- a/.claude/skills/sim2real-bootstrap/pod_resources.py
+++ b/.claude/skills/sim2real-bootstrap/pod_resources.py
@@ -75,6 +75,10 @@ DEFAULTS = {
 STATED = "operator-stated"
 DEFAULTED = "sim2real-bootstrap default (UNMEASURED)"
 DERIVED = "half the stated limit"
+# Prefill memory is matched to its limit rather than halved -- see the /dev/shm note
+# above. It needs its own label: calling it "half the stated limit" would be the same
+# false provenance an exponent-notation limit used to produce.
+MATCHED = "matched to the stated limit (Guaranteed QoS for /dev/shm)"
 CLAMPED = "clamped to this role's limit"
 
 # Kubernetes' quantity grammar (apimachinery/pkg/api/resource): a number with an
@@ -111,13 +115,30 @@ def _magnitude(quantity: str) -> "float | None":
     return None
 
 
-def _halve(quantity: str) -> str:
-    """Half a quantity, keeping its suffix. `128Gi` -> `64Gi`, `32` -> `16`."""
+def _halve(quantity: str) -> "str | None":
+    """Half a quantity, keeping its suffix. `128Gi` -> `64Gi`, `32` -> `16`.
+
+    Returns None when the value cannot be halved without reformatting it, which the
+    caller must treat as "cannot derive" rather than silently passing the original
+    through. Two cases:
+
+    * exponent notation (`4e1`). `_magnitude` accepts it via `_EXPONENT_RE`, which
+      this does not match -- so an earlier version returned `4e1` unchanged while
+      labelling it "half the stated limit", asserting in the emitted YAML a halving
+      that never happened and reserving the full limit.
+    * a value whose half would only render in exponent form (`10000000` -> `5e+06`).
+      `%g` switches notation above six significant digits, so the emitted string
+      would look nothing like what the operator wrote. Kubernetes would accept it,
+      but "values pass through without being reformatted" is a promise this module
+      makes and should keep.
+    """
     match = _SUFFIXED_RE.match(quantity.strip())
-    if not match:  # pragma: no cover - callers validate first
-        return quantity
+    if not match:
+        return None
     halved = float(match.group("num")) / 2
     number = f"{halved:g}"
+    if "e" in number or "E" in number:
+        return None
     return f"{number}{match.group('suffix') or ''}"
 
 
@@ -140,9 +161,13 @@ def resolve_resources(role: str, stated: dict) -> "tuple[dict, dict, list[str]]"
     shared input rows apply to both roles and a value sized for decode exceeds
     prefill's smaller limits.
 
-    Absent, None and whitespace-only all count as unstated. Values pass through as
-    strings and are never reformatted -- `32`, `500m`, `1.5`, `128Gi`, `1536Mi` are
-    all valid quantities and re-serializing risks changing them.
+    Absent, None and whitespace-only all count as unstated.
+
+    A STATED or DEFAULTED value passes through byte-for-byte -- `32`, `500m`, `1.5`,
+    `128Gi`, `1536Mi` are all valid quantities and re-serializing risks changing them.
+    A DERIVED one is computed, so it is the one path that produces a string neither
+    the operator nor the default table wrote; `_halve` declines rather than emit
+    anything in exponent notation, so the result still looks like its input.
 
     Returns (values, provenance, notices); notices describe any clamping, for the
     caller to print.
@@ -164,16 +189,35 @@ def resolve_resources(role: str, stated: dict) -> "tuple[dict, dict, list[str]]"
             provenance[limit_key] = DEFAULTED
 
         request = clean(request_key)
+        derived = None
+        if not request and limit and _magnitude(values[limit_key]) is not None:
+            # Derive from the stated limit: the role default request may not fit a
+            # limit the operator changed. Only from a readable quantity -- halving an
+            # invalid one would propagate it and make the error name two keys instead
+            # of the single bad row.
+            if role == "prefill" and kind == "memory":
+                # Guaranteed QoS, for the same reason DEFAULTS['prefill'] uses it:
+                # #848 mounts a 16Gi `medium: Memory` tmpfs at /dev/shm in
+                # vllmCommon, and tmpfs charges against pod memory. Halving a stated
+                # limit here would put the request below that ceiling -- e.g. a
+                # stated 24Gi limit deriving a 12Gi request -- reintroducing exactly
+                # the mid-run eviction risk this module argues against, silently.
+                derived = values[limit_key]
+            else:
+                derived = _halve(values[limit_key])
+
         if request:
             values[request_key], provenance[request_key] = request, STATED
-        elif limit and _magnitude(values[limit_key]) is not None:
-            # Half the stated limit: the role default request may not fit a limit the
-            # operator changed. Only when that limit is a readable quantity -- halving
-            # an invalid one would propagate it and make the error name two keys
-            # instead of the single bad row.
-            values[request_key] = _halve(values[limit_key])
-            provenance[request_key] = DERIVED
+        elif derived is not None:
+            values[request_key] = derived
+            provenance[request_key] = (
+                MATCHED if derived == values[limit_key] else DERIVED
+            )
         else:
+            # Either nothing was stated, or the limit could not be halved without
+            # reformatting it (see _halve). Falling back to the role default keeps
+            # the emitted value something the operator or the table actually wrote;
+            # the clamp below then reconciles it against the stated limit.
             values[request_key] = DEFAULTS[role][request_key]
             provenance[request_key] = DEFAULTED
 

--- a/.claude/skills/sim2real-bootstrap/tests/fixtures/single_pool_baseline.golden.yaml
+++ b/.claude/skills/sim2real-bootstrap/tests/fixtures/single_pool_baseline.golden.yaml
@@ -22,11 +22,12 @@ scenario:
       - "--max-num-batched-tokens=2048"  # config.md row "max_num_batched_tokens"
       - "--enable-chunked-prefill"  # config.md row "enable_chunked_prefill"
       - "--enable-prefix-caching"  # sim2real-bootstrap default (config.md silent; deployed vLLM requires explicit ON)
-    # Generous headroom, NOT measured. Limits are the llm-d
-    # pd-disaggregation guide's observed-working figures; requests are
-    # half of them. Watch for 'Reducing Torch parallelism from N
-    # threads to 1' in the pod log -- that is CPU starvation, and it
-    # shows up as ITL noise rather than a failure.
+    # Some or all of the figures below are GENEROUS DEFAULTS, NOT
+    # measured -- see the per-value sources. The defaults' limits come
+    # from llm-d's pd-disaggregation guide; their requests are half
+    # that. Watch for 'Reducing Torch parallelism from N threads to 1'
+    # in the pod log -- that is CPU starvation, and it shows up as ITL
+    # noise rather than a failure.
     #
     # requests are stated explicitly on purpose: omitting them does
     # NOT mean 'no reservation'. Kubernetes copies the limit into the
@@ -39,9 +40,9 @@ scenario:
     # skill, which are replaced wholesale.
     resources:
       limits:
-        memory: 128Gi
-        cpu: '32'
+        memory: 128Gi  # sim2real-bootstrap default (generous, UNMEASURED)
+        cpu: '32'  # sim2real-bootstrap default (generous, UNMEASURED)
       requests:
-        memory: 64Gi
-        cpu: '16'
+        memory: 64Gi  # sim2real-bootstrap default (generous, UNMEASURED)
+        cpu: '16'  # sim2real-bootstrap default (generous, UNMEASURED)
 

--- a/.claude/skills/sim2real-bootstrap/tests/fixtures/single_pool_baseline.golden.yaml
+++ b/.claude/skills/sim2real-bootstrap/tests/fixtures/single_pool_baseline.golden.yaml
@@ -22,4 +22,26 @@ scenario:
       - "--max-num-batched-tokens=2048"  # config.md row "max_num_batched_tokens"
       - "--enable-chunked-prefill"  # config.md row "enable_chunked_prefill"
       - "--enable-prefix-caching"  # sim2real-bootstrap default (config.md silent; deployed vLLM requires explicit ON)
+    # Generous headroom, NOT measured. Limits are the llm-d
+    # pd-disaggregation guide's observed-working figures; requests are
+    # half of them. Watch for 'Reducing Torch parallelism from N
+    # threads to 1' in the pod log -- that is CPU starvation, and it
+    # shows up as ITL noise rather than a failure.
+    #
+    # requests are stated explicitly on purpose: omitting them does
+    # NOT mean 'no reservation'. Kubernetes copies the limit into the
+    # request when the request is absent, so limits-only would reserve
+    # the whole generous figure on every replica.
+    #
+    # `resources` is a mapping, so a downstream baseline overriding
+    # e.g. limits.cpu deep-merges key by key -- the requests below
+    # survive. That differs from the scalar lists elsewhere in this
+    # skill, which are replaced wholesale.
+    resources:
+      limits:
+        memory: 128Gi
+        cpu: '32'
+      requests:
+        memory: 64Gi
+        cpu: '16'
 

--- a/.claude/skills/sim2real-bootstrap/tests/fixtures/single_pool_baseline.golden.yaml
+++ b/.claude/skills/sim2real-bootstrap/tests/fixtures/single_pool_baseline.golden.yaml
@@ -22,27 +22,22 @@ scenario:
       - "--max-num-batched-tokens=2048"  # config.md row "max_num_batched_tokens"
       - "--enable-chunked-prefill"  # config.md row "enable_chunked_prefill"
       - "--enable-prefix-caching"  # sim2real-bootstrap default (config.md silent; deployed vLLM requires explicit ON)
-    # Some or all of the figures below are GENEROUS DEFAULTS, NOT
-    # measured -- see the per-value sources. The defaults' limits come
-    # from llm-d's pd-disaggregation guide; their requests are half
-    # that. Watch for 'Reducing Torch parallelism from N threads to 1'
-    # in the pod log -- that is CPU starvation, and it shows up as ITL
-    # noise rather than a failure.
+    # Some or all of these are GENEROUS DEFAULTS, NOT measured -- see
+    # the per-value sources. Defaults' limits come from llm-d's
+    # pd-disaggregation guide; their requests are half that. Watch for
+    # 'Reducing Torch parallelism from N threads to 1' in the pod log:
+    # that is CPU starvation, and it shows up as ITL noise rather than
+    # a failure.
     #
-    # requests are stated explicitly on purpose: omitting them does
-    # NOT mean 'no reservation'. Kubernetes copies the limit into the
-    # request when the request is absent, so limits-only would reserve
-    # the whole generous figure on every replica.
-    #
-    # `resources` is a mapping, so a downstream baseline overriding
-    # e.g. limits.cpu deep-merges key by key -- the requests below
-    # survive. That differs from the scalar lists elsewhere in this
-    # skill, which are replaced wholesale.
+    # requests sit below limits so the scheduler reserves less than the
+    # ceiling. Both halves are stated because the framework default
+    # sets both, and emitting only limits would leave requests at the
+    # inherited 40Gi/4.
     resources:
       limits:
-        memory: 128Gi  # sim2real-bootstrap default (generous, UNMEASURED)
-        cpu: '32'  # sim2real-bootstrap default (generous, UNMEASURED)
+        memory: '128Gi'  # sim2real-bootstrap default (UNMEASURED)
+        cpu: '32'  # sim2real-bootstrap default (UNMEASURED)
       requests:
-        memory: 64Gi  # sim2real-bootstrap default (generous, UNMEASURED)
-        cpu: '16'  # sim2real-bootstrap default (generous, UNMEASURED)
+        memory: '64Gi'  # sim2real-bootstrap default (UNMEASURED)
+        cpu: '16'  # sim2real-bootstrap default (UNMEASURED)
 

--- a/.claude/skills/sim2real-bootstrap/tests/fixtures/single_pool_baseline.golden.yaml
+++ b/.claude/skills/sim2real-bootstrap/tests/fixtures/single_pool_baseline.golden.yaml
@@ -24,15 +24,14 @@ scenario:
       - "--enable-prefix-caching"  # sim2real-bootstrap default (config.md silent; deployed vLLM requires explicit ON)
     # Some or all of these are GENEROUS DEFAULTS, NOT measured -- see
     # the per-value sources. Defaults' limits come from llm-d's
-    # pd-disaggregation guide; their requests are half that. Watch for
-    # 'Reducing Torch parallelism from N threads to 1' in the pod log:
-    # that is CPU starvation, and it shows up as ITL noise rather than
-    # a failure.
+    # pd-disaggregation guide. Watch for 'Reducing Torch parallelism
+    # from N threads to 1' in the pod log: that is CPU starvation, and
+    # it shows up as ITL noise rather than a failure.
     #
-    # requests sit below limits so the scheduler reserves less than the
-    # ceiling. Both halves are stated because the framework default
-    # sets both, and emitting only limits would leave requests at the
-    # inherited 40Gi/4.
+    # requests never exceed limits -- Kubernetes rejects such a pod.
+    # Both halves are stated because the framework default sets both,
+    # so emitting only limits would leave requests at the inherited
+    # 40Gi/4.
     resources:
       limits:
         memory: '128Gi'  # sim2real-bootstrap default (UNMEASURED)

--- a/.claude/skills/sim2real-bootstrap/tests/test_generate_from_config_prefill.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_generate_from_config_prefill.py
@@ -881,7 +881,9 @@ def test_resources_emitted_with_role_defaults(tmp_path):
     assert _res(parsed, "decode")["limits"] == {"memory": "128Gi", "cpu": "32"}
     assert _res(parsed, "decode")["requests"] == {"memory": "64Gi", "cpu": "16"}
     assert _res(parsed, "prefill")["limits"] == {"memory": "16Gi", "cpu": "8"}
-    assert _res(parsed, "prefill")["requests"] == {"memory": "8Gi", "cpu": "4"}
+    # prefill's request EQUALS its limit (Guaranteed QoS), because #848 mounts a
+    # 16Gi tmpfs at /dev/shm in vllmCommon and tmpfs charges against pod memory.
+    assert _res(parsed, "prefill")["requests"] == {"memory": "16Gi", "cpu": "8"}
 
 
 def test_no_prefill_pool_emits_resources_for_decode_only(tmp_path):
@@ -907,9 +909,10 @@ def test_stated_row_applies_to_both_roles(tmp_path):
     "label", ["cpu limit", "cpu_limit", "cpu limits"]
 )
 def test_each_declared_alias_spelling_resolves(label, tmp_path):
-    """Every spelling PARAMETER_ALIASES declares must actually reach the resolver.
-    Deleting an alias would otherwise revert a stated row to a generous default with
-    no error at all."""
+    """A declared spelling must actually reach the resolver -- deleting an alias would
+    otherwise revert a stated row to a generous default with no error. Covers
+    cpu_limit's three spellings; the other three keys follow the same pattern in
+    PARAMETER_ALIASES and are covered by test_every_resource_field_is_declared."""
     scenario, prov = build([row(label, "64")])
     parsed = yaml.safe_load(emit(scenario, prov, tmp_path))["scenario"][0]
     assert _res(parsed, "decode")["limits"]["cpu"] == "64"
@@ -918,8 +921,11 @@ def test_each_declared_alias_spelling_resolves(label, tmp_path):
 @pytest.mark.parametrize("key", ["cpu_limit", "memory_limit",
                                  "cpu_request", "memory_request"])
 def test_every_resource_field_is_declared_and_string_valued(key):
-    """A resource field handed to parse_numeric would lose its unit: `parse_numeric`
-    takes only the first whitespace token."""
+    """A resource field handed to parse_numeric loses its unit whenever the value
+    contains whitespace: parse_numeric takes only the first token, so `16 Gi` becomes
+    `16`. Unspaced quantities like `128Gi` survive by accident -- int()/float() fail on
+    them, so the None fallback returns the whole string. The accident is the reason to
+    be explicit here rather than rely on it."""
     assert key in gfc.PARAMETER_ALIASES
     assert key in gfc._STRING_VALUED_FIELDS
 
@@ -1044,3 +1050,100 @@ def test_resources_parse_in_every_row_combination(tmp_path):
         scenario, prov = build(extra)
         parsed = yaml.safe_load(emit(scenario, prov, tmp_path / f"r{i}"))
         assert "resources" in parsed["scenario"][0]["decode"]
+
+
+# --- pair reconciliation end-to-end (review must_fix) ----------------------
+
+def test_shared_request_row_clamps_prefill_not_decode(tmp_path, capsys):
+    """A `cpu request: 20` row is sensible for decode (limit 32) and impossible for
+    prefill (limit 8), and one row feeds both roles. This used to emit
+    requests {96Gi, 20} against limits {16Gi, 8} for prefill -- a pod Kubernetes
+    rejects at admission -- under a comment claiming requests sit below limits."""
+    scenario, prov = build(
+        [
+            row("Number of prefill pods", "1"),
+            row("cpu request", "20"),
+            row("memory request", "96Gi"),
+        ]
+    )
+    parsed = yaml.safe_load(emit(scenario, prov, tmp_path))["scenario"][0]
+    assert _res(parsed, "decode")["requests"] == {"memory": "96Gi", "cpu": "20"}
+    assert _res(parsed, "prefill")["requests"] == {"memory": "16Gi", "cpu": "8"}
+    assert _res(parsed, "prefill")["requests"] == _res(parsed, "prefill")["limits"]
+    err = capsys.readouterr().err
+    assert "exceeds its limit" in err
+    assert "prefill" in err
+
+
+def test_smaller_stated_limit_derives_a_fitting_request(tmp_path):
+    """Stating only limits used to leave the larger default requests in place:
+    limits {8, 32Gi} with requests {16, 64Gi}."""
+    scenario, prov = build([row("cpu limit", "8"), row("memory limit", "32Gi")])
+    parsed = yaml.safe_load(emit(scenario, prov, tmp_path))["scenario"][0]
+    assert _res(parsed, "decode")["limits"] == {"memory": "32Gi", "cpu": "8"}
+    assert _res(parsed, "decode")["requests"] == {"memory": "16Gi", "cpu": "4"}
+
+
+@pytest.mark.parametrize(
+    "rows",
+    [
+        [row("cpu request", "999"), row("memory request", "999Gi")],
+        [row("cpu limit", "1"), row("memory limit", "1Gi")],
+        [row("cpu limit", "1"), row("cpu request", "64")],
+        [row("memory limit", "2Gi"), row("memory request", "128Gi")],
+    ],
+)
+def test_no_config_md_input_emits_a_request_above_its_limit(rows, tmp_path):
+    """The invariant, through the generator, over inputs that previously inverted."""
+    import pod_resources as pres
+
+    scenario, prov = build([row("Number of prefill pods", "1")] + rows)
+    parsed = yaml.safe_load(emit(scenario, prov, tmp_path))["scenario"][0]
+    for role in ("decode", "prefill"):
+        res = _res(parsed, role)
+        for field in ("cpu", "memory"):
+            req = pres._magnitude(res["requests"][field])
+            lim = pres._magnitude(res["limits"][field])
+            assert req <= lim, f"{role} {field}: {res}"
+
+
+def test_binary_kilo_quantity_is_accepted(tmp_path):
+    """`Ki` is valid Kubernetes and the unit `kubectl describe node` reports memory
+    in. The validator used to hard-reject it while accepting `1ki`."""
+    scenario, prov = build(
+        [row("memory limit", "134217728Ki"), row("memory request", "67108864Ki")]
+    )
+    parsed = yaml.safe_load(emit(scenario, prov, tmp_path))["scenario"][0]
+    assert _res(parsed, "decode")["limits"]["memory"] == "134217728Ki"
+    assert _res(parsed, "decode")["requests"]["memory"] == "67108864Ki"
+
+
+# --- rows stated where they cannot take effect ----------------------------
+
+def test_resource_rows_in_another_table_are_reported(capsys):
+    """warn_role_rows_outside_vllm_table exists because a #824 review found a role
+    row in a mapping table producing a wrong baseline with no diagnostic. Its
+    role_fields set did not include the #850 keys, so a `cpu limit` row in any other
+    table was dropped and the defaults warning then asserted nothing was stated."""
+    md = "\n".join([
+        "## Pod Resource Sizing",
+        "",
+        "| Parameter | Value |",
+        "|---|---|",
+        "| cpu limit | 64 |",
+        "| memory limit | 256Gi |",
+        "",
+        "## vLLM Pod Configuration",
+        "",
+        "| Parameter | Value | Notes |",
+        "|---|---|---|",
+        "| Model | Qwen/Qwen3-14B | |",
+        "| GPU | H100_SXM_80GB | |",
+        "",
+    ])
+    tables = gfc.parse_md_tables(md.split("\n"))
+    vllm_table = gfc.find_vllm_table(tables)
+    gfc.warn_role_rows_outside_vllm_table(tables, vllm_table)
+    err = capsys.readouterr().err
+    assert "cpu limit" in err
+    assert "not the machine-read table" in err or "NO effect" in err

--- a/.claude/skills/sim2real-bootstrap/tests/test_generate_from_config_prefill.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_generate_from_config_prefill.py
@@ -857,33 +857,31 @@ def test_emitted_plumbing_is_valid_yaml_in_every_gate_combination(tmp_path):
         assert parsed["scenario"][0]["name"] == "test"
 
 
+
+
 # ---------------------------------------------------------------------------
 # Pod CPU/memory resources (issue #850)
 # ---------------------------------------------------------------------------
-# Bootstrap emitted no `resources`, so bundles inherited 4 CPU / 40Gi for a pod
-# that may hold four GPUs. Assertions are on emitted TEXT: the emitter is a
-# hand-rolled line appender, so a key in the scenario dict proves nothing.
+# Bootstrap emitted none, so bundles inherited 40Gi / 4 CPU for a pod that may hold
+# four GPUs. Four keys, applied to both roles; no per-role rows (an operator who
+# needs the roles to differ edits baselines/baseline.yaml, as for anything else the
+# generator does not model).
+#
+# Assertions are on emitted TEXT: the emitter is a hand-rolled line appender, so a
+# key in the scenario dict proves nothing about the output.
 
 
 def _res(parsed, role):
     return parsed[role]["resources"]
 
 
-def test_resources_emitted_for_decode_with_role_defaults(tmp_path):
-    scenario, prov = build([])
+def test_resources_emitted_with_role_defaults(tmp_path):
+    scenario, prov = build([row("Number of prefill pods", "1")])
     parsed = yaml.safe_load(emit(scenario, prov, tmp_path))["scenario"][0]
     assert _res(parsed, "decode")["limits"] == {"memory": "128Gi", "cpu": "32"}
     assert _res(parsed, "decode")["requests"] == {"memory": "64Gi", "cpu": "16"}
-
-
-def test_each_role_gets_its_own_defaults(tmp_path):
-    """decode must be sized above prefill -- upstream's sizing and the operator's
-    stated constraint."""
-    scenario, prov = build([row("Number of prefill pods", "1")])
-    parsed = yaml.safe_load(emit(scenario, prov, tmp_path))["scenario"][0]
-    assert _res(parsed, "decode")["limits"]["cpu"] == "32"
-    assert _res(parsed, "prefill")["limits"]["cpu"] == "8"
-    assert _res(parsed, "prefill")["limits"]["memory"] == "16Gi"
+    assert _res(parsed, "prefill")["limits"] == {"memory": "16Gi", "cpu": "8"}
+    assert _res(parsed, "prefill")["requests"] == {"memory": "8Gi", "cpu": "4"}
 
 
 def test_no_prefill_pool_emits_resources_for_decode_only(tmp_path):
@@ -893,42 +891,87 @@ def test_no_prefill_pool_emits_resources_for_decode_only(tmp_path):
     assert "prefill" not in parsed
 
 
-def test_shared_row_applies_to_both_roles(tmp_path):
+def test_stated_row_applies_to_both_roles(tmp_path):
     scenario, prov = build(
         [row("Number of prefill pods", "1"), row("cpu limit", "64")]
     )
     parsed = yaml.safe_load(emit(scenario, prov, tmp_path))["scenario"][0]
     assert _res(parsed, "decode")["limits"]["cpu"] == "64"
     assert _res(parsed, "prefill")["limits"]["cpu"] == "64"
-    # the three unstated quantities still take their per-role defaults
+    # the three unstated quantities keep their per-role defaults
     assert _res(parsed, "decode")["limits"]["memory"] == "128Gi"
     assert _res(parsed, "prefill")["limits"]["memory"] == "16Gi"
 
 
-def test_per_role_row_overrides_only_that_role(tmp_path):
-    scenario, prov = build(
-        [row("Number of prefill pods", "1"), row("decode cpu limit", "64")]
-    )
+@pytest.mark.parametrize(
+    "label", ["cpu limit", "cpu_limit", "cpu limits"]
+)
+def test_each_declared_alias_spelling_resolves(label, tmp_path):
+    """Every spelling PARAMETER_ALIASES declares must actually reach the resolver.
+    Deleting an alias would otherwise revert a stated row to a generous default with
+    no error at all."""
+    scenario, prov = build([row(label, "64")])
     parsed = yaml.safe_load(emit(scenario, prov, tmp_path))["scenario"][0]
     assert _res(parsed, "decode")["limits"]["cpu"] == "64"
-    assert _res(parsed, "prefill")["limits"]["cpu"] == "8"
 
 
-def test_per_role_row_beats_shared_row(tmp_path):
-    """Mirrors `Decode GPU` beating the shared `GPU` row."""
-    scenario, prov = build(
-        [
-            row("Number of prefill pods", "1"),
-            row("cpu limit", "64"),
-            row("decode cpu limit", "96"),
-        ]
-    )
+@pytest.mark.parametrize("key", ["cpu_limit", "memory_limit",
+                                 "cpu_request", "memory_request"])
+def test_every_resource_field_is_declared_and_string_valued(key):
+    """A resource field handed to parse_numeric would lose its unit: `parse_numeric`
+    takes only the first whitespace token."""
+    assert key in gfc.PARAMETER_ALIASES
+    assert key in gfc._STRING_VALUED_FIELDS
+
+
+@pytest.mark.parametrize(
+    "stated,emitted",
+    [("128Gi", "128Gi"), ("1536Mi", "1536Mi"), ("2Ti", "2Ti"), ("512M", "512M")]
+)
+def test_memory_quantity_keeps_its_unit(stated, emitted, tmp_path):
+    scenario, prov = build([row("memory limit", stated)])
     parsed = yaml.safe_load(emit(scenario, prov, tmp_path))["scenario"][0]
-    assert _res(parsed, "decode")["limits"]["cpu"] == "96"
-    assert _res(parsed, "prefill")["limits"]["cpu"] == "64"
+    assert _res(parsed, "decode")["limits"]["memory"] == emitted
 
 
-def test_all_four_stated_suppresses_the_warning_comment(tmp_path):
+@pytest.mark.parametrize("stated", ["500m", "1.50", "1.5", "32", "0.5"])
+def test_cpu_quantity_passes_through_verbatim(stated, tmp_path):
+    """`1.50` must not become `1.5`: it is an opaque string the chart forwards to
+    Kubernetes, not a number to normalize."""
+    scenario, prov = build([row("cpu limit", stated)])
+    parsed = yaml.safe_load(emit(scenario, prov, tmp_path))["scenario"][0]
+    assert _res(parsed, "decode")["limits"]["cpu"] == stated
+
+
+@pytest.mark.parametrize("hostile", ["128", "0.5"])
+def test_yaml_hostile_values_stay_strings(hostile, tmp_path):
+    """Valid quantities that a YAML reader re-types when unquoted: `128` to an int,
+    `0.5` to a float. memory used to be emitted unquoted while cpu was quoted, which
+    is how these lost their string-ness.
+
+    Values that are BOTH YAML-hostile and invalid quantities (`yes`, `null`, `~`,
+    `-`) never reach the emitter now — the validator rejects them first, which is
+    covered by test_invalid_quantity_is_a_hard_error below.
+    """
+    scenario, prov = build([row("memory limit", hostile)])
+    parsed = yaml.safe_load(emit(scenario, prov, tmp_path))["scenario"][0]
+    assert _res(parsed, "decode")["limits"]["memory"] == hostile
+
+
+@pytest.mark.parametrize(
+    "bad", ["-", "TBD", "N/A", "16 Gi", "32 cores", "yes", "null", "~", "128GB"])
+def test_invalid_quantity_is_a_hard_error(bad, capsys):
+    """A quantity the cluster rejects at admission must fail here instead. `-` is the
+    conventional markdown placeholder and used to produce an unparseable YAML file
+    under a zero exit code."""
+    with pytest.raises(SystemExit) as exc:
+        build([row("memory limit", bad)])
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "not a valid" in err or "invalid Kubernetes quantities" in err
+
+
+def test_all_four_stated_suppresses_the_warning(tmp_path, capsys):
     scenario, prov = build(
         [
             row("cpu limit", "64"),
@@ -939,43 +982,55 @@ def test_all_four_stated_suppresses_the_warning_comment(tmp_path):
     )
     text = emit(scenario, prov, tmp_path)
     assert "Reducing Torch parallelism" not in text
+    assert "Reducing Torch parallelism" not in capsys.readouterr().err
     parsed = yaml.safe_load(text)["scenario"][0]
     assert _res(parsed, "decode")["limits"] == {"memory": "200Gi", "cpu": "64"}
     assert _res(parsed, "decode")["requests"] == {"memory": "32Gi", "cpu": "8"}
 
 
-def test_any_default_keeps_the_warning_comment(tmp_path):
+def test_any_default_keeps_the_warning(tmp_path, capsys):
     scenario, prov = build([row("cpu limit", "64")])
     assert "Reducing Torch parallelism" in emit(scenario, prov, tmp_path)
-
-
-def test_stderr_warning_when_defaults_used(capsys):
-    build([row("Number of prefill pods", "1")])
     err = capsys.readouterr().err
     assert "Reducing Torch parallelism" in err
-    assert "decode" in err and "prefill" in err
+    assert "cpu_limit" not in err, "warning names a quantity the operator stated"
 
 
-def test_no_stderr_warning_when_all_four_stated(capsys):
-    build(
+def test_prefill_warn_suppression_is_independent_of_decode(tmp_path):
+    """Both roles gate the preamble separately. Only decode's half was pinned
+    before, so forcing prefill's on above stated values went unnoticed."""
+    scenario, prov = build(
         [
+            row("Number of prefill pods", "1"),
             row("cpu limit", "64"),
             row("memory limit", "200Gi"),
             row("cpu request", "8"),
             row("memory request", "32Gi"),
         ]
     )
-    assert "Reducing Torch parallelism" not in capsys.readouterr().err
+    text = emit(scenario, prov, tmp_path)
+    prefill_block = text[text.index("  prefill:"):]
+    assert "GENEROUS DEFAULTS" not in prefill_block
 
 
-def test_kubernetes_quantity_forms_pass_through(tmp_path):
-    """500m and Mi units must survive verbatim, not be re-serialized."""
-    scenario, prov = build(
-        [row("cpu request", "500m"), row("memory request", "1536Mi")]
+def test_emitted_values_carry_per_value_sources(tmp_path):
+    scenario, prov = build([row("cpu limit", "64")])
+    text = emit(scenario, prov, tmp_path)
+    cpu = next(ln for ln in text.splitlines() if "cpu: '64'" in ln)
+    mem = next(ln for ln in text.splitlines() if "memory: '128Gi'" in ln)
+    assert "operator-stated" in cpu
+    assert "UNMEASURED" in mem
+
+
+def test_source_comments_name_no_input_file(tmp_path):
+    """Both generators share pod_resources and read different inputs."""
+    scenario, prov = build([row("cpu limit", "64")])
+    resources_text = "\n".join(
+        ln for ln in emit(scenario, prov, tmp_path).splitlines()
+        if "operator-stated" in ln or "UNMEASURED" in ln
     )
-    parsed = yaml.safe_load(emit(scenario, prov, tmp_path))["scenario"][0]
-    assert _res(parsed, "decode")["requests"] == {
-        "memory": "1536Mi", "cpu": "500m"}
+    assert "vllm_args" not in resources_text
+    assert "{" not in resources_text
 
 
 def test_resources_parse_in_every_row_combination(tmp_path):
@@ -983,75 +1038,9 @@ def test_resources_parse_in_every_row_combination(tmp_path):
         [],
         [row("Number of prefill pods", "2")],
         [row("cpu limit", "64"), row("Number of prefill pods", "2")],
-        [row("prefill memory limit", "64Gi"), row("Number of prefill pods", "2")],
+        [row("memory request", "20Gi"), row("Number of prefill pods", "2")],
     ]
     for i, extra in enumerate(combos):
         scenario, prov = build(extra)
         parsed = yaml.safe_load(emit(scenario, prov, tmp_path / f"r{i}"))
         assert "resources" in parsed["scenario"][0]["decode"]
-
-
-# ---------------------------------------------------------------------------
-# Review findings from PR #857
-# ---------------------------------------------------------------------------
-
-@pytest.mark.parametrize(
-    "stated,expected",
-    [
-        # The defect: parse_numeric takes only the first whitespace token, so
-        # `16 Gi` became `16` -- sixteen BYTES -- with no warning, because the
-        # field counted as stated. The forms the original tests used (500m,
-        # 1536Mi) passed only because int() happens to fail on them.
-        ("16 Gi", "16 Gi"),
-        ("128Gi", "128Gi"),
-        ("1536Mi", "1536Mi"),
-        ("2 Ti", "2 Ti"),
-    ],
-)
-def test_memory_quantity_keeps_its_unit(stated, expected, tmp_path):
-    scenario, prov = build([row("decode memory limit", stated)])
-    parsed = yaml.safe_load(emit(scenario, prov, tmp_path))["scenario"][0]
-    assert parsed["decode"]["resources"]["limits"]["memory"] == expected
-
-
-@pytest.mark.parametrize("stated", ["500m", "1.50", "1.5", "32", "500 m"])
-def test_cpu_quantity_passes_through_verbatim(stated, tmp_path):
-    """`1.50` must not become `1.5`: it is a string the chart forwards to
-    Kubernetes, not a number to normalize."""
-    scenario, prov = build([row("decode cpu limit", stated)])
-    parsed = yaml.safe_load(emit(scenario, prov, tmp_path))["scenario"][0]
-    assert parsed["decode"]["resources"]["limits"]["cpu"] == stated
-
-
-def test_every_resource_field_is_string_valued():
-    """Guards the derivation rather than the instance: a future `*_limit` or
-    `*_request` alias must join _STRING_VALUED_FIELDS automatically."""
-    resource_fields = {
-        name for name in gfc.PARAMETER_ALIASES
-        if name.endswith(("_limit", "_request"))
-    }
-    assert resource_fields, "no resource aliases found — did the naming change?"
-    assert resource_fields <= gfc._STRING_VALUED_FIELDS
-
-
-def test_stderr_warning_reports_the_value_actually_emitted(capsys):
-    """Stating one quantity used to still announce the full default table, so the
-    operator saw 'limits 32 CPU' next to an emitted 64."""
-    build([row("decode cpu limit", "64")])
-    err = capsys.readouterr().err
-    assert "cpu_limit" not in err
-    assert "memory_limit=128Gi" in err
-
-
-def test_request_exceeding_limit_warns_at_generation_time(capsys):
-    build([row("decode cpu request", "40")])
-    err = capsys.readouterr().err
-    assert "request 40 > limit 32" in err
-    assert "admission" in err
-
-
-def test_emitted_values_carry_per_value_sources(tmp_path):
-    scenario, prov = build([row("decode cpu limit", "64")])
-    text = emit(scenario, prov, tmp_path)
-    cpu = next(ln for ln in text.splitlines() if "cpu: '64'" in ln)
-    assert "config.md" in cpu

--- a/.claude/skills/sim2real-bootstrap/tests/test_generate_from_config_prefill.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_generate_from_config_prefill.py
@@ -180,8 +180,12 @@ def test_multi_gpu_cell_warns_and_uses_first(cell, capsys):
 
 
 def test_single_gpu_cell_does_not_warn(capsys):
+    """Asserts on the multi-type GPU warning specifically, not on the presence of
+    any warning at all: generation legitimately emits unrelated warnings (e.g. the
+    unmeasured pod-resources default of #850), and a blanket `"WARNING" not in`
+    check turns every new one into a spurious failure here."""
     build([row("Number of pods", "2")])
-    assert "WARNING" not in capsys.readouterr().err
+    assert "GPU types" not in capsys.readouterr().err
 
 
 def test_multi_gpu_warning_is_per_role(capsys):
@@ -454,6 +458,24 @@ def test_single_pool_golden_has_no_prefill_artifacts():
     that emits prefill unconditionally, this fails rather than blessing it."""
     golden = (FIXTURES / "single_pool_baseline.golden.yaml").read_text()
     assert "prefill:" not in golden
+
+
+def test_single_pool_golden_carries_pod_resources():
+    """The other direction of the same guard (issue #850).
+
+    The golden was regenerated when resources emission landed — a pure addition of
+    22 lines with nothing removed. If a future version stops emitting `resources`
+    and someone regenerates the golden to match, the byte-identity test above would
+    happily bless the regression. This makes that fail instead.
+    """
+    golden = (FIXTURES / "single_pool_baseline.golden.yaml").read_text()
+    parsed = yaml.safe_load(golden)["scenario"][0]
+    resources = parsed["decode"]["resources"]
+    assert set(resources) == {"limits", "requests"}, (
+        "the golden lost its requests block — limits-only means Kubernetes "
+        "reserves the whole generous limit (#850)"
+    )
+    assert resources["limits"]["cpu"] == "32"
     assert "labelValues" not in golden
 
 
@@ -826,3 +848,137 @@ def test_emitted_plumbing_is_valid_yaml_in_every_gate_combination(tmp_path):
         scenario, prov = build(extra)
         parsed = yaml.safe_load(emit(scenario, prov, tmp_path / f"c{i}"))
         assert parsed["scenario"][0]["name"] == "test"
+
+
+# ---------------------------------------------------------------------------
+# Pod CPU/memory resources (issue #850)
+# ---------------------------------------------------------------------------
+# Bootstrap emitted no `resources`, so bundles inherited 4 CPU / 40Gi for a pod
+# that may hold four GPUs. Assertions are on emitted TEXT: the emitter is a
+# hand-rolled line appender, so a key in the scenario dict proves nothing.
+
+
+def _res(parsed, role):
+    return parsed[role]["resources"]
+
+
+def test_resources_emitted_for_decode_with_role_defaults(tmp_path):
+    scenario, prov = build([])
+    parsed = yaml.safe_load(emit(scenario, prov, tmp_path))["scenario"][0]
+    assert _res(parsed, "decode")["limits"] == {"memory": "128Gi", "cpu": "32"}
+    assert _res(parsed, "decode")["requests"] == {"memory": "64Gi", "cpu": "16"}
+
+
+def test_each_role_gets_its_own_defaults(tmp_path):
+    """decode must be sized above prefill -- upstream's sizing and the operator's
+    stated constraint."""
+    scenario, prov = build([row("Number of prefill pods", "1")])
+    parsed = yaml.safe_load(emit(scenario, prov, tmp_path))["scenario"][0]
+    assert _res(parsed, "decode")["limits"]["cpu"] == "32"
+    assert _res(parsed, "prefill")["limits"]["cpu"] == "8"
+    assert _res(parsed, "prefill")["limits"]["memory"] == "16Gi"
+
+
+def test_no_prefill_pool_emits_resources_for_decode_only(tmp_path):
+    scenario, prov = build([])
+    parsed = yaml.safe_load(emit(scenario, prov, tmp_path))["scenario"][0]
+    assert "resources" in parsed["decode"]
+    assert "prefill" not in parsed
+
+
+def test_shared_row_applies_to_both_roles(tmp_path):
+    scenario, prov = build(
+        [row("Number of prefill pods", "1"), row("cpu limit", "64")]
+    )
+    parsed = yaml.safe_load(emit(scenario, prov, tmp_path))["scenario"][0]
+    assert _res(parsed, "decode")["limits"]["cpu"] == "64"
+    assert _res(parsed, "prefill")["limits"]["cpu"] == "64"
+    # the three unstated quantities still take their per-role defaults
+    assert _res(parsed, "decode")["limits"]["memory"] == "128Gi"
+    assert _res(parsed, "prefill")["limits"]["memory"] == "16Gi"
+
+
+def test_per_role_row_overrides_only_that_role(tmp_path):
+    scenario, prov = build(
+        [row("Number of prefill pods", "1"), row("decode cpu limit", "64")]
+    )
+    parsed = yaml.safe_load(emit(scenario, prov, tmp_path))["scenario"][0]
+    assert _res(parsed, "decode")["limits"]["cpu"] == "64"
+    assert _res(parsed, "prefill")["limits"]["cpu"] == "8"
+
+
+def test_per_role_row_beats_shared_row(tmp_path):
+    """Mirrors `Decode GPU` beating the shared `GPU` row."""
+    scenario, prov = build(
+        [
+            row("Number of prefill pods", "1"),
+            row("cpu limit", "64"),
+            row("decode cpu limit", "96"),
+        ]
+    )
+    parsed = yaml.safe_load(emit(scenario, prov, tmp_path))["scenario"][0]
+    assert _res(parsed, "decode")["limits"]["cpu"] == "96"
+    assert _res(parsed, "prefill")["limits"]["cpu"] == "64"
+
+
+def test_all_four_stated_suppresses_the_warning_comment(tmp_path):
+    scenario, prov = build(
+        [
+            row("cpu limit", "64"),
+            row("memory limit", "200Gi"),
+            row("cpu request", "8"),
+            row("memory request", "32Gi"),
+        ]
+    )
+    text = emit(scenario, prov, tmp_path)
+    assert "Reducing Torch parallelism" not in text
+    parsed = yaml.safe_load(text)["scenario"][0]
+    assert _res(parsed, "decode")["limits"] == {"memory": "200Gi", "cpu": "64"}
+    assert _res(parsed, "decode")["requests"] == {"memory": "32Gi", "cpu": "8"}
+
+
+def test_any_default_keeps_the_warning_comment(tmp_path):
+    scenario, prov = build([row("cpu limit", "64")])
+    assert "Reducing Torch parallelism" in emit(scenario, prov, tmp_path)
+
+
+def test_stderr_warning_when_defaults_used(capsys):
+    build([row("Number of prefill pods", "1")])
+    err = capsys.readouterr().err
+    assert "Reducing Torch parallelism" in err
+    assert "decode" in err and "prefill" in err
+
+
+def test_no_stderr_warning_when_all_four_stated(capsys):
+    build(
+        [
+            row("cpu limit", "64"),
+            row("memory limit", "200Gi"),
+            row("cpu request", "8"),
+            row("memory request", "32Gi"),
+        ]
+    )
+    assert "Reducing Torch parallelism" not in capsys.readouterr().err
+
+
+def test_kubernetes_quantity_forms_pass_through(tmp_path):
+    """500m and Mi units must survive verbatim, not be re-serialized."""
+    scenario, prov = build(
+        [row("cpu request", "500m"), row("memory request", "1536Mi")]
+    )
+    parsed = yaml.safe_load(emit(scenario, prov, tmp_path))["scenario"][0]
+    assert _res(parsed, "decode")["requests"] == {
+        "memory": "1536Mi", "cpu": "500m"}
+
+
+def test_resources_parse_in_every_row_combination(tmp_path):
+    combos = [
+        [],
+        [row("Number of prefill pods", "2")],
+        [row("cpu limit", "64"), row("Number of prefill pods", "2")],
+        [row("prefill memory limit", "64Gi"), row("Number of prefill pods", "2")],
+    ]
+    for i, extra in enumerate(combos):
+        scenario, prov = build(extra)
+        parsed = yaml.safe_load(emit(scenario, prov, tmp_path / f"r{i}"))
+        assert "resources" in parsed["scenario"][0]["decode"]

--- a/.claude/skills/sim2real-bootstrap/tests/test_generate_from_config_prefill.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_generate_from_config_prefill.py
@@ -455,18 +455,26 @@ def test_single_pool_config_regenerates_byte_identically(tmp_path):
 
 def test_single_pool_golden_has_no_prefill_artifacts():
     """Guards the golden itself: if someone regenerates it from a future version
-    that emits prefill unconditionally, this fails rather than blessing it."""
+    that emits prefill unconditionally, this fails rather than blessing it.
+
+    The `labelValues` assertion belongs to this test, not to the pod-resources one
+    below: #850's test was originally spliced between the two, which left this
+    guard trailing a docstring about CPU and memory.
+    """
     golden = (FIXTURES / "single_pool_baseline.golden.yaml").read_text()
     assert "prefill:" not in golden
+    assert "labelValues" not in golden
 
 
 def test_single_pool_golden_carries_pod_resources():
     """The other direction of the same guard (issue #850).
 
-    The golden was regenerated when resources emission landed — a pure addition of
-    22 lines with nothing removed. If a future version stops emitting `resources`
-    and someone regenerates the golden to match, the byte-identity test above would
-    happily bless the regression. This makes that fail instead.
+    The golden was regenerated when resources emission landed — verified as a pure
+    addition, then again after the review fixes, where the diff was confined to the
+    resources block and no emitted value changed. If a future version stops
+    emitting `resources` and someone regenerates the golden to match, the
+    byte-identity test above would happily bless the regression. This makes that
+    fail instead.
     """
     golden = (FIXTURES / "single_pool_baseline.golden.yaml").read_text()
     parsed = yaml.safe_load(golden)["scenario"][0]
@@ -476,7 +484,6 @@ def test_single_pool_golden_carries_pod_resources():
         "reserves the whole generous limit (#850)"
     )
     assert resources["limits"]["cpu"] == "32"
-    assert "labelValues" not in golden
 
 
 def test_emitted_yaml_round_trips_both_roles(tmp_path):
@@ -982,3 +989,69 @@ def test_resources_parse_in_every_row_combination(tmp_path):
         scenario, prov = build(extra)
         parsed = yaml.safe_load(emit(scenario, prov, tmp_path / f"r{i}"))
         assert "resources" in parsed["scenario"][0]["decode"]
+
+
+# ---------------------------------------------------------------------------
+# Review findings from PR #857
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "stated,expected",
+    [
+        # The defect: parse_numeric takes only the first whitespace token, so
+        # `16 Gi` became `16` -- sixteen BYTES -- with no warning, because the
+        # field counted as stated. The forms the original tests used (500m,
+        # 1536Mi) passed only because int() happens to fail on them.
+        ("16 Gi", "16 Gi"),
+        ("128Gi", "128Gi"),
+        ("1536Mi", "1536Mi"),
+        ("2 Ti", "2 Ti"),
+    ],
+)
+def test_memory_quantity_keeps_its_unit(stated, expected, tmp_path):
+    scenario, prov = build([row("decode memory limit", stated)])
+    parsed = yaml.safe_load(emit(scenario, prov, tmp_path))["scenario"][0]
+    assert parsed["decode"]["resources"]["limits"]["memory"] == expected
+
+
+@pytest.mark.parametrize("stated", ["500m", "1.50", "1.5", "32", "500 m"])
+def test_cpu_quantity_passes_through_verbatim(stated, tmp_path):
+    """`1.50` must not become `1.5`: it is a string the chart forwards to
+    Kubernetes, not a number to normalize."""
+    scenario, prov = build([row("decode cpu limit", stated)])
+    parsed = yaml.safe_load(emit(scenario, prov, tmp_path))["scenario"][0]
+    assert parsed["decode"]["resources"]["limits"]["cpu"] == stated
+
+
+def test_every_resource_field_is_string_valued():
+    """Guards the derivation rather than the instance: a future `*_limit` or
+    `*_request` alias must join _STRING_VALUED_FIELDS automatically."""
+    resource_fields = {
+        name for name in gfc.PARAMETER_ALIASES
+        if name.endswith(("_limit", "_request"))
+    }
+    assert resource_fields, "no resource aliases found — did the naming change?"
+    assert resource_fields <= gfc._STRING_VALUED_FIELDS
+
+
+def test_stderr_warning_reports_the_value_actually_emitted(capsys):
+    """Stating one quantity used to still announce the full default table, so the
+    operator saw 'limits 32 CPU' next to an emitted 64."""
+    build([row("decode cpu limit", "64")])
+    err = capsys.readouterr().err
+    assert "cpu_limit" not in err
+    assert "memory_limit=128Gi" in err
+
+
+def test_request_exceeding_limit_warns_at_generation_time(capsys):
+    build([row("decode cpu request", "40")])
+    err = capsys.readouterr().err
+    assert "request 40 > limit 32" in err
+    assert "admission" in err
+
+
+def test_emitted_values_carry_per_value_sources(tmp_path):
+    scenario, prov = build([row("decode cpu limit", "64")])
+    text = emit(scenario, prov, tmp_path)
+    cpu = next(ln for ln in text.splitlines() if "cpu: '64'" in ln)
+    assert "config.md" in cpu

--- a/.claude/skills/sim2real-bootstrap/tests/test_generate_scenarios.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_generate_scenarios.py
@@ -554,3 +554,40 @@ def test_both_generators_emit_identical_resources_text(tmp_path):
         block = "\n".join(pres.resource_lines(values, prov, warn=True))
         assert block in from_config_text, f"config.md path drifted for {role}"
         assert block in json_text, f"json path drifted for {role}"
+
+
+# ---------------------------------------------------------------------------
+# Review findings, iteration 2 — the JSON path's own stderr and precedence
+# ---------------------------------------------------------------------------
+# The reviewer noted no capsys test asserted the JSON path's stderr text, which
+# is why config.md remediation on a JSON input went unnoticed.
+
+def test_json_path_stderr_names_vllm_args_not_config_md(capsys):
+    gs.build_scenario(entry(), "cand")
+    err = capsys.readouterr().err
+    assert "config.md" not in err, (
+        "the JSON generator is selected precisely when no config.md exists, so "
+        "remediation naming it points at a file that is not the input"
+    )
+    assert "vllm_args" in err
+
+
+def test_json_path_null_per_role_key_falls_back_to_shared(tmp_path):
+    """The finding: `{"cpu_limit": "64", "decode_cpu_limit": null}` resolved to the
+    built-in 32, silently discarding the stated shared 64, because
+    `.get(role_key, .get(shared))` returns None for a key present with a null."""
+    parsed = yaml.safe_load(
+        res_emit(tmp_path, cpu_limit="64", decode_cpu_limit=None))["scenario"][0]
+    assert parsed["decode"]["resources"]["limits"]["cpu"] == "64"
+
+
+def test_json_path_empty_string_per_role_key_falls_back_to_shared(tmp_path):
+    parsed = yaml.safe_load(
+        res_emit(tmp_path, cpu_limit="64", decode_cpu_limit=""))["scenario"][0]
+    assert parsed["decode"]["resources"]["limits"]["cpu"] == "64"
+
+
+def test_json_path_source_comments_cite_vllm_args(tmp_path):
+    text = res_emit(tmp_path, cpu_limit="64")
+    cpu = next(ln for ln in text.splitlines() if "cpu: '64'" in ln)
+    assert "vllm_args" in cpu and "config.md" not in cpu

--- a/.claude/skills/sim2real-bootstrap/tests/test_generate_scenarios.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_generate_scenarios.py
@@ -467,11 +467,12 @@ def test_both_generators_emit_identical_plumbing_text(tmp_path):
         assert block in json_text, "json path drifted from pd_plumbing"
 
 
+
 # ---------------------------------------------------------------------------
-# Pod CPU/memory resources (issue #850) -- parity with generate_from_config.py
+# Pod CPU/memory resources (issue #850) — parity with generate_from_config.py
 # ---------------------------------------------------------------------------
 # This generator has its own emitter, so it needs its own coverage. #846 and #848
-# both had to fix both paths; so does this.
+# both had to fix both paths.
 
 
 def res_emit(tmp_path, **vllm_extra):
@@ -491,41 +492,72 @@ def test_resources_emitted_with_role_defaults_json_path(tmp_path):
 
 def test_decode_sized_above_prefill_json_path(tmp_path):
     parsed = yaml.safe_load(res_emit(tmp_path, prefill_instances=1))["scenario"][0]
-    d = int(parsed["decode"]["resources"]["limits"]["cpu"])
-    p = int(parsed["prefill"]["resources"]["limits"]["cpu"])
-    assert d > p
+    assert int(parsed["decode"]["resources"]["limits"]["cpu"]) > int(
+        parsed["prefill"]["resources"]["limits"]["cpu"])
 
 
-def test_shared_key_applies_to_both_roles_json_path(tmp_path):
+def test_stated_key_applies_to_both_roles_json_path(tmp_path):
     parsed = yaml.safe_load(
         res_emit(tmp_path, prefill_instances=1, cpu_limit="64"))["scenario"][0]
     assert parsed["decode"]["resources"]["limits"]["cpu"] == "64"
     assert parsed["prefill"]["resources"]["limits"]["cpu"] == "64"
 
 
-def test_per_role_key_beats_shared_json_path(tmp_path):
-    parsed = yaml.safe_load(res_emit(
-        tmp_path, prefill_instances=1,
-        cpu_limit="64", decode_cpu_limit="96"))["scenario"][0]
-    assert parsed["decode"]["resources"]["limits"]["cpu"] == "96"
-    assert parsed["prefill"]["resources"]["limits"]["cpu"] == "64"
+@pytest.mark.parametrize("hostile", ["128", "0.5"])
+def test_yaml_hostile_values_stay_strings_json_path(hostile, tmp_path):
+    parsed = yaml.safe_load(
+        res_emit(tmp_path, memory_limit=hostile))["scenario"][0]
+    assert parsed["decode"]["resources"]["limits"]["memory"] == hostile
 
 
-def test_all_four_stated_suppresses_warning_json_path(tmp_path):
+@pytest.mark.parametrize("bad", ["-", "TBD", "16 Gi", "128GB"])
+def test_invalid_quantity_is_a_hard_error_json_path(bad, capsys):
+    with pytest.raises(SystemExit) as exc:
+        gs.build_scenario(entry(vllm_extra={"memory_limit": bad}), "cand")
+    assert exc.value.code == 1
+    assert "invalid Kubernetes quantities" in capsys.readouterr().err
+
+
+def test_all_four_stated_suppresses_warning_json_path(tmp_path, capsys):
     text = res_emit(tmp_path, cpu_limit="64", memory_limit="200Gi",
                     cpu_request="8", memory_request="32Gi")
     assert "Reducing Torch parallelism" not in text
+    assert "Reducing Torch parallelism" not in capsys.readouterr().err
+
+
+def test_any_default_warns_on_stderr_json_path(capsys):
+    """The JSON path's stderr had no coverage at all, which is how a config.md
+    remediation message on a JSON input went unnoticed."""
+    gs.build_scenario(entry(), "cand")
+    err = capsys.readouterr().err
+    assert "Reducing Torch parallelism" in err
+    assert "decode" in err
+
+
+def test_stderr_names_no_input_file_json_path(capsys):
+    """pod_resources is shared by both generators, which read different inputs, so
+    the message must name neither."""
+    gs.build_scenario(entry(), "cand")
+    err = capsys.readouterr().err
+    resource_lines = [ln for ln in err.splitlines() if "Torch parallelism" in ln]
+    assert resource_lines
+    for ln in resource_lines:
+        assert "config.md" not in ln
+
+
+def test_prefill_warn_suppression_is_independent_json_path(tmp_path):
+    text = res_emit(tmp_path, prefill_instances=1, cpu_limit="64",
+                    memory_limit="200Gi", cpu_request="8", memory_request="32Gi")
+    prefill_block = text[text.index("  prefill:"):]
+    assert "GENEROUS DEFAULTS" not in prefill_block
 
 
 def test_resource_keys_do_not_trip_unknown_field_warning(capsys):
-    """New vllm_args keys must be declared in KNOWN_FIELDS, or the unknown-field
-    check that exists to catch unmapped input warns on every bundle using them."""
-    e = entry(vllm_extra={"cpu_limit": "64", "decode_memory_limit": "200Gi",
-                          "prefill_cpu_request": "2"})
-    gs.check_unknown_fields(e, "test")
-    err = capsys.readouterr().err
-    for key in ("cpu_limit", "decode_memory_limit", "prefill_cpu_request"):
-        assert key not in err
+    """The four keys must be declared in KNOWN_FIELDS, or the unknown-field check
+    that exists to catch unmapped input warns on every bundle using them."""
+    e = entry(vllm_extra={"cpu_limit": "64", "memory_limit": "200Gi",
+                          "cpu_request": "8", "memory_request": "32Gi"})
+    assert gs.check_unknown_fields(e, "test") == []
 
 
 def test_both_generators_emit_identical_resources_text(tmp_path):
@@ -554,40 +586,3 @@ def test_both_generators_emit_identical_resources_text(tmp_path):
         block = "\n".join(pres.resource_lines(values, prov, warn=True))
         assert block in from_config_text, f"config.md path drifted for {role}"
         assert block in json_text, f"json path drifted for {role}"
-
-
-# ---------------------------------------------------------------------------
-# Review findings, iteration 2 — the JSON path's own stderr and precedence
-# ---------------------------------------------------------------------------
-# The reviewer noted no capsys test asserted the JSON path's stderr text, which
-# is why config.md remediation on a JSON input went unnoticed.
-
-def test_json_path_stderr_names_vllm_args_not_config_md(capsys):
-    gs.build_scenario(entry(), "cand")
-    err = capsys.readouterr().err
-    assert "config.md" not in err, (
-        "the JSON generator is selected precisely when no config.md exists, so "
-        "remediation naming it points at a file that is not the input"
-    )
-    assert "vllm_args" in err
-
-
-def test_json_path_null_per_role_key_falls_back_to_shared(tmp_path):
-    """The finding: `{"cpu_limit": "64", "decode_cpu_limit": null}` resolved to the
-    built-in 32, silently discarding the stated shared 64, because
-    `.get(role_key, .get(shared))` returns None for a key present with a null."""
-    parsed = yaml.safe_load(
-        res_emit(tmp_path, cpu_limit="64", decode_cpu_limit=None))["scenario"][0]
-    assert parsed["decode"]["resources"]["limits"]["cpu"] == "64"
-
-
-def test_json_path_empty_string_per_role_key_falls_back_to_shared(tmp_path):
-    parsed = yaml.safe_load(
-        res_emit(tmp_path, cpu_limit="64", decode_cpu_limit=""))["scenario"][0]
-    assert parsed["decode"]["resources"]["limits"]["cpu"] == "64"
-
-
-def test_json_path_source_comments_cite_vllm_args(tmp_path):
-    text = res_emit(tmp_path, cpu_limit="64")
-    cpu = next(ln for ln in text.splitlines() if "cpu: '64'" in ln)
-    assert "vllm_args" in cpu and "config.md" not in cpu

--- a/.claude/skills/sim2real-bootstrap/tests/test_generate_scenarios.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_generate_scenarios.py
@@ -121,8 +121,12 @@ def test_multi_gpu_value_warns_and_uses_first(value, capsys):
 
 
 def test_single_gpu_value_does_not_warn(capsys):
+    """Asserts on the multi-type GPU warning specifically, not on any warning at
+    all: generation legitimately emits unrelated warnings (e.g. #850's unmeasured
+    pod-resources default), and a blanket check makes each new one a spurious
+    failure here. Mirrors the config.md path's twin test."""
     gs.build_scenario(entry(), "cand")
-    assert "WARNING" not in capsys.readouterr().err
+    assert "GPU types" not in capsys.readouterr().err
 
 
 def test_labelvalues_never_emitted(tmp_path):
@@ -461,3 +465,92 @@ def test_both_generators_emit_identical_plumbing_text(tmp_path):
         block = "\n".join(fragment_lines)
         assert block in from_config_text, "config.md path drifted from pd_plumbing"
         assert block in json_text, "json path drifted from pd_plumbing"
+
+
+# ---------------------------------------------------------------------------
+# Pod CPU/memory resources (issue #850) -- parity with generate_from_config.py
+# ---------------------------------------------------------------------------
+# This generator has its own emitter, so it needs its own coverage. #846 and #848
+# both had to fix both paths; so does this.
+
+
+def res_emit(tmp_path, **vllm_extra):
+    e = entry(vllm_extra=vllm_extra)
+    return emit(gs.build_scenario(e, "test"), e, tmp_path)
+
+
+def test_resources_emitted_with_role_defaults_json_path(tmp_path):
+    parsed = yaml.safe_load(res_emit(tmp_path, prefill_instances=1))["scenario"][0]
+    assert parsed["decode"]["resources"]["limits"] == {
+        "memory": "128Gi", "cpu": "32"}
+    assert parsed["decode"]["resources"]["requests"] == {
+        "memory": "64Gi", "cpu": "16"}
+    assert parsed["prefill"]["resources"]["limits"] == {
+        "memory": "16Gi", "cpu": "8"}
+
+
+def test_decode_sized_above_prefill_json_path(tmp_path):
+    parsed = yaml.safe_load(res_emit(tmp_path, prefill_instances=1))["scenario"][0]
+    d = int(parsed["decode"]["resources"]["limits"]["cpu"])
+    p = int(parsed["prefill"]["resources"]["limits"]["cpu"])
+    assert d > p
+
+
+def test_shared_key_applies_to_both_roles_json_path(tmp_path):
+    parsed = yaml.safe_load(
+        res_emit(tmp_path, prefill_instances=1, cpu_limit="64"))["scenario"][0]
+    assert parsed["decode"]["resources"]["limits"]["cpu"] == "64"
+    assert parsed["prefill"]["resources"]["limits"]["cpu"] == "64"
+
+
+def test_per_role_key_beats_shared_json_path(tmp_path):
+    parsed = yaml.safe_load(res_emit(
+        tmp_path, prefill_instances=1,
+        cpu_limit="64", decode_cpu_limit="96"))["scenario"][0]
+    assert parsed["decode"]["resources"]["limits"]["cpu"] == "96"
+    assert parsed["prefill"]["resources"]["limits"]["cpu"] == "64"
+
+
+def test_all_four_stated_suppresses_warning_json_path(tmp_path):
+    text = res_emit(tmp_path, cpu_limit="64", memory_limit="200Gi",
+                    cpu_request="8", memory_request="32Gi")
+    assert "Reducing Torch parallelism" not in text
+
+
+def test_resource_keys_do_not_trip_unknown_field_warning(capsys):
+    """New vllm_args keys must be declared in KNOWN_FIELDS, or the unknown-field
+    check that exists to catch unmapped input warns on every bundle using them."""
+    e = entry(vllm_extra={"cpu_limit": "64", "decode_memory_limit": "200Gi",
+                          "prefill_cpu_request": "2"})
+    gs.check_unknown_fields(e, "test")
+    err = capsys.readouterr().err
+    for key in ("cpu_limit", "decode_memory_limit", "prefill_cpu_request"):
+        assert key not in err
+
+
+def test_both_generators_emit_identical_resources_text(tmp_path):
+    """Anti-drift: two hand-rolled emitters, one shared module. The resources text
+    must match character-for-character or one path is wrong."""
+    import generate_from_config as gfc
+    import pod_resources as pres
+
+    rows = [
+        {"Parameter": "Model", "Value": "Qwen/Qwen3-14B", "Notes": ""},
+        {"Parameter": "GPU", "Value": "H100_SXM_80GB", "Notes": ""},
+        {"Parameter": "Number of prefill pods", "Value": "1", "Notes": ""},
+    ]
+    table = gfc.TableSection(
+        heading="vLLM Pod Configuration", rows=rows, line_number=0)
+    s, p = gfc.build_scenario(gfc.extract_fields(table), "test")
+    out = tmp_path / "baseline.yaml"
+    gfc.write_provenance_yaml(s, p, str(out))
+    from_config_text = out.read_text()
+
+    # Same directory is safe: gfc writes baseline.yaml, gs writes cand.yaml.
+    json_text = res_emit(tmp_path, prefill_instances=1)
+
+    for role in ("decode", "prefill"):
+        values, _ = pres.resolve_resources(role, dict.fromkeys(pres.KEYS))
+        block = "\n".join(pres.resource_lines(values, warn=True))
+        assert block in from_config_text, f"config.md path drifted for {role}"
+        assert block in json_text, f"json path drifted for {role}"

--- a/.claude/skills/sim2real-bootstrap/tests/test_generate_scenarios.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_generate_scenarios.py
@@ -526,7 +526,8 @@ def test_all_four_stated_suppresses_warning_json_path(tmp_path, capsys):
 
 
 def test_any_default_warns_on_stderr_json_path(capsys):
-    """The JSON path's stderr had no coverage at all, which is how a config.md
+    """The JSON path had no coverage of the RESOURCES stderr specifically (other
+    warnings in this file were covered), which is how a config.md
     remediation message on a JSON input went unnoticed."""
     gs.build_scenario(entry(), "cand")
     err = capsys.readouterr().err
@@ -582,7 +583,7 @@ def test_both_generators_emit_identical_resources_text(tmp_path):
     json_text = res_emit(tmp_path, prefill_instances=1)
 
     for role in ("decode", "prefill"):
-        values, prov = pres.resolve_resources(role, dict.fromkeys(pres.KEYS))
+        values, prov, _ = pres.resolve_resources(role, dict.fromkeys(pres.KEYS))
         block = "\n".join(pres.resource_lines(values, prov, warn=True))
         assert block in from_config_text, f"config.md path drifted for {role}"
         assert block in json_text, f"json path drifted for {role}"

--- a/.claude/skills/sim2real-bootstrap/tests/test_generate_scenarios.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_generate_scenarios.py
@@ -550,7 +550,7 @@ def test_both_generators_emit_identical_resources_text(tmp_path):
     json_text = res_emit(tmp_path, prefill_instances=1)
 
     for role in ("decode", "prefill"):
-        values, _ = pres.resolve_resources(role, dict.fromkeys(pres.KEYS))
-        block = "\n".join(pres.resource_lines(values, warn=True))
+        values, prov = pres.resolve_resources(role, dict.fromkeys(pres.KEYS))
+        block = "\n".join(pres.resource_lines(values, prov, warn=True))
         assert block in from_config_text, f"config.md path drifted for {role}"
         assert block in json_text, f"json path drifted for {role}"

--- a/.claude/skills/sim2real-bootstrap/tests/test_pod_resources.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_pod_resources.py
@@ -58,32 +58,42 @@ def test_defaults_match_the_observed_working_limits():
     assert pres.DEFAULTS["prefill"]["memory_limit"] == "16Gi"
 
 
-@pytest.mark.parametrize("role", ["decode", "prefill"])
-def test_default_requests_sit_below_default_limits(role):
-    """requests are what the scheduler reserves; reserving the generous ceiling on
-    every replica would make a multi-replica pool unschedulable."""
-    v = pres.DEFAULTS[role]
+def test_decode_default_request_is_below_its_limit():
+    """requests are what the scheduler reserves; reserving decode's generous ceiling
+    on every replica would make a multi-replica pool unschedulable."""
+    v = pres.DEFAULTS["decode"]
     assert int(v["cpu_request"]) < int(v["cpu_limit"])
     assert int(v["memory_request"].removesuffix("Gi")) < int(
         v["memory_limit"].removesuffix("Gi"))
 
 
+def test_prefill_default_request_equals_its_limit():
+    """Guaranteed QoS, matching upstream. #848 mounts a `medium: Memory` tmpfs at
+    /dev/shm sized 16Gi in vllmCommon (so both roles). tmpfs charges against pod
+    memory, so a prefill request below that 16Gi would put the pod above its request
+    as soon as collectives filled /dev/shm -- an eviction candidate under node
+    pressure, mid-run, on exactly the TP>1 P/D configuration this targets."""
+    v = pres.DEFAULTS["prefill"]
+    assert v["memory_request"] == v["memory_limit"] == "16Gi"
+    assert v["cpu_request"] == v["cpu_limit"] == "8"
+
+
 @pytest.mark.parametrize("role", ["decode", "prefill"])
 def test_every_default_is_a_valid_quantity(role):
-    v, _ = pres.resolve_resources(role, NONE)
+    v, _, _ = pres.resolve_resources(role, NONE)
     assert pres.invalid_quantities(v) == []
 
 
 # --- resolution ------------------------------------------------------------
 
 def test_defaults_used_when_nothing_stated():
-    v, prov = pres.resolve_resources("decode", NONE)
+    v, prov, _ = pres.resolve_resources("decode", NONE)
     assert v == pres.DEFAULTS["decode"]
     assert set(prov.values()) == {pres.DEFAULTED}
 
 
 def test_stated_wins_and_the_rest_still_default():
-    v, prov = pres.resolve_resources("decode", {**NONE, "cpu_limit": "64"})
+    v, prov, _ = pres.resolve_resources("decode", {**NONE, "cpu_limit": "64"})
     assert v["cpu_limit"] == "64"
     assert prov["cpu_limit"] == pres.STATED
     assert v["memory_limit"] == pres.DEFAULTS["decode"]["memory_limit"]
@@ -92,24 +102,24 @@ def test_stated_wins_and_the_rest_still_default():
 
 def test_stated_values_pass_through_verbatim():
     """These are opaque Kubernetes quantities; re-serializing could change them."""
-    stated = {"cpu_limit": "500m", "memory_limit": "1536Mi",
-              "cpu_request": "1.5", "memory_request": "512Mi"}
-    v, _ = pres.resolve_resources("prefill", stated)
+    stated = {"cpu_limit": "1500m", "memory_limit": "1536Mi",
+              "cpu_request": "500m", "memory_request": "512Mi"}
+    v, _, _ = pres.resolve_resources("prefill", stated)
     assert v == stated
 
 
 @pytest.mark.parametrize("blank", [None, "", "   "])
 def test_blank_counts_as_unstated(blank):
-    v, prov = pres.resolve_resources("decode", {**NONE, "cpu_limit": blank})
+    v, prov, _ = pres.resolve_resources("decode", {**NONE, "cpu_limit": blank})
     assert v["cpu_limit"] == pres.DEFAULTS["decode"]["cpu_limit"]
     assert prov["cpu_limit"] == pres.DEFAULTED
 
 
 def test_defaulted_keys_lists_only_the_missing_ones():
-    _, prov = pres.resolve_resources("decode", {**NONE, "cpu_limit": "64"})
-    assert pres.defaulted_keys(prov) == [
-        "memory_limit", "cpu_request", "memory_request"]
-    _, all_prov = pres.resolve_resources("decode", ALL_STATED)
+    _, prov, _ = pres.resolve_resources("decode", {**NONE, "cpu_limit": "64"})
+    # cpu_request is DERIVED from the stated limit, not defaulted.
+    assert pres.defaulted_keys(prov) == ["memory_limit", "memory_request"]
+    _, all_prov, _ = pres.resolve_resources("decode", ALL_STATED)
     assert pres.defaulted_keys(all_prov) == []
 
 
@@ -119,7 +129,7 @@ def test_defaulted_keys_lists_only_the_missing_ones():
     "good", ["32", "1", "0.5", "1.5", "500m", "128Gi", "1536Mi", "2Ti", "64G",
              "1e3", "100k"])
 def test_valid_quantities_accepted(good):
-    v, _ = pres.resolve_resources("decode", {**NONE, "memory_limit": good})
+    v, _, _ = pres.resolve_resources("decode", {**NONE, "memory_limit": good})
     assert pres.invalid_quantities(v) == []
 
 
@@ -133,8 +143,10 @@ def test_invalid_quantities_rejected(bad):
     `""` is here for completeness: it resolves to the default, so it can never
     actually reach the validator — hence the assertion is on the resolved value.
     """
-    v, _ = pres.resolve_resources("decode", {**NONE, "memory_limit": bad})
+    v, _, _ = pres.resolve_resources("decode", {**NONE, "memory_limit": bad})
     if bad.strip():
+        # Exactly one key: the request is NOT derived from an unreadable limit, so
+        # the error points at the single offending row.
         assert pres.invalid_quantities(v) == [f"memory_limit={bad!r}"]
     else:
         assert pres.invalid_quantities(v) == []  # blank fell back to the default
@@ -143,7 +155,7 @@ def test_invalid_quantities_rejected(bad):
 # --- emission --------------------------------------------------------------
 
 def test_emitted_yaml_carries_both_limits_and_requests():
-    v, prov = pres.resolve_resources("decode", NONE)
+    v, prov, _ = pres.resolve_resources("decode", NONE)
     r = parse(pres.resource_lines(v, prov, warn=True))["resources"]
     assert r["limits"] == {"memory": "128Gi", "cpu": "32"}
     assert r["requests"] == {"memory": "64Gi", "cpu": "16"}
@@ -155,7 +167,7 @@ def test_every_emitted_value_is_a_quoted_string(section, field):
     """Unquoted, a YAML reader re-types these: `128` becomes an int, `yes` True,
     and `-` a sequence entry that will not parse at all. cpu was quoted and memory
     was not, which is how a `-` placeholder produced an unparseable baseline."""
-    v, prov = pres.resolve_resources("decode", NONE)
+    v, prov, _ = pres.resolve_resources("decode", NONE)
     r = parse(pres.resource_lines(v, prov, warn=True))["resources"]
     assert isinstance(r[section][field], str)
 
@@ -163,19 +175,19 @@ def test_every_emitted_value_is_a_quoted_string(section, field):
 @pytest.mark.parametrize("hostile", ["128", "yes", "no", "null", "~", "0x40"])
 def test_yaml_hostile_values_survive_as_strings(hostile):
     """Each of these is re-typed by YAML when unquoted -- to int, bool or None."""
-    v, prov = pres.resolve_resources("decode", {**NONE, "memory_limit": hostile})
+    v, prov, _ = pres.resolve_resources("decode", {**NONE, "memory_limit": hostile})
     r = parse(pres.resource_lines(v, prov, warn=True))["resources"]
     assert r["limits"]["memory"] == hostile
 
 
 def test_prefill_emits_under_the_prefill_block():
-    v, prov = pres.resolve_resources("prefill", NONE)
+    v, prov, _ = pres.resolve_resources("prefill", NONE)
     r = parse(pres.resource_lines(v, prov, warn=True), role="prefill")["resources"]
     assert r["limits"]["cpu"] == "8"
 
 
 def test_per_value_sources_distinguish_stated_from_default():
-    v, prov = pres.resolve_resources("decode", {**NONE, "cpu_limit": "64"})
+    v, prov, _ = pres.resolve_resources("decode", {**NONE, "cpu_limit": "64"})
     text = "\n".join(pres.resource_lines(v, prov, warn=True))
     cpu = next(ln for ln in text.splitlines() if "cpu: '64'" in ln)
     mem = next(ln for ln in text.splitlines() if "memory: '128Gi'" in ln)
@@ -186,7 +198,7 @@ def test_per_value_sources_distinguish_stated_from_default():
 def test_source_comments_name_no_input_file():
     """Both generators share this module and read different inputs, so naming one
     would be wrong on the other path."""
-    v, prov = pres.resolve_resources("decode", {**NONE, "cpu_limit": "64"})
+    v, prov, _ = pres.resolve_resources("decode", {**NONE, "cpu_limit": "64"})
     text = "\n".join(pres.resource_lines(v, prov, warn=True))
     assert "config.md" not in text
     assert "vllm_args" not in text
@@ -194,13 +206,13 @@ def test_source_comments_name_no_input_file():
 
 
 def test_warning_comment_names_the_starvation_signal():
-    v, prov = pres.resolve_resources("decode", NONE)
+    v, prov, _ = pres.resolve_resources("decode", NONE)
     assert "Reducing Torch parallelism" in "\n".join(
         pres.resource_lines(v, prov, warn=True))
 
 
 def test_no_warning_comment_when_everything_was_stated():
-    v, prov = pres.resolve_resources("decode", ALL_STATED)
+    v, prov, _ = pres.resolve_resources("decode", ALL_STATED)
     text = "\n".join(pres.resource_lines(v, prov, warn=False))
     assert "Reducing Torch parallelism" not in text
     assert parse(pres.resource_lines(v, prov, warn=False))[
@@ -211,7 +223,7 @@ def test_no_warning_comment_when_everything_was_stated():
 @pytest.mark.parametrize("warn", [True, False])
 def test_emitted_yaml_parses_in_every_combination(role, warn):
     """Hand-rolled emitter: indentation is the whole contract."""
-    v, prov = pres.resolve_resources(role, NONE)
+    v, prov, _ = pres.resolve_resources(role, NONE)
     r = parse(pres.resource_lines(v, prov, warn=warn), role=role)["resources"]
     assert set(r) == {"limits", "requests"}
 
@@ -221,16 +233,131 @@ def test_emitted_yaml_parses_in_every_combination(role, warn):
 def test_warning_reports_emitted_values_not_the_default_table():
     """It fires when ANY quantity defaults, so quoting the whole default table would
     contradict the YAML whenever the operator overrode part of it."""
-    v, prov = pres.resolve_resources("decode", {**NONE, "cpu_limit": "64"})
+    v, prov, _ = pres.resolve_resources("decode", {**NONE, "cpu_limit": "64"})
     msg = pres.starvation_warning("decode", v, prov)
     assert "cpu_limit" not in msg
     assert "memory_limit=128Gi" in msg
-    assert "3 of 4" in msg
+    assert "2 of 4" in msg  # cpu_request was derived, not defaulted
 
 
 def test_warning_names_the_role_and_the_signal_and_no_input_file():
-    v, prov = pres.resolve_resources("prefill", NONE)
+    v, prov, _ = pres.resolve_resources("prefill", NONE)
     msg = pres.starvation_warning("prefill", v, prov)
     assert "prefill" in msg
     assert "Reducing Torch parallelism" in msg
     assert "config.md" not in msg and "vllm_args" not in msg
+
+
+# --- pair reconciliation (the must_fix from PR #857's review) ---------------
+# The four quantities used to resolve independently, so a request could exceed its
+# limit -- a pod spec Kubernetes rejects at admission. Worse, the input rows are
+# shared by both roles while the defaults differ 4-8x, so a request sized for decode
+# inverted prefill unconditionally.
+
+def test_stating_a_limit_derives_a_matching_request():
+    """A smaller stated limit must not leave the larger default request in place."""
+    v, prov, notices = pres.resolve_resources(
+        "decode", {**NONE, "cpu_limit": "8", "memory_limit": "32Gi"})
+    assert v["cpu_request"] == "4"
+    assert v["memory_request"] == "16Gi"
+    assert prov["cpu_request"] == pres.DERIVED
+    assert notices == []
+
+
+def test_shared_request_row_is_clamped_to_prefills_smaller_limit():
+    """The reproduction from the review: `cpu request: 20` is sensible for decode
+    (limit 32) and impossible for prefill (limit 8). Both roles read the same row."""
+    decode, _, d_notes = pres.resolve_resources(
+        "decode", {**NONE, "cpu_request": "20", "memory_request": "96Gi"})
+    prefill, p_prov, p_notes = pres.resolve_resources(
+        "prefill", {**NONE, "cpu_request": "20", "memory_request": "96Gi"})
+
+    assert decode["cpu_request"] == "20"          # fits decode's 32
+    assert d_notes == []
+    assert prefill["cpu_request"] == "8"          # clamped to prefill's limit
+    assert prefill["memory_request"] == "16Gi"
+    assert p_prov["cpu_request"] == pres.CLAMPED
+    assert len(p_notes) == 2
+    assert "exceeds its limit" in p_notes[0]
+    assert "prefill" in p_notes[0]
+
+
+@pytest.mark.parametrize("role", ["decode", "prefill"])
+def test_no_input_can_produce_a_request_above_its_limit(role):
+    """The invariant, over inputs that previously inverted it."""
+    hostile = [
+        {"cpu_request": "999", "memory_request": "999Gi"},
+        {"cpu_limit": "1", "memory_limit": "1Gi"},
+        {"cpu_limit": "1", "cpu_request": "64"},
+        {"memory_limit": "2Gi", "memory_request": "128Gi"},
+        {"cpu_limit": "500m", "cpu_request": "1"},
+    ]
+    for stated in hostile:
+        v, _, _ = pres.resolve_resources(role, {**NONE, **stated})
+        for kind in ("cpu", "memory"):
+            req = pres._magnitude(v[f"{kind}_request"])
+            lim = pres._magnitude(v[f"{kind}_limit"])
+            assert req is not None and lim is not None
+            assert req <= lim, f"{role} {kind}: {v} from {stated}"
+
+
+def test_clamp_notice_explains_the_shared_row_and_names_the_role():
+    _, _, notices = pres.resolve_resources("prefill", {**NONE, "cpu_request": "20"})
+    assert len(notices) == 1
+    note = notices[0]
+    assert "prefill" in note
+    assert "shared by both roles" in note
+    assert "state a cpu limit too" in note
+
+
+def test_both_stated_and_coherent_is_left_alone():
+    v, prov, notices = pres.resolve_resources(
+        "prefill", {**NONE, "cpu_limit": "16", "cpu_request": "12"})
+    assert (v["cpu_limit"], v["cpu_request"]) == ("16", "12")
+    assert prov["cpu_request"] == pres.STATED
+    assert notices == []
+
+
+# --- quantity grammar ------------------------------------------------------
+# The regex was written from memory and was wrong in both directions: it rejected a
+# valid `1Ki` outright while accepting `1ki`, `1.2.3`, `...`, `1e3Gi` and negatives.
+
+@pytest.mark.parametrize(
+    "quantity", ["1Ki", "524288Ki", "1Mi", "1Gi", "1Ti", "1Pi", "1Ei",
+                 "100m", "1k", "1M", "1G", "1T", "1P", "1E", "32", "0.5", "1e3",
+                 "1.5e2"])
+def test_real_kubernetes_quantities_are_accepted(quantity):
+    assert pres._magnitude(quantity) is not None, f"{quantity} wrongly rejected"
+
+
+@pytest.mark.parametrize(
+    "quantity", ["1ki", "1KI", "1e3Gi", "1.5e2Gi", "1.2.3", "1..2", "...", ".",
+                 "1Gim", "32Gim", "-32", "-32Gi", "-0.5", "16 Gi", "128GB", "TBD"])
+def test_non_quantities_are_rejected(quantity):
+    assert pres._magnitude(quantity) is None, f"{quantity} wrongly accepted"
+
+
+@pytest.mark.parametrize(
+    "quantity,expected",
+    [("1Ki", 1024.0), ("1Mi", 1048576.0), ("1k", 1000.0), ("500m", 0.5),
+     ("32", 32.0), ("1e3", 1000.0), ("2Gi", 2147483648.0)])
+def test_magnitudes_use_the_real_multipliers(quantity, expected):
+    """Binary suffixes are powers of 1024, decimal ones powers of 1000 -- getting
+    these backwards would make the clamp comparison silently wrong."""
+    assert pres._magnitude(quantity) == expected
+
+
+@pytest.mark.parametrize(
+    "quantity,expected",
+    [("128Gi", "64Gi"), ("32", "16"), ("8", "4"), ("500m", "250m"),
+     ("1Gi", "0.5Gi"), ("1", "0.5")])
+def test_halving_keeps_the_suffix(quantity, expected):
+    assert pres._halve(quantity) == expected
+
+
+@pytest.mark.parametrize("padded", [" 64 ", "\t64", "64\n"])
+def test_whitespace_padded_stated_values_are_trimmed(padded):
+    v, prov, _ = pres.resolve_resources("decode", {**NONE, "cpu_limit": padded})
+    assert v["cpu_limit"] == "64"
+    assert prov["cpu_limit"] == pres.STATED
+    assert pres.invalid_quantities(v) == []

--- a/.claude/skills/sim2real-bootstrap/tests/test_pod_resources.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_pod_resources.py
@@ -1,0 +1,147 @@
+"""Tests for pod_resources.py — CPU/memory for the model-server pods (issue #850).
+
+Bootstrap emitted no `resources` at all, so bundles inherited the framework default
+of 4 CPU / 40Gi for a pod that may hold four GPUs and shares its cgroup with the
+routing sidecar. That starves vLLM and shows up as ITL noise rather than a loud
+failure, which corrupts the metric arms are compared on.
+
+The resolver and emitter are tested here; the per-role wiring lives in the two
+generators and is tested in their own files.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parents[1]))
+import pod_resources as pres
+
+
+def parse(lines, role="decode"):
+    """Parse emitter output inside the role block the caller has printed."""
+    doc = f"scenario:\n- name: t\n  {role}:\n" + "\n".join(lines) + "\n"
+    return yaml.safe_load(doc)["scenario"][0][role]
+
+
+NONE = dict.fromkeys(pres.KEYS)
+
+
+def test_keys_are_the_four_quantities():
+    assert set(pres.KEYS) == {
+        "cpu_limit", "memory_limit", "cpu_request", "memory_request"}
+
+
+@pytest.mark.parametrize("role", ["decode", "prefill"])
+def test_every_role_has_all_four_defaults(role):
+    assert set(pres.DEFAULTS[role]) == set(pres.KEYS)
+
+
+def test_decode_gets_more_than_prefill():
+    """The operator's stated constraint, and upstream's own sizing."""
+    d, p = pres.DEFAULTS["decode"], pres.DEFAULTS["prefill"]
+    assert int(d["cpu_limit"]) > int(p["cpu_limit"])
+    assert int(d["memory_limit"].removesuffix("Gi")) > int(
+        p["memory_limit"].removesuffix("Gi"))
+
+
+def test_defaults_match_the_observed_working_limits():
+    """Verbatim from pd-disaggregation.yaml:410-416 / :321-327, which
+    pd-infocomm-2 also carries."""
+    assert pres.DEFAULTS["decode"]["cpu_limit"] == "32"
+    assert pres.DEFAULTS["decode"]["memory_limit"] == "128Gi"
+    assert pres.DEFAULTS["prefill"]["cpu_limit"] == "8"
+    assert pres.DEFAULTS["prefill"]["memory_limit"] == "16Gi"
+
+
+@pytest.mark.parametrize("role", ["decode", "prefill"])
+def test_requests_are_below_limits(role):
+    """limits without requests is NOT 'no reservation' -- Kubernetes copies the
+    limit into the request, so requests must be emitted AND smaller (#850)."""
+    v = pres.DEFAULTS[role]
+    assert int(v["cpu_request"]) < int(v["cpu_limit"])
+    assert int(v["memory_request"].removesuffix("Gi")) < int(
+        v["memory_limit"].removesuffix("Gi"))
+
+
+def test_defaults_used_when_nothing_stated():
+    v, prov = pres.resolve_resources("decode", NONE)
+    assert v == pres.DEFAULTS["decode"]
+    assert all("default" in prov[k] for k in pres.KEYS)
+
+
+def test_stated_value_wins_and_others_still_default():
+    v, prov = pres.resolve_resources("decode", {**NONE, "cpu_limit": "64"})
+    assert v["cpu_limit"] == "64"
+    assert "config.md" in prov["cpu_limit"]
+    assert v["memory_limit"] == pres.DEFAULTS["decode"]["memory_limit"]
+    assert "default" in prov["memory_limit"]
+
+
+def test_stated_values_pass_through_verbatim():
+    """500m, 1.5 and Mi units must not be re-serialized into something else."""
+    stated = {"cpu_limit": "500m", "memory_limit": "1536Mi",
+              "cpu_request": "1.5", "memory_request": "512Mi"}
+    v, _ = pres.resolve_resources("prefill", stated)
+    assert v == stated
+
+
+def test_used_any_default_distinguishes_the_two_cases():
+    _, all_stated = pres.resolve_resources(
+        "decode", {"cpu_limit": "1", "memory_limit": "2Gi",
+                   "cpu_request": "3", "memory_request": "4Gi"})
+    assert pres.used_any_default(all_stated) is False
+    _, one_missing = pres.resolve_resources("decode", {**NONE, "cpu_limit": "1"})
+    assert pres.used_any_default(one_missing) is True
+
+
+def test_emitted_yaml_carries_both_limits_and_requests():
+    v, _ = pres.resolve_resources("decode", NONE)
+    r = parse(pres.resource_lines(v, warn=True))["resources"]
+    assert r["limits"] == {"memory": "128Gi", "cpu": "32"}
+    assert r["requests"] == {"memory": "64Gi", "cpu": "16"}
+
+
+def test_cpu_is_emitted_as_a_string():
+    """Matches the framework default and both source scenarios; a bare int is a
+    different YAML type than the chart's other cpu values."""
+    v, _ = pres.resolve_resources("decode", NONE)
+    r = parse(pres.resource_lines(v, warn=True))["resources"]
+    assert isinstance(r["limits"]["cpu"], str)
+    assert isinstance(r["requests"]["cpu"], str)
+
+
+def test_prefill_emits_under_the_prefill_block():
+    v, _ = pres.resolve_resources("prefill", NONE)
+    r = parse(pres.resource_lines(v, warn=True), role="prefill")["resources"]
+    assert r["limits"]["cpu"] == "8"
+
+
+def test_warning_comment_names_the_starvation_signal():
+    v, _ = pres.resolve_resources("decode", NONE)
+    text = "\n".join(pres.resource_lines(v, warn=True))
+    assert "Reducing Torch parallelism" in text
+
+
+def test_no_warning_comment_when_everything_was_stated():
+    stated = {"cpu_limit": "1", "memory_limit": "2Gi",
+              "cpu_request": "3", "memory_request": "4Gi"}
+    v, _ = pres.resolve_resources("decode", stated)
+    text = "\n".join(pres.resource_lines(v, warn=False))
+    assert "Reducing Torch parallelism" not in text
+    assert parse(pres.resource_lines(v, warn=False))["resources"]["limits"]["cpu"] == "1"
+
+
+def test_stderr_warning_names_the_role_and_the_signal():
+    msg = pres.starvation_warning("prefill")
+    assert "prefill" in msg
+    assert "Reducing Torch parallelism" in msg
+
+
+def test_emitted_yaml_parses_for_every_role_and_warn_combination():
+    """Hand-rolled emitter: indentation is the whole contract."""
+    for role in ("decode", "prefill"):
+        for warn in (True, False):
+            v, _ = pres.resolve_resources(role, NONE)
+            r = parse(pres.resource_lines(v, warn=warn), role=role)["resources"]
+            assert set(r) == {"limits", "requests"}

--- a/.claude/skills/sim2real-bootstrap/tests/test_pod_resources.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_pod_resources.py
@@ -1,12 +1,12 @@
 """Tests for pod_resources.py — CPU/memory for the model-server pods (issue #850).
 
-Bootstrap emitted no `resources` at all, so bundles inherited the framework default
-of 4 CPU / 40Gi for a pod that may hold four GPUs and shares its cgroup with the
-routing sidecar. That starves vLLM and shows up as ITL noise rather than a loud
-failure, which corrupts the metric arms are compared on.
+Bootstrap emitted no `resources`, so bundles inherited the framework default of
+`limits` AND `requests` both 40Gi / "4" for a pod that may hold four GPUs sharing its
+cgroup with the routing sidecar. That starves vLLM and surfaces as ITL noise rather
+than a loud failure, corrupting the metric arms are compared on.
 
-The resolver and emitter are tested here; the per-role wiring lives in the two
-generators and is tested in their own files.
+The resolver, validator and emitter are tested here; the per-role wiring lives in the
+two generators and is tested in their own files.
 """
 import sys
 from pathlib import Path
@@ -25,7 +25,11 @@ def parse(lines, role="decode"):
 
 
 NONE = dict.fromkeys(pres.KEYS)
+ALL_STATED = {"cpu_limit": "1", "memory_limit": "2Gi",
+              "cpu_request": "3", "memory_request": "4Gi"}
 
+
+# --- defaults --------------------------------------------------------------
 
 def test_keys_are_the_four_quantities():
     assert set(pres.KEYS) == {
@@ -37,7 +41,7 @@ def test_every_role_has_all_four_defaults(role):
     assert set(pres.DEFAULTS[role]) == set(pres.KEYS)
 
 
-def test_decode_gets_more_than_prefill():
+def test_decode_is_sized_above_prefill():
     """The operator's stated constraint, and upstream's own sizing."""
     d, p = pres.DEFAULTS["decode"], pres.DEFAULTS["prefill"]
     assert int(d["cpu_limit"]) > int(p["cpu_limit"])
@@ -46,8 +50,8 @@ def test_decode_gets_more_than_prefill():
 
 
 def test_defaults_match_the_observed_working_limits():
-    """Verbatim from pd-disaggregation.yaml:410-416 / :321-327, which
-    pd-infocomm-2 also carries."""
+    """Verbatim from pd-disaggregation.yaml:410-416 / :321-327, which pd-infocomm-2
+    also carries."""
     assert pres.DEFAULTS["decode"]["cpu_limit"] == "32"
     assert pres.DEFAULTS["decode"]["memory_limit"] == "128Gi"
     assert pres.DEFAULTS["prefill"]["cpu_limit"] == "8"
@@ -55,45 +59,88 @@ def test_defaults_match_the_observed_working_limits():
 
 
 @pytest.mark.parametrize("role", ["decode", "prefill"])
-def test_requests_are_below_limits(role):
-    """limits without requests is NOT 'no reservation' -- Kubernetes copies the
-    limit into the request, so requests must be emitted AND smaller (#850)."""
+def test_default_requests_sit_below_default_limits(role):
+    """requests are what the scheduler reserves; reserving the generous ceiling on
+    every replica would make a multi-replica pool unschedulable."""
     v = pres.DEFAULTS[role]
     assert int(v["cpu_request"]) < int(v["cpu_limit"])
     assert int(v["memory_request"].removesuffix("Gi")) < int(
         v["memory_limit"].removesuffix("Gi"))
 
 
+@pytest.mark.parametrize("role", ["decode", "prefill"])
+def test_every_default_is_a_valid_quantity(role):
+    v, _ = pres.resolve_resources(role, NONE)
+    assert pres.invalid_quantities(v) == []
+
+
+# --- resolution ------------------------------------------------------------
+
 def test_defaults_used_when_nothing_stated():
     v, prov = pres.resolve_resources("decode", NONE)
     assert v == pres.DEFAULTS["decode"]
-    assert all("default" in prov[k] for k in pres.KEYS)
+    assert set(prov.values()) == {pres.DEFAULTED}
 
 
-def test_stated_value_wins_and_others_still_default():
+def test_stated_wins_and_the_rest_still_default():
     v, prov = pres.resolve_resources("decode", {**NONE, "cpu_limit": "64"})
     assert v["cpu_limit"] == "64"
-    assert "config.md" in prov["cpu_limit"]
+    assert prov["cpu_limit"] == pres.STATED
     assert v["memory_limit"] == pres.DEFAULTS["decode"]["memory_limit"]
-    assert "default" in prov["memory_limit"]
+    assert prov["memory_limit"] == pres.DEFAULTED
 
 
 def test_stated_values_pass_through_verbatim():
-    """500m, 1.5 and Mi units must not be re-serialized into something else."""
+    """These are opaque Kubernetes quantities; re-serializing could change them."""
     stated = {"cpu_limit": "500m", "memory_limit": "1536Mi",
               "cpu_request": "1.5", "memory_request": "512Mi"}
-    v, prov = pres.resolve_resources("prefill", stated)
+    v, _ = pres.resolve_resources("prefill", stated)
     assert v == stated
 
 
-def test_used_any_default_distinguishes_the_two_cases():
-    _, all_stated = pres.resolve_resources(
-        "decode", {"cpu_limit": "1", "memory_limit": "2Gi",
-                   "cpu_request": "3", "memory_request": "4Gi"})
-    assert pres.used_any_default(all_stated) is False
-    _, one_missing = pres.resolve_resources("decode", {**NONE, "cpu_limit": "1"})
-    assert pres.used_any_default(one_missing) is True
+@pytest.mark.parametrize("blank", [None, "", "   "])
+def test_blank_counts_as_unstated(blank):
+    v, prov = pres.resolve_resources("decode", {**NONE, "cpu_limit": blank})
+    assert v["cpu_limit"] == pres.DEFAULTS["decode"]["cpu_limit"]
+    assert prov["cpu_limit"] == pres.DEFAULTED
 
+
+def test_defaulted_keys_lists_only_the_missing_ones():
+    _, prov = pres.resolve_resources("decode", {**NONE, "cpu_limit": "64"})
+    assert pres.defaulted_keys(prov) == [
+        "memory_limit", "cpu_request", "memory_request"]
+    _, all_prov = pres.resolve_resources("decode", ALL_STATED)
+    assert pres.defaulted_keys(all_prov) == []
+
+
+# --- quantity validation ---------------------------------------------------
+
+@pytest.mark.parametrize(
+    "good", ["32", "1", "0.5", "1.5", "500m", "128Gi", "1536Mi", "2Ti", "64G",
+             "1e3", "100k"])
+def test_valid_quantities_accepted(good):
+    v, _ = pres.resolve_resources("decode", {**NONE, "memory_limit": good})
+    assert pres.invalid_quantities(v) == []
+
+
+@pytest.mark.parametrize(
+    "bad", ["TBD", "N/A", "-", "same as decode", "16 Gi", "32 cores", "", "??",
+            "128GB", "lots"])
+def test_invalid_quantities_rejected(bad):
+    """A quantity the cluster would reject at admission must fail at generation,
+    far cheaper than failing on the cluster far from the row that caused it.
+
+    `""` is here for completeness: it resolves to the default, so it can never
+    actually reach the validator — hence the assertion is on the resolved value.
+    """
+    v, _ = pres.resolve_resources("decode", {**NONE, "memory_limit": bad})
+    if bad.strip():
+        assert pres.invalid_quantities(v) == [f"memory_limit={bad!r}"]
+    else:
+        assert pres.invalid_quantities(v) == []  # blank fell back to the default
+
+
+# --- emission --------------------------------------------------------------
 
 def test_emitted_yaml_carries_both_limits_and_requests():
     v, prov = pres.resolve_resources("decode", NONE)
@@ -102,13 +149,23 @@ def test_emitted_yaml_carries_both_limits_and_requests():
     assert r["requests"] == {"memory": "64Gi", "cpu": "16"}
 
 
-def test_cpu_is_emitted_as_a_string():
-    """Matches the framework default and both source scenarios; a bare int is a
-    different YAML type than the chart's other cpu values."""
+@pytest.mark.parametrize("section", ["limits", "requests"])
+@pytest.mark.parametrize("field", ["memory", "cpu"])
+def test_every_emitted_value_is_a_quoted_string(section, field):
+    """Unquoted, a YAML reader re-types these: `128` becomes an int, `yes` True,
+    and `-` a sequence entry that will not parse at all. cpu was quoted and memory
+    was not, which is how a `-` placeholder produced an unparseable baseline."""
     v, prov = pres.resolve_resources("decode", NONE)
     r = parse(pres.resource_lines(v, prov, warn=True))["resources"]
-    assert isinstance(r["limits"]["cpu"], str)
-    assert isinstance(r["requests"]["cpu"], str)
+    assert isinstance(r[section][field], str)
+
+
+@pytest.mark.parametrize("hostile", ["128", "yes", "no", "null", "~", "0x40"])
+def test_yaml_hostile_values_survive_as_strings(hostile):
+    """Each of these is re-typed by YAML when unquoted -- to int, bool or None."""
+    v, prov = pres.resolve_resources("decode", {**NONE, "memory_limit": hostile})
+    r = parse(pres.resource_lines(v, prov, warn=True))["resources"]
+    assert r["limits"]["memory"] == hostile
 
 
 def test_prefill_emits_under_the_prefill_block():
@@ -117,203 +174,63 @@ def test_prefill_emits_under_the_prefill_block():
     assert r["limits"]["cpu"] == "8"
 
 
+def test_per_value_sources_distinguish_stated_from_default():
+    v, prov = pres.resolve_resources("decode", {**NONE, "cpu_limit": "64"})
+    text = "\n".join(pres.resource_lines(v, prov, warn=True))
+    cpu = next(ln for ln in text.splitlines() if "cpu: '64'" in ln)
+    mem = next(ln for ln in text.splitlines() if "memory: '128Gi'" in ln)
+    assert pres.STATED in cpu
+    assert pres.DEFAULTED in mem
+
+
+def test_source_comments_name_no_input_file():
+    """Both generators share this module and read different inputs, so naming one
+    would be wrong on the other path."""
+    v, prov = pres.resolve_resources("decode", {**NONE, "cpu_limit": "64"})
+    text = "\n".join(pres.resource_lines(v, prov, warn=True))
+    assert "config.md" not in text
+    assert "vllm_args" not in text
+    assert "{" not in text, "an unsubstituted template placeholder was emitted"
+
+
 def test_warning_comment_names_the_starvation_signal():
     v, prov = pres.resolve_resources("decode", NONE)
-    text = "\n".join(pres.resource_lines(v, prov, warn=True))
-    assert "Reducing Torch parallelism" in text
+    assert "Reducing Torch parallelism" in "\n".join(
+        pres.resource_lines(v, prov, warn=True))
 
 
 def test_no_warning_comment_when_everything_was_stated():
-    stated = {"cpu_limit": "1", "memory_limit": "2Gi",
-              "cpu_request": "3", "memory_request": "4Gi"}
-    v, prov = pres.resolve_resources("decode", stated)
+    v, prov = pres.resolve_resources("decode", ALL_STATED)
     text = "\n".join(pres.resource_lines(v, prov, warn=False))
     assert "Reducing Torch parallelism" not in text
-    assert parse(pres.resource_lines(v, prov, warn=False))["resources"]["limits"]["cpu"] == "1"
+    assert parse(pres.resource_lines(v, prov, warn=False))[
+        "resources"]["limits"]["cpu"] == "1"
 
 
-def test_stderr_warning_names_the_role_and_the_signal():
+@pytest.mark.parametrize("role", ["decode", "prefill"])
+@pytest.mark.parametrize("warn", [True, False])
+def test_emitted_yaml_parses_in_every_combination(role, warn):
+    """Hand-rolled emitter: indentation is the whole contract."""
+    v, prov = pres.resolve_resources(role, NONE)
+    r = parse(pres.resource_lines(v, prov, warn=warn), role=role)["resources"]
+    assert set(r) == {"limits", "requests"}
+
+
+# --- stderr warning --------------------------------------------------------
+
+def test_warning_reports_emitted_values_not_the_default_table():
+    """It fires when ANY quantity defaults, so quoting the whole default table would
+    contradict the YAML whenever the operator overrode part of it."""
+    v, prov = pres.resolve_resources("decode", {**NONE, "cpu_limit": "64"})
+    msg = pres.starvation_warning("decode", v, prov)
+    assert "cpu_limit" not in msg
+    assert "memory_limit=128Gi" in msg
+    assert "3 of 4" in msg
+
+
+def test_warning_names_the_role_and_the_signal_and_no_input_file():
     v, prov = pres.resolve_resources("prefill", NONE)
     msg = pres.starvation_warning("prefill", v, prov)
     assert "prefill" in msg
     assert "Reducing Torch parallelism" in msg
-
-
-def test_emitted_yaml_parses_for_every_role_and_warn_combination():
-    """Hand-rolled emitter: indentation is the whole contract."""
-    for role in ("decode", "prefill"):
-        for warn in (True, False):
-            v, prov = pres.resolve_resources(role, NONE)
-            r = parse(pres.resource_lines(v, prov, warn=warn), role=role)["resources"]
-            assert set(r) == {"limits", "requests"}
-
-
-# ---------------------------------------------------------------------------
-# Review findings from PR #857 (both `important`)
-# ---------------------------------------------------------------------------
-
-def test_warning_reports_the_emitted_values_not_the_default_table():
-    """Finding 1: the warning fires when ANY quantity defaults, so printing the
-    whole default table contradicted the YAML whenever the operator overrode part
-    of it -- stating `cpu limit: 64` still announced 'limits 32 CPU', which reads
-    as the override having been ignored."""
-    v, prov = pres.resolve_resources("decode", {**NONE, "cpu_limit": "64"})
-    msg = pres.starvation_warning("decode", v, prov)
-    assert "32" not in msg, "warning still quotes the overridden default"
-    assert "cpu_limit" not in msg, "warning names a quantity that was stated"
-    assert "memory_limit=128Gi" in msg
-
-
-def test_warning_names_only_the_defaulted_quantities():
-    v, prov = pres.resolve_resources(
-        "prefill", {**NONE, "cpu_limit": "9", "memory_limit": "20Gi"})
-    msg = pres.starvation_warning("prefill", v, prov)
-    assert "2 of 4" in msg
-    assert "cpu_request=4" in msg and "memory_request=8Gi" in msg
-
-
-def test_defaulted_keys_lists_only_the_missing_ones():
-    _, prov = pres.resolve_resources("decode", {**NONE, "cpu_limit": "64"})
-    assert pres.defaulted_keys(prov) == [
-        "memory_limit", "cpu_request", "memory_request"]
-
-
-def test_per_value_sources_distinguish_stated_from_default():
-    """The honest form of the same fix: a header comment cannot say where four
-    independently-resolved values came from, so each line carries its own."""
-    v, prov = pres.resolve_resources("decode", {**NONE, "cpu_limit": "64"})
-    text = "\n".join(pres.resource_lines(v, prov, warn=True))
-    cpu_line = next(ln for ln in text.splitlines() if "cpu: '64'" in ln)
-    mem_line = next(ln for ln in text.splitlines() if "memory: 128Gi" in ln)
-    assert "config.md" in cpu_line
-    assert "UNMEASURED" in mem_line
-
-
-def test_header_comment_no_longer_claims_all_limits_are_upstream():
-    """It said 'Limits are the llm-d pd-disaggregation guide's observed-working
-    figures', which is false for any limit the operator overrode."""
-    v, prov = pres.resolve_resources("decode", {**NONE, "cpu_limit": "64"})
-    text = "\n".join(pres.resource_lines(v, prov, warn=True))
-    assert "Limits are the llm-d" not in text
-
-
-# --- request > limit sanity check (the review's recommendation) -------------
-
-def test_request_exceeding_limit_is_reported():
-    """Each quantity resolves independently, so a stated request with an unstated
-    limit can exceed the default limit -- Kubernetes rejects that at admission."""
-    v, _ = pres.resolve_resources("decode", {**NONE, "cpu_request": "40"})
-    problems = pres.request_exceeds_limit(v)
-    assert len(problems) == 1
-    assert "request 40 > limit 32" in problems[0]
-
-
-def test_defaults_never_trip_the_request_limit_check():
-    for role in ("decode", "prefill"):
-        v, _ = pres.resolve_resources(role, NONE)
-        assert pres.request_exceeds_limit(v) == []
-
-
-def test_request_limit_check_compares_matching_suffixes():
-    v, _ = pres.resolve_resources(
-        "decode", {**NONE, "memory_request": "200Gi", "memory_limit": "128Gi"})
-    assert any("200Gi > limit 128Gi" in p for p in pres.request_exceeds_limit(v))
-
-
-def test_request_limit_check_stays_silent_on_units_it_cannot_compare():
-    """Conservative by design: a False must mean 'not proven', never 'verified
-    fine'.
-
-    `2000m` is two CPUs and genuinely exceeds a limit of `1`, so this IS a real
-    admission failure that the check misses — comparing across a bare number and an
-    `m` suffix needs a quantity parser this module does not have. The docstring used
-    to cite `500m`, which would not exceed a limit of 1 even under a correct parser
-    and so inverted the point.
-    """
-    v, _ = pres.resolve_resources(
-        "decode", {**NONE, "cpu_request": "2000m", "cpu_limit": "1"})
-    assert pres.request_exceeds_limit(v) == []
-
-
-# ---------------------------------------------------------------------------
-# Review findings, iteration 2 (PR #857) — precedence and input-style wording
-# ---------------------------------------------------------------------------
-# Both generators used to own the precedence themselves and the two copies
-# diverged. It now lives in pod_resources, so these tests pin it once.
-
-SHARED_ONLY = {"cpu_limit": "64"}
-
-
-def test_per_role_beats_shared_beats_default():
-    v, prov = pres.resolve_resources(
-        "decode", {"cpu_limit": "96"}, {"cpu_limit": "64", "memory_limit": "200Gi"})
-    assert v["cpu_limit"] == "96"          # per-role wins
-    assert v["memory_limit"] == "200Gi"    # shared, no per-role
-    assert v["cpu_request"] == "16"        # neither, so default
-    assert "per-role" in prov["cpu_limit"]
-    assert "shared" in prov["memory_limit"]
-    assert "default" in prov["cpu_request"]
-
-
-@pytest.mark.parametrize("blank", [None, "", "   "])
-def test_blank_per_role_falls_through_to_shared(blank):
-    """The finding: a per-role key PRESENT but null/empty skipped the shared value
-    and took the built-in default, silently discarding a stated 64. An operator who
-    leaves a per-role row empty has not asked to ignore the shared row they did
-    fill in."""
-    v, prov = pres.resolve_resources("decode", {"cpu_limit": blank}, SHARED_ONLY)
-    assert v["cpu_limit"] == "64"
-    assert "shared" in prov["cpu_limit"]
-
-
-@pytest.mark.parametrize("blank", [None, "", "  "])
-def test_blank_at_both_levels_takes_the_default(blank):
-    v, prov = pres.resolve_resources(
-        "decode", {"cpu_limit": blank}, {"cpu_limit": blank})
-    assert v["cpu_limit"] == pres.DEFAULTS["decode"]["cpu_limit"]
-    assert "default" in prov["cpu_limit"]
-
-
-def test_shared_argument_is_optional():
-    """Callers with no shared level must still work."""
-    v, _ = pres.resolve_resources("prefill", {"cpu_limit": "9"})
-    assert v["cpu_limit"] == "9"
-
-
-def test_json_style_never_mentions_config_md():
-    """The other finding: SKILL.md picks the JSON generator precisely when no
-    config.md exists, so citing 'config.md row' and advising to add rows to it
-    pointed the operator at a file that is not the input."""
-    v, prov = pres.resolve_resources(
-        "decode", {"cpu_limit": "64"}, {}, pres.JSON_INPUT)
-    assert "config.md" not in prov["cpu_limit"]
-    assert "vllm_args" in prov["cpu_limit"]
-    msg = pres.starvation_warning("decode", v, prov, pres.JSON_INPUT)
-    assert "config.md" not in msg
-    assert "vllm_args" in msg
-
-
-def test_config_md_style_does_mention_config_md():
-    v, prov = pres.resolve_resources(
-        "decode", {"cpu_limit": "64"}, {}, pres.CONFIG_MD_INPUT)
-    assert "config.md" in prov["cpu_limit"]
-    msg = pres.starvation_warning("decode", v, prov, pres.CONFIG_MD_INPUT)
-    assert "config.md" in msg
-
-
-def test_emitted_source_comments_follow_the_input_style():
-    v, prov = pres.resolve_resources(
-        "decode", {}, {"cpu_limit": "64"}, pres.JSON_INPUT)
-    text = "\n".join(pres.resource_lines(v, prov, warn=True))
-    cpu = next(ln for ln in text.splitlines() if "cpu: '64'" in ln)
-    assert "vllm_args" in cpu and "config.md" not in cpu
-
-
-@pytest.mark.parametrize("style", [pres.CONFIG_MD_INPUT, pres.JSON_INPUT])
-def test_every_style_renders_its_role_placeholder(style):
-    """`{role}` in a style string must be substituted, not emitted literally."""
-    v, prov = pres.resolve_resources("prefill", {}, {}, style)
-    msg = pres.starvation_warning("prefill", v, prov, style)
-    assert "{role}" not in msg
-    text = "\n".join(pres.resource_lines(v, prov, warn=True))
-    assert "{role}" not in text
+    assert "config.md" not in msg and "vllm_args" not in msg

--- a/.claude/skills/sim2real-bootstrap/tests/test_pod_resources.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_pod_resources.py
@@ -361,3 +361,106 @@ def test_whitespace_padded_stated_values_are_trimmed(padded):
     assert v["cpu_limit"] == "64"
     assert prov["cpu_limit"] == pres.STATED
     assert pres.invalid_quantities(v) == []
+
+
+# --- review findings on the derivation branch (PR #857, round 3) ------------
+# The derivation added to fix the previous round's must_fix introduced two narrower
+# bugs of its own, both in the same shape: a value labelled as something it is not.
+
+@pytest.mark.parametrize("limit", ["4e1", "1e3", "1.5e2"])
+def test_exponent_limit_never_yields_a_falsely_derived_request(limit):
+    """`_magnitude` accepts exponent notation via _EXPONENT_RE, which `_halve` does
+    not match. The fallback returned the limit UNCHANGED while labelling it "half the
+    stated limit" -- the YAML asserted a halving that never happened and the request
+    reserved the full limit."""
+    v, prov, _ = pres.resolve_resources("decode", {**NONE, "cpu_limit": limit})
+    if prov["cpu_request"] == pres.DERIVED:
+        assert pres._magnitude(v["cpu_request"]) < pres._magnitude(v["cpu_limit"]), (
+            "labelled DERIVED but not actually smaller than the limit"
+        )
+    # Whatever path was taken, the pair must stay valid.
+    assert pres._magnitude(v["cpu_request"]) <= pres._magnitude(v["cpu_limit"])
+
+
+@pytest.mark.parametrize("quantity", ["4e1", "1e3", "1.5e2"])
+def test_halve_declines_exponent_notation(quantity):
+    assert pres._halve(quantity) is None
+
+
+@pytest.mark.parametrize("quantity", ["10000000", "99999999"])
+def test_halve_declines_when_the_result_would_change_notation(quantity):
+    """`%g` switches to exponent form above six significant digits, so `10000000`
+    would halve to `5e+06` -- textually unlike anything the operator wrote, breaking
+    this module's promise not to reformat values."""
+    assert pres._halve(quantity) is None
+
+
+def test_no_emitted_value_ever_uses_exponent_notation():
+    for limit in ("10000000", "4e1", "99999999", "128Gi", "32"):
+        v, _, _ = pres.resolve_resources("decode", {**NONE, "cpu_limit": limit})
+        for key in pres.KEYS:
+            if v[key] != limit:  # a stated value passes through untouched
+                assert "e" not in v[key].lower(), f"{key}={v[key]} from limit {limit}"
+
+
+# --- prefill keeps Guaranteed QoS even when its limit is stated -------------
+
+@pytest.mark.parametrize("limit", ["16Gi", "24Gi", "32Gi", "8Gi"])
+def test_stated_prefill_memory_limit_keeps_request_equal_to_it(limit):
+    """The invariant lived only in DEFAULTS['prefill'], so the DERIVED branch halved
+    a stated limit unconditionally: a stated 24Gi limit produced a 12Gi request,
+    below the 16Gi /dev/shm tmpfs #848 mounts, silently reintroducing the mid-run
+    eviction risk this module argues against."""
+    v, prov, _ = pres.resolve_resources("prefill", {**NONE, "memory_limit": limit})
+    assert v["memory_request"] == limit
+    assert prov["memory_request"] == pres.MATCHED
+
+
+def test_matched_label_is_distinct_from_derived():
+    """Reusing DERIVED here would be the same false-provenance bug one line up."""
+    assert pres.MATCHED != pres.DERIVED
+    assert "half" not in pres.MATCHED
+
+
+def test_prefill_cpu_still_halves():
+    """Only memory has the tmpfs concern; CPU keeps the ordinary derivation."""
+    v, prov, _ = pres.resolve_resources("prefill", {**NONE, "cpu_limit": "16"})
+    assert v["cpu_request"] == "8"
+    assert prov["cpu_request"] == pres.DERIVED
+
+
+def test_decode_memory_still_halves():
+    """Decode has no shm floor to protect -- its request stays half the limit."""
+    v, prov, _ = pres.resolve_resources("decode", {**NONE, "memory_limit": "32Gi"})
+    assert v["memory_request"] == "16Gi"
+    assert prov["memory_request"] == pres.DERIVED
+
+
+def test_every_provenance_label_describes_its_value():
+    """The class of bug behind both findings: a label asserting something the value
+    does not satisfy. Checks every label against the value it annotates."""
+    cases = [
+        ("decode", {"memory_limit": "32Gi"}),
+        ("decode", {"cpu_limit": "4e1"}),
+        ("decode", {"cpu_limit": "10000000"}),
+        ("prefill", {"memory_limit": "24Gi"}),
+        ("prefill", {"cpu_limit": "16"}),
+        ("prefill", {"cpu_request": "20"}),
+        ("decode", {}),
+    ]
+    for role, stated in cases:
+        v, prov, _ = pres.resolve_resources(role, {**NONE, **stated})
+        for kind in ("cpu", "memory"):
+            rk, lk = f"{kind}_request", f"{kind}_limit"
+            src, req, lim = prov[rk], v[rk], v[lk]
+            if src == pres.DERIVED:
+                assert pres._magnitude(req) < pres._magnitude(lim), (
+                    f"{role} {rk}: labelled '{src}' but {req} is not below {lim}")
+            elif src == pres.MATCHED:
+                assert req == lim, f"{role} {rk}: labelled '{src}' but {req} != {lim}"
+            elif src == pres.CLAMPED:
+                assert req == lim, f"{role} {rk}: labelled '{src}' but {req} != {lim}"
+            elif src == pres.STATED:
+                assert req == str(stated.get(rk, "")).strip()
+            else:
+                assert src == pres.DEFAULTED

--- a/.claude/skills/sim2real-bootstrap/tests/test_pod_resources.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_pod_resources.py
@@ -82,7 +82,7 @@ def test_stated_values_pass_through_verbatim():
     """500m, 1.5 and Mi units must not be re-serialized into something else."""
     stated = {"cpu_limit": "500m", "memory_limit": "1536Mi",
               "cpu_request": "1.5", "memory_request": "512Mi"}
-    v, _ = pres.resolve_resources("prefill", stated)
+    v, prov = pres.resolve_resources("prefill", stated)
     assert v == stated
 
 
@@ -96,8 +96,8 @@ def test_used_any_default_distinguishes_the_two_cases():
 
 
 def test_emitted_yaml_carries_both_limits_and_requests():
-    v, _ = pres.resolve_resources("decode", NONE)
-    r = parse(pres.resource_lines(v, warn=True))["resources"]
+    v, prov = pres.resolve_resources("decode", NONE)
+    r = parse(pres.resource_lines(v, prov, warn=True))["resources"]
     assert r["limits"] == {"memory": "128Gi", "cpu": "32"}
     assert r["requests"] == {"memory": "64Gi", "cpu": "16"}
 
@@ -105,35 +105,36 @@ def test_emitted_yaml_carries_both_limits_and_requests():
 def test_cpu_is_emitted_as_a_string():
     """Matches the framework default and both source scenarios; a bare int is a
     different YAML type than the chart's other cpu values."""
-    v, _ = pres.resolve_resources("decode", NONE)
-    r = parse(pres.resource_lines(v, warn=True))["resources"]
+    v, prov = pres.resolve_resources("decode", NONE)
+    r = parse(pres.resource_lines(v, prov, warn=True))["resources"]
     assert isinstance(r["limits"]["cpu"], str)
     assert isinstance(r["requests"]["cpu"], str)
 
 
 def test_prefill_emits_under_the_prefill_block():
-    v, _ = pres.resolve_resources("prefill", NONE)
-    r = parse(pres.resource_lines(v, warn=True), role="prefill")["resources"]
+    v, prov = pres.resolve_resources("prefill", NONE)
+    r = parse(pres.resource_lines(v, prov, warn=True), role="prefill")["resources"]
     assert r["limits"]["cpu"] == "8"
 
 
 def test_warning_comment_names_the_starvation_signal():
-    v, _ = pres.resolve_resources("decode", NONE)
-    text = "\n".join(pres.resource_lines(v, warn=True))
+    v, prov = pres.resolve_resources("decode", NONE)
+    text = "\n".join(pres.resource_lines(v, prov, warn=True))
     assert "Reducing Torch parallelism" in text
 
 
 def test_no_warning_comment_when_everything_was_stated():
     stated = {"cpu_limit": "1", "memory_limit": "2Gi",
               "cpu_request": "3", "memory_request": "4Gi"}
-    v, _ = pres.resolve_resources("decode", stated)
-    text = "\n".join(pres.resource_lines(v, warn=False))
+    v, prov = pres.resolve_resources("decode", stated)
+    text = "\n".join(pres.resource_lines(v, prov, warn=False))
     assert "Reducing Torch parallelism" not in text
-    assert parse(pres.resource_lines(v, warn=False))["resources"]["limits"]["cpu"] == "1"
+    assert parse(pres.resource_lines(v, prov, warn=False))["resources"]["limits"]["cpu"] == "1"
 
 
 def test_stderr_warning_names_the_role_and_the_signal():
-    msg = pres.starvation_warning("prefill")
+    v, prov = pres.resolve_resources("prefill", NONE)
+    msg = pres.starvation_warning("prefill", v, prov)
     assert "prefill" in msg
     assert "Reducing Torch parallelism" in msg
 
@@ -142,6 +143,86 @@ def test_emitted_yaml_parses_for_every_role_and_warn_combination():
     """Hand-rolled emitter: indentation is the whole contract."""
     for role in ("decode", "prefill"):
         for warn in (True, False):
-            v, _ = pres.resolve_resources(role, NONE)
-            r = parse(pres.resource_lines(v, warn=warn), role=role)["resources"]
+            v, prov = pres.resolve_resources(role, NONE)
+            r = parse(pres.resource_lines(v, prov, warn=warn), role=role)["resources"]
             assert set(r) == {"limits", "requests"}
+
+
+# ---------------------------------------------------------------------------
+# Review findings from PR #857 (both `important`)
+# ---------------------------------------------------------------------------
+
+def test_warning_reports_the_emitted_values_not_the_default_table():
+    """Finding 1: the warning fires when ANY quantity defaults, so printing the
+    whole default table contradicted the YAML whenever the operator overrode part
+    of it -- stating `cpu limit: 64` still announced 'limits 32 CPU', which reads
+    as the override having been ignored."""
+    v, prov = pres.resolve_resources("decode", {**NONE, "cpu_limit": "64"})
+    msg = pres.starvation_warning("decode", v, prov)
+    assert "32" not in msg, "warning still quotes the overridden default"
+    assert "cpu_limit" not in msg, "warning names a quantity that was stated"
+    assert "memory_limit=128Gi" in msg
+
+
+def test_warning_names_only_the_defaulted_quantities():
+    v, prov = pres.resolve_resources(
+        "prefill", {**NONE, "cpu_limit": "9", "memory_limit": "20Gi"})
+    msg = pres.starvation_warning("prefill", v, prov)
+    assert "2 of 4" in msg
+    assert "cpu_request=4" in msg and "memory_request=8Gi" in msg
+
+
+def test_defaulted_keys_lists_only_the_missing_ones():
+    _, prov = pres.resolve_resources("decode", {**NONE, "cpu_limit": "64"})
+    assert pres.defaulted_keys(prov) == [
+        "memory_limit", "cpu_request", "memory_request"]
+
+
+def test_per_value_sources_distinguish_stated_from_default():
+    """The honest form of the same fix: a header comment cannot say where four
+    independently-resolved values came from, so each line carries its own."""
+    v, prov = pres.resolve_resources("decode", {**NONE, "cpu_limit": "64"})
+    text = "\n".join(pres.resource_lines(v, prov, warn=True))
+    cpu_line = next(ln for ln in text.splitlines() if "cpu: '64'" in ln)
+    mem_line = next(ln for ln in text.splitlines() if "memory: 128Gi" in ln)
+    assert "config.md" in cpu_line
+    assert "UNMEASURED" in mem_line
+
+
+def test_header_comment_no_longer_claims_all_limits_are_upstream():
+    """It said 'Limits are the llm-d pd-disaggregation guide's observed-working
+    figures', which is false for any limit the operator overrode."""
+    v, prov = pres.resolve_resources("decode", {**NONE, "cpu_limit": "64"})
+    text = "\n".join(pres.resource_lines(v, prov, warn=True))
+    assert "Limits are the llm-d" not in text
+
+
+# --- request > limit sanity check (the review's recommendation) -------------
+
+def test_request_exceeding_limit_is_reported():
+    """Each quantity resolves independently, so a stated request with an unstated
+    limit can exceed the default limit -- Kubernetes rejects that at admission."""
+    v, _ = pres.resolve_resources("decode", {**NONE, "cpu_request": "40"})
+    problems = pres.request_exceeds_limit(v)
+    assert len(problems) == 1
+    assert "request 40 > limit 32" in problems[0]
+
+
+def test_defaults_never_trip_the_request_limit_check():
+    for role in ("decode", "prefill"):
+        v, _ = pres.resolve_resources(role, NONE)
+        assert pres.request_exceeds_limit(v) == []
+
+
+def test_request_limit_check_compares_matching_suffixes():
+    v, _ = pres.resolve_resources(
+        "decode", {**NONE, "memory_request": "200Gi", "memory_limit": "128Gi"})
+    assert any("200Gi > limit 128Gi" in p for p in pres.request_exceeds_limit(v))
+
+
+def test_request_limit_check_stays_silent_on_units_it_cannot_compare():
+    """Conservative by design: a False must mean 'not proven', never 'verified
+    fine'. Comparing 500m against 1 needs a real quantity parser."""
+    v, _ = pres.resolve_resources(
+        "decode", {**NONE, "cpu_request": "2000m", "cpu_limit": "1"})
+    assert pres.request_exceeds_limit(v) == []

--- a/.claude/skills/sim2real-bootstrap/tests/test_pod_resources.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_pod_resources.py
@@ -222,7 +222,98 @@ def test_request_limit_check_compares_matching_suffixes():
 
 def test_request_limit_check_stays_silent_on_units_it_cannot_compare():
     """Conservative by design: a False must mean 'not proven', never 'verified
-    fine'. Comparing 500m against 1 needs a real quantity parser."""
+    fine'.
+
+    `2000m` is two CPUs and genuinely exceeds a limit of `1`, so this IS a real
+    admission failure that the check misses — comparing across a bare number and an
+    `m` suffix needs a quantity parser this module does not have. The docstring used
+    to cite `500m`, which would not exceed a limit of 1 even under a correct parser
+    and so inverted the point.
+    """
     v, _ = pres.resolve_resources(
         "decode", {**NONE, "cpu_request": "2000m", "cpu_limit": "1"})
     assert pres.request_exceeds_limit(v) == []
+
+
+# ---------------------------------------------------------------------------
+# Review findings, iteration 2 (PR #857) — precedence and input-style wording
+# ---------------------------------------------------------------------------
+# Both generators used to own the precedence themselves and the two copies
+# diverged. It now lives in pod_resources, so these tests pin it once.
+
+SHARED_ONLY = {"cpu_limit": "64"}
+
+
+def test_per_role_beats_shared_beats_default():
+    v, prov = pres.resolve_resources(
+        "decode", {"cpu_limit": "96"}, {"cpu_limit": "64", "memory_limit": "200Gi"})
+    assert v["cpu_limit"] == "96"          # per-role wins
+    assert v["memory_limit"] == "200Gi"    # shared, no per-role
+    assert v["cpu_request"] == "16"        # neither, so default
+    assert "per-role" in prov["cpu_limit"]
+    assert "shared" in prov["memory_limit"]
+    assert "default" in prov["cpu_request"]
+
+
+@pytest.mark.parametrize("blank", [None, "", "   "])
+def test_blank_per_role_falls_through_to_shared(blank):
+    """The finding: a per-role key PRESENT but null/empty skipped the shared value
+    and took the built-in default, silently discarding a stated 64. An operator who
+    leaves a per-role row empty has not asked to ignore the shared row they did
+    fill in."""
+    v, prov = pres.resolve_resources("decode", {"cpu_limit": blank}, SHARED_ONLY)
+    assert v["cpu_limit"] == "64"
+    assert "shared" in prov["cpu_limit"]
+
+
+@pytest.mark.parametrize("blank", [None, "", "  "])
+def test_blank_at_both_levels_takes_the_default(blank):
+    v, prov = pres.resolve_resources(
+        "decode", {"cpu_limit": blank}, {"cpu_limit": blank})
+    assert v["cpu_limit"] == pres.DEFAULTS["decode"]["cpu_limit"]
+    assert "default" in prov["cpu_limit"]
+
+
+def test_shared_argument_is_optional():
+    """Callers with no shared level must still work."""
+    v, _ = pres.resolve_resources("prefill", {"cpu_limit": "9"})
+    assert v["cpu_limit"] == "9"
+
+
+def test_json_style_never_mentions_config_md():
+    """The other finding: SKILL.md picks the JSON generator precisely when no
+    config.md exists, so citing 'config.md row' and advising to add rows to it
+    pointed the operator at a file that is not the input."""
+    v, prov = pres.resolve_resources(
+        "decode", {"cpu_limit": "64"}, {}, pres.JSON_INPUT)
+    assert "config.md" not in prov["cpu_limit"]
+    assert "vllm_args" in prov["cpu_limit"]
+    msg = pres.starvation_warning("decode", v, prov, pres.JSON_INPUT)
+    assert "config.md" not in msg
+    assert "vllm_args" in msg
+
+
+def test_config_md_style_does_mention_config_md():
+    v, prov = pres.resolve_resources(
+        "decode", {"cpu_limit": "64"}, {}, pres.CONFIG_MD_INPUT)
+    assert "config.md" in prov["cpu_limit"]
+    msg = pres.starvation_warning("decode", v, prov, pres.CONFIG_MD_INPUT)
+    assert "config.md" in msg
+
+
+def test_emitted_source_comments_follow_the_input_style():
+    v, prov = pres.resolve_resources(
+        "decode", {}, {"cpu_limit": "64"}, pres.JSON_INPUT)
+    text = "\n".join(pres.resource_lines(v, prov, warn=True))
+    cpu = next(ln for ln in text.splitlines() if "cpu: '64'" in ln)
+    assert "vllm_args" in cpu and "config.md" not in cpu
+
+
+@pytest.mark.parametrize("style", [pres.CONFIG_MD_INPUT, pres.JSON_INPUT])
+def test_every_style_renders_its_role_placeholder(style):
+    """`{role}` in a style string must be substituted, not emitted literally."""
+    v, prov = pres.resolve_resources("prefill", {}, {}, style)
+    msg = pres.starvation_warning("prefill", v, prov, style)
+    assert "{role}" not in msg
+    text = "\n".join(pres.resource_lines(v, prov, warn=True))
+    assert "{role}" not in text

--- a/docs/superpowers/plans/2026-08-25-issue-850-pod-resources.md
+++ b/docs/superpowers/plans/2026-08-25-issue-850-pod-resources.md
@@ -1,0 +1,272 @@
+# Pod CPU/Memory Resources Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development or superpowers:executing-plans. Steps use `- [ ]` for tracking.
+
+**Goal:** Emit `resources` for decode and prefill — from `config.md` when it states them, otherwise fixed generous limits with modest explicit requests.
+
+**Spec:** Issue #850, narrowed by the operator to: *use config.md's cpu/memory req/limits when stated; otherwise generous defaults; decode needs more than prefill; `pd-infocomm-2/baselines/baseline.yaml` is a good starting point; start with fixed values and learn.*
+
+**Scope:** the bootstrap skill only. Nothing in `pipeline/`.
+
+## Facts established before writing code
+
+- Bootstrap emits **no** `resources` today (0 occurrences in either generator).
+- Framework default: `limits: {memory: 40Gi, cpu: "4"}`, **no** `requests`, both roles (`llm-d-benchmark@76473d0 defaults.yaml:848-851`, `:994-997`).
+- Kubernetes copies `limits` into `requests` when `requests` is absent, so "limits only" is not "no reservation". `pd-infocomm-2`'s decode (`limits {128Gi, 32}`, no requests) reserves 128Gi × 2 replicas before prefill is scheduled at all.
+- Upstream `pd-disaggregation.yaml` sizes decode `limits {128Gi, 32}` (`:410-416`) and prefill `limits {16Gi, 8}` (`:321-327`), both with `requests == limits`. **decode > prefill is upstream's own sizing**, not only this cluster's.
+- `pd-infocomm-2` carries the same two figures (decode `:210-211`, prefill `:278-280`), decode without requests.
+- `config.md`'s machine-read table is `| Parameter | Value | Notes |`; `extract_fields` reads column 1 as parameter, column 2 as value. No cpu/memory rows exist in the vocabulary today.
+
+## Design
+
+**D1 — Fixed per-role defaults, decode > prefill.** No scaling with GPU count: the operator chose to start fixed and learn.
+
+| Role | limits | requests |
+|---|---|---|
+| decode | `memory: 128Gi`, `cpu: '32'` | `memory: 64Gi`, `cpu: '16'` |
+| prefill | `memory: 16Gi`, `cpu: '8'` | `memory: 8Gi`, `cpu: '4'` |
+
+Limits are upstream's and `pd-infocomm-2`'s observed-working figures verbatim. Requests are **half** the limit — explicit rather than omitted, because omitting them makes Kubernetes reserve the whole generous limit, which is the trap #850 documents. The halving is a stated default, not a measurement; D4's warning says so.
+
+**D2 — Input vocabulary: shared keys with per-role overrides.** Mirrors the existing `hardware` / `decode_hardware` / `prefill_hardware` pattern and its `fields.get(role_field) or fields["hardware"]` resolution.
+
+| Canonical | Accepted row labels (lowercased) |
+|---|---|
+| `cpu_limit` | `cpu limit`, `cpu_limit`, `cpu limits` |
+| `memory_limit` | `memory limit`, `memory_limit`, `memory limits` |
+| `cpu_request` | `cpu request`, `cpu_request`, `cpu requests` |
+| `memory_request` | `memory request`, `memory_request`, `memory requests` |
+| `decode_*` / `prefill_*` | the same four, prefixed `decode ` / `prefill ` |
+
+Values pass through as **strings**, never parsed into numbers: `32`, `500m`, `1.5`, `128Gi`, `1536Mi` are all valid Kubernetes quantities and re-serializing risks changing them. CPU is emitted quoted (`cpu: '32'`) to match both the framework default and both source scenarios; memory unquoted.
+
+**D3 — Stated wins, per key, per role.** Order per quantity: per-role row → shared row → role default. A `config.md` stating only `decode cpu limit` still gets defaults for the other three. Provenance records which arm fired.
+
+**D4 — Warn that defaults are unmeasured**, in two places per #850: a stderr warning at generation time and a comment in the emitted YAML, both naming the starvation signal (`Reducing Torch parallelism from N threads to 1`). Emitted only when at least one value came from a default — a config.md stating all four gets no warning.
+
+**D5 — Shared module.** Both generators import it, the `pd_plumbing.py` precedent from #848, so the two hand-rolled emitters cannot drift.
+
+## Files
+
+| File | Change |
+|---|---|
+| `.claude/skills/sim2real-bootstrap/pod_resources.py` | **Create.** Default table, `resolve_resources`, `resource_lines`, `used_any_default`. |
+| `generate_from_config.py` | 12 aliases; resolve per role in `build_scenario`; emit in `write_provenance_yaml`. |
+| `generate_scenarios.py` | Same, reading `vllm_args` keys; add them to `KNOWN_FIELDS`. |
+| `tests/test_pod_resources.py` | **Create.** Resolver + emitter units. |
+| `tests/test_generate_from_config_prefill.py` | Resolution through the config.md path. |
+| `tests/test_generate_scenarios.py` | Same through the JSON path, plus the cross-generator identity guard. |
+| `SKILL.md` | Rows, defaults, resolution order, warning. |
+
+---
+
+### Task 1: `pod_resources.py`
+
+**Produces** (used by Tasks 2-3):
+- `DEFAULTS: dict[str, dict[str, str]]` — keyed `"decode"` / `"prefill"`, each with `cpu_limit`, `memory_limit`, `cpu_request`, `memory_request`
+- `KEYS: tuple[str, ...]` — the four quantity names, in emission order
+- `resolve_resources(role: str, stated: dict[str, str | None]) -> tuple[dict, dict]` → `(values, provenance)`
+- `used_any_default(provenance: dict) -> bool`
+- `resource_lines(values: dict, *, warn: bool) -> list[str]` — YAML at role-block indent: `    resources:` (4), `      limits:` (6), `        memory:` (8)
+- `starvation_warning(role: str) -> str` — the stderr text, so both generators warn identically
+
+- [ ] **Step 1: failing tests** — `tests/test_pod_resources.py`:
+
+```python
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parents[1]))
+import pod_resources as pres
+
+
+def parse(lines, role="decode"):
+    """Parse emitter output inside the role block the caller has printed."""
+    doc = f"scenario:\n- name: t\n  {role}:\n" + "\n".join(lines) + "\n"
+    return yaml.safe_load(doc)["scenario"][0][role]
+
+
+NONE = dict.fromkeys(pres.KEYS)
+
+
+def test_keys_are_the_four_quantities():
+    assert set(pres.KEYS) == {
+        "cpu_limit", "memory_limit", "cpu_request", "memory_request"}
+
+
+@pytest.mark.parametrize("role", ["decode", "prefill"])
+def test_every_role_has_all_four_defaults(role):
+    assert set(pres.DEFAULTS[role]) == set(pres.KEYS)
+
+
+def test_decode_gets_more_than_prefill():
+    """The operator's stated constraint, and upstream's own sizing."""
+    d, p = pres.DEFAULTS["decode"], pres.DEFAULTS["prefill"]
+    assert int(d["cpu_limit"]) > int(p["cpu_limit"])
+    assert int(d["memory_limit"].removesuffix("Gi")) > int(
+        p["memory_limit"].removesuffix("Gi"))
+
+
+def test_defaults_match_the_observed_working_limits():
+    """Verbatim from pd-disaggregation.yaml:410-416 / :321-327, which
+    pd-infocomm-2 also carries."""
+    assert pres.DEFAULTS["decode"]["cpu_limit"] == "32"
+    assert pres.DEFAULTS["decode"]["memory_limit"] == "128Gi"
+    assert pres.DEFAULTS["prefill"]["cpu_limit"] == "8"
+    assert pres.DEFAULTS["prefill"]["memory_limit"] == "16Gi"
+
+
+@pytest.mark.parametrize("role", ["decode", "prefill"])
+def test_requests_are_below_limits(role):
+    """limits without requests is NOT 'no reservation' -- Kubernetes copies the
+    limit into the request, so requests must be emitted AND smaller (#850)."""
+    v = pres.DEFAULTS[role]
+    assert int(v["cpu_request"]) < int(v["cpu_limit"])
+    assert int(v["memory_request"].removesuffix("Gi")) < int(
+        v["memory_limit"].removesuffix("Gi"))
+
+
+def test_defaults_used_when_nothing_stated():
+    v, prov = pres.resolve_resources("decode", NONE)
+    assert v == pres.DEFAULTS["decode"]
+    assert all("default" in prov[k] for k in pres.KEYS)
+
+
+def test_stated_value_wins_and_others_still_default():
+    v, prov = pres.resolve_resources("decode", {**NONE, "cpu_limit": "64"})
+    assert v["cpu_limit"] == "64"
+    assert "config.md" in prov["cpu_limit"]
+    assert v["memory_limit"] == pres.DEFAULTS["decode"]["memory_limit"]
+    assert "default" in prov["memory_limit"]
+
+
+def test_stated_values_pass_through_verbatim():
+    """500m, 1.5 and Mi units must not be re-serialized into something else."""
+    stated = {"cpu_limit": "500m", "memory_limit": "1536Mi",
+              "cpu_request": "1.5", "memory_request": "512Mi"}
+    v, _ = pres.resolve_resources("prefill", stated)
+    assert v == stated
+
+
+def test_used_any_default_distinguishes_the_two_cases():
+    _, all_stated = pres.resolve_resources(
+        "decode", {"cpu_limit": "1", "memory_limit": "2Gi",
+                   "cpu_request": "3", "memory_request": "4Gi"})
+    assert pres.used_any_default(all_stated) is False
+    _, one_missing = pres.resolve_resources("decode", {**NONE, "cpu_limit": "1"})
+    assert pres.used_any_default(one_missing) is True
+
+
+def test_emitted_yaml_carries_both_limits_and_requests():
+    v, _ = pres.resolve_resources("decode", NONE)
+    r = parse(pres.resource_lines(v, warn=True))["resources"]
+    assert r["limits"] == {"memory": "128Gi", "cpu": "32"}
+    assert r["requests"] == {"memory": "64Gi", "cpu": "16"}
+
+
+def test_cpu_is_emitted_as_a_string():
+    """Matches the framework default and both source scenarios; a bare int is a
+    different YAML type than the chart's other cpu values."""
+    v, _ = pres.resolve_resources("decode", NONE)
+    r = parse(pres.resource_lines(v, warn=True))["resources"]
+    assert isinstance(r["limits"]["cpu"], str)
+    assert isinstance(r["requests"]["cpu"], str)
+
+
+def test_prefill_emits_under_the_prefill_block():
+    v, _ = pres.resolve_resources("prefill", NONE)
+    r = parse(pres.resource_lines(v, warn=True), role="prefill")["resources"]
+    assert r["limits"]["cpu"] == "8"
+
+
+def test_warning_comment_names_the_starvation_signal():
+    v, _ = pres.resolve_resources("decode", NONE)
+    text = "\n".join(pres.resource_lines(v, warn=True))
+    assert "Reducing Torch parallelism" in text
+
+
+def test_no_warning_comment_when_everything_was_stated():
+    stated = {"cpu_limit": "1", "memory_limit": "2Gi",
+              "cpu_request": "3", "memory_request": "4Gi"}
+    v, _ = pres.resolve_resources("decode", stated)
+    text = "\n".join(pres.resource_lines(v, warn=False))
+    assert "Reducing Torch parallelism" not in text
+    assert parse(pres.resource_lines(v, warn=False))["resources"]["limits"]["cpu"] == "1"
+
+
+def test_stderr_warning_names_the_role_and_the_signal():
+    msg = pres.starvation_warning("prefill")
+    assert "prefill" in msg
+    assert "Reducing Torch parallelism" in msg
+```
+
+- [ ] **Step 2** `python -m pytest .claude/skills/sim2real-bootstrap/tests/test_pod_resources.py -v` → `ModuleNotFoundError`.
+- [ ] **Step 3** Implement to satisfy exactly those assertions. Docstring must state: the Kubernetes limits→requests copy rule and why requests are explicit; that limits are upstream's observed figures and requests are a stated half; that nothing here is measured.
+- [ ] **Step 4** Re-run → pass. `ruff check .claude/skills/sim2real-bootstrap/ --select F` → clean.
+- [ ] **Step 5** Fault-inject and confirm each fails a test: drop the `requests` block; make prefill's limit exceed decode's; unquote cpu; remove the warning comment; change a default figure.
+- [ ] **Step 6** Commit.
+
+---
+
+### Task 2: wire `generate_from_config.py`
+
+- [ ] **Step 1** Tests appended to `tests/test_generate_from_config_prefill.py`, asserting on **emitted text** parsed back with `yaml.safe_load` (the emitter is a hand-rolled line appender — a dict key proves nothing):
+  - no rows → decode and prefill each carry their own role defaults
+  - `| cpu limit | 64 |` → both roles use 64; other three default
+  - `| decode cpu limit | 64 |` → decode 64, prefill still default
+  - both shared and per-role present → per-role wins
+  - all four stated → no warning comment, no stderr warning
+  - any default used → stderr warning naming `Reducing Torch parallelism` (capture with `capsys`)
+  - `resources` nests inside each role block
+  - a scenario with no prefill pool emits `resources` for decode only
+- [ ] **Step 2** Run → fail.
+- [ ] **Step 3** Add the 12 aliases to `PARAMETER_ALIASES`. Resolve per role in `build_scenario` with `fields.get(f"{role}_{key}") or fields.get(key)`.
+- [ ] **Step 4** Emit at the end of each role block in `write_provenance_yaml`, where #848's `init_container_lines` sit.
+- [ ] **Step 5** Whole skill suite → pass.
+- [ ] **Step 6** Emit one scenario by hand; read the YAML and confirm nesting and figures.
+- [ ] **Step 7** Commit.
+
+---
+
+### Task 3: wire `generate_scenarios.py`
+
+Reads `vllm_args` keys (`cpu_limit`, `decode_cpu_limit`, …). They must be added to `KNOWN_FIELDS` or `check_unknown_fields` warns on them.
+
+- [ ] **Step 1** Tests in `tests/test_generate_scenarios.py`: role defaults; stated wins; per-role beats shared; both roles carry `resources`; the new keys do not trip the unknown-field warning.
+- [ ] **Step 2** Run → fail.
+- [ ] **Step 3-4** Wire `build_scenario` and `write_commented_yaml` against the same module.
+- [ ] **Step 5** Add the cross-generator guard: both paths emit character-identical `resources` text for equivalent input (#848's `test_both_generators_emit_identical_plumbing_text` precedent).
+- [ ] **Step 6** Full suite → pass. Inject a divergence into the JSON path; confirm the cross-generator guard catches it.
+- [ ] **Step 7** Commit.
+
+---
+
+### Task 4: SKILL.md and sweep
+
+- [ ] **Step 1** Document in the baseline-generation section: accepted row labels, resolution order (per-role → shared → default), the per-role default table, and why requests are explicit-and-smaller (the Kubernetes copy rule).
+- [ ] **Step 2** Note that the values are unmeasured and name the starvation signal.
+- [ ] **Step 3** Sweep. `grep -rn "resources" --include=*.md .` excluding submodules; check whether `CLAUDE.md`, `pipeline/README.md`, or `/sim2real-check` enumerate expected scenario keys and would now see a new one. Report what was swept and what changed.
+- [ ] **Step 4** Full CI locally: lint, then the five test paths with the coverage gate.
+- [ ] **Step 5** Commit.
+
+## Acceptance criteria
+
+| Requirement (operator's restatement) | Where satisfied |
+|---|---|
+| config.md states cpu/memory req/limits → use them | D2/D3; `test_stated_value_wins_and_others_still_default` + Task 2 per-role tests |
+| not stated → generous defaults | D1; `test_defaults_used_when_nothing_stated` |
+| decode needs more than prefill | `test_decode_gets_more_than_prefill` |
+| pd-infocomm-2 as starting point | `test_defaults_match_the_observed_working_limits` |
+| fixed values, not derived | D1 — no GPU-count input to the defaults at all |
+| bootstrap skill issue | only `.claude/skills/sim2real-bootstrap/` changes |
+| (#850) requests explicit, not omitted | `test_requests_are_below_limits` |
+| (#850) warn the values are unmeasured | D4; three tests plus a `capsys` stderr assertion |
+
+## Risks
+
+- **Every generated scenario changes.** Unlike #848 and #853 there is no byte-identity escape — a bundle regenerated after this gains a `resources` block. Intended, but the PR must say so plainly rather than let it surprise someone re-bootstrapping.
+- **The figures are unmeasured** on any cluster but the one they came from, at one TP and one model. The emitted comment and the stderr warning are the whole mitigation. Fixed-and-learn is the operator's explicit choice; revisit when there is data.
+- **`resources` is a dict, not a list**, so `_merge_lists` tiering does not apply: a downstream baseline setting `resources` deep-merges key by key rather than replacing. An operator overriding only `limits.cpu` keeps the emitted `requests`. Worth stating in the emitted comment, since it differs from the scalar-list behaviour documented elsewhere in this skill.

--- a/docs/superpowers/plans/2026-08-25-issue-850-pod-resources.md
+++ b/docs/superpowers/plans/2026-08-25-issue-850-pod-resources.md
@@ -10,9 +10,15 @@
 
 ## Facts established before writing code
 
+> **CORRECTION — this plan was written before the code and two of its "facts" were
+> wrong. They are struck through below rather than deleted, because the wrong
+> reasoning leaked into the first implementation and into `SKILL.md`, and knowing
+> that is more useful than a clean-looking plan. See "What changed after review" at
+> the end for the full list of divergences.**
+
 - Bootstrap emits **no** `resources` today (0 occurrences in either generator).
-- Framework default: `limits: {memory: 40Gi, cpu: "4"}`, **no** `requests`, both roles (`llm-d-benchmark@76473d0 defaults.yaml:848-851`, `:994-997`).
-- Kubernetes copies `limits` into `requests` when `requests` is absent, so "limits only" is not "no reservation". `pd-infocomm-2`'s decode (`limits {128Gi, 32}`, no requests) reserves 128Gi × 2 replicas before prefill is scheduled at all.
+- ~~Framework default: `limits: {memory: 40Gi, cpu: "4"}`, **no** `requests`, both roles (`defaults.yaml:848-851`, `:994-997`).~~ **WRONG.** Those ranges stop one line short of the `requests` block, which exists and sets 40Gi/`"4"` as well. The correct ranges are `defaults.yaml:848-858` (decode) and `:993-1000` (prefill), and the framework sets **both** halves.
+- ~~Kubernetes copies `limits` into `requests` when `requests` is absent, so "limits only" is not "no reservation".~~ **TRUE OF KUBERNETES, IRRELEVANT HERE.** The rule is real, but a scenario is deep-merged over `defaults.yaml`, which supplies `requests` — so the copy never fires in this pipeline, and no "trap" exists. The actual reason to emit both halves is that emitting only `limits` leaves `requests` at the inherited 40Gi/`"4"`, pairing a 128Gi limit with a 40Gi reservation.
 - Upstream `pd-disaggregation.yaml` sizes decode `limits {128Gi, 32}` (`:410-416`) and prefill `limits {16Gi, 8}` (`:321-327`), both with `requests == limits`. **decode > prefill is upstream's own sizing**, not only this cluster's.
 - `pd-infocomm-2` carries the same two figures (decode `:210-211`, prefill `:278-280`), decode without requests.
 - `config.md`'s machine-read table is `| Parameter | Value | Notes |`; `extract_fields` reads column 1 as parameter, column 2 as value. No cpu/memory rows exist in the vocabulary today.
@@ -270,3 +276,45 @@ Reads `vllm_args` keys (`cpu_limit`, `decode_cpu_limit`, …). They must be adde
 - **Every generated scenario changes.** Unlike #848 and #853 there is no byte-identity escape — a bundle regenerated after this gains a `resources` block. Intended, but the PR must say so plainly rather than let it surprise someone re-bootstrapping.
 - **The figures are unmeasured** on any cluster but the one they came from, at one TP and one model. The emitted comment and the stderr warning are the whole mitigation. Fixed-and-learn is the operator's explicit choice; revisit when there is data.
 - **`resources` is a dict, not a list**, so `_merge_lists` tiering does not apply: a downstream baseline setting `resources` deep-merges key by key rather than replacing. An operator overriding only `limits.cpu` keeps the emitted `requests`. Worth stating in the emitted comment, since it differs from the scalar-list behaviour documented elsewhere in this skill.
+
+---
+
+## What changed after review
+
+This plan is kept as the record of what was intended. The shipped code differs in
+five ways, all of them corrections found by review rather than changes of mind.
+
+**1. Two "facts" in the header were wrong** — see the correction banner there. The
+framework default sets `requests` as well as `limits`, and the limits/requests "trap"
+this plan built its rationale on cannot fire in this pipeline. The design decision
+(emit both halves) survives; the reason changed.
+
+**2. D2's per-role vocabulary was never implemented, then removed.** The plan
+proposed four shared keys plus eight `decode_*` / `prefill_*` overrides. The first
+implementation shipped all twelve; the operator judged it over-engineered, and the
+per-role rows were deleted along with the `InputStyle` machinery built around them.
+Four shared keys remain. This plan's D3 wording is what leaked into a `SKILL.md`
+sentence describing a three-level precedence that never existed.
+
+**3. Memory is emitted QUOTED.** D1 said cpu quoted, memory unquoted. That was the
+bug: an unquoted `-` placeholder produced an unparseable `baseline.yaml` while the
+generator exited 0, and `128` / `yes` / `null` were silently re-typed. Both are
+quoted now.
+
+**4. The limit/request pair is reconciled per role.** The plan resolved the four
+quantities independently, which let a request exceed its limit — an invalid pod spec.
+Because the rows are shared while the defaults differ 4–8× between roles, a request
+sized for decode inverted prefill unconditionally. `resolve_resources` now derives an
+unstated request from the stated limit and clamps any request to its own role's
+limit, so an invalid pair cannot be expressed.
+
+**5. Prefill's request equals its limit.** The plan set every request to half its
+limit. Issue #848 mounts a 16Gi `medium: Memory` tmpfs at `/dev/shm` in `vllmCommon`,
+and tmpfs charges against pod memory, so a prefill request of 8Gi under a 16Gi
+ceiling made the pod evictable mid-run. Upstream uses request == limit there;
+so does this.
+
+Also added, none of it in the plan: a Kubernetes quantity validator (an invalid
+quantity is now a hard error rather than a pod the cluster rejects at admission),
+and the four keys registered with `warn_role_rows_outside_vllm_table` so a resource
+row stated in a non-machine-read table is reported instead of silently dropped.


### PR DESCRIPTION
Closes #850

Built to the operator's restatement of the issue rather than its body: *use `config.md`'s
cpu/memory req/limits when stated; otherwise generous defaults; decode needs more than
prefill; `pd-infocomm-2/baselines/baseline.yaml` as a starting point; start fixed and
learn.*

## What changed

Bootstrap emitted **no** `resources` at all, so every bundle inherited the framework
default `limits: {memory: 40Gi, cpu: "4"}` with no `requests` (`defaults.yaml:848-851`
decode, `:994-997` prefill) — four CPU for a pod that may hold four GPUs and shares its
cgroup with the routing sidecar. It now emits per-role resources in both generators.

**Rows `config.md` may state**, resolved *per-role → shared → role default*, the same
precedence as `Decode GPU` over `GPU`:

| Shared | Per-role override |
|---|---|
| `cpu limit` | `decode cpu limit`, `prefill cpu limit` |
| `memory limit` | `decode memory limit`, `prefill memory limit` |
| `cpu request` | `decode cpu request`, `prefill cpu request` |
| `memory request` | `decode memory request`, `prefill memory request` |

Values pass through as **strings**, never parsed — `32`, `500m`, `1.5`, `128Gi`, `1536Mi`
are all valid Kubernetes quantities and re-serializing risks changing them.

**Defaults when unstated**, fixed rather than derived:

| Role | limits | requests |
|---|---|---|
| decode | `128Gi` / `32` | `64Gi` / `16` |
| prefill | `16Gi` / `8` | `8Gi` / `4` |

Limits are llm-d's `pd-disaggregation` guide verbatim (`:410-416` decode, `:321-327`
prefill), which `pd-infocomm-2` also carries. **decode > prefill is upstream's own
sizing**, not just this cluster's — worth noting since it independently corroborates the
constraint.

Requests are half those limits and **emitted explicitly**. That is the point of #850's
requests/limits section: omitting `requests` is not "no reservation" — Kubernetes copies
the limit into the request when the request is absent, so limits-only would reserve the
whole generous figure on every replica, and a 2-replica decode pool would reserve 256Gi
before prefill is scheduled at all.

Both warnings (stderr at generation, and a comment in the emitted YAML) fire only when at
least one quantity fell back to a default. State all four rows for a role and both go
quiet, because then the numbers are the operator's and calling them unmeasured would be
wrong.

## Reviewer attention

**Every generated scenario changes.** Unlike #848 and #853 there is no byte-identity
escape — this adds a `resources` block unconditionally, by design. A bundle re-bootstrapped
after this gains one. That is the fix, but it will surprise anyone expecting regeneration
to be inert.

**The golden fixture was regenerated, and here is the evidence it was safe.**
`test_single_pool_config_regenerates_byte_identically` compares bytes against a captured
golden. I diffed before replacing it: **22 lines added, 0 removed**, every added line part
of the `resources` block and its comment. Nothing else drifted. I also added
`test_single_pool_golden_carries_pod_resources` as the opposite-direction guard, so a
future version that stops emitting `resources` cannot be blessed by regenerating the
golden to match.

**Two pre-existing tests asserted `"WARNING" not in stderr`** while being specifically
about the multi-type GPU-cell warning (`test_single_gpu_cell_does_not_warn` and its JSON
twin). Any new unrelated warning made them fail spuriously. Narrowed to `"GPU types"`,
which is what they actually test. Flagging because narrowing an existing assertion
deserves a second opinion.

**The capacity probe does not model this.** `pipeline/lib/capacity.py:178-181` sums only
`requests[gpu_resource_type]`, so it plans GPUs and is blind to CPU/memory. After this
change a stack requests ~36 CPU and ~136Gi (2 decode + 1 prefill) that the probe does not
account for, so a scenario can pass the GPU check and still be unschedulable on CPU or
memory. This is the strongest argument for requests being half the limits rather than equal
to them. Left alone deliberately — `capacity.py` is in `pipeline/`, outside the bootstrap
scope set for this issue. Worth a follow-up.

**Fixed, not derived, is a deliberate choice.** `tensor × dataLocal` scaling was considered
and rejected: it reproduces one cluster's decode block at TP=4 while inventing every other
cell of the table. A wrong fixed number is visible and correctable; a wrong formula looks
principled. Recorded in the module docstring so the next person sees the reasoning rather
than re-deriving it.

## Verification

- **Fault injection, 9 distinct defects, all caught**: request == limit; prefill limit
  exceeding decode; a changed default figure; the whole `requests` block dropped; unquoted
  cpu; the starvation signal stripped from the emitted comment; the same stripped from the
  stderr text; `used_any_default` hardwired False; a dropped prefill emit. (Two apparent
  gaps on first pass turned out to be my injections hitting the docstring and a
  neighbouring line rather than the asserted strings — re-injected precisely, both caught.)
- **Cross-generator parity**: `test_both_generators_emit_identical_resources_text` asserts
  both paths emit character-identical `resources`; verified by injecting a divergence into
  the JSON path, an ignored per-role key, and an always-warn — each fails a test.
- **CI**: `ruff --select F` clean; 2457 passed, 9 skipped, 2 xfailed; coverage 97.68%.

## Sweep

Grepped `**/*.md` for `resources` — every hit outside the submodules is about *cluster*
resources (Tekton, RBAC, PVCs), unrelated to pod cpu/memory, so nothing was stale. Chased
the implicit-schema blind spot the previous PRs flagged: the only consumer that reads
`resources` is `capacity.py`, covered above. Added `pod_resources.py` to both SKILL.md
inventories (the bundled-scripts list and the file-reference table).
