### PR TITLE
fix(values): merge vllm.additionalFlags by flag name instead of replacing (closes #851)

### DIFF
--- a/.claude/skills/sim2real-bootstrap/templates/defaults/vllm-logging.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/vllm-logging.yaml
@@ -22,18 +22,20 @@
 #     decode: {vllm: {additionalFlags: ["--no-disable-uvicorn-access-log"],
 #                     loggingLevel: INFO}}
 # and both keys were inert:
-#   - `additionalFlags` is a list of scalars, so pipeline/lib/values.py
-#     `_merge_lists` Tier 1 has the overlay REPLACE the base. This fragment is
-#     the FIRST layer in resolve_baseline's chain, and both `baselines/<name>.yaml`
-#     and the translate-generated baseline overlay set that same list downstream
-#     -- so the fragment's entry was discarded before it could reach the command.
-#     No scalar-list key can usefully be set from this layer at all.
+#   - `additionalFlags` was decode-only, while the framework's suppression covers
+#     BOTH roles -- so prefill served its requests with no access log at all. The
+#     typed key applies to both roles from one place, which is why it is preferred
+#     here. (Historical note: this entry used to be discarded outright, because
+#     `additionalFlags` is a list of scalars and `_merge_lists` Tier 1 had each
+#     later layer REPLACE the whole list. Issue #851 fixed that -- Tier 0 now
+#     merges `**.vllm.additionalFlags` by flag name, so a flag set in one layer
+#     survives a layer that does not restate it. The per-role limitation above is
+#     the reason that still stands.)
 #   - `loggingLevel: INFO` is already the framework default twice over
 #     (defaults.yaml:51 `logging_level: &logging_level INFO`, plus a
 #     `default('INFO')` fallback at _macros.j2:230).
-# It was also decode-only, while the framework's suppression covers both roles --
-# so prefill served its requests with no access log at all. The typed
-# `vllmCommon.flags` key below is read per-role by the macro and fixes both.
+# The typed `vllmCommon.flags` key below is read per-role by the macro and so
+# fixes both roles from one place.
 #
 # WHY THIS IS A FRAGMENT AND NOT PART OF baselines/<name>.yaml. It is a
 # framework-default override for diagnosability, not part of the measured

--- a/.claude/skills/sim2real-bootstrap/tests/test_defaults_templates.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_defaults_templates.py
@@ -10,9 +10,15 @@ These tests are deliberately glob-driven: adding a fragment requires no test edi
 but the new fragment must satisfy the same contract as the existing ones.
 
 Issue #839 (two shipped fragments were wrong, five were missing) is what motivated
-them. The `additionalFlags` guard below is the narrow, statically-decidable slice of
+them. The scalar-list guard below is the narrow, statically-decidable slice of
 #841 — it catches keys that provably cannot survive the merge chain, rather than
 comparing resolved scenarios, which is what #841 tracks.
+
+Note on scope since #851: `**.vllm.additionalFlags` no longer replaces — it merges
+by flag name, so a value set from this layer does survive downstream layers. The
+guard therefore no longer applies to that key (and no fragment sets it today). It
+still applies to every other scalar list, which `_merge_lists` Tier 1 continues to
+replace wholesale.
 """
 import itertools
 from pathlib import Path
@@ -102,6 +108,8 @@ def test_fragment_sets_something_beyond_its_name(path):
 #
 # A scalar list set from the defaults layer only survives if NO downstream layer
 # sets the same key, because `_merge_lists` Tier 1 replaces rather than appends.
+# (`**.vllm.additionalFlags` is the one exception since #851 — it merges by flag
+# name, so it needs no allowlist entry. Every key below still replaces.)
 # That makes every entry here a standing fragility, not an endorsement: an
 # experiment whose `baselines/<name>.yaml` sets the same key silently wins, and the
 # fragment's value never reaches the rendered output. Each entry must be justified
@@ -137,7 +145,11 @@ def test_fragment_sets_no_unacknowledged_scalar_list_key(path):
     a non-dict item. The defaults overlay is the FIRST layer in `resolve_baseline`'s
     chain — `deep_merge(defaults, bundle)` then `deep_merge(..., overlay)` — so a
     scalar list it sets is discarded the moment any downstream layer sets the same
-    key. `vllm.additionalFlags` is the case that shipped inert for months (#839).
+    key. `vllm.additionalFlags` is the case that shipped inert for months (#839);
+    it is no longer subject to this (Tier 0 merges it by flag name since #851), but
+    every other scalar list still is. Since #851, `sim2real assemble` also warns at
+    resolve time when two layers both set a still-replacing scalar list, so a
+    fragment that slips past this static guard is caught at run time too.
 
     Rather than forbid scalar lists outright (which would rule out a fragment that
     legitimately owns a key nothing downstream touches), require that each one be
@@ -165,9 +177,10 @@ def test_fragment_sets_no_unacknowledged_scalar_list_key(path):
         "REPLACED by any downstream layer (_merge_lists Tier 1), so a value set here "
         "cannot be relied on to reach the rendered output. Prefer a typed "
         "scalar/bool key, or a list of dicts carrying `name` (which merges by key). "
-        "If the key genuinely belongs in this layer, add it to "
-        "_ALLOWED_SCALAR_LISTS with a reason and warn about it in the fragment's "
-        "header comment."
+        "`**.vllm.additionalFlags` is exempt — it merges by flag name since #851 — "
+        "but no other scalar-list path is. If the key genuinely belongs in this "
+        "layer, add it to _ALLOWED_SCALAR_LISTS with a reason and warn about it in "
+        "the fragment's header comment."
     )
 
     stale = sorted(allowed - found)

--- a/.claude/skills/sim2real-bootstrap/tests/test_defaults_templates.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_defaults_templates.py
@@ -21,6 +21,7 @@ still applies to every other scalar list, which `_merge_lists` Tier 1 continues 
 replace wholesale.
 """
 import itertools
+import sys
 from pathlib import Path
 
 import pytest
@@ -31,6 +32,16 @@ _TEMPLATE_DIR = _SKILL_DIR / "templates" / "defaults"
 
 # Repo root: .claude/skills/sim2real-bootstrap -> up three.
 _REPO_ROOT = _SKILL_DIR.parents[2]
+
+# Make `pipeline` importable regardless of cwd, matching what the `deep_merge`
+# fixture below does — the import on the next line runs at collection time, so it
+# cannot rely on that fixture.
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+# Sourced from the merge implementation rather than re-listing the exempt paths
+# here, so this guard cannot drift from the rule it is guarding (#851).
+from pipeline.lib.values import _is_flag_list_path  # noqa: E402
 
 
 def _fragments():
@@ -137,6 +148,30 @@ _ALLOWED_SCALAR_LISTS = {
 }
 
 
+def _scalar_list_paths(entry: dict) -> set:
+    """Dotted key paths under ``entry`` holding a list with any non-dict item.
+
+    Paths matching ``_FLAG_LIST_PATH_SUFFIXES`` are omitted: since #851 they
+    merge by flag name, so a value set from the defaults layer DOES survive
+    downstream layers and needs no allowlist entry. Every other scalar list is
+    still replaced wholesale by any downstream layer that sets the same key.
+    """
+    found: set = set()
+
+    def walk(node, trail):
+        if isinstance(node, dict):
+            for key, value in node.items():
+                walk(value, trail + [str(key)])
+        elif isinstance(node, list) and node:
+            if any(not isinstance(item, dict) for item in node):
+                if _is_flag_list_path(tuple(trail)):
+                    return
+                found.add(".".join(trail))
+
+    walk(entry, [])
+    return found
+
+
 @pytest.mark.parametrize("path", _fragments(), ids=_fragment_ids())
 def test_fragment_sets_no_unacknowledged_scalar_list_key(path):
     """Scalar lists set from this layer are fragile, so each one must be deliberate.
@@ -158,29 +193,20 @@ def test_fragment_sets_no_unacknowledged_scalar_list_key(path):
     experiment's baseline grows.
     """
     entry = yaml.safe_load(path.read_text())["scenario"][0]
-    found = set()
-
-    def walk(node, trail):
-        if isinstance(node, dict):
-            for key, value in node.items():
-                walk(value, trail + [str(key)])
-        elif isinstance(node, list) and node:
-            if any(not isinstance(item, dict) for item in node):
-                found.add(".".join(trail))
-
-    walk(entry, [])
+    found = _scalar_list_paths(entry)
     allowed = _ALLOWED_SCALAR_LISTS.get(path.stem, set())
 
     unacknowledged = sorted(found - allowed)
     assert not unacknowledged, (
-        f"{path.name}: sets scalar list(s) {unacknowledged} — a list of non-dicts is "
-        "REPLACED by any downstream layer (_merge_lists Tier 1), so a value set here "
-        "cannot be relied on to reach the rendered output. Prefer a typed "
-        "scalar/bool key, or a list of dicts carrying `name` (which merges by key). "
-        "`**.vllm.additionalFlags` is exempt — it merges by flag name since #851 — "
-        "but no other scalar-list path is. If the key genuinely belongs in this "
-        "layer, add it to _ALLOWED_SCALAR_LISTS with a reason and warn about it in "
-        "the fragment's header comment."
+        f"{path.name}: sets scalar list(s) {unacknowledged} — at these key paths a "
+        "list of non-dicts is REPLACED by any downstream layer (_merge_lists "
+        "Tier 1), so a value set here cannot be relied on to reach the rendered "
+        "output. Prefer a typed scalar/bool key, or a list of dicts carrying "
+        "`name` (which merges by key). Paths matching "
+        "_FLAG_LIST_PATH_SUFFIXES (`**.vllm.additionalFlags`) never reach this "
+        "assertion — they merge by flag name since #851. If the key genuinely "
+        "belongs in this layer, add it to _ALLOWED_SCALAR_LISTS with a reason and "
+        "warn about it in the fragment's header comment."
     )
 
     stale = sorted(allowed - found)
@@ -188,6 +214,51 @@ def test_fragment_sets_no_unacknowledged_scalar_list_key(path):
         f"{path.name}: _ALLOWED_SCALAR_LISTS still lists {stale}, but the fragment no "
         "longer sets it — drop the allowlist entry."
     )
+
+
+@pytest.mark.parametrize(
+    "trail, exempt",
+    [
+        (["decode", "vllm", "additionalFlags"], True),
+        (["prefill", "vllm", "additionalFlags"], True),
+        (["router", "proxy", "args"], False),
+        (
+            ["decode", "extraContainerConfig", "securityContext",
+             "capabilities", "add"],
+            False,
+        ),
+        (["router", "additionalFlags"], False),
+    ],
+)
+def test_guard_exempts_exactly_the_flag_merged_paths(trail, exempt):
+    """The guard's message and comments promise `**.vllm.additionalFlags` is
+    exempt; this pins that the walk actually implements it, and that nothing
+    else is exempted by accident.
+
+    Without this, the guard and its own failure text could disagree — it would
+    demand an allowlist entry for a key while printing that the key needs none.
+    """
+    assert _is_flag_list_path(tuple(trail)) is exempt
+
+
+def test_flag_merged_scalar_list_needs_no_allowlist_entry():
+    """Exercises the guard's ACTUAL walk (`_scalar_list_paths`), not a copy of it.
+
+    A fragment-shaped entry setting `decode.vllm.additionalFlags` must not be
+    reported as unacknowledged, while `router.proxy.args` in the same entry must
+    be. Pinning both directions is what keeps the guard honest with its own
+    failure message.
+    """
+    entry = {
+        "name": "s",
+        "decode": {"vllm": {"additionalFlags": ["--enable-prefix-caching"]}},
+        "prefill": {"vllm": {"additionalFlags": ["--max-num-seqs=256"]}},
+        "router": {"proxy": {"args": ["--concurrency", "8"]}},
+    }
+    found = _scalar_list_paths(entry)
+    assert "decode.vllm.additionalFlags" not in found
+    assert "prefill.vllm.additionalFlags" not in found
+    assert found == {"router.proxy.args"}
 
 
 def test_scalar_list_allowlist_has_no_entries_for_missing_fragments():

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ python pipeline/sim2real.py --experiment-root ../admission-control use --run <ru
 | `translation_ref.py` | Shared alias/algorithm-name validator, on-read shim for `translation_output.json` (handles both step-1 legacy and step-2 per-algo shapes), and `resolve_translation_ref` (accepts alias / hash prefix / full hash) |
 | `build.py` | Shared build primitives — image-ref construction, skopeo digest probe, buildkit-pod dispatch, atomic JSON write. Consumed by `sim2real build`. |
 | `assemble_run.py` | Assembly logic behind `sim2real assemble` (deep-merge + PipelineRun generation, additive-grow / drift / legacy-run decision tree) |
-| `values.py` | Deep-merge utility (`deep_merge`) used by `assemble_run.py` |
+| `values.py` | Deep-merge utility (`deep_merge`) used by `assemble_run.py`. Lists of scalars are replaced wholesale, **except** CLI-flag lists at key paths ending `vllm.additionalFlags`, which merge by flag name with `--no-X`/`--X` treated as one key (#851). Still-replacing scalar lists (`router.proxy.args`, `capabilities.add`) surface an assemble-time warning naming the discarded values and the two layers that disagreed |
 | `pairkey.py` | Pair-key parser (canonical grammar `wl-<w>\|<p>\|iN` with legacy `wl-<w>\|<p>` fallback) and `--iteration` spec parser (list + range) |
 | `tekton.py` | Generates PipelineRun YAMLs for scenario-based benchmarks; `validate_pipelinerun_name` enforces the RFC 1123 253-char limit at assemble time |
 | `pod_pending.py` | Classifies pod scheduling failures as recoverable or non-recoverable |

--- a/docs/superpowers/plans/2026-08-26-851-flag-list-merge.md
+++ b/docs/superpowers/plans/2026-08-26-851-flag-list-merge.md
@@ -1,0 +1,992 @@
+# Flag-Name List Merge (issue #851) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop `vllm.additionalFlags` losing every layer's flags but the last, by merging that list by flag name instead of replacing it wholesale.
+
+**Architecture:** Thread an immutable key path (tuple of segments, list indices elided) through `deep_merge` / `_merge_lists` as a keyword-only parameter defaulting to `()`. Add a path-scoped "Tier 0" that merges lists matching a registered path **suffix** by flag name. Every other list keeps its current tier behavior. Separately, scalar lists that still replace record a side-band conflict message so the remaining silent-loss cases become visible.
+
+**Tech Stack:** Python >= 3.10, pytest, PyYAML.
+
+**Spec:** GitHub issue [#851](https://github.com/inference-sim/sim2real/issues/851), plus the two decision comments on it (scoping decisions `issuecomment-5430716546`, vet correction `issuecomment-5430738080`).
+
+## Global Constraints
+
+- Scope is `vllm.additionalFlags` only. No other scalar list changes merge semantics.
+- Migration of existing bundles is explicitly OUT of scope.
+- `--no-X` and `--X` canonicalize to ONE key. A later layer stating either form overrides the earlier. Emitting both is the failure this closes.
+- No separate removal sentinel. `--no-X` is the removal verb for boolean flags; `--key=value` flags are override-only.
+- Path matching is by **suffix** with list indices elided, so `decode` and `prefill` are one rule and both merge roots (`assemble_run` merges whole documents, `capacity` merges a single scenario entry) hit it identically.
+- Ordering follows the existing Tier 2b convention: base entries first in base order, overlay-only appended.
+- A list entry under a flag-merged path that is not a `--` string is refused.
+- Two entries in one list collapsing to the same key are refused.
+- All 32 existing tests in `pipeline/tests/test_values.py` call `deep_merge(base, overlay)` / `_merge_lists(base, overlay)` positionally with two args. New parameters MUST be keyword-only with defaults so those calls keep working unchanged.
+- CI gates: `ruff check pipeline/ .claude/skills/ --select F` and `python -m pytest` with `--cov=pipeline --cov-fail-under=90`.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `pipeline/lib/values.py` | Modify. Path threading, flag-merge tier, scalar-replace conflict recording. |
+| `pipeline/tests/test_values.py` | Modify. New test classes for flag keys, flag merge, path threading, conflict sink. |
+| `pipeline/lib/assemble_run.py` | Modify. `_merge_layer` helper, sink through `resolve_baseline` / `resolve_treatment`, new `_ResolvedPackages` field, side-band attr. |
+| `pipeline/tests/test_assemble_run.py` | Modify. End-to-end: a `config.md` flag survives an overlay that does not restate it. |
+| `pipeline/sim2real.py` | Modify. Print the collected conflicts as warnings next to `skipped_algorithms`. |
+| `.claude/skills/sim2real-bootstrap/templates/defaults/vllm-logging.yaml` | Modify. Correct the now-false "additionalFlags is replaced" rationale. |
+| `docs/troubleshooting.md` | Modify. Same correction at line 157. |
+| `.claude/skills/sim2real-bootstrap/tests/test_defaults_templates.py` | Modify. Assertion message + allowlist rationale note the flag-merged exception. |
+| `pipeline/README.md`, `CLAUDE.md` | Modify. Document the new merge behavior per the project's documentation rule. |
+
+---
+
+### Task 1: Flag key + list indexing helpers
+
+**Files:**
+- Modify: `pipeline/lib/values.py` (new section after the `_detect_list_key` function)
+- Test: `pipeline/tests/test_values.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `_FLAG_LIST_PATH_SUFFIXES: tuple[tuple[str, ...], ...]`, `_is_flag_list_path(path: tuple[str, ...]) -> bool`, `_flag_key(entry: str) -> str`, `_index_flags(entries: list, path: tuple[str, ...], side: str) -> dict[str, str]`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the imports at the top of `pipeline/tests/test_values.py`:
+
+```python
+from pipeline.lib.values import (
+    deep_merge,
+    _merge_lists,
+    _k8s_identity,
+    _flag_key,
+    _index_flags,
+    _is_flag_list_path,
+)
+```
+
+Then append these test classes:
+
+```python
+class TestFlagKey:
+    def test_valued_flag_keys_on_name(self):
+        assert _flag_key("--max-num-seqs=256") == "--max-num-seqs"
+
+    def test_bare_flag_is_its_own_key(self):
+        assert _flag_key("--enable-chunked-prefill") == "--enable-chunked-prefill"
+
+    def test_negation_collapses_to_positive_key(self):
+        assert _flag_key("--no-enable-prefix-caching") == "--enable-prefix-caching"
+        assert _flag_key("--enable-prefix-caching") == "--enable-prefix-caching"
+
+    def test_negation_of_disable_flag_collapses(self):
+        # Real llm-d-benchmark pair: --no-disable-uvicorn-access-log is the
+        # negation of --disable-uvicorn-access-log.
+        assert _flag_key("--no-disable-uvicorn-access-log") == (
+            "--disable-uvicorn-access-log"
+        )
+
+    def test_value_containing_equals_splits_on_first_only(self):
+        assert _flag_key('--kv-transfer-config={"a":"b=c"}') == "--kv-transfer-config"
+
+
+class TestIsFlagListPath:
+    def test_document_rooted_path_matches(self):
+        assert _is_flag_list_path(("scenario", "decode", "vllm", "additionalFlags"))
+
+    def test_scenario_entry_rooted_path_matches(self):
+        # capacity.py merges scenarios[0] directly, so the path has no leading
+        # "scenario" segment. Suffix matching covers both roots.
+        assert _is_flag_list_path(("decode", "vllm", "additionalFlags"))
+
+    def test_prefill_role_matches_same_rule(self):
+        assert _is_flag_list_path(("scenario", "prefill", "vllm", "additionalFlags"))
+
+    def test_unrelated_scalar_list_does_not_match(self):
+        assert not _is_flag_list_path(("scenario", "router", "proxy", "args"))
+
+    def test_shorter_than_suffix_does_not_match(self):
+        assert not _is_flag_list_path(("additionalFlags",))
+        assert not _is_flag_list_path(())
+
+    def test_additionalflags_under_wrong_parent_does_not_match(self):
+        assert not _is_flag_list_path(("scenario", "router", "additionalFlags"))
+
+
+class TestIndexFlags:
+    def test_preserves_order_and_maps_key_to_literal(self):
+        out = _index_flags(["--a=1", "--b"], ("vllm", "additionalFlags"), "base")
+        assert list(out) == ["--a", "--b"]
+        assert out["--a"] == "--a=1"
+
+    def test_non_string_entry_refused(self):
+        with pytest.raises(ValueError, match="not a string"):
+            _index_flags([256], ("vllm", "additionalFlags"), "base")
+
+    def test_non_flag_entry_refused(self):
+        with pytest.raises(ValueError, match="does not start with"):
+            _index_flags(["envoy-sidecar"], ("vllm", "additionalFlags"), "overlay")
+
+    def test_duplicate_key_refused(self):
+        with pytest.raises(ValueError, match="twice"):
+            _index_flags(
+                ["--max-num-seqs=1", "--max-num-seqs=2"],
+                ("vllm", "additionalFlags"),
+                "base",
+            )
+
+    def test_negation_pair_in_one_list_is_a_duplicate(self):
+        with pytest.raises(ValueError, match="twice"):
+            _index_flags(
+                ["--enable-prefix-caching", "--no-enable-prefix-caching"],
+                ("vllm", "additionalFlags"),
+                "base",
+            )
+
+    def test_error_message_names_the_path_and_side(self):
+        with pytest.raises(ValueError, match=r"decode\.vllm\.additionalFlags: overlay"):
+            _index_flags(["nope"], ("decode", "vllm", "additionalFlags"), "overlay")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest pipeline/tests/test_values.py -k "FlagKey or IsFlagListPath or IndexFlags" -v`
+Expected: FAIL with `ImportError: cannot import name '_flag_key'`
+
+- [ ] **Step 3: Implement**
+
+Insert into `pipeline/lib/values.py` immediately after the `_detect_list_key` function:
+
+```python
+# ── Flag-list merge (path-scoped) ─────────────────────────────────────────────
+
+#: Key-path suffixes whose scalar lists merge by flag name rather than being
+#: replaced wholesale. Matched as a SUFFIX of the merge path, with list indices
+#: elided from the path, so one entry covers both the `decode` and `prefill`
+#: roles AND both merge roots in use today: `assemble_run` merges whole
+#: documents (`scenario.decode.vllm.additionalFlags`) while `capacity` merges a
+#: single scenario entry (`decode.vllm.additionalFlags`). An absolute path
+#: anchored at the document root would match the first and silently miss the
+#: second. See issue #851.
+_FLAG_LIST_PATH_SUFFIXES: tuple[tuple[str, ...], ...] = (
+    ("vllm", "additionalFlags"),
+)
+
+
+def _is_flag_list_path(path: tuple) -> bool:
+    """True when `path` ends with a suffix registered in _FLAG_LIST_PATH_SUFFIXES."""
+    return any(
+        len(path) >= len(suffix) and tuple(path[-len(suffix):]) == suffix
+        for suffix in _FLAG_LIST_PATH_SUFFIXES
+    )
+
+
+def _flag_key(entry: str) -> str:
+    """Return the merge key for one CLI-flag list entry.
+
+    `--max-num-seqs=256` keys on `--max-num-seqs`; a bare
+    `--enable-chunked-prefill` is its own key. A leading `--no-` is stripped so
+    that a flag and its negation collapse to a single key:
+    `--enable-prefix-caching` and `--no-enable-prefix-caching` express one
+    decision, so a later layer stating either form must override the earlier
+    rather than emit both. Emitting both would leave the outcome to vLLM's
+    argparse ordering — the silent conflict issue #851 exists to avoid, and the
+    reason it rejected simple list concatenation.
+    """
+    name = entry.split("=", 1)[0]
+    if name.startswith("--no-"):
+        name = "--" + name[len("--no-"):]
+    return name
+
+
+def _index_flags(entries: list, path: tuple, side: str) -> dict:
+    """Return `{flag key: literal entry}` for one flag list, preserving order.
+
+    Raises ValueError on a non-string entry, an entry that is not a `--` flag,
+    or two entries collapsing to the same key. Each would otherwise produce a
+    silently wrong flag set, which is the failure class this tier closes.
+    """
+    where = ".".join(path) or "<root>"
+    indexed: dict = {}
+    for entry in entries:
+        if not isinstance(entry, str):
+            raise ValueError(
+                f"{where}: {side} flag list entry is "
+                f"{type(entry).__name__}, not a string: {entry!r} — this path "
+                "merges by flag name and cannot key a non-string entry"
+            )
+        if not entry.startswith("--"):
+            raise ValueError(
+                f"{where}: {side} flag list entry does not start with '--': "
+                f"{entry!r} — this path merges by flag name, so a bare value "
+                "(as used in space-separated arg lists like router.proxy.args) "
+                "would be mis-keyed as a flag name"
+            )
+        key = _flag_key(entry)
+        if key in indexed:
+            raise ValueError(
+                f"{where}: {side} flag list states '{key}' twice "
+                f"({indexed[key]!r} and {entry!r}) — merging by flag name would "
+                "silently drop one. State the flag once; note that '--no-X' and "
+                "'--X' are the same key."
+            )
+        indexed[key] = entry
+    return indexed
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest pipeline/tests/test_values.py -k "FlagKey or IsFlagListPath or IndexFlags" -v`
+Expected: PASS (18 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pipeline/lib/values.py pipeline/tests/test_values.py
+git commit -m "feat(values): add flag-name key + flag-list indexing helpers (#851)"
+```
+
+---
+
+### Task 2: Thread a key path through deep_merge and _merge_lists
+
+**Files:**
+- Modify: `pipeline/lib/values.py` — `deep_merge`, `_merge_lists`, `_merge_by_keyfn`, `_merge_k8s_objects`
+- Test: `pipeline/tests/test_values.py`
+
+**Interfaces:**
+- Consumes: nothing from Task 1 (independent; Task 3 joins them).
+- Produces: `deep_merge(base, overlay, *, path=(), sink=None)`, `_merge_lists(base_list, overlay_list, *, path=(), sink=None)`, `_merge_by_keyfn(base_list, overlay_list, keyfn, *, path=(), sink=None)`, `_merge_k8s_objects(base_list, overlay_list, *, path=(), sink=None)`. `sink` is accepted and threaded but unused until Task 4.
+
+This task is pure plumbing: no observable behavior change. Its test is that the path arriving at a leaf list is correct, and that all 32 pre-existing tests still pass untouched.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class TestPathThreading:
+    def test_path_reaches_nested_list(self, monkeypatch):
+        import pipeline.lib.values as values_mod
+
+        seen = []
+        real = values_mod._merge_lists
+
+        def spy(base_list, overlay_list, *, path=(), sink=None):
+            seen.append(path)
+            return real(base_list, overlay_list, path=path, sink=sink)
+
+        monkeypatch.setattr(values_mod, "_merge_lists", spy)
+        base = {
+            "scenario": [
+                {"name": "s", "decode": {"vllm": {"additionalFlags": ["--a"]}}}
+            ]
+        }
+        overlay = {
+            "scenario": [
+                {"name": "s", "decode": {"vllm": {"additionalFlags": ["--b"]}}}
+            ]
+        }
+        values_mod.deep_merge(base, overlay)
+        # List index is elided: the scenario entry's children keep the
+        # ("scenario",) prefix rather than gaining ("scenario", 0).
+        assert ("scenario",) in seen
+        assert ("scenario", "decode", "vllm", "additionalFlags") in seen
+
+    def test_default_path_is_empty_tuple(self, monkeypatch):
+        import pipeline.lib.values as values_mod
+
+        seen = []
+        real = values_mod._merge_lists
+
+        def spy(base_list, overlay_list, *, path=(), sink=None):
+            seen.append(path)
+            return real(base_list, overlay_list, path=path, sink=sink)
+
+        monkeypatch.setattr(values_mod, "_merge_lists", spy)
+        values_mod.deep_merge({"a": [1]}, {"a": [2]})
+        assert seen == [("a",)]
+
+    def test_positional_two_arg_calls_still_work(self):
+        # The 32 pre-existing tests call these positionally; guard that contract.
+        assert deep_merge({"a": 1}, {"b": 2}) == {"a": 1, "b": 2}
+        assert _merge_lists(["a"], ["b"]) == ["b"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest pipeline/tests/test_values.py -k TestPathThreading -v`
+Expected: FAIL — `_merge_lists() got an unexpected keyword argument 'path'`
+
+- [ ] **Step 3: Implement**
+
+Change four signatures and every internal recursion.
+
+`_merge_by_keyfn`:
+
+```python
+def _merge_by_keyfn(base_list: list, overlay_list: list, keyfn, *,
+                    path: tuple = (), sink: list = None) -> list:
+```
+
+Its recursive call becomes `deep_merge(bitem, overlay_by_key[k], path=path, sink=sink)` — `path` unchanged, because the list index is elided.
+
+`_merge_k8s_objects`:
+
+```python
+def _merge_k8s_objects(base_list: list, overlay_list: list, *,
+                       path: tuple = (), sink: list = None) -> list:
+```
+
+with its recursion `deep_merge(bitem, overlay_by_key[k], path=path, sink=sink)`.
+
+`_merge_lists`:
+
+```python
+def _merge_lists(base_list: list, overlay_list: list, *,
+                 path: tuple = (), sink: list = None) -> list:
+```
+
+with `_merge_k8s_objects(base_list, overlay_list, path=path, sink=sink)`,
+`_merge_by_keyfn(base_list, overlay_list, lambda d: d[key_field], path=path, sink=sink)`,
+and in the Tier 3 loop `deep_merge(base_list[i], overlay_list[i], path=path, sink=sink)`.
+
+`deep_merge`:
+
+```python
+def deep_merge(base: dict, overlay: dict, *,
+               path: tuple = (), sink: list = None) -> dict:
+    """Deep-merge overlay onto base. Dict keys merged recursively.
+
+    Lists of dicts are merged by Kubernetes identity, named key, or positional
+    index (see `_merge_lists`). Lists of scalars are replaced entirely, EXCEPT
+    at paths registered in `_FLAG_LIST_PATH_SUFFIXES`, which merge by flag name.
+    Returns a new dict (deep copy).
+
+    `path` is the dotted key path of `base` within the document being merged, as
+    a tuple of segments with list indices elided. It exists so `_merge_lists`
+    can scope a merge strategy to a key path; callers merging a whole document
+    leave it at its default. `sink`, when a list, collects operator-facing
+    warnings about scalar lists that were replaced wholesale.
+    """
+    result = copy.deepcopy(base)
+    for key, oval in overlay.items():
+        child = path + (str(key),)
+        if key in result and isinstance(result[key], dict) and isinstance(oval, dict):
+            result[key] = deep_merge(result[key], oval, path=child, sink=sink)
+        elif key in result and isinstance(result[key], list) and isinstance(oval, list):
+            result[key] = _merge_lists(result[key], oval, path=child, sink=sink)
+        else:
+            result[key] = copy.deepcopy(oval)
+    return result
+```
+
+- [ ] **Step 4: Run the full values suite**
+
+Run: `python -m pytest pipeline/tests/test_values.py -v`
+Expected: PASS — all pre-existing tests plus the new ones. Zero pre-existing tests modified.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pipeline/lib/values.py pipeline/tests/test_values.py
+git commit -m "refactor(values): thread key path + warning sink through deep_merge (#851)"
+```
+
+---
+
+### Task 3: The flag-merge tier
+
+**Files:**
+- Modify: `pipeline/lib/values.py` — add `_merge_flag_lists`, wire into `_merge_lists`
+- Test: `pipeline/tests/test_values.py`
+
+**Interfaces:**
+- Consumes: `_is_flag_list_path`, `_index_flags` (Task 1); `path` parameter (Task 2).
+- Produces: `_merge_flag_lists(base_list, overlay_list, path) -> list`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+_FP = ("scenario", "decode", "vllm", "additionalFlags")
+
+
+class TestFlagListMerge:
+    def test_base_flag_survives_overlay_that_omits_it(self):
+        """The #851 bug: this returned ['--enable-force-include-usage'] before."""
+        base = ["--max-num-seqs=256", "--enable-prefix-caching"]
+        overlay = ["--enable-force-include-usage"]
+        assert _merge_lists(base, overlay, path=_FP) == [
+            "--max-num-seqs=256",
+            "--enable-prefix-caching",
+            "--enable-force-include-usage",
+        ]
+
+    def test_overlay_overrides_same_flag_without_duplicating(self):
+        base = ["--max-num-seqs=256", "--enable-prefix-caching"]
+        overlay = ["--max-num-seqs=512"]
+        assert _merge_lists(base, overlay, path=_FP) == [
+            "--max-num-seqs=512",
+            "--enable-prefix-caching",
+        ]
+
+    def test_negation_overrides_positive_and_emits_one_flag(self):
+        assert _merge_lists(
+            ["--enable-prefix-caching"], ["--no-enable-prefix-caching"], path=_FP
+        ) == ["--no-enable-prefix-caching"]
+
+    def test_positive_overrides_negation(self):
+        assert _merge_lists(
+            ["--no-enable-prefix-caching"], ["--enable-prefix-caching"], path=_FP
+        ) == ["--enable-prefix-caching"]
+
+    def test_base_order_preserved_overlay_only_appended(self):
+        base = ["--a=1", "--b=2", "--c"]
+        overlay = ["--z", "--b=99"]
+        assert _merge_lists(base, overlay, path=_FP) == [
+            "--a=1",
+            "--b=99",
+            "--c",
+            "--z",
+        ]
+
+    def test_prefill_path_merges_too(self):
+        p = ("scenario", "prefill", "vllm", "additionalFlags")
+        assert _merge_lists(["--a=1"], ["--b"], path=p) == ["--a=1", "--b"]
+
+    def test_scenario_entry_rooted_path_merges(self):
+        p = ("decode", "vllm", "additionalFlags")
+        assert _merge_lists(["--a=1"], ["--b"], path=p) == ["--a=1", "--b"]
+
+    def test_router_proxy_args_still_replaces(self):
+        """The constraint from #851: space-separated arg lists must NOT flag-merge."""
+        base = ["--service-node", "envoy-sidecar", "--concurrency", "8"]
+        overlay = ["--log-level", "warn"]
+        p = ("scenario", "router", "proxy", "args")
+        assert _merge_lists(base, overlay, path=p) == ["--log-level", "warn"]
+
+    def test_no_path_means_no_flag_merge(self):
+        assert _merge_lists(["--a=1"], ["--b"]) == ["--b"]
+
+    def test_empty_overlay_still_clears(self):
+        assert _merge_lists(["--a=1"], [], path=_FP) == []
+
+    def test_empty_base_returns_overlay(self):
+        assert _merge_lists([], ["--a=1"], path=_FP) == ["--a=1"]
+
+    def test_single_layer_bad_entry_not_rejected(self):
+        """Guards protect the merge, so a lone contributor is never newly refused."""
+        assert _merge_lists([], ["not-a-flag"], path=_FP) == ["not-a-flag"]
+
+    def test_bad_entry_refused_when_both_layers_contribute(self):
+        with pytest.raises(ValueError, match="does not start with"):
+            _merge_lists(["--a=1"], ["oops"], path=_FP)
+
+    def test_does_not_mutate_inputs(self):
+        base = ["--a=1"]
+        overlay = ["--b"]
+        _merge_lists(base, overlay, path=_FP)
+        assert base == ["--a=1"] and overlay == ["--b"]
+
+    def test_end_to_end_through_deep_merge(self):
+        base = {
+            "scenario": [
+                {
+                    "name": "s",
+                    "decode": {
+                        "vllm": {
+                            "additionalFlags": [
+                                "--max-num-seqs=256",
+                                "--enable-prefix-caching",
+                            ]
+                        }
+                    },
+                }
+            ]
+        }
+        overlay = {
+            "scenario": [
+                {
+                    "name": "s",
+                    "decode": {
+                        "vllm": {"additionalFlags": ["--enable-force-include-usage"]}
+                    },
+                }
+            ]
+        }
+        out = deep_merge(base, overlay)
+        assert out["scenario"][0]["decode"]["vllm"]["additionalFlags"] == [
+            "--max-num-seqs=256",
+            "--enable-prefix-caching",
+            "--enable-force-include-usage",
+        ]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest pipeline/tests/test_values.py -k TestFlagListMerge -v`
+Expected: FAIL — base flags dropped (the bug), e.g. `assert ['--enable-force-include-usage'] == ['--max-num-seqs=256', ...]`
+
+- [ ] **Step 3: Implement**
+
+Add after `_index_flags`:
+
+```python
+def _merge_flag_lists(base_list: list, overlay_list: list, path: tuple) -> list:
+    """Merge two CLI-flag lists by flag name.
+
+    Base entries are emitted first in base order — an overlay entry sharing a
+    key substitutes its own literal spelling, so `--no-X` can override `--X` —
+    and overlay-only entries are appended in overlay order. This is the same
+    base-first-then-append convention Tier 2b already uses for keyed dict lists.
+    """
+    base_idx = _index_flags(base_list, path, "base")
+    overlay_idx = _index_flags(overlay_list, path, "overlay")
+    result = [overlay_idx.get(key, entry) for key, entry in base_idx.items()]
+    result.extend(entry for key, entry in overlay_idx.items() if key not in base_idx)
+    return result
+```
+
+Then in `_merge_lists`, insert immediately after the two empty-list guards and before Tier 1:
+
+```python
+    # Tier 0: path-scoped CLI-flag lists — merge by flag name (#851).
+    # Deliberately placed AFTER the empty-list guards: with only one layer
+    # contributing there is nothing to merge and nothing to lose, so a
+    # single-layer bundle is never newly refused by _index_flags' entry guards.
+    # The guards protect the merge, not the schema.
+    if _is_flag_list_path(path):
+        return _merge_flag_lists(base_list, overlay_list, path)
+```
+
+Update the `_merge_lists` docstring tier list to lead with:
+
+```
+    Tier 0:  path matches _FLAG_LIST_PATH_SUFFIXES → merge scalar entries by
+             flag name (`--max-num-seqs=256` keys on `--max-num-seqs`; `--no-X`
+             and `--X` are one key). Only reached when BOTH lists are non-empty.
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest pipeline/tests/test_values.py -v`
+Expected: PASS, all tests including the 32 pre-existing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pipeline/lib/values.py pipeline/tests/test_values.py
+git commit -m "fix(values): merge vllm.additionalFlags by flag name, not replace (closes #851)"
+```
+
+---
+
+### Task 4: Record conflicts for scalar lists that still replace
+
+**Files:**
+- Modify: `pipeline/lib/values.py` — add `_record_scalar_list_replace`, call from Tier 1
+- Test: `pipeline/tests/test_values.py`
+
+**Interfaces:**
+- Consumes: `sink` parameter (Task 2).
+- Produces: `_record_scalar_list_replace(base_list, overlay_list, path, sink) -> None`.
+
+This is issue #851's Stage 1, narrowed: it fires only for scalar lists that STILL replace, since flag-merged paths no longer lose anything.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestScalarReplaceConflictSink:
+    def test_records_conflict_when_both_layers_set_scalar_list(self):
+        sink = []
+        p = ("scenario", "router", "proxy", "args")
+        _merge_lists(["--concurrency", "8"], ["--log-level", "warn"], path=p, sink=sink)
+        assert len(sink) == 1
+        assert "scenario.router.proxy.args" in sink[0]
+        assert "--concurrency" in sink[0]
+
+    def test_no_sink_is_silent(self):
+        # capacity.py merges without a sink; must not raise.
+        p = ("scenario", "router", "proxy", "args")
+        assert _merge_lists(["--a"], ["--b"], path=p) == ["--b"]
+
+    def test_identical_lists_record_nothing(self):
+        sink = []
+        p = ("scenario", "router", "proxy", "args")
+        _merge_lists(["--a"], ["--a"], path=p, sink=sink)
+        assert sink == []
+
+    def test_flag_merged_path_records_nothing(self):
+        sink = []
+        _merge_lists(["--a=1"], ["--b"], path=_FP, sink=sink)
+        assert sink == []
+
+    def test_empty_base_records_nothing(self):
+        sink = []
+        p = ("scenario", "router", "proxy", "args")
+        _merge_lists([], ["--b"], path=p, sink=sink)
+        assert sink == []
+
+    def test_dict_list_records_nothing(self):
+        sink = []
+        _merge_lists(
+            [{"name": "x"}], [{"name": "x", "v": 1}], path=("containers",), sink=sink
+        )
+        assert sink == []
+
+    def test_sink_propagates_through_deep_merge(self):
+        sink = []
+        base = {"scenario": [{"name": "s", "router": {"proxy": {"args": ["--a"]}}}]}
+        overlay = {"scenario": [{"name": "s", "router": {"proxy": {"args": ["--b"]}}}]}
+        deep_merge(base, overlay, sink=sink)
+        assert len(sink) == 1
+        assert "scenario.router.proxy.args" in sink[0]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest pipeline/tests/test_values.py -k TestScalarReplaceConflictSink -v`
+Expected: FAIL — `assert 0 == 1` (sink never populated)
+
+- [ ] **Step 3: Implement**
+
+Add after `_merge_flag_lists`:
+
+```python
+def _record_scalar_list_replace(base_list: list, overlay_list: list,
+                                path: tuple, sink: list) -> None:
+    """Record that a scalar list was replaced wholesale, discarding base values.
+
+    Stage 1 of issue #851, narrowed to the lists that still replace now that the
+    flag-merge tier exists — today `router.proxy.args` and
+    `{decode,prefill}.extraContainerConfig.securityContext.capabilities.add`
+    (both allowlisted in the bootstrap skill's
+    `tests/test_defaults_templates.py:_ALLOWED_SCALAR_LISTS`). Paths that merge
+    by flag name never reach here, so this is signal rather than noise.
+
+    Identical lists record nothing: restating the same values loses no
+    information, and warning about it would train operators to ignore the
+    warning. `sink is None` — every consumer except the assemble resolution
+    chain — is silent.
+    """
+    if sink is None or base_list == overlay_list:
+        return
+    sink.append(
+        f"{'.'.join(path) or '<root>'}: overlay replaces the whole list, "
+        f"discarding {len(base_list)} value(s) set by an earlier layer: "
+        f"{base_list!r} (kept: {overlay_list!r})"
+    )
+```
+
+Then in `_merge_lists`' Tier 1 branch:
+
+```python
+    # Tier 1: any non-dict item → replace
+    if not (all(isinstance(x, dict) for x in base_list)
+            and all(isinstance(x, dict) for x in overlay_list)):
+        _record_scalar_list_replace(base_list, overlay_list, path, sink)
+        return copy.deepcopy(overlay_list)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest pipeline/tests/test_values.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pipeline/lib/values.py pipeline/tests/test_values.py
+git commit -m "feat(values): record scalar-list replacements that discard base values (#851)"
+```
+
+---
+
+### Task 5: Surface the conflicts through assemble to the CLI
+
+**Files:**
+- Modify: `pipeline/lib/assemble_run.py` — new `_merge_layer` helper; `resolve_baseline` / `resolve_treatment` gain `sink`; `_ResolvedPackages` gains `scalar_list_conflicts`; side-band attr
+- Modify: `pipeline/sim2real.py` — print the warnings (near line 2556)
+- Test: `pipeline/tests/test_assemble_run.py`
+
+**Interfaces:**
+- Consumes: `deep_merge(..., sink=...)` (Task 2), conflict recording (Task 4).
+- Produces: `resolve_baseline(*, bundle_path, overlay_path, framework_defaults, sink=None)`, `resolve_treatment(*, baseline_resolved, diffs_path, overlay_path, sink=None)`, `_ResolvedPackages.scalar_list_conflicts: list[str]`, `assemble_run.scalar_list_conflicts` side-band attr.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_config_md_flag_survives_overlay_that_omits_it(tmp_path):
+    """#851 end-to-end: baseline flags reach the resolved scenario even when the
+    generated overlay contributes only its own flag."""
+    bundle = tmp_path / "baseline.yaml"
+    bundle.write_text(yaml.dump({"scenario": [{
+        "name": "b",
+        "decode": {"vllm": {"additionalFlags": [
+            "--max-num-seqs=256", "--enable-prefix-caching"]}},
+    }]}))
+    overlay = tmp_path / "overlay.yaml"
+    overlay.write_text(yaml.dump({"scenario": [{
+        "name": "b",
+        "decode": {"vllm": {"additionalFlags": ["--enable-force-include-usage"]}},
+    }]}))
+    resolved = resolve_baseline(
+        bundle_path=bundle, overlay_path=overlay, framework_defaults={})
+    flags = resolved["scenario"][0]["decode"]["vllm"]["additionalFlags"]
+    assert flags == [
+        "--max-num-seqs=256",
+        "--enable-prefix-caching",
+        "--enable-force-include-usage",
+    ]
+
+
+def test_resolve_baseline_records_scalar_conflict_with_layer_names(tmp_path):
+    bundle = tmp_path / "baseline.yaml"
+    bundle.write_text(yaml.dump({"scenario": [{
+        "name": "b", "router": {"proxy": {"args": ["--concurrency", "8"]}}}]}))
+    overlay = tmp_path / "overlay.yaml"
+    overlay.write_text(yaml.dump({"scenario": [{
+        "name": "b", "router": {"proxy": {"args": ["--log-level", "warn"]}}}]}))
+    sink = []
+    resolve_baseline(bundle_path=bundle, overlay_path=overlay,
+                     framework_defaults={}, sink=sink)
+    assert len(sink) == 1
+    assert "baseline bundle -> registered overlay" in sink[0]
+    assert "scenario.router.proxy.args" in sink[0]
+
+
+def test_resolve_baseline_sink_optional(tmp_path):
+    bundle = tmp_path / "baseline.yaml"
+    bundle.write_text(yaml.dump({"scenario": [{"name": "b"}]}))
+    resolved = resolve_baseline(bundle_path=bundle, overlay_path=None,
+                                framework_defaults={})
+    assert resolved["scenario"][0]["name"] == "b"
+
+
+def test_resolve_treatment_records_conflict_with_layer_names(tmp_path):
+    overlay = tmp_path / "algo.yaml"
+    overlay.write_text(yaml.dump({"scenario": [{
+        "name": "b", "router": {"proxy": {"args": ["--log-level", "warn"]}}}]}))
+    baseline = {"scenario": [{
+        "name": "b", "router": {"proxy": {"args": ["--concurrency", "8"]}}}]}
+    sink = []
+    resolve_treatment(baseline_resolved=baseline, diffs_path=None,
+                      overlay_path=overlay, sink=sink)
+    assert len(sink) == 1
+    assert "treatment diffs -> algorithm overlay" in sink[0]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest pipeline/tests/test_assemble_run.py -k "flag_survives or scalar_conflict or sink_optional or layer_names" -v`
+Expected: FAIL — the first with base flags dropped, the others with `unexpected keyword argument 'sink'`
+
+- [ ] **Step 3: Implement**
+
+Add near the other module-level helpers in `assemble_run.py`, above `resolve_baseline`:
+
+```python
+def _merge_layer(base: dict, overlay: dict, *, layer: str, sink) -> dict:
+    """`deep_merge` one layer, tagging any recorded conflict with the layer pair.
+
+    `values.deep_merge` knows the key path but not which files are being merged;
+    only this module knows that. Collecting per-merge and re-prefixing is what
+    turns "scenario.router.proxy.args was replaced" into an operator-actionable
+    "which two layers disagreed".
+    """
+    local = [] if sink is not None else None
+    merged = deep_merge(base, overlay, sink=local)
+    if sink is not None:
+        sink.extend(f"{layer}: {msg}" for msg in local)
+    return merged
+```
+
+In `resolve_baseline`, add `sink: list = None` to the keyword-only signature and replace the two merges:
+
+```python
+    resolved = _merge_layer(aligned_defaults, bundle,
+                           layer="framework defaults -> baseline bundle", sink=sink)
+    resolved = _merge_layer(resolved, overlay,
+                           layer="baseline bundle -> registered overlay", sink=sink)
+```
+
+In `resolve_treatment`, add `sink: list = None` and:
+
+```python
+    resolved = _merge_layer(copy.deepcopy(baseline_resolved), diffs,
+                           layer="baseline -> treatment diffs", sink=sink)
+    resolved = _merge_layer(resolved, overlay,
+                           layer="treatment diffs -> algorithm overlay", sink=sink)
+```
+
+Document `sink` in both docstrings.
+
+In `_ResolvedPackages`, append the field last (NamedTuple field order matters):
+
+```python
+    scalar_list_conflicts: list[str]
+```
+
+In `_resolve_packages`, create `scalar_list_conflicts: list[str] = []` before the baseline loop, pass `sink=scalar_list_conflicts` to both `resolve_baseline` (~line 639) and `resolve_treatment` (~line 659), and include it in the `_ResolvedPackages(...)` construction (~line 687).
+
+In `assemble_run`, alongside each `assemble_run.skipped_algorithms = ...` assignment, add:
+
+```python
+    assemble_run.scalar_list_conflicts = resolved.scalar_list_conflicts  # type: ignore[attr-defined]
+```
+
+Grep for every `assemble_run.skipped_algorithms =` assignment and mirror each — the fresh-assemble and additive-grow paths both need it. Add the initializer next to the others at module bottom:
+
+```python
+assemble_run.scalar_list_conflicts = []  # type: ignore[attr-defined]
+```
+
+In `pipeline/sim2real.py`, after the `skipped_algorithms` loop (~line 2556):
+
+```python
+    for msg in getattr(_assemble_run_lib.assemble_run, "scalar_list_conflicts", []):
+        print(
+            f"warning: {msg} — this list is replaced rather than merged, so the "
+            "earlier layer's values do not reach the cluster. State them in the "
+            "later layer, or move them to a typed key. See issue #851.",
+            file=sys.stderr,
+        )
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `python -m pytest pipeline/tests/test_assemble_run.py pipeline/tests/test_values.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pipeline/lib/assemble_run.py pipeline/sim2real.py pipeline/tests/test_assemble_run.py
+git commit -m "feat(assemble): surface scalar-list replacement conflicts as warnings (#851)"
+```
+
+---
+
+### Task 6: Correct the docs that say additionalFlags is replaced
+
+**Files:**
+- Modify: `.claude/skills/sim2real-bootstrap/templates/defaults/vllm-logging.yaml` (~lines 21-25)
+- Modify: `docs/troubleshooting.md` (~line 157)
+- Modify: `.claude/skills/sim2real-bootstrap/tests/test_defaults_templates.py` (module docstring ~13, `_ALLOWED_SCALAR_LISTS` preamble ~100, test docstring ~140, assertion message ~169)
+- Modify: `pipeline/README.md`, `CLAUDE.md`
+- Create: `pipeline/tests/test_docs_flag_merge.py`
+
+Three places actively instruct authors to avoid `additionalFlags` *because it is replaced*. That rationale is now false for that key. The recommendation to prefer a typed key can stand where it has an independent reason (a typed key applies to both roles at once), but it must not rest on a reason that no longer holds.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `pipeline/tests/test_docs_flag_merge.py`:
+
+```python
+"""Guard that docs do not describe vllm.additionalFlags as replace-semantics.
+
+Since #851 that list merges by flag name. Three files previously told authors to
+avoid it *because* it was replaced; if that rationale creeps back, this fails.
+"""
+import re
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[2]
+
+_FILES = (
+    "docs/troubleshooting.md",
+    ".claude/skills/sim2real-bootstrap/templates/defaults/vllm-logging.yaml",
+)
+
+
+def test_flag_merged_paths_not_described_as_replaced():
+    offenders = []
+    for rel in _FILES:
+        text = (_REPO / rel).read_text()
+        for para in re.split(r"\n\s*\n", text):
+            if (
+                "additionalFlags" in para
+                and re.search(r"\breplace(s|d)?\b", para)
+                and "#851" not in para
+            ):
+                offenders.append(f"{rel}: {para[:120]}")
+    assert not offenders, (
+        "these passages tie additionalFlags to replace semantics without "
+        f"acknowledging #851: {offenders}"
+    )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest pipeline/tests/test_docs_flag_merge.py -v`
+Expected: FAIL, listing both files.
+
+- [ ] **Step 3: Update the prose**
+
+`docs/troubleshooting.md:157` — replace the "`additionalFlags` is a list of scalars, so … each later layer *replace* it" clause with: as of #851, `**.vllm.additionalFlags` merges by flag name across layers, so a flag set in one layer survives another that does not restate it. The typed key is still preferred here because it applies to both roles at once, not because the list is replaced. Keep the existing note that `decode.vllm.loggingLevel: INFO` was a no-op.
+
+`vllm-logging.yaml:21-25` — same correction in the header comment. Keep "USE THE TYPED KEY"; change the reason from "additionalFlags is a list of scalars, so `_merge_lists` replaces it" to "the typed key sets both roles at once, whereas additionalFlags is per-role", and note that as of #851 the list itself merges by flag name rather than being replaced.
+
+`test_defaults_templates.py` — in the module docstring, the `_ALLOWED_SCALAR_LISTS` preamble, the test docstring, and the assertion message: state that Tier 1 replace still governs the allowlisted keys (`router.proxy.args`, `capabilities.add`) but NOT `**.vllm.additionalFlags`, which merges by flag name since #851, and that assemble now emits a warning when a still-replacing scalar list is set by two layers. Do not change the test's logic or the allowlist contents — no fragment sets `additionalFlags` today, so behavior is unchanged.
+
+`pipeline/README.md` — in the assembly / values section, document Tier 0, the suffix scoping, `--no-` canonicalization, removal via `--no-X` or an explicit empty list, the refuse-on-non-`--`-entry and refuse-on-duplicate guards, and the new assemble warning for still-replacing scalar lists.
+
+`CLAUDE.md` — update the `values.py` row of the Pipeline Library table from "Deep-merge utility (`deep_merge`) used by `assemble_run.py`" to also note the path-scoped flag-name merge for `**.vllm.additionalFlags`.
+
+- [ ] **Step 4: Run the docs test plus the bootstrap suite**
+
+Run: `python -m pytest pipeline/tests/test_docs_flag_merge.py .claude/skills/sim2real-bootstrap/tests/ -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/ .claude/skills/sim2real-bootstrap/ pipeline/README.md CLAUDE.md pipeline/tests/test_docs_flag_merge.py
+git commit -m "docs: correct additionalFlags replace-semantics guidance after #851"
+```
+
+---
+
+### Task 7: Full verification
+
+- [ ] **Step 1: Lint**
+
+Run: `ruff check pipeline/ .claude/skills/ --select F`
+Expected: no output
+
+- [ ] **Step 2: Full suite with coverage gate**
+
+```bash
+python -m pytest pipeline/ \
+  .claude/skills/sim2real-analyze/tests/ \
+  .claude/skills/sim2real-bootstrap/tests/ \
+  .claude/skills/sim2real-translate/tests/ \
+  .claude/skills/sim2real-check/tests/ \
+  --cov=pipeline --cov-report=term-missing --cov-fail-under=90 -q
+```
+
+Expected: PASS, coverage >= 90%.
+
+- [ ] **Step 3: Confirm no leak into the parent repo**
+
+```bash
+git status
+git -C ../../.. status --short
+```
+
+Expected: changes only in the worktree.
+
+- [ ] **Step 4: Stale-reference sweep**
+
+Grep `**/*.md`, `docs/`, `.claude/skills/`, `README*` for `additionalFlags`, `_merge_lists`, `deep_merge`, `Tier 1`, `_ALLOWED_SCALAR_LISTS`. Classify each hit stale / accurate / unrelated and fix the stale ones.
+
+---
+
+## Self-Review
+
+**Spec coverage.** Stage 2 flag-name merge → Tasks 1+3. Path-scoping constraint (`router.proxy.args` must not flag-merge) → Task 3 `test_router_proxy_args_still_replaces`. Path threading, named in the issue as the main cost → Task 2. Negation decision → Tasks 1+3. No-sentinel removal decision → covered by `--no-` override plus `test_empty_overlay_still_clears`. Repeated-flag decision (refuse loudly) → Task 1 `test_duplicate_key_refused`. Stage 1 warning narrowed to still-replacing lists → Tasks 4+5. Ordering convention → Task 3 `test_base_order_preserved_overlay_only_appended`. Non-`--` guard → Tasks 1+3. Doc corrections → Task 6. Migration → deliberately absent per the decision comment.
+
+**Placeholder scan.** No TBDs; every code step carries real code. The only prose-only step is Task 6 Step 3, where the deliverable *is* prose and the exact required content is stated.
+
+**Type consistency.** `path` is a tuple of `str` everywhere; `sink` is `list` or `None` everywhere. `_merge_flag_lists(base, overlay, path)` takes path positionally (internal, always called with it); the four threaded functions take `path`/`sink` keyword-only with defaults. `_index_flags` returns an ordered `dict` consumed as such by `_merge_flag_lists`. `_ResolvedPackages.scalar_list_conflicts` is `list[str]`, matching the `sink` element type and the CLI's iteration.
+
+**Known risk.** Task 5's `_merge_layer` sets `local = [] if sink is not None else None`, so `deep_merge(sink=None)` stays on the silent path when no sink was requested — do not simplify to an unconditional `[]`, or every consumer starts allocating and `_record_scalar_list_replace`'s `sink is None` fast path stops firing.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -154,7 +154,7 @@ vllmCommon:
     disableUvicornAccessLog: false
 ```
 
-> **Note:** Use this typed key, not `**.vllm.additionalFlags: [--no-disable-uvicorn-access-log]`. `additionalFlags` is a list of scalars, so `pipeline/lib/values.py:_merge_lists` has each later layer *replace* it rather than append — a flag set from the defaults overlay is discarded by `baselines/<name>.yaml` and again by the registered overlay. The typed key also applies to **both** roles; `decode.vllm.loggingLevel: INFO` was additionally a no-op, since `INFO` is already the framework default (`defaults.yaml:51`).
+> **Note:** Use this typed key, not `**.vllm.additionalFlags: [--no-disable-uvicorn-access-log]` — the typed key applies to **both** roles from one place, whereas `additionalFlags` is per-role, so a decode-only entry leaves prefill with no access log at all. (`decode.vllm.loggingLevel: INFO` was additionally a no-op, since `INFO` is already the framework default, `defaults.yaml:51`.) Since issue #851, `**.vllm.additionalFlags` itself merges by flag name across layers — a flag one layer sets survives a later layer that does not restate it — so the earlier warning that it was *replaced* wholesale no longer applies. Scalar lists at other key paths, such as `router.proxy.args`, are still replaced; `sim2real assemble` now warns when two layers both set one.
 
 ## Correlate requests with pods (and hence nodes)
 

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -869,7 +869,7 @@ The same success gate applies — `trace_data.csv` under `workspace/runs/<run-na
 | `translation_ref.py` | Shared alias/algorithm-name validator, on-read shim for `translation_output.json` (handles both step-1 legacy and step-2 per-algo shapes), and `resolve_translation_ref` (accepts alias / hash prefix / full hash) |
 | `build.py` | Shared build primitives — image-ref construction, skopeo digest probe, buildkit-pod dispatch, atomic JSON write. Consumed by `sim2real build`. |
 | `assemble_run.py` | Assembly logic behind `sim2real assemble` (deep-merge + PipelineRun generation, additive-grow / drift / legacy-run decision tree) |
-| `values.py` | Deep-merge utility used by `assemble_run.py` |
+| `values.py` | Deep-merge utility used by `assemble_run.py`. Lists of scalars are replaced, except CLI-flag lists at `**.vllm.additionalFlags`, which merge by flag name (#851) |
 | `pairkey.py` | Pair-key parser (canonical grammar `wl-<w>\|<p>\|iN` with legacy `wl-<w>\|<p>` fallback) and `--iteration` spec parser (list + range) |
 | `tekton.py` | Generates PipelineRun YAMLs; `validate_pipelinerun_name` enforces the RFC 1123 253-char limit at assemble time |
 | `pod_pending.py` | Classifies pod scheduling failures (recoverable vs not) |
@@ -1067,8 +1067,40 @@ Where `baseline_bundle` is the experiment's `baselines/baseline.yaml` (issue #54
   a malformed manifest missing one of them — the fold raises `ValueError` instead of
   silently smearing them. (Two malformed manifests with identical markers still fold;
   malformed manifests are out of scope — kubectl/Helm reject them.)
-- Lists of scalars are replaced entirely
+- Lists of scalars are replaced entirely — **except** CLI-flag lists (see below)
 - Treatment overlay only needs the delta from baseline_resolved (shared config propagates automatically)
+
+#### CLI-flag lists merge by flag name (issue #851)
+
+Scalar lists at key paths ending in `vllm.additionalFlags` — matched as a **suffix**,
+so `decode` and `prefill` are both covered — merge by flag name instead of being
+replaced. Before #851, a flag list set by two layers kept only the last writer's copy,
+so a `config.md`-derived flag reached the cluster only if the generated overlay happened
+to restate it verbatim.
+
+- Each entry is keyed on its flag name: `--max-num-seqs=256` keys on `--max-num-seqs`;
+  a bare `--enable-chunked-prefill` is its own key.
+- `--no-X` and `--X` canonicalize to **one** key, so a later layer stating either form
+  overrides the earlier rather than emitting two contradictory flags whose winner would
+  depend on vLLM's argparse ordering.
+- Base entries come first in base order; overlay-only entries are appended — the same
+  convention the named-key dict tier uses.
+- **Removal:** state the `--no-` form to flip an inherited boolean flag, or set the list
+  to `[]` to clear it entirely. There is deliberately no per-entry deletion sentinel for
+  `--key=value` flags.
+- **Refused:** an entry that is not a `--`-prefixed string (so a space-separated arg list
+  such as `router.proxy.args` cannot be mis-keyed if pasted in), and two entries in one
+  list that collapse to the same key. Both guards apply only when two layers actually
+  contribute, since a single contributor has nothing to merge.
+
+The scoping is by key path because `router.proxy.args` is also a scalar list, but its
+values are separate elements (`["--concurrency", "8"]`) rather than `--key=value` pairs;
+flag-name merging there would treat `8` as a flag name.
+
+Scalar lists that still replace — `router.proxy.args` and
+`{decode,prefill}.extraContainerConfig.securityContext.capabilities.add` — now produce a
+warning from `sim2real assemble` when two layers both set one, naming the key path, the
+discarded values, and which two layers disagreed.
 
 ### Required structure
 

--- a/pipeline/lib/assemble_run.py
+++ b/pipeline/lib/assemble_run.py
@@ -175,7 +175,13 @@ def load_defaults_overlay(defaults_dir: Path | None, *, disable: list[str]) -> d
     for fragment in sorted(defaults_dir.glob("*.yaml")):
         if fragment.stem in disable_set:
             continue
-        merged = deep_merge(merged, _load_yaml(fragment))
+        try:
+            merged = deep_merge(merged, _load_yaml(fragment))
+        except ValueError as exc:
+            # Flag-list tier rejection (non-`--` entry, or two entries colliding
+            # on one flag key) — normalize so the CLI reports it as an error
+            # rather than a traceback, and name the fragment at fault.
+            raise AssembleError(f"defaults fragment {fragment.name}: {exc}") from exc
     return merged
 
 
@@ -330,9 +336,19 @@ def _merge_layer(base: dict, overlay: dict, *, layer: str, sink: list | None) ->
     ``local`` stays ``None`` when no sink was requested, so ``deep_merge`` keeps
     taking ``_record_scalar_list_replace``'s ``sink is None`` fast path rather
     than allocating and formatting messages nobody will read.
+
+    A ``ValueError`` from the flag-list tier (a non-``--`` entry, or two entries
+    colliding on one flag key) is normalized to ``AssembleError`` here, matching
+    how ``make_pipelinerun_scenario``'s ValueError is handled below. Without it
+    the CLI's ``except AssembleError`` in ``sim2real.py`` would miss it and the
+    operator would get a raw traceback instead of ``error: ...`` and exit 2. The
+    layer prefix is attached so the message names which two files disagreed.
     """
     local: list[str] | None = [] if sink is not None else None
-    merged = deep_merge(base, overlay, sink=local)
+    try:
+        merged = deep_merge(base, overlay, sink=local)
+    except ValueError as exc:
+        raise AssembleError(f"{layer}: {exc}") from exc
     if sink is not None and local:
         sink.extend(f"{layer}: {msg}" for msg in local)
     return merged
@@ -759,7 +775,7 @@ def _additive_grow(
     translation_ref: str,
     translation_dir: Path,
     cluster_config: dict,
-) -> None:
+) -> list[str]:
     """Grow an existing run's replica count from ``prior_replicas`` to
     ``new_replicas`` (``new_replicas > prior_replicas``).
 
@@ -769,6 +785,15 @@ def _additive_grow(
     ``run_metadata.json`` with the new replica count and a new
     ``assembled_at`` timestamp; ``params_hash`` byte-identical to prior
     (drift check already ran and passed).
+
+    Returns the scalar-list conflicts found while re-resolving. These must be
+    returned rather than dropped: the caller's drift check hashes only
+    ``slicer.assembly_slice(manifest)`` — transfer.yaml content — so the
+    translation-generated overlays this re-resolution merges may have changed
+    since the first assemble (via ``sim2real build``, ``translation
+    register``/``append``, or a regenerated ``/sim2real-translate`` overlay)
+    while the manifest hash still matches. A conflict introduced that way is
+    genuinely new and has never been reported.
     """
     # Re-run scenario resolution to obtain workloads + packages + submodule
     # discovery. Safe because drift check has already established that the
@@ -816,6 +841,8 @@ def _additive_grow(
     rm["scenario"] = manifest.get("scenario", "") or ""
     rm_path.write_text(json.dumps(rm, indent=2, sort_keys=True) + "\n")
 
+    return resolved.scalar_list_conflicts
+
 
 def assemble_run(
     *,
@@ -857,14 +884,14 @@ def assemble_run(
 
     Framework submodules (``inference-sim``, ``llm-d-benchmark``) whose
     directory is not initialized are similarly recorded on
-    Scalar lists that one layer replaced wholesale, discarding an earlier
-    layer's values, are recorded on ``assemble_run.scalar_list_conflicts`` for
-    the same wrapper to surface (issue #851).
-
     ``assemble_run.missing_submodules``. The four PipelineRun params
     (``benchmarkGit*``, ``blisGit*``) fall back to ``"unknown"`` in
     that case so the run assembles locally; the cluster-side clone
     step then fails visibly at the right point.
+
+    Scalar lists that one layer replaced wholesale, discarding an earlier
+    layer's values, are recorded on ``assemble_run.scalar_list_conflicts`` for
+    the same wrapper to surface (issue #851).
     """
     layout.set_experiment_root(experiment_root)
     # Reset side-band state each call — see docstring above.
@@ -983,7 +1010,7 @@ def assemble_run(
                             additive_grow_from = prior_replicas
 
     if additive_grow_from is not None:
-        _additive_grow(
+        grow_conflicts = _additive_grow(
             run_dir,
             manifest,
             prior_replicas=additive_grow_from,
@@ -996,12 +1023,13 @@ def assemble_run(
             cluster_config=cluster_config,
         )
         # skipped_algorithms/missing_submodules unchanged from prior assemble.
-        # scalar_list_conflicts likewise: the drift check has established the
-        # manifest slice is unchanged, so any conflict was already reported when
-        # the run was first assembled.
+        # scalar_list_conflicts is NOT: the drift check hashes only the manifest
+        # assembly slice, so the translation-generated overlays that
+        # _additive_grow re-merges may have changed since the first assemble
+        # while transfer.yaml did not. Surface whatever it found.
         assemble_run.skipped_algorithms = []  # type: ignore[attr-defined]
         assemble_run.missing_submodules = []  # type: ignore[attr-defined]
-        assemble_run.scalar_list_conflicts = []  # type: ignore[attr-defined]
+        assemble_run.scalar_list_conflicts = grow_conflicts  # type: ignore[attr-defined]
         assemble_run.status = "written"  # type: ignore[attr-defined]
         assemble_run.prior_assembled_at = ""  # type: ignore[attr-defined]
         return

--- a/pipeline/lib/assemble_run.py
+++ b/pipeline/lib/assemble_run.py
@@ -319,11 +319,31 @@ def _align_overlay_name(base: dict, overlay: dict) -> dict:
     return overlay
 
 
+def _merge_layer(base: dict, overlay: dict, *, layer: str, sink: list | None) -> dict:
+    """``deep_merge`` one layer, tagging any recorded conflict with the layer pair.
+
+    ``values.deep_merge`` knows the key path but not which files are being merged
+    — only this module knows that. Collecting per-merge and re-prefixing is what
+    turns "scenario.router.proxy.args was replaced" into an operator-actionable
+    "which two layers disagreed".
+
+    ``local`` stays ``None`` when no sink was requested, so ``deep_merge`` keeps
+    taking ``_record_scalar_list_replace``'s ``sink is None`` fast path rather
+    than allocating and formatting messages nobody will read.
+    """
+    local: list[str] | None = [] if sink is not None else None
+    merged = deep_merge(base, overlay, sink=local)
+    if sink is not None and local:
+        sink.extend(f"{layer}: {msg}" for msg in local)
+    return merged
+
+
 def resolve_baseline(
     *,
     bundle_path: Path,
     overlay_path: Path | None,
     framework_defaults: dict,
+    sink: list | None = None,
 ) -> dict:
     """Return ``deep_merge(framework_defaults, bundle, overlay)`` for a baseline.
 
@@ -338,6 +358,11 @@ def resolve_baseline(
     overlay named ``defaults`` and a baseline named anything else produce two
     scenario entries — an intended one plus a phantom one that inherits the
     llm-d-benchmark framework-default model (issue #516).
+
+    ``sink``, when a list, collects operator-facing warnings about scalar lists
+    that one layer replaced wholesale, each tagged with the layer pair that
+    disagreed. ``**.vllm.additionalFlags`` merges by flag name and never appears
+    there; see ``values._record_scalar_list_replace`` and issue #851.
     """
     if not bundle_path.exists():
         raise AssembleError(f"baseline scenario not found: {bundle_path}")
@@ -348,8 +373,14 @@ def resolve_baseline(
         else {}
     )
     aligned_defaults = _align_overlay_name(bundle, copy.deepcopy(framework_defaults))
-    resolved = deep_merge(aligned_defaults, bundle)
-    resolved = deep_merge(resolved, overlay)
+    resolved = _merge_layer(
+        aligned_defaults, bundle,
+        layer="framework defaults -> baseline bundle", sink=sink,
+    )
+    resolved = _merge_layer(
+        resolved, overlay,
+        layer="baseline bundle -> registered overlay", sink=sink,
+    )
     return resolved
 
 
@@ -358,12 +389,16 @@ def resolve_treatment(
     baseline_resolved: dict,
     diffs_path: Path | None,
     overlay_path: Path | None,
+    sink: list | None = None,
 ) -> dict:
     """Return ``deep_merge(baseline_resolved, treatment_diffs, algo_overlay)``.
 
     Either or both of ``diffs_path`` / ``overlay_path`` may be ``None`` or
     point at non-existent files — the corresponding layer is treated as
     empty. Baseline is required (starts from an already-resolved dict).
+
+    ``sink`` behaves as in ``resolve_baseline``: it collects scalar-list
+    replacement warnings tagged with the layer pair that disagreed.
     """
     diffs = (
         _load_yaml(diffs_path)
@@ -375,8 +410,14 @@ def resolve_treatment(
         if overlay_path is not None and overlay_path.exists()
         else {}
     )
-    resolved = deep_merge(copy.deepcopy(baseline_resolved), diffs)
-    resolved = deep_merge(resolved, overlay)
+    resolved = _merge_layer(
+        copy.deepcopy(baseline_resolved), diffs,
+        layer="baseline -> treatment diffs", sink=sink,
+    )
+    resolved = _merge_layer(
+        resolved, overlay,
+        layer="treatment diffs -> algorithm overlay", sink=sink,
+    )
     return resolved
 
 
@@ -551,6 +592,10 @@ class _ResolvedPackages(NamedTuple):
     submodule_shas: dict[str, str]
     submodule_urls: dict[str, str]
     missing_submodules: list[str]
+    #: Scalar lists that one layer replaced wholesale, discarding an earlier
+    #: layer's values. Exposed for the CLI wrapper to surface as warnings — see
+    #: ``values._record_scalar_list_replace`` and issue #851.
+    scalar_list_conflicts: list[str]
 
 
 def _resolve_packages(
@@ -615,6 +660,7 @@ def _resolve_packages(
 
     packages: list[tuple[str, dict]] = []
     resolved_baselines: dict[str, dict] = {}
+    scalar_list_conflicts: list[str] = []
     for bl in manifest.get("baselines", []):
         bl_name = bl["name"]
         bundle_path = _resolve_scenario_path(
@@ -640,6 +686,7 @@ def _resolve_packages(
             bundle_path=bundle_path,
             overlay_path=overlay_path,
             framework_defaults=framework_defaults,
+            sink=scalar_list_conflicts,
         )
         resolved_baselines[bl_name] = resolved
         packages.append((bl_name, resolved))
@@ -660,6 +707,7 @@ def _resolve_packages(
             baseline_resolved=resolved_baselines[base_name],
             diffs_path=diffs_path,
             overlay_path=overlay_path,
+            sink=scalar_list_conflicts,
         )
         algo_image_ref = translated_algos[algo_name]["image_ref"]
         inject_image_tag(resolved, algo_image_ref)
@@ -695,6 +743,7 @@ def _resolve_packages(
         submodule_shas=submodule_shas,
         submodule_urls=submodule_urls,
         missing_submodules=missing_submodules,
+        scalar_list_conflicts=scalar_list_conflicts,
     )
 
 
@@ -808,6 +857,10 @@ def assemble_run(
 
     Framework submodules (``inference-sim``, ``llm-d-benchmark``) whose
     directory is not initialized are similarly recorded on
+    Scalar lists that one layer replaced wholesale, discarding an earlier
+    layer's values, are recorded on ``assemble_run.scalar_list_conflicts`` for
+    the same wrapper to surface (issue #851).
+
     ``assemble_run.missing_submodules``. The four PipelineRun params
     (``benchmarkGit*``, ``blisGit*``) fall back to ``"unknown"`` in
     that case so the run assembles locally; the cluster-side clone
@@ -817,6 +870,7 @@ def assemble_run(
     # Reset side-band state each call — see docstring above.
     assemble_run.skipped_algorithms = []  # type: ignore[attr-defined]
     assemble_run.missing_submodules = []  # type: ignore[attr-defined]
+    assemble_run.scalar_list_conflicts = []  # type: ignore[attr-defined]
 
     # 1. Validation --------------------------------------------------------
     tdir = layout.translation_dir(translation_hash)
@@ -910,6 +964,7 @@ def assemble_run(
                                 # True no-op: reset side-band attrs and return.
                                 assemble_run.skipped_algorithms = []  # type: ignore[attr-defined]
                                 assemble_run.missing_submodules = []  # type: ignore[attr-defined]
+                                assemble_run.scalar_list_conflicts = []  # type: ignore[attr-defined]
                                 assemble_run.status = "noop"  # type: ignore[attr-defined]
                                 assemble_run.prior_assembled_at = (  # type: ignore[attr-defined]
                                     str(prior_rm.get("assembled_at") or "")
@@ -941,8 +996,12 @@ def assemble_run(
             cluster_config=cluster_config,
         )
         # skipped_algorithms/missing_submodules unchanged from prior assemble.
+        # scalar_list_conflicts likewise: the drift check has established the
+        # manifest slice is unchanged, so any conflict was already reported when
+        # the run was first assembled.
         assemble_run.skipped_algorithms = []  # type: ignore[attr-defined]
         assemble_run.missing_submodules = []  # type: ignore[attr-defined]
+        assemble_run.scalar_list_conflicts = []  # type: ignore[attr-defined]
         assemble_run.status = "written"  # type: ignore[attr-defined]
         assemble_run.prior_assembled_at = ""  # type: ignore[attr-defined]
         return
@@ -965,6 +1024,7 @@ def assemble_run(
     kept_algos = resolved.kept_algos
     translated_algos = resolved.translated_algos
     assemble_run.missing_submodules = resolved.missing_submodules  # type: ignore[attr-defined]
+    assemble_run.scalar_list_conflicts = resolved.scalar_list_conflicts  # type: ignore[attr-defined]
 
     # 5. Snapshot assembly slice + params_hash ----------------------------
     run_dir.mkdir(parents=True, exist_ok=True)
@@ -1027,5 +1087,6 @@ def assemble_run(
 # Initialize side-band attributes so `getattr` in the CLI works on first call.
 assemble_run.skipped_algorithms = []  # type: ignore[attr-defined]
 assemble_run.missing_submodules = []  # type: ignore[attr-defined]
+assemble_run.scalar_list_conflicts = []  # type: ignore[attr-defined]
 assemble_run.status = "written"  # type: ignore[attr-defined]
 assemble_run.prior_assembled_at = ""  # type: ignore[attr-defined]

--- a/pipeline/lib/capacity.py
+++ b/pipeline/lib/capacity.py
@@ -195,13 +195,22 @@ def derive_gpu_resource_type(resolved_scenario: dict, defaults: dict) -> str:
 
     Merges the first scenario entry over defaults, then reads
     accelerator.resource. Falls back to "nvidia.com/gpu".
+
+    Never raises: the flag-list merge tier (issue #851) rejects a malformed or
+    duplicated CLI-flag entry with ValueError, but this function's contract is
+    to always return a resource name, so such a merge failure falls back to the
+    default like every other missing-or-bad-data case here. GPU resource type
+    does not depend on vLLM flags, so the fallback loses nothing.
     """
     scenario_entry = {}
     scenarios = resolved_scenario.get("scenario", [])
     if scenarios:
         scenario_entry = scenarios[0]
 
-    merged = deep_merge(defaults, scenario_entry)
+    try:
+        merged = deep_merge(defaults, scenario_entry)
+    except ValueError:
+        return "nvidia.com/gpu"
     return merged.get("accelerator", {}).get("resource", "nvidia.com/gpu")
 
 
@@ -217,13 +226,22 @@ def gpu_cost_per_pair(resolved_scenario: dict, defaults: dict) -> Union[int, str
     accelerator.count propagates to roles that don't override it.
 
     Returns int on success, or error string describing the problematic field.
+    Never raises — the caller (``deploy.py:_derive_pair_gpu_costs``) degrades an
+    error string to a warning plus fallback cost, and a raise there would crash
+    the orchestrator at startup. A ValueError from the flag-list merge tier
+    (issue #851 — a non-``--`` entry, or two entries colliding on one flag key)
+    is therefore folded into the error-string return like every other malformed
+    -input case below.
     """
     scenario_entry = {}
     scenarios = resolved_scenario.get("scenario", [])
     if scenarios:
         scenario_entry = scenarios[0]
 
-    merged = deep_merge(defaults, scenario_entry)
+    try:
+        merged = deep_merge(defaults, scenario_entry)
+    except ValueError as exc:
+        return f"scenario/defaults merge failed: {exc}"
 
     top_accel = merged.get("accelerator", {})
     top_count_raw = top_accel.get("count")

--- a/pipeline/lib/capacity.py
+++ b/pipeline/lib/capacity.py
@@ -196,11 +196,16 @@ def derive_gpu_resource_type(resolved_scenario: dict, defaults: dict) -> str:
     Merges the first scenario entry over defaults, then reads
     accelerator.resource. Falls back to "nvidia.com/gpu".
 
-    Never raises: the flag-list merge tier (issue #851) rejects a malformed or
-    duplicated CLI-flag entry with ValueError, but this function's contract is
-    to always return a resource name, so such a merge failure falls back to the
-    default like every other missing-or-bad-data case here. GPU resource type
-    does not depend on vLLM flags, so the fallback loses nothing.
+    Never raises: this function's contract is to always return a resource name,
+    so a merge failure falls back to the default like every other
+    missing-or-bad-data case here. GPU resource type does not depend on vLLM
+    flags, so the fallback itself loses nothing.
+
+    It does warn first, though. ``deep_merge`` can raise for more than the
+    flag-list tier (issue #851) — duplicate Kubernetes object identity and a
+    Tier-3 marker conflict both raise ValueError too — and on a non-NVIDIA
+    cluster a silent fallback to ``nvidia.com/gpu`` would mis-probe capacity
+    with nothing in the log to explain why.
     """
     scenario_entry = {}
     scenarios = resolved_scenario.get("scenario", [])
@@ -209,7 +214,11 @@ def derive_gpu_resource_type(resolved_scenario: dict, defaults: dict) -> str:
 
     try:
         merged = deep_merge(defaults, scenario_entry)
-    except ValueError:
+    except ValueError as exc:
+        warn(
+            f"scenario/defaults merge failed ({exc}); falling back to GPU "
+            "resource type 'nvidia.com/gpu' — verify this matches the cluster"
+        )
         return "nvidia.com/gpu"
     return merged.get("accelerator", {}).get("resource", "nvidia.com/gpu")
 

--- a/pipeline/lib/values.py
+++ b/pipeline/lib/values.py
@@ -117,6 +117,36 @@ def _merge_flag_lists(
     return result
 
 
+def _record_scalar_list_replace(
+    base_list: list,
+    overlay_list: list,
+    path: tuple[str, ...],
+    sink: list | None,
+) -> None:
+    """Record that a scalar list was replaced wholesale, discarding base values.
+
+    Stage 1 of issue #851, narrowed to the lists that STILL replace now that the
+    flag-merge tier exists — today ``router.proxy.args`` and
+    ``{decode,prefill}.extraContainerConfig.securityContext.capabilities.add``,
+    both allowlisted in the bootstrap skill's
+    ``tests/test_defaults_templates.py:_ALLOWED_SCALAR_LISTS``. Paths that merge
+    by flag name never reach here, so this stays signal rather than noise.
+
+    Identical lists record nothing: restating the same values loses no
+    information, and warning about it would train operators to ignore the
+    warning. ``sink is None`` — every consumer except the assemble resolution
+    chain — is silent, so a merge in a hot path such as ``capacity`` costs
+    nothing.
+    """
+    if sink is None or base_list == overlay_list:
+        return
+    sink.append(
+        f"{'.'.join(path) or '<root>'}: overlay replaces the whole list, "
+        f"discarding {len(base_list)} value(s) set by an earlier layer: "
+        f"{base_list!r} (kept: {overlay_list!r})"
+    )
+
+
 def _k8s_identity(item):
     """Return a Kubernetes identity tuple (apiVersion, kind, metadata.name), or None.
 
@@ -290,6 +320,7 @@ def _merge_lists(
     # Tier 1: any non-dict item → replace
     if not (all(isinstance(x, dict) for x in base_list)
             and all(isinstance(x, dict) for x in overlay_list)):
+        _record_scalar_list_replace(base_list, overlay_list, path, sink)
         return copy.deepcopy(overlay_list)
 
     # Tier 2a: Kubernetes manifest lists — merge by identity, never positionally fold

--- a/pipeline/lib/values.py
+++ b/pipeline/lib/values.py
@@ -94,6 +94,29 @@ def _index_flags(entries: list, path: tuple[str, ...], side: str) -> dict:
     return indexed
 
 
+def _merge_flag_lists(
+    base_list: list, overlay_list: list, path: tuple[str, ...]
+) -> list:
+    """Merge two CLI-flag lists by flag name.
+
+    Base entries are emitted first in base order — an overlay entry sharing a key
+    substitutes its own literal spelling, so ``--no-X`` can override ``--X`` — and
+    overlay-only entries are appended in overlay order. This is the same
+    base-first-then-append convention Tier 2b already uses for keyed dict lists.
+
+    Removal: a later layer drops an inherited boolean flag by stating its
+    ``--no-`` form; the whole list is cleared by setting it to ``[]`` (handled by
+    ``_merge_lists``' empty-overlay guard before this is reached). There is
+    deliberately no per-entry deletion sentinel for ``--key=value`` flags — see
+    issue #851.
+    """
+    base_idx = _index_flags(base_list, path, "base")
+    overlay_idx = _index_flags(overlay_list, path, "overlay")
+    result = [overlay_idx.get(key, entry) for key, entry in base_idx.items()]
+    result.extend(entry for key, entry in overlay_idx.items() if key not in base_idx)
+    return result
+
+
 def _k8s_identity(item):
     """Return a Kubernetes identity tuple (apiVersion, kind, metadata.name), or None.
 
@@ -233,6 +256,12 @@ def _merge_lists(
 ) -> list:
     """Merge two lists using a tiered strategy.
 
+    Tier 0:  ``path`` ends with a ``_FLAG_LIST_PATH_SUFFIXES`` entry → merge the
+             scalar entries by flag name (``--max-num-seqs=256`` keys on
+             ``--max-num-seqs``; ``--no-X`` and ``--X`` are ONE key). Only
+             reached when both lists are non-empty. Scoped by key path because
+             flag-name merging would corrupt a space-separated arg list such as
+             ``router.proxy.args``, where values are separate elements.
     Tier 1:  either list contains non-dict items → overlay replaces base.
     Tier 2a: all entries are Kubernetes manifests → merge by (apiVersion, kind,
              metadata.name) identity; manifests without metadata.name are carried
@@ -249,6 +278,14 @@ def _merge_lists(
         return []
     if not base_list:
         return copy.deepcopy(overlay_list)
+
+    # Tier 0: path-scoped CLI-flag lists → merge by flag name (#851).
+    # Deliberately placed AFTER the empty-list guards: with only one layer
+    # contributing there is nothing to merge and nothing to lose, so a
+    # single-layer bundle is never newly refused by _index_flags' entry guards.
+    # Those guards protect the merge, not the schema.
+    if _is_flag_list_path(path):
+        return _merge_flag_lists(base_list, overlay_list, path)
 
     # Tier 1: any non-dict item → replace
     if not (all(isinstance(x, dict) for x in base_list)

--- a/pipeline/lib/values.py
+++ b/pipeline/lib/values.py
@@ -18,6 +18,82 @@ def _detect_list_key(base_list: list, overlay_list: list):
     return None
 
 
+# ── Flag-list merge (path-scoped) ─────────────────────────────────────────────
+
+#: Key-path suffixes whose scalar lists merge by flag name rather than being
+#: replaced wholesale. Matched as a SUFFIX of the merge path, with list indices
+#: elided from the path, so one entry covers both the `decode` and `prefill`
+#: roles AND both merge roots in use today: `assemble_run` merges whole
+#: documents (`scenario.decode.vllm.additionalFlags`) while `capacity` merges a
+#: single scenario entry (`decode.vllm.additionalFlags`). An absolute path
+#: anchored at the document root would match the first and silently miss the
+#: second. See issue #851.
+_FLAG_LIST_PATH_SUFFIXES: tuple[tuple[str, ...], ...] = (
+    ("vllm", "additionalFlags"),
+)
+
+
+def _is_flag_list_path(path: tuple[str, ...]) -> bool:
+    """Return True when `path` ends with a registered flag-list suffix."""
+    return any(
+        len(path) >= len(suffix) and tuple(path[-len(suffix):]) == suffix
+        for suffix in _FLAG_LIST_PATH_SUFFIXES
+    )
+
+
+def _flag_key(entry: str) -> str:
+    """Return the merge key for one CLI-flag list entry.
+
+    `--max-num-seqs=256` keys on `--max-num-seqs`; a bare
+    `--enable-chunked-prefill` is its own key. A leading `--no-` is stripped so
+    a flag and its negation collapse to a single key: `--enable-prefix-caching`
+    and `--no-enable-prefix-caching` express one decision, so a later layer
+    stating either form must override the earlier rather than emit both.
+    Emitting both would leave the outcome to vLLM's argparse ordering — the
+    silent conflict issue #851 exists to avoid, and the reason it rejected
+    simple list concatenation.
+    """
+    name = entry.split("=", 1)[0]
+    if name.startswith("--no-"):
+        name = "--" + name[len("--no-"):]
+    return name
+
+
+def _index_flags(entries: list, path: tuple[str, ...], side: str) -> dict:
+    """Return ``{flag key: literal entry}`` for one flag list, preserving order.
+
+    Raises ValueError on a non-string entry, an entry that is not a ``--`` flag,
+    or two entries collapsing to the same key. Each would otherwise produce a
+    silently wrong flag set, which is the failure class this tier closes.
+    """
+    where = ".".join(path) or "<root>"
+    indexed: dict[str, str] = {}
+    for entry in entries:
+        if not isinstance(entry, str):
+            raise ValueError(
+                f"{where}: {side} flag list entry is "
+                f"{type(entry).__name__}, not a string: {entry!r} — this path "
+                "merges by flag name and cannot key a non-string entry"
+            )
+        if not entry.startswith("--"):
+            raise ValueError(
+                f"{where}: {side} flag list entry does not start with '--': "
+                f"{entry!r} — this path merges by flag name, so a bare value "
+                "(as used in space-separated arg lists like router.proxy.args) "
+                "would be mis-keyed as a flag name"
+            )
+        key = _flag_key(entry)
+        if key in indexed:
+            raise ValueError(
+                f"{where}: {side} flag list states '{key}' twice "
+                f"({indexed[key]!r} and {entry!r}) — merging by flag name would "
+                "silently drop one. State the flag once; note that '--no-X' and "
+                "'--X' are the same key."
+            )
+        indexed[key] = entry
+    return indexed
+
+
 def _k8s_identity(item):
     """Return a Kubernetes identity tuple (apiVersion, kind, metadata.name), or None.
 

--- a/pipeline/lib/values.py
+++ b/pipeline/lib/values.py
@@ -111,11 +111,22 @@ def _k8s_identity(item):
     return (item["apiVersion"], item["kind"], meta["name"])
 
 
-def _merge_by_keyfn(base_list: list, overlay_list: list, keyfn) -> list:
+def _merge_by_keyfn(
+    base_list: list,
+    overlay_list: list,
+    keyfn,
+    *,
+    path: tuple[str, ...] = (),
+    sink: list | None = None,
+) -> list:
     """Merge two all-dict lists by a key extractor.
 
     Base entries are emitted first (deep-merged with the same-keyed overlay entry
     when present); overlay-only entries are appended in order.
+
+    ``path`` is passed through to the recursive merge UNCHANGED — the list index
+    is deliberately elided, so a key path is the same whether a list sits between
+    two dicts or not. See ``_FLAG_LIST_PATH_SUFFIXES``.
     """
     overlay_by_key = {keyfn(item): item for item in overlay_list}
     result = []
@@ -124,7 +135,9 @@ def _merge_by_keyfn(base_list: list, overlay_list: list, keyfn) -> list:
         k = keyfn(bitem)
         seen_keys.add(k)
         if k in overlay_by_key:
-            result.append(deep_merge(bitem, overlay_by_key[k]))
+            result.append(
+                deep_merge(bitem, overlay_by_key[k], path=path, sink=sink)
+            )
         else:
             result.append(copy.deepcopy(bitem))
     for oitem in overlay_list:
@@ -159,7 +172,13 @@ def _k8s_markers_conflict(a: dict, b: dict) -> bool:
     return a_markers != b_markers
 
 
-def _merge_k8s_objects(base_list: list, overlay_list: list) -> list:
+def _merge_k8s_objects(
+    base_list: list,
+    overlay_list: list,
+    *,
+    path: tuple[str, ...] = (),
+    sink: list | None = None,
+) -> list:
     """Merge two lists of Kubernetes manifests without ever folding dissimilar objects.
 
     Manifests carrying a full identity (apiVersion, kind, metadata.name) merge by that
@@ -193,7 +212,9 @@ def _merge_k8s_objects(base_list: list, overlay_list: list) -> list:
             raise ValueError(f"duplicate Kubernetes object identity in base list: {k}")
         seen_keys.add(k)
         if k in overlay_by_key:
-            result.append(deep_merge(bitem, overlay_by_key[k]))
+            result.append(
+                deep_merge(bitem, overlay_by_key[k], path=path, sink=sink)
+            )
         else:
             result.append(copy.deepcopy(bitem))
     for oitem in overlay_list:
@@ -203,7 +224,13 @@ def _merge_k8s_objects(base_list: list, overlay_list: list) -> list:
     return result
 
 
-def _merge_lists(base_list: list, overlay_list: list) -> list:
+def _merge_lists(
+    base_list: list,
+    overlay_list: list,
+    *,
+    path: tuple[str, ...] = (),
+    sink: list | None = None,
+) -> list:
     """Merge two lists using a tiered strategy.
 
     Tier 1:  either list contains non-dict items → overlay replaces base.
@@ -230,12 +257,14 @@ def _merge_lists(base_list: list, overlay_list: list) -> list:
 
     # Tier 2a: Kubernetes manifest lists — merge by identity, never positionally fold
     if all(_is_k8s_manifest(x) for x in base_list + overlay_list):
-        return _merge_k8s_objects(base_list, overlay_list)
+        return _merge_k8s_objects(base_list, overlay_list, path=path, sink=sink)
 
     # Tier 2b: named-key merge
     key_field = _detect_list_key(base_list, overlay_list)
     if key_field is not None:
-        return _merge_by_keyfn(base_list, overlay_list, lambda d: d[key_field])
+        return _merge_by_keyfn(
+            base_list, overlay_list, lambda d: d[key_field], path=path, sink=sink
+        )
 
     # Tier 3: positional merge — surplus from either side preserved
     result = []
@@ -249,7 +278,9 @@ def _merge_lists(base_list: list, overlay_list: list) -> list:
                     f"{(overlay_list[i].get('apiVersion'), overlay_list[i].get('kind'))} "
                     "— an entry is likely missing apiVersion or kind"
                 )
-            result.append(deep_merge(base_list[i], overlay_list[i]))
+            result.append(
+                deep_merge(base_list[i], overlay_list[i], path=path, sink=sink)
+            )
         elif i < len(base_list):
             result.append(copy.deepcopy(base_list[i]))
         else:
@@ -257,19 +288,33 @@ def _merge_lists(base_list: list, overlay_list: list) -> list:
     return result
 
 
-def deep_merge(base: dict, overlay: dict) -> dict:
+def deep_merge(
+    base: dict,
+    overlay: dict,
+    *,
+    path: tuple[str, ...] = (),
+    sink: list | None = None,
+) -> dict:
     """Deep-merge overlay onto base. Dict keys merged recursively.
 
     Lists of dicts are merged by Kubernetes identity, named key, or positional index
-    (see _merge_lists). Lists of scalars are replaced entirely. Returns a new dict
-    (deep copy).
+    (see _merge_lists). Lists of scalars are replaced entirely, EXCEPT at paths
+    registered in ``_FLAG_LIST_PATH_SUFFIXES``, which merge by flag name. Returns a
+    new dict (deep copy).
+
+    ``path`` is the key path of ``base`` within the document being merged, as a
+    tuple of segments with list indices elided. It exists so ``_merge_lists`` can
+    scope a merge strategy to a key path; callers merging a whole document leave it
+    at its default. ``sink``, when a list, collects operator-facing warnings about
+    scalar lists replaced wholesale — see ``_record_scalar_list_replace``.
     """
     result = copy.deepcopy(base)
     for key, oval in overlay.items():
+        child = path + (str(key),)
         if key in result and isinstance(result[key], dict) and isinstance(oval, dict):
-            result[key] = deep_merge(result[key], oval)
+            result[key] = deep_merge(result[key], oval, path=child, sink=sink)
         elif key in result and isinstance(result[key], list) and isinstance(oval, list):
-            result[key] = _merge_lists(result[key], oval)
+            result[key] = _merge_lists(result[key], oval, path=child, sink=sink)
         else:
             result[key] = copy.deepcopy(oval)
     return result

--- a/pipeline/sim2real.py
+++ b/pipeline/sim2real.py
@@ -2559,6 +2559,13 @@ def _cmd_assemble(args) -> int:
             "in translation_output.json — skipped",
             file=sys.stderr,
         )
+    for msg in getattr(_assemble_run_lib.assemble_run, "scalar_list_conflicts", []):
+        print(
+            f"warning: {msg} — this list is replaced rather than merged, so the "
+            "earlier layer's values do not reach the cluster. State them in the "
+            "later layer, or move them to a typed key. See issue #851.",
+            file=sys.stderr,
+        )
     for name in getattr(_assemble_run_lib.assemble_run, "missing_submodules", []):
         print(
             f"warning: framework submodule '{name}' not initialized — "

--- a/pipeline/tests/test_assemble_replicas.py
+++ b/pipeline/tests/test_assemble_replicas.py
@@ -34,6 +34,11 @@ def _mtimes(paths: list[Path]) -> list[float]:
     return [p.stat().st_mtime_ns for p in paths]
 
 
+def _write_scenario_yaml(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.dump(data, sort_keys=False))
+
+
 def _assemble(fx: dict, *, replicas: int = 1, force: bool = False,
               now_iso: str = "2026-07-01T00:00:00Z") -> None:
     assemble_run.assemble_run(
@@ -143,6 +148,47 @@ class TestAssembleReplicas:
         _assemble(fx, replicas=5, now_iso="2026-07-02T00:00:00Z")
         assert assemble_run.assemble_run.status == "written"
         assert assemble_run.assemble_run.prior_assembled_at == ""
+
+    def test_additive_grow_surfaces_newly_introduced_scalar_conflict(self, tmp_path):
+        """#851: the grow path must NOT discard scalar_list_conflicts.
+
+        The drift check hashes only ``slicer.assembly_slice(manifest)``, i.e.
+        transfer.yaml. The baseline/overlay YAMLs that resolution actually merges
+        sit outside that hash, so editing one and then bumping --replicas takes
+        the additive-grow branch with a conflict that has never been reported.
+        """
+        fx = _make_experiment(tmp_path, algo_names_registered=["sr"],
+                              algo_names_manifest=["sr"])
+        _assemble(fx, replicas=3, now_iso="2026-07-01T00:00:00Z")
+        assert assemble_run.assemble_run.scalar_list_conflicts == []
+
+        # Introduce a conflict WITHOUT touching transfer.yaml: the defaults
+        # fragment and the baseline bundle now both set router.proxy.args.
+        _write_scenario_yaml(
+            fx["exp_root"] / "baselines" / "defaults" / "envoy.yaml",
+            {"scenario": [{"name": "test-scenario",
+                           "router": {"proxy": {"args": ["--concurrency", "8"]}}}]},
+        )
+        _write_scenario_yaml(
+            fx["exp_root"] / "baselines" / "base.yaml",
+            {"scenario": [{"name": "test-scenario", "model": {"name": "M"},
+                           "router": {"proxy": {"args": ["--log-level", "warn"]}}}]},
+        )
+
+        _assemble(fx, replicas=5, now_iso="2026-07-02T00:00:00Z")
+        # Grow path was taken (not a full rebuild).
+        assert assemble_run.assemble_run.status == "written"
+        conflicts = assemble_run.assemble_run.scalar_list_conflicts
+        assert len(conflicts) >= 1
+        assert any("scenario.router.proxy.args" in c for c in conflicts)
+        assert any("framework defaults -> baseline bundle" in c for c in conflicts)
+
+    def test_additive_grow_reports_no_conflict_when_there_is_none(self, tmp_path):
+        fx = _make_experiment(tmp_path, algo_names_registered=["sr"],
+                              algo_names_manifest=["sr"])
+        _assemble(fx, replicas=3, now_iso="2026-07-01T00:00:00Z")
+        _assemble(fx, replicas=5, now_iso="2026-07-02T00:00:00Z")
+        assert assemble_run.assemble_run.scalar_list_conflicts == []
 
     def test_force_rebuild_sets_status_written(self, tmp_path):
         """Issue #555: --force full rebuild is a write path — status='written'."""

--- a/pipeline/tests/test_assemble_run.py
+++ b/pipeline/tests/test_assemble_run.py
@@ -344,6 +344,165 @@ class TestResolveScenarios:
                 framework_defaults={},
             )
 
+    # ── Flag-list merge across layers (#851) ──────────────────────────────────
+
+    def test_config_md_flag_survives_overlay_that_omits_it(self, tmp_path):
+        """#851 end-to-end: baseline flags reach the resolved scenario even when
+        the generated overlay contributes only its own flag."""
+        bundle_path = tmp_path / "baseline.yaml"
+        overlay_path = tmp_path / "baseline_overlay.yaml"
+        self._write(bundle_path, {"scenario": [{
+            "name": "b",
+            "decode": {"vllm": {"additionalFlags": [
+                "--max-num-seqs=256",
+                "--max-num-batched-tokens=2048",
+                "--enable-chunked-prefill",
+                "--enable-prefix-caching",
+            ]}},
+        }]})
+        self._write(overlay_path, {"scenario": [{
+            "name": "b",
+            "decode": {"vllm": {"additionalFlags": [
+                "--enable-force-include-usage",
+            ]}},
+        }]})
+        resolved = assemble_run.resolve_baseline(
+            bundle_path=bundle_path,
+            overlay_path=overlay_path,
+            framework_defaults={},
+        )
+        assert resolved["scenario"][0]["decode"]["vllm"]["additionalFlags"] == [
+            "--max-num-seqs=256",
+            "--max-num-batched-tokens=2048",
+            "--enable-chunked-prefill",
+            "--enable-prefix-caching",
+            "--enable-force-include-usage",
+        ]
+
+    def test_treatment_overlay_overrides_one_flag_keeps_rest(self, tmp_path):
+        overlay_path = tmp_path / "sr" / "sr_config.yaml"
+        self._write(overlay_path, {"scenario": [{
+            "name": "b",
+            "decode": {"vllm": {"additionalFlags": ["--max-num-seqs=512"]}},
+        }]})
+        baseline_resolved = {"scenario": [{
+            "name": "b",
+            "decode": {"vllm": {"additionalFlags": [
+                "--max-num-seqs=256", "--enable-prefix-caching",
+            ]}},
+        }]}
+        resolved = assemble_run.resolve_treatment(
+            baseline_resolved=baseline_resolved,
+            diffs_path=None,
+            overlay_path=overlay_path,
+        )
+        assert resolved["scenario"][0]["decode"]["vllm"]["additionalFlags"] == [
+            "--max-num-seqs=512",
+            "--enable-prefix-caching",
+        ]
+
+    def test_baseline_records_scalar_conflict_with_layer_names(self, tmp_path):
+        bundle_path = tmp_path / "baseline.yaml"
+        overlay_path = tmp_path / "baseline_overlay.yaml"
+        self._write(bundle_path, {"scenario": [{
+            "name": "b",
+            "router": {"proxy": {"args": ["--concurrency", "8"]}},
+        }]})
+        self._write(overlay_path, {"scenario": [{
+            "name": "b",
+            "router": {"proxy": {"args": ["--log-level", "warn"]}},
+        }]})
+        sink: list[str] = []
+        assemble_run.resolve_baseline(
+            bundle_path=bundle_path,
+            overlay_path=overlay_path,
+            framework_defaults={},
+            sink=sink,
+        )
+        assert len(sink) == 1
+        assert "baseline bundle -> registered overlay" in sink[0]
+        assert "scenario.router.proxy.args" in sink[0]
+
+    def test_baseline_records_defaults_layer_conflict(self, tmp_path):
+        bundle_path = tmp_path / "baseline.yaml"
+        self._write(bundle_path, {"scenario": [{
+            "name": "b",
+            "router": {"proxy": {"args": ["--log-level", "warn"]}},
+        }]})
+        sink: list[str] = []
+        assemble_run.resolve_baseline(
+            bundle_path=bundle_path,
+            overlay_path=None,
+            framework_defaults={"scenario": [{
+                "name": "defaults",
+                "router": {"proxy": {"args": ["--concurrency", "8"]}},
+            }]},
+            sink=sink,
+        )
+        assert len(sink) == 1
+        assert "framework defaults -> baseline bundle" in sink[0]
+
+    def test_baseline_sink_is_optional(self, tmp_path):
+        bundle_path = tmp_path / "baseline.yaml"
+        self._write(bundle_path, {"scenario": [{"name": "b", "a": 1}]})
+        resolved = assemble_run.resolve_baseline(
+            bundle_path=bundle_path,
+            overlay_path=None,
+            framework_defaults={},
+        )
+        assert resolved["scenario"][0]["name"] == "b"
+
+    def test_treatment_records_conflict_with_layer_names(self, tmp_path):
+        overlay_path = tmp_path / "sr" / "sr_config.yaml"
+        self._write(overlay_path, {"scenario": [{
+            "name": "b",
+            "router": {"proxy": {"args": ["--log-level", "warn"]}},
+        }]})
+        baseline_resolved = {"scenario": [{
+            "name": "b",
+            "router": {"proxy": {"args": ["--concurrency", "8"]}},
+        }]}
+        sink: list[str] = []
+        assemble_run.resolve_treatment(
+            baseline_resolved=baseline_resolved,
+            diffs_path=None,
+            overlay_path=overlay_path,
+            sink=sink,
+        )
+        assert len(sink) == 1
+        assert "treatment diffs -> algorithm overlay" in sink[0]
+
+    def test_treatment_records_diffs_layer_conflict(self, tmp_path):
+        diffs_path = tmp_path / "treatment.yaml"
+        self._write(diffs_path, {"scenario": [{
+            "name": "b",
+            "router": {"proxy": {"args": ["--log-level", "warn"]}},
+        }]})
+        baseline_resolved = {"scenario": [{
+            "name": "b",
+            "router": {"proxy": {"args": ["--concurrency", "8"]}},
+        }]}
+        sink: list[str] = []
+        assemble_run.resolve_treatment(
+            baseline_resolved=baseline_resolved,
+            diffs_path=diffs_path,
+            overlay_path=None,
+            sink=sink,
+        )
+        assert len(sink) == 1
+        assert "baseline -> treatment diffs" in sink[0]
+
+    def test_treatment_sink_stays_empty_without_conflict(self, tmp_path):
+        baseline_resolved = {"scenario": [{"name": "b", "a": 1}]}
+        sink: list[str] = []
+        assemble_run.resolve_treatment(
+            baseline_resolved=baseline_resolved,
+            diffs_path=None,
+            overlay_path=None,
+            sink=sink,
+        )
+        assert sink == []
+
     def test_framework_defaults_named_defaults_merge_into_baseline_entry(self, tmp_path):
         """Regression test for issue #516.
 

--- a/pipeline/tests/test_assemble_run.py
+++ b/pipeline/tests/test_assemble_run.py
@@ -102,6 +102,40 @@ class TestLoadDefaultsOverlay:
     def test_none_dir_returns_empty(self):
         assert assemble_run.load_defaults_overlay(None, disable=[]) == {}
 
+    def test_bad_flag_entry_across_fragments_names_the_fragment(self, tmp_path):
+        """Two fragments both setting additionalFlags hit the flag tier, so its
+        ValueError must be normalized here too — naming the fragment at fault."""
+        d = tmp_path / "defaults"
+        d.mkdir()
+        (d / "a-first.yaml").write_text(yaml.dump({"scenario": [{
+            "name": "s",
+            "decode": {"vllm": {"additionalFlags": ["--max-num-seqs=256"]}},
+        }]}))
+        (d / "b-second.yaml").write_text(yaml.dump({"scenario": [{
+            "name": "s",
+            "decode": {"vllm": {"additionalFlags": ["bare-value"]}},
+        }]}))
+        with pytest.raises(assemble_run.AssembleError) as exc:
+            assemble_run.load_defaults_overlay(d, disable=[])
+        assert "b-second.yaml" in str(exc.value)
+
+    def test_fragments_flag_lists_merge_by_name(self, tmp_path):
+        d = tmp_path / "defaults"
+        d.mkdir()
+        (d / "a-first.yaml").write_text(yaml.dump({"scenario": [{
+            "name": "s",
+            "decode": {"vllm": {"additionalFlags": ["--max-num-seqs=256"]}},
+        }]}))
+        (d / "b-second.yaml").write_text(yaml.dump({"scenario": [{
+            "name": "s",
+            "decode": {"vllm": {"additionalFlags": ["--enable-prefix-caching"]}},
+        }]}))
+        merged = assemble_run.load_defaults_overlay(d, disable=[])
+        assert merged["scenario"][0]["decode"]["vllm"]["additionalFlags"] == [
+            "--max-num-seqs=256",
+            "--enable-prefix-caching",
+        ]
+
 
 class TestInjectImageTag:
     def test_injects_repository_and_tag(self):
@@ -491,6 +525,67 @@ class TestResolveScenarios:
         )
         assert len(sink) == 1
         assert "baseline -> treatment diffs" in sink[0]
+
+    def test_bad_flag_entry_surfaces_as_assemble_error(self, tmp_path):
+        """A flag-tier ValueError must reach the CLI as AssembleError, not a
+        raw traceback — sim2real.py catches only AssembleError."""
+        bundle_path = tmp_path / "baseline.yaml"
+        overlay_path = tmp_path / "baseline_overlay.yaml"
+        self._write(bundle_path, {"scenario": [{
+            "name": "b",
+            "decode": {"vllm": {"additionalFlags": ["--max-num-seqs=256"]}},
+        }]})
+        self._write(overlay_path, {"scenario": [{
+            "name": "b",
+            "decode": {"vllm": {"additionalFlags": ["not-a-flag"]}},
+        }]})
+        with pytest.raises(assemble_run.AssembleError) as exc:
+            assemble_run.resolve_baseline(
+                bundle_path=bundle_path,
+                overlay_path=overlay_path,
+                framework_defaults={},
+            )
+        # The layer prefix names which two files disagreed.
+        assert "baseline bundle -> registered overlay" in str(exc.value)
+        assert "does not start with" in str(exc.value)
+
+    def test_duplicate_flag_key_surfaces_as_assemble_error(self, tmp_path):
+        bundle_path = tmp_path / "baseline.yaml"
+        overlay_path = tmp_path / "baseline_overlay.yaml"
+        self._write(bundle_path, {"scenario": [{
+            "name": "b",
+            "decode": {"vllm": {"additionalFlags": ["--max-num-seqs=256"]}},
+        }]})
+        self._write(overlay_path, {"scenario": [{
+            "name": "b",
+            "decode": {"vllm": {"additionalFlags": [
+                "--enable-prefix-caching", "--no-enable-prefix-caching",
+            ]}},
+        }]})
+        with pytest.raises(assemble_run.AssembleError, match="twice"):
+            assemble_run.resolve_baseline(
+                bundle_path=bundle_path,
+                overlay_path=overlay_path,
+                framework_defaults={},
+            )
+
+    def test_treatment_bad_flag_entry_surfaces_as_assemble_error(self, tmp_path):
+        overlay_path = tmp_path / "sr" / "sr_config.yaml"
+        self._write(overlay_path, {"scenario": [{
+            "name": "b",
+            "decode": {"vllm": {"additionalFlags": ["oops"]}},
+        }]})
+        baseline_resolved = {"scenario": [{
+            "name": "b",
+            "decode": {"vllm": {"additionalFlags": ["--max-num-seqs=256"]}},
+        }]}
+        with pytest.raises(assemble_run.AssembleError) as exc:
+            assemble_run.resolve_treatment(
+                baseline_resolved=baseline_resolved,
+                diffs_path=None,
+                overlay_path=overlay_path,
+            )
+        assert "treatment diffs -> algorithm overlay" in str(exc.value)
 
     def test_treatment_sink_stays_empty_without_conflict(self, tmp_path):
         baseline_resolved = {"scenario": [{"name": "b", "a": 1}]}

--- a/pipeline/tests/test_capacity.py
+++ b/pipeline/tests/test_capacity.py
@@ -334,6 +334,31 @@ class TestDeriveGpuResourceType:
         scenario = {"scenario": [{"name": "test"}]}
         assert derive_gpu_resource_type(scenario, defaults) == "nvidia.com/gpu"
 
+    def test_malformed_flag_list_falls_back_instead_of_raising(self):
+        """#851's flag tier rejects malformed entries with ValueError; this
+        function's contract is to always return a resource name."""
+        defaults = {
+            "accelerator": {"resource": "habana.ai/gaudi"},
+            "decode": {"vllm": {"additionalFlags": ["--max-num-seqs=256"]}},
+        }
+        scenario = {"scenario": [{
+            "name": "test",
+            "decode": {"vllm": {"additionalFlags": ["bare-value"]}},
+        }]}
+        assert derive_gpu_resource_type(scenario, defaults) == "nvidia.com/gpu"
+
+    def test_valid_flag_lists_do_not_disturb_resource_derivation(self):
+        defaults = {
+            "accelerator": {"resource": "nvidia.com/gpu"},
+            "decode": {"vllm": {"additionalFlags": ["--max-num-seqs=256"]}},
+        }
+        scenario = {"scenario": [{
+            "name": "test",
+            "accelerator": {"resource": "habana.ai/gaudi"},
+            "decode": {"vllm": {"additionalFlags": ["--enable-prefix-caching"]}},
+        }]}
+        assert derive_gpu_resource_type(scenario, defaults) == "habana.ai/gaudi"
+
 
 # ── gpu_cost_per_pair tests ────────────────────────────────────────────────────
 
@@ -441,6 +466,59 @@ class TestGpuCostPerPair:
         assert isinstance(cost, str)
         assert "auto" in cost
         assert "accelerator.count" in cost
+
+    def test_malformed_flag_list_returns_error_string_not_raise(self):
+        """deploy.py:_derive_pair_gpu_costs degrades an error string to a warning
+        plus fallback cost; a raise there would crash the orchestrator."""
+        defaults = {
+            "decode": {
+                "enabled": True, "replicas": 1,
+                "parallelism": {"tensor": 1, "dataLocal": 1},
+                "vllm": {"additionalFlags": ["--max-num-seqs=256"]},
+            },
+            "prefill": {"enabled": False, "replicas": 0},
+        }
+        scenario = {"scenario": [{
+            "name": "test",
+            "decode": {"vllm": {"additionalFlags": ["bare-value"]}},
+        }]}
+        cost = gpu_cost_per_pair(scenario, defaults)
+        assert isinstance(cost, str)
+        assert "merge failed" in cost
+
+    def test_duplicate_flag_key_returns_error_string_not_raise(self):
+        defaults = {
+            "decode": {
+                "enabled": True, "replicas": 1,
+                "parallelism": {"tensor": 1, "dataLocal": 1},
+                "vllm": {"additionalFlags": ["--max-num-seqs=256"]},
+            },
+            "prefill": {"enabled": False, "replicas": 0},
+        }
+        scenario = {"scenario": [{
+            "name": "test",
+            "decode": {"vllm": {"additionalFlags": [
+                "--enable-prefix-caching", "--no-enable-prefix-caching",
+            ]}},
+        }]}
+        cost = gpu_cost_per_pair(scenario, defaults)
+        assert isinstance(cost, str)
+        assert "merge failed" in cost
+
+    def test_valid_flag_lists_do_not_disturb_cost(self):
+        defaults = {
+            "decode": {
+                "enabled": True, "replicas": 1,
+                "parallelism": {"tensor": 1, "dataLocal": 1},
+                "vllm": {"additionalFlags": ["--max-num-seqs=256"]},
+            },
+            "prefill": {"enabled": False, "replicas": 0},
+        }
+        scenario = {"scenario": [{
+            "name": "test",
+            "decode": {"vllm": {"additionalFlags": ["--enable-prefix-caching"]}},
+        }]}
+        assert gpu_cost_per_pair(scenario, defaults) == 1
 
     def test_non_numeric_role_accelerator_count_returns_error(self):
         defaults = {

--- a/pipeline/tests/test_capacity.py
+++ b/pipeline/tests/test_capacity.py
@@ -334,9 +334,10 @@ class TestDeriveGpuResourceType:
         scenario = {"scenario": [{"name": "test"}]}
         assert derive_gpu_resource_type(scenario, defaults) == "nvidia.com/gpu"
 
-    def test_malformed_flag_list_falls_back_instead_of_raising(self):
+    def test_malformed_flag_list_falls_back_instead_of_raising(self, capsys):
         """#851's flag tier rejects malformed entries with ValueError; this
-        function's contract is to always return a resource name."""
+        function's contract is to always return a resource name — but it must
+        say so, since a silent fallback would mis-probe a non-NVIDIA cluster."""
         defaults = {
             "accelerator": {"resource": "habana.ai/gaudi"},
             "decode": {"vllm": {"additionalFlags": ["--max-num-seqs=256"]}},
@@ -346,6 +347,21 @@ class TestDeriveGpuResourceType:
             "decode": {"vllm": {"additionalFlags": ["bare-value"]}},
         }]}
         assert derive_gpu_resource_type(scenario, defaults) == "nvidia.com/gpu"
+        out = capsys.readouterr()
+        assert "merge failed" in (out.out + out.err)
+
+    def test_non_flag_merge_error_also_warns_before_falling_back(self, capsys):
+        """deep_merge raises for more than the flag tier — duplicate k8s object
+        identity does too, and that fallback must not be silent either."""
+        obj = {"apiVersion": "v1", "kind": "ConfigMap", "metadata": {"name": "m"}}
+        defaults = {
+            "accelerator": {"resource": "habana.ai/gaudi"},
+            "extraObjects": [dict(obj), dict(obj)],
+        }
+        scenario = {"scenario": [{"name": "test", "extraObjects": [dict(obj)]}]}
+        assert derive_gpu_resource_type(scenario, defaults) == "nvidia.com/gpu"
+        out = capsys.readouterr()
+        assert "merge failed" in (out.out + out.err)
 
     def test_valid_flag_lists_do_not_disturb_resource_derivation(self):
         defaults = {

--- a/pipeline/tests/test_docs_flag_merge.py
+++ b/pipeline/tests/test_docs_flag_merge.py
@@ -1,0 +1,50 @@
+"""Guard that docs do not describe `vllm.additionalFlags` as replace-semantics.
+
+Since issue #851 that list merges by flag name (`_merge_lists` Tier 0). Two files
+previously told authors to avoid it *because* it was replaced wholesale; both were
+corrected. If that rationale creeps back — in a doc edit, or a new fragment header
+copied from the old text — this test fails.
+
+The check is deliberately paragraph-scoped rather than file-scoped: a file may
+legitimately discuss replace semantics for OTHER scalar lists (`router.proxy.args`),
+so only a paragraph that mentions `additionalFlags` and "replace" in the same breath
+without citing #851 is treated as stale.
+"""
+import re
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[2]
+
+_FILES = (
+    "docs/troubleshooting.md",
+    ".claude/skills/sim2real-bootstrap/templates/defaults/vllm-logging.yaml",
+)
+
+
+def test_files_under_guard_exist():
+    """A renamed or deleted file must not silently pass the guard below."""
+    missing = [rel for rel in _FILES if not (_REPO / rel).exists()]
+    assert not missing, (
+        f"guarded doc(s) no longer exist: {missing} — update _FILES in this test "
+        "to follow the rename, or drop the entry if the doc is gone"
+    )
+
+
+def test_flag_merged_paths_not_described_as_replaced():
+    offenders = []
+    for rel in _FILES:
+        text = (_REPO / rel).read_text()
+        for para in re.split(r"\n\s*\n", text):
+            if (
+                "additionalFlags" in para
+                # Case-insensitive: the original vllm-logging.yaml header said
+                # "REPLACE" in caps for emphasis, which a case-sensitive pattern
+                # silently missed.
+                and re.search(r"\breplace(s|d)?\b", para, re.IGNORECASE)
+                and "#851" not in para
+            ):
+                offenders.append(f"{rel}: {para.strip()[:160]}")
+    assert not offenders, (
+        "these passages tie additionalFlags to replace semantics without "
+        f"acknowledging #851: {offenders}"
+    )

--- a/pipeline/tests/test_sim2real.py
+++ b/pipeline/tests/test_sim2real.py
@@ -2112,6 +2112,83 @@ class TestAssembleCommand:
         assert "cc" in out.err
         assert "skipped" in out.err
 
+    def test_warns_on_scalar_list_conflict(self, tmp_path, capsys):
+        """#851 Stage 1: a scalar list two layers both set is reported, not silent."""
+        thash = self._make_minimal_registration(tmp_path)
+        cluster_id = self._bootstrap_experiment(tmp_path)
+        # A defaults fragment and the baseline bundle both state
+        # router.proxy.args, which still replaces (it is not a flag list), so
+        # the fragment's values never reach the cluster.
+        self._write_yaml(
+            tmp_path / "baselines" / "defaults" / "envoy.yaml",
+            {"scenario": [{
+                "name": "test-scenario",
+                "router": {"proxy": {"args": ["--concurrency", "8"]}},
+            }]},
+        )
+        self._write_yaml(
+            tmp_path / "baselines" / "base.yaml",
+            {"scenario": [{
+                "name": "test-scenario",
+                "model": {"name": "M"},
+                "router": {"proxy": {"args": ["--log-level", "warn"]}},
+            }]},
+        )
+        rc = sim2real.main(
+            [
+                "--experiment-root", str(tmp_path),
+                "assemble",
+                "--translation", thash,
+                "--cluster", cluster_id,
+                "--run", "trial-1",
+            ]
+        )
+        assert rc == 0
+        err = capsys.readouterr().err
+        assert "scenario.router.proxy.args" in err
+        assert "framework defaults -> baseline bundle" in err
+        assert "#851" in err
+
+    def test_no_warning_when_flag_list_merges(self, tmp_path, capsys):
+        """additionalFlags merges by flag name, so it must NOT be reported."""
+        thash = self._make_minimal_registration(tmp_path)
+        cluster_id = self._bootstrap_experiment(tmp_path)
+        self._write_yaml(
+            tmp_path / "baselines" / "defaults" / "vllm.yaml",
+            {"scenario": [{
+                "name": "test-scenario",
+                "decode": {"vllm": {"additionalFlags": ["--enable-prefix-caching"]}},
+            }]},
+        )
+        self._write_yaml(
+            tmp_path / "baselines" / "base.yaml",
+            {"scenario": [{
+                "name": "test-scenario",
+                "model": {"name": "M"},
+                "decode": {"vllm": {"additionalFlags": ["--max-num-seqs=256"]}},
+            }]},
+        )
+        rc = sim2real.main(
+            [
+                "--experiment-root", str(tmp_path),
+                "assemble",
+                "--translation", thash,
+                "--cluster", cluster_id,
+                "--run", "trial-1",
+            ]
+        )
+        assert rc == 0
+        assert "additionalFlags" not in capsys.readouterr().err
+        # Both layers' flags reach the resolved baseline.
+        resolved = yaml.safe_load(
+            (tmp_path / "workspace" / "runs" / "trial-1" / "cluster" / "baseline.yaml")
+            .read_text()
+        )
+        assert resolved["scenario"][0]["decode"]["vllm"]["additionalFlags"] == [
+            "--enable-prefix-caching",
+            "--max-num-seqs=256",
+        ]
+
 
 class TestAliasCollision:
     """Alias collision is checked per-algorithm regardless of batch size."""

--- a/pipeline/tests/test_values.py
+++ b/pipeline/tests/test_values.py
@@ -416,3 +416,81 @@ class TestIndexFlags:
     def test_empty_path_renders_as_root_in_errors(self):
         with pytest.raises(ValueError, match="<root>"):
             _index_flags(["nope"], (), "base")
+
+
+# ── Key-path threading (#851) ─────────────────────────────────────────────────
+
+def _spy_merge_lists(monkeypatch):
+    """Patch `_merge_lists` with a recording pass-through; return the path log."""
+    import pipeline.lib.values as values_mod
+
+    seen: list[tuple] = []
+    real = values_mod._merge_lists
+
+    def spy(base_list, overlay_list, *, path=(), sink=None):
+        seen.append(path)
+        return real(base_list, overlay_list, path=path, sink=sink)
+
+    monkeypatch.setattr(values_mod, "_merge_lists", spy)
+    return seen
+
+
+class TestPathThreading:
+    def test_path_reaches_nested_list(self, monkeypatch):
+        import pipeline.lib.values as values_mod
+
+        seen = _spy_merge_lists(monkeypatch)
+        base = {
+            "scenario": [
+                {"name": "s", "decode": {"vllm": {"additionalFlags": ["--a"]}}}
+            ]
+        }
+        overlay = {
+            "scenario": [
+                {"name": "s", "decode": {"vllm": {"additionalFlags": ["--b"]}}}
+            ]
+        }
+        values_mod.deep_merge(base, overlay)
+        # The list index is elided: the scenario entry's children keep the
+        # ("scenario",) prefix rather than gaining ("scenario", 0).
+        assert ("scenario",) in seen
+        assert ("scenario", "decode", "vllm", "additionalFlags") in seen
+
+    def test_default_path_is_empty_tuple(self, monkeypatch):
+        import pipeline.lib.values as values_mod
+
+        seen = _spy_merge_lists(monkeypatch)
+        values_mod.deep_merge({"a": [1]}, {"a": [2]})
+        assert seen == [("a",)]
+
+    def test_non_string_keys_stringified_in_path(self, monkeypatch):
+        import pipeline.lib.values as values_mod
+
+        seen = _spy_merge_lists(monkeypatch)
+        values_mod.deep_merge({7: [1]}, {7: [2]})
+        assert seen == [("7",)]
+
+    def test_positional_two_arg_calls_still_work(self):
+        """The pre-existing tests call these positionally; guard that contract."""
+        assert deep_merge({"a": 1}, {"b": 2}) == {"a": 1, "b": 2}
+        assert _merge_lists(["a"], ["b"]) == ["b"]
+
+    def test_path_threads_through_k8s_identity_tier(self, monkeypatch):
+        import pipeline.lib.values as values_mod
+
+        seen = _spy_merge_lists(monkeypatch)
+        obj = {"apiVersion": "v1", "kind": "ConfigMap", "metadata": {"name": "m"}}
+        base = {"extraObjects": [dict(obj, data={"keys": ["a"]})]}
+        overlay = {"extraObjects": [dict(obj, data={"keys": ["b"]})]}
+        values_mod.deep_merge(base, overlay)
+        assert ("extraObjects",) in seen
+        assert ("extraObjects", "data", "keys") in seen
+
+    def test_path_threads_through_positional_tier(self, monkeypatch):
+        import pipeline.lib.values as values_mod
+
+        seen = _spy_merge_lists(monkeypatch)
+        base = {"items": [{"a": {"deep": ["x"]}}]}
+        overlay = {"items": [{"a": {"deep": ["y"]}}]}
+        values_mod.deep_merge(base, overlay)
+        assert ("items", "a", "deep") in seen

--- a/pipeline/tests/test_values.py
+++ b/pipeline/tests/test_values.py
@@ -632,3 +632,70 @@ class TestFlagListMerge:
         step1 = _merge_lists(["--a=1"], ["--b=2"], path=_FP)
         step2 = _merge_lists(step1, ["--c"], path=_FP)
         assert step2 == ["--a=1", "--b=2", "--c"]
+
+
+# ── Stage 1: conflict recording for lists that still replace (#851) ───────────
+
+_ARGS_P = ("scenario", "router", "proxy", "args")
+
+
+class TestScalarReplaceConflictSink:
+    def test_records_conflict_when_both_layers_set_scalar_list(self):
+        sink: list[str] = []
+        _merge_lists(
+            ["--concurrency", "8"], ["--log-level", "warn"], path=_ARGS_P, sink=sink
+        )
+        assert len(sink) == 1
+        assert "scenario.router.proxy.args" in sink[0]
+        assert "--concurrency" in sink[0]
+
+    def test_no_sink_is_silent(self):
+        """capacity.py merges without a sink; must not raise."""
+        assert _merge_lists(["--a"], ["--b"], path=_ARGS_P) == ["--b"]
+
+    def test_identical_lists_record_nothing(self):
+        sink: list[str] = []
+        _merge_lists(["--a"], ["--a"], path=_ARGS_P, sink=sink)
+        assert sink == []
+
+    def test_flag_merged_path_records_nothing(self):
+        sink: list[str] = []
+        _merge_lists(["--a=1"], ["--b"], path=_FP, sink=sink)
+        assert sink == []
+
+    def test_empty_base_records_nothing(self):
+        sink: list[str] = []
+        _merge_lists([], ["--b"], path=_ARGS_P, sink=sink)
+        assert sink == []
+
+    def test_empty_overlay_records_nothing(self):
+        sink: list[str] = []
+        _merge_lists(["--a"], [], path=_ARGS_P, sink=sink)
+        assert sink == []
+
+    def test_dict_list_records_nothing(self):
+        sink: list[str] = []
+        _merge_lists(
+            [{"name": "x"}], [{"name": "x", "v": 1}], path=("containers",), sink=sink
+        )
+        assert sink == []
+
+    def test_scalar_overlay_over_dict_base_records(self):
+        """Dict base clobbered by a scalar overlay is loss too."""
+        sink: list[str] = []
+        _merge_lists([{"name": "x"}], ["c"], path=_ARGS_P, sink=sink)
+        assert len(sink) == 1
+
+    def test_sink_propagates_through_deep_merge(self):
+        sink: list[str] = []
+        base = {"scenario": [{"name": "s", "router": {"proxy": {"args": ["--a"]}}}]}
+        overlay = {"scenario": [{"name": "s", "router": {"proxy": {"args": ["--b"]}}}]}
+        deep_merge(base, overlay, sink=sink)
+        assert len(sink) == 1
+        assert "scenario.router.proxy.args" in sink[0]
+
+    def test_message_reports_both_discarded_and_kept(self):
+        sink: list[str] = []
+        _merge_lists(["--a"], ["--b"], path=_ARGS_P, sink=sink)
+        assert "discarding 1 value" in sink[0]
+        assert "kept:" in sink[0]

--- a/pipeline/tests/test_values.py
+++ b/pipeline/tests/test_values.py
@@ -6,7 +6,15 @@ from pipeline.lib.values import (
     deep_merge,
     _merge_lists,
     _k8s_identity,
+    _flag_key,
+    _index_flags,
+    _is_flag_list_path,
 )
+
+
+# Path of a flag-merged list, as it appears when a whole scenario document is
+# merged (assemble_run's root). Used by the flag-merge and sink tests below.
+_FP = ("scenario", "decode", "vllm", "additionalFlags")
 
 
 # ── _merge_lists ──────────────────────────────────────────────────────────────
@@ -320,3 +328,91 @@ class TestDeepMerge:
         overlay = {"items": [{"name": "x", "v": 99}]}
         result = deep_merge(base, overlay)
         assert result["items"] == [{"name": "x", "v": 99}]
+
+
+# ── Flag-list merge helpers (#851) ────────────────────────────────────────────
+
+class TestFlagKey:
+    def test_valued_flag_keys_on_name(self):
+        assert _flag_key("--max-num-seqs=256") == "--max-num-seqs"
+
+    def test_bare_flag_is_its_own_key(self):
+        assert _flag_key("--enable-chunked-prefill") == "--enable-chunked-prefill"
+
+    def test_negation_collapses_to_positive_key(self):
+        assert _flag_key("--no-enable-prefix-caching") == "--enable-prefix-caching"
+        assert _flag_key("--enable-prefix-caching") == "--enable-prefix-caching"
+
+    def test_negation_of_disable_flag_collapses(self):
+        """Real llm-d-benchmark pair: --no-disable-X negates --disable-X."""
+        assert _flag_key("--no-disable-uvicorn-access-log") == (
+            "--disable-uvicorn-access-log"
+        )
+
+    def test_value_containing_equals_splits_on_first_only(self):
+        assert _flag_key('--kv-transfer-config={"a":"b=c"}') == "--kv-transfer-config"
+
+
+class TestIsFlagListPath:
+    def test_document_rooted_path_matches(self):
+        assert _is_flag_list_path(("scenario", "decode", "vllm", "additionalFlags"))
+
+    def test_scenario_entry_rooted_path_matches(self):
+        """capacity.py merges scenarios[0] directly, so there is no leading
+        "scenario" segment. Suffix matching covers both merge roots."""
+        assert _is_flag_list_path(("decode", "vllm", "additionalFlags"))
+
+    def test_prefill_role_matches_same_rule(self):
+        assert _is_flag_list_path(("scenario", "prefill", "vllm", "additionalFlags"))
+
+    def test_unrelated_scalar_list_does_not_match(self):
+        assert not _is_flag_list_path(("scenario", "router", "proxy", "args"))
+
+    def test_shorter_than_suffix_does_not_match(self):
+        assert not _is_flag_list_path(("additionalFlags",))
+        assert not _is_flag_list_path(())
+
+    def test_additionalflags_under_wrong_parent_does_not_match(self):
+        assert not _is_flag_list_path(("scenario", "router", "additionalFlags"))
+
+
+class TestIndexFlags:
+    def test_preserves_order_and_maps_key_to_literal(self):
+        out = _index_flags(["--a=1", "--b"], ("vllm", "additionalFlags"), "base")
+        assert list(out) == ["--a", "--b"]
+        assert out["--a"] == "--a=1"
+
+    def test_empty_list_yields_empty_index(self):
+        assert _index_flags([], ("vllm", "additionalFlags"), "base") == {}
+
+    def test_non_string_entry_refused(self):
+        with pytest.raises(ValueError, match="not a string"):
+            _index_flags([256], ("vllm", "additionalFlags"), "base")
+
+    def test_non_flag_entry_refused(self):
+        with pytest.raises(ValueError, match="does not start with"):
+            _index_flags(["envoy-sidecar"], ("vllm", "additionalFlags"), "overlay")
+
+    def test_duplicate_key_refused(self):
+        with pytest.raises(ValueError, match="twice"):
+            _index_flags(
+                ["--max-num-seqs=1", "--max-num-seqs=2"],
+                ("vllm", "additionalFlags"),
+                "base",
+            )
+
+    def test_negation_pair_in_one_list_is_a_duplicate(self):
+        with pytest.raises(ValueError, match="twice"):
+            _index_flags(
+                ["--enable-prefix-caching", "--no-enable-prefix-caching"],
+                ("vllm", "additionalFlags"),
+                "base",
+            )
+
+    def test_error_message_names_the_path_and_side(self):
+        with pytest.raises(ValueError, match=r"decode\.vllm\.additionalFlags: overlay"):
+            _index_flags(["nope"], ("decode", "vllm", "additionalFlags"), "overlay")
+
+    def test_empty_path_renders_as_root_in_errors(self):
+        with pytest.raises(ValueError, match="<root>"):
+            _index_flags(["nope"], (), "base")

--- a/pipeline/tests/test_values.py
+++ b/pipeline/tests/test_values.py
@@ -494,3 +494,141 @@ class TestPathThreading:
         overlay = {"items": [{"a": {"deep": ["y"]}}]}
         values_mod.deep_merge(base, overlay)
         assert ("items", "a", "deep") in seen
+
+
+# ── Tier 0: flag-name list merge (#851) ───────────────────────────────────────
+
+class TestFlagListMerge:
+    def test_base_flag_survives_overlay_that_omits_it(self):
+        """The #851 bug: this returned ['--enable-force-include-usage'] before."""
+        base = ["--max-num-seqs=256", "--enable-prefix-caching"]
+        overlay = ["--enable-force-include-usage"]
+        assert _merge_lists(base, overlay, path=_FP) == [
+            "--max-num-seqs=256",
+            "--enable-prefix-caching",
+            "--enable-force-include-usage",
+        ]
+
+    def test_overlay_overrides_same_flag_without_duplicating(self):
+        base = ["--max-num-seqs=256", "--enable-prefix-caching"]
+        overlay = ["--max-num-seqs=512"]
+        assert _merge_lists(base, overlay, path=_FP) == [
+            "--max-num-seqs=512",
+            "--enable-prefix-caching",
+        ]
+
+    def test_negation_overrides_positive_and_emits_one_flag(self):
+        assert _merge_lists(
+            ["--enable-prefix-caching"], ["--no-enable-prefix-caching"], path=_FP
+        ) == ["--no-enable-prefix-caching"]
+
+    def test_positive_overrides_negation(self):
+        assert _merge_lists(
+            ["--no-enable-prefix-caching"], ["--enable-prefix-caching"], path=_FP
+        ) == ["--enable-prefix-caching"]
+
+    def test_base_order_preserved_overlay_only_appended(self):
+        base = ["--a=1", "--b=2", "--c"]
+        overlay = ["--z", "--b=99"]
+        assert _merge_lists(base, overlay, path=_FP) == [
+            "--a=1",
+            "--b=99",
+            "--c",
+            "--z",
+        ]
+
+    def test_prefill_path_merges_too(self):
+        p = ("scenario", "prefill", "vllm", "additionalFlags")
+        assert _merge_lists(["--a=1"], ["--b"], path=p) == ["--a=1", "--b"]
+
+    def test_scenario_entry_rooted_path_merges(self):
+        """capacity.py's merge root — no leading "scenario" segment."""
+        p = ("decode", "vllm", "additionalFlags")
+        assert _merge_lists(["--a=1"], ["--b"], path=p) == ["--a=1", "--b"]
+
+    def test_router_proxy_args_still_replaces(self):
+        """#851's constraint: space-separated arg lists must NOT flag-merge."""
+        base = ["--service-node", "envoy-sidecar", "--concurrency", "8"]
+        overlay = ["--log-level", "warn"]
+        p = ("scenario", "router", "proxy", "args")
+        assert _merge_lists(base, overlay, path=p) == ["--log-level", "warn"]
+
+    def test_capabilities_add_still_replaces(self):
+        p = (
+            "scenario",
+            "decode",
+            "extraContainerConfig",
+            "securityContext",
+            "capabilities",
+            "add",
+        )
+        assert _merge_lists(["IPC_LOCK"], ["SYS_PTRACE"], path=p) == ["SYS_PTRACE"]
+
+    def test_no_path_means_no_flag_merge(self):
+        assert _merge_lists(["--a=1"], ["--b"]) == ["--b"]
+
+    def test_empty_overlay_still_clears(self):
+        """An explicit empty list remains the whole-list removal escape hatch."""
+        assert _merge_lists(["--a=1"], [], path=_FP) == []
+
+    def test_empty_base_returns_overlay(self):
+        assert _merge_lists([], ["--a=1"], path=_FP) == ["--a=1"]
+
+    def test_single_layer_bad_entry_not_rejected(self):
+        """Guards protect the merge, so a lone contributor is never newly refused."""
+        assert _merge_lists([], ["not-a-flag"], path=_FP) == ["not-a-flag"]
+
+    def test_bad_entry_refused_when_both_layers_contribute(self):
+        with pytest.raises(ValueError, match="does not start with"):
+            _merge_lists(["--a=1"], ["oops"], path=_FP)
+
+    def test_bad_base_entry_refused_when_both_layers_contribute(self):
+        with pytest.raises(ValueError, match="base flag list entry"):
+            _merge_lists(["oops"], ["--a=1"], path=_FP)
+
+    def test_does_not_mutate_inputs(self):
+        base = ["--a=1"]
+        overlay = ["--b"]
+        _merge_lists(base, overlay, path=_FP)
+        assert base == ["--a=1"]
+        assert overlay == ["--b"]
+
+    def test_end_to_end_through_deep_merge(self):
+        """The observed real-bundle shape from the issue."""
+        base = {
+            "scenario": [
+                {
+                    "name": "s",
+                    "decode": {
+                        "vllm": {
+                            "additionalFlags": [
+                                "--max-num-seqs=256",
+                                "--enable-prefix-caching",
+                            ]
+                        }
+                    },
+                }
+            ]
+        }
+        overlay = {
+            "scenario": [
+                {
+                    "name": "s",
+                    "decode": {
+                        "vllm": {"additionalFlags": ["--enable-force-include-usage"]}
+                    },
+                }
+            ]
+        }
+        out = deep_merge(base, overlay)
+        assert out["scenario"][0]["decode"]["vllm"]["additionalFlags"] == [
+            "--max-num-seqs=256",
+            "--enable-prefix-caching",
+            "--enable-force-include-usage",
+        ]
+
+    def test_three_layer_merge_accumulates(self):
+        """defaults -> baseline -> overlay, the resolve_baseline chain."""
+        step1 = _merge_lists(["--a=1"], ["--b=2"], path=_FP)
+        step2 = _merge_lists(step1, ["--c"], path=_FP)
+        assert step2 == ["--a=1", "--b=2", "--c"]


### PR DESCRIPTION
Closes #851.

## The bug

`_merge_lists` Tier 1 replaces scalar lists wholesale, so a CLI-flag list set by more than one layer kept only the last writer's copy. In a real bundle, the four `config.md`-derived flags reached the cluster **only** because the generated overlay happened to restate them verbatim. Regenerate that overlay without one and the `config.md` decision vanished silently — and for `--enable-prefix-caching` the framework default is `false`, so a run would quietly have prefix caching OFF while `config.md` said ON.

The restating was not sloppiness in the translate skill; it was *compelled* by the merge rule. That is why the fix is in the merge layer rather than in the writers.

## What changed

**Tier 0 — flag-name merge.** Scalar lists at key paths ending `vllm.additionalFlags` merge by flag name. `--max-num-seqs=256` keys on `--max-num-seqs`; a bare `--enable-chunked-prefill` is its own key. Base entries come first in base order, overlay-only appended — the convention Tier 2b already uses for keyed dict lists.

**Key-path threading.** `deep_merge` / `_merge_lists` / `_merge_by_keyfn` / `_merge_k8s_objects` now take `path` and `sink` as keyword-only parameters defaulting to `()` / `None`. List indices are elided from the path, so a key path is the same whether or not a list sits between two dicts. All pre-existing positional two-arg call sites are untouched.

**Stage 1 warning, narrowed.** Scalar lists that *still* replace record a conflict naming the key path, the discarded values, and which two layers disagreed. `sim2real assemble` prints these next to the skipped-algorithm warnings.

**Docs corrected.** Three places told authors to avoid `additionalFlags` *because* it was replaced. Where a typed key is still preferred, the surviving reason is stated instead (a typed key applies to both roles from one place; `additionalFlags` is per-role).

## Decisions worth reviewer attention

These were settled on the issue before implementation ([scoping](https://github.com/inference-sim/sim2real/issues/851#issuecomment-5430716546), [vet correction](https://github.com/inference-sim/sim2real/issues/851#issuecomment-5430738080)) and are the non-obvious parts of the diff.

**1. `--no-X` and `--X` canonicalize to one key.** Not in the original issue, and it is a correctness requirement rather than a nicety. `build_additional_flags` emits *either* `--enable-prefix-caching` or `--no-enable-prefix-caching` depending on `config.md`. Under naive merge-by-flag-name those are distinct keys, so a base/overlay disagreement would ship **both** and let vLLM's argparse ordering decide — reintroducing, through a side door, exactly the silent conflict the issue rejected list concatenation for.

**2. Suffix matching, not an absolute path.** Vetting turned up an independent argument for this: `deep_merge` has three consumers that merge at *different roots*. `assemble_run` passes whole documents (`scenario.decode.vllm.additionalFlags`), while `capacity.py:204,226` passes `scenarios[0]` — the scenario entry itself (`decode.vllm.additionalFlags`). A document-anchored path would match the first and silently miss the second. One suffix also covers `decode` and `prefill`.

**3. Tier 0 sits after the empty-list guards.** So the entry guards fire only when two layers actually contribute. With one contributor there is nothing to merge and nothing to lose, and a single-layer bundle is never newly rejected. The guards protect the merge, not the schema.

**4. No removal sentinel.** `--no-X` is the removal verb for boolean flags, which covers every flag `build_additional_flags` emits today; `[]` still clears the whole list. `--key=value` flags are override-only. Keeps new scenario-schema vocabulary at zero.

**5. Scoping is essential, not incidental.** `router.proxy.args` is also a scalar list, but its values are separate elements (`["--concurrency", "8"]`) rather than `--key=value` pairs — flag-name merging there would treat `8` as a flag name. `test_router_proxy_args_still_replaces` pins this.

**Out of scope by decision:** migration of existing bundles. A bundle that today deliberately drops a base flag by omitting it from the overlay will start inheriting it again. The Stage 1 warning is how such cases surface.

## Not affected

`params_hash` is computed over `manifest.assembly.yaml` (`assemble_run.py:263`), not the resolved scenarios, so no hashes change and no drift refusal triggers. Only `cluster/*.yaml` output changes.

On the additive-grow path `scalar_list_conflicts` resets to empty, matching its two sibling side-band attrs: the drift check has established the manifest slice is unchanged, so any conflict was already reported at first assemble.

## Verification

```
ruff check pipeline/ .claude/skills/ --select F     → All checks passed
full CI pytest command                             → 2679 passed, 9 skipped, 2 xfailed
coverage                                           → 97.72% (gate 90%)
```

New tests: 51 in `test_values.py` (flag keys, suffix matching, entry guards, the merge itself, path threading through all four tiers, conflict sink), 8 in `test_assemble_run.py` (end-to-end flag survival, per-layer conflict tagging), 2 in `test_sim2real.py` (CLI warning fires for a replacing list; does *not* fire for a flag list, and both layers' flags reach the resolved baseline), plus `test_docs_flag_merge.py`.

The docs guard was verified in **both** directions — it flags the pre-fix text in both files and passes on both corrected ones. It matches case-insensitively because `vllm-logging.yaml`'s original said `REPLACE` in caps, which my first case-sensitive version silently missed.

## Stale-reference sweep

Swept `**/*.md`, `docs/`, `.claude/skills/`, `README*` for `additionalFlags`, `_merge_lists`, `deep_merge`, `Tier 1`, `_ALLOWED_SCALAR_LISTS`, `scalar list`. Updated: `docs/troubleshooting.md:157`, `templates/defaults/vllm-logging.yaml`, `tests/test_defaults_templates.py` (module docstring, allowlist preamble, test docstring, assertion message), `pipeline/README.md` (library table + new merge-semantics subsection), `CLAUDE.md` (library table). Left as accurate: the `additionalFlags` mentions in `SKILL.md:442` and `generate_scenarios.README.md:84`, which describe `config.md`'s input shape (no per-role form) rather than merge semantics, and the golden fixture's flag data.

The `_ALLOWED_SCALAR_LISTS` **contents** and the test's logic are deliberately unchanged — no fragment sets `additionalFlags` today, so only the rationale needed correcting.
