### PR TITLE
docs(bootstrap,specify): make context.text state its confidence, not just its claim (closes #859)

### DIFF
--- a/.claude/skills/sim2real-bootstrap/SKILL.md
+++ b/.claude/skills/sim2real-bootstrap/SKILL.md
@@ -714,7 +714,63 @@ Assemble transfer manifest from all prior task outputs.
 7. `workloads`: from task-4 output
 8. `context.files`: files in experiment root with deployment config or signal
    mapping (README.md, config.md, etc.)
-9. `context.text`: summary of target interface and placement from algorithm source
+9. `context.text`: summary of the algorithm and where it plugs into the component.
+
+   Read it from the operator-supplied context files listed in step 8 — in practice
+   `README.md`, which is where `/sim2real-specify` records its Phase 2 "Shape"
+   conclusion. Fall back to the algorithm source only when no context file states it.
+   (Earlier wording said "from algorithm source"; in practice the placement claim is
+   almost always already written in `README.md` and bootstrap is transcribing it.)
+
+   This text is substituted into the `/sim2real-translate` writer and reviewer prompts
+   as `{CONTEXT_TEXT}` and is treated as authoritative for the science. Two accuracy
+   constraints follow from that, and both are the operator's to satisfy — no gate
+   downstream checks either one.
+
+   **(a) Every `path:line` citation must bound the construct it names.** Open each
+   cited range and confirm its first and last line are the construct's own start and
+   end. `/sim2real-specify`'s `lint_citations.py` cannot do this for you — it verifies
+   that a path resolves in exactly one pinned tree and that the line numbers fall
+   inside the file, and its own docstring says it "cannot detect a correct citation
+   attached to a wrong transcription." A range that starts correctly and stops early
+   passes the linter and still misdescribes the code.
+
+   **(b) Separate what is ruled out from what is proposed.** These carry different
+   confidence and must not be written in the same voice:
+
+   - **Eliminations** — extension points shown NOT to work, each with the citation and
+     the mechanism that rules it out. These are conclusions. State them as settled;
+     they are the expensive, reusable part.
+   - **Placement** — the extension point(s) proposed to carry the algorithm. Unless
+     you have confirmed it is constructible, this is a **declared unknown**, in the
+     same sense `/sim2real-specify` already uses for target-API adapters: *declared
+     unknowns rather than guesses, so a wrong guess fails loudly rather than
+     mis-scoring silently* (`sim2real-specify/SKILL.md:166-167`). Write it as a
+     candidate, not as *the* extension point.
+
+   Confirming a placement is constructible means more than "the data can flow."
+   Citations showing that a value is reachable do not show that one type can carry
+   the interface set you are naming: two interfaces that declare the same method name
+   with different signatures cannot coexist on one Go type, and no citation about data
+   flow will reveal that. If you have not checked the method sets, the placement stays
+   a declared unknown.
+
+   State the count too — how many separate plugin registrations the placement implies.
+   "A custom X plus a custom Y" is ambiguous between one type implementing both and
+   two registrations, and a reader who resolves it the cheap way discovers the
+   difference as a compile error after designing around it.
+
+   **Say what happens if the placement fails.** The writer's build gate has a finite
+   retry budget, and a placement asserted as settled leaves it no licence to look
+   elsewhere — it will spend the budget trying to make the stated shape work. Say
+   explicitly that if the candidate does not hold, the eliminations still do, and the
+   search continues within them. That tells the writer where NOT to spend retries.
+   Where no extension point fits at all, see #862 — a core modification is a legitimate
+   outcome, not a dead end.
+
+   Do not invent a new marker convention for any of this. Bundles already carry
+   `PLACEMENT` and `DECLARED DEGRADATION (Dn)` as plain prose labels in this field;
+   reuse them.
 10. `blis_observe`: obtained by invoking
     `python3 "$SKILL_DIR/generate_from_config.py" "$EXPERIMENT_ROOT/config.md" --emit-observe-yaml`
     and pasting its stdout verbatim between `workloads:` and `context:`. The
@@ -776,7 +832,24 @@ blis_observe:
   extraArgs: <value>       # source: config.md | sim2real-bootstrap default
 
 context:
-  text: <derived summary>
+  # Substituted into the /sim2real-translate writer and reviewer prompts as
+  # {CONTEXT_TEXT} and treated as authoritative for the science. See derivation
+  # step 9 for the two accuracy constraints: every path:line citation must bound
+  # the construct it names, and eliminations (settled) must be written in a
+  # different voice from the proposed placement (a declared unknown until its
+  # interface set is confirmed constructible on one type).
+  text: |
+    <what the algorithm computes, and the required shape of the decision>
+
+    <ELIMINATIONS -- extension points ruled out, each with citation + mechanism.
+    Settled conclusions.>
+
+    <PLACEMENT -- the candidate extension point(s), how many separate plugin
+    registrations it implies, and every interface each type must implement. A
+    declared unknown until the method sets are checked. State what still holds
+    if it fails, so the writer knows where to search next.>
+
+    <DECLARED DEGRADATION (Dn) -- any substitution, with the direction of bias.>
   files: <list of context files>
 
 defaults:

--- a/.claude/skills/sim2real-bootstrap/SKILL.md
+++ b/.claude/skills/sim2real-bootstrap/SKILL.md
@@ -735,6 +735,14 @@ Assemble transfer manifest from all prior task outputs.
    attached to a wrong transcription." A range that starts correctly and stops early
    passes the linter and still misdescribes the code.
 
+   Two ways a citation goes wrong, and both need checking. It can be wrong when
+   written — the range does not bound the construct. Or it can **rot**: it was right
+   when written, then an edit above it in the cited file shifted every line below.
+   So re-verify any citation whose target file you have edited in the same change,
+   and when citing a file that is itself in flux, prefer a stable section or symbol
+   reference over a line range. Line numbers are the most precise citation and the
+   least durable one.
+
    **(b) Separate what is ruled out from what is proposed.** These carry different
    confidence and must not be written in the same voice:
 
@@ -745,8 +753,9 @@ Assemble transfer manifest from all prior task outputs.
      you have confirmed it is constructible, this is a **declared unknown**, in the
      same sense `/sim2real-specify` already uses for target-API adapters: *declared
      unknowns rather than guesses, so a wrong guess fails loudly rather than
-     mis-scoring silently* (`sim2real-specify/SKILL.md:166-167`). Write it as a
-     candidate, not as *the* extension point.
+     mis-scoring silently* (the TARGET-API ADAPTERS bullet in `/sim2real-specify`'s
+     specification-layer contract — referenced by section rather than line, since both
+     files move). Write it as a candidate, not as *the* extension point.
 
    Confirming a placement is constructible means more than "the data can flow."
    Citations showing that a value is reachable do not show that one type can carry
@@ -768,9 +777,14 @@ Assemble transfer manifest from all prior task outputs.
    Where no extension point fits at all, see #862 — a core modification is a legitimate
    outcome, not a dead end.
 
-   Do not invent a new marker convention for any of this. Bundles already carry
-   `PLACEMENT` and `DECLARED DEGRADATION (Dn)` as plain prose labels in this field;
-   reuse them.
+   Use plain prose labels, in the style bundles already use in this field — do not
+   invent a marker syntax. `PLACEMENT` and `DECLARED DEGRADATION (Dn)` are established;
+   `ELIMINATIONS` is added here for the half that was previously folded into the
+   placement paragraph and lost its separate standing. Those three are the sanctioned
+   set for this field (see the output schema below); prefer them over coining a fourth.
+   In particular do not introduce a new marker into `algorithms/*.go` — the
+   specification layer's contract in `/sim2real-specify` forbids in-source marker
+   conventions outright, and that rule is unaffected by the labels used here.
 10. `blis_observe`: obtained by invoking
     `python3 "$SKILL_DIR/generate_from_config.py" "$EXPERIMENT_ROOT/config.md" --emit-observe-yaml`
     and pasting its stdout verbatim between `workloads:` and `context:`. The

--- a/.claude/skills/sim2real-bootstrap/tests/test_context_text_guidance.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_context_text_guidance.py
@@ -1,0 +1,98 @@
+"""Guard issue #859: Task 5's context.text guidance must keep its accuracy constraints.
+
+`context.text` is substituted into the /sim2real-translate writer and reviewer prompts
+as {CONTEXT_TEXT} and treated as authoritative for the science. Nothing downstream
+checks it: no linter, no build gate, no pipeline validation. The field was specified as
+`<derived summary>`, which imposed no accuracy requirement, and two defects were
+therefore within spec -- a citation range that stopped short of the construct it named,
+and a placement asserted as settled that could not be built at all (two interfaces
+declaring the same method name with different signatures cannot sit on one Go type).
+
+Two bounded-region guards here, mirroring test_build_commands_guidance.py (#858):
+
+- the schema block must not regress to a bare placeholder, and must route to the
+  derivation step where the constraints live;
+- the derivation step must keep both constraints -- citation bounding, and the
+  settled-vs-declared-unknown split.
+
+Prose beyond these regions is not asserted on (see test_byo.py's note on why NL
+frontends are not CI-tested); what is asserted is that the two constraints the issue
+states outright have not been quietly dropped.
+"""
+
+import re
+from pathlib import Path
+
+_SKILL_MD = Path(__file__).resolve().parents[1] / "SKILL.md"
+
+# The placeholder #859 retired. Its return would mean the constraints were dropped.
+_RETIRED_PLACEHOLDER = "<derived summary>"
+
+
+def _task5() -> str:
+    """Return the Task 5 section of SKILL.md."""
+    text = _SKILL_MD.read_text(encoding="utf-8")
+    start = text.index("### Task 5: Create transfer.yaml")
+    return text[start : text.index("### Task 6:", start)]
+
+
+def _task5_context_block() -> str:
+    """Return the ``context:`` mapping from Task 5's output-schema YAML block."""
+    m = re.search(r"\ncontext:\n(?P<body>(?:[ #].*\n|\n)+)", _task5())
+    assert m, "Task 5 output schema has no `context:` block -- did the schema move?"
+    return m.group("body")
+
+
+def _task5_step9() -> str:
+    """Return derivation step 9 (`context.text`) up to the start of step 10."""
+    task5 = _task5()
+    m = re.search(
+        r"\n9\. `context\.text`:(?P<body>.*?)(?=\n10\. `blis_observe`)",
+        task5,
+        re.S,
+    )
+    assert m, "Task 5 derivation step 9 (`context.text`) not found -- did it move?"
+    return m.group("body")
+
+
+def test_context_block_is_not_a_bare_placeholder():
+    """#859: `<derived summary>` imposed no accuracy requirement and was retired."""
+    assert _RETIRED_PLACEHOLDER not in _task5_context_block(), (
+        f"Task 5's context: block is back to the bare {_RETIRED_PLACEHOLDER!r} "
+        "placeholder. Issue #859 replaced it because it imposed no accuracy "
+        "requirement on a field /sim2real-translate treats as authoritative."
+    )
+
+
+def test_context_block_points_at_the_derivation_step():
+    """The block must route the agent to where the constraints are stated."""
+    assert "step 9" in _task5_context_block(), (
+        "Task 5's context: block does not point at derivation step 9, so the "
+        "accuracy constraints are reachable only by luck."
+    )
+
+
+def test_step9_requires_citations_to_bound_their_construct():
+    """#859 constraint 1: a citation must cover the whole construct it names."""
+    step9 = _task5_step9()
+    assert "bound the construct" in step9, (
+        "Task 5 step 9 no longer requires citations to bound the construct they "
+        "name. lint_citations.py cannot catch this -- it checks that lines fall "
+        "inside the file, not that a range bounds what it describes."
+    )
+
+
+def test_step9_separates_settled_eliminations_from_declared_placement():
+    """#859 constraint 2: the two claim kinds must not share one voice."""
+    step9 = _task5_step9()
+    missing = [
+        term
+        for term in ("Elimination", "declared unknown", "registration")
+        if term not in step9
+    ]
+    assert not missing, (
+        f"Task 5 step 9 dropped {missing} from the context.text guidance. #859 "
+        "requires eliminations (settled) to be written in a different voice from "
+        "the proposed placement (a declared unknown until its interface set is "
+        "confirmed constructible), and requires the registration count to be stated."
+    )

--- a/.claude/skills/sim2real-bootstrap/tests/test_defaults_templates.py
+++ b/.claude/skills/sim2real-bootstrap/tests/test_defaults_templates.py
@@ -299,7 +299,7 @@ def _skill_md_disable_list() -> list[str]:
     """Read the `disable:` list items out of SKILL.md's Task 5 transfer.yaml block.
 
     Line-oriented rather than a YAML parse because the surrounding template holds
-    placeholders (`<derived summary>`) that are not valid YAML values.
+    placeholders (`scenario: <derived>`) that are not valid YAML values.
     """
     lines = _SKILL_MD.read_text().splitlines()
     stems: list[str] = []

--- a/.claude/skills/sim2real-specify/SKILL.md
+++ b/.claude/skills/sim2real-specify/SKILL.md
@@ -119,6 +119,37 @@ HALT if no extension point can express the required shape. The hazard is silent
 fallback to the weaker natural decomposition, which transfers a different
 algorithm while resembling success. Say so loudly instead.
 
+**Expressible is not constructible.** Finding an extension point that can express the
+shape shows that the data can reach the decision — that the candidates are all visible,
+that a pair fits in the return type, that a result can be split downstream. It does not
+show that the placement you are about to name can be built. Two interfaces declaring the
+same method name with different signatures cannot coexist on one Go type, and no
+citation about data flow will reveal that.
+
+So the placement is subject to the same rule this skill already applies to target-API
+adapters — a **declared unknown rather than a guess, so a wrong guess fails loudly
+rather than mis-scoring silently** (see the specification-layer contract below). Until
+you have read the method sets of every interface you are naming and confirmed they can
+sit on the types you are proposing:
+
+- Write the placement as a **candidate**, not as *the* extension point that can express
+  it. `/sim2real-bootstrap` copies this sentence into `transfer.yaml:context.text`, and
+  `/sim2real-translate`'s writer treats it as authoritative — so a flat assertion here
+  leaves the writer no licence to look elsewhere when it does not compile.
+- State **how many separate plugin registrations** the placement implies, and every
+  interface each type must implement. "A custom X plus a custom Y" is ambiguous between
+  one type doing both and two registrations; a reader who resolves it the cheap way
+  discovers the difference as a compile error after designing around it.
+
+Keep the eliminations in a different voice from the placement. An extension point ruled
+out with a cited mechanism is a settled conclusion and the durable half of this phase's
+output — it stays true even when the candidate placement fails, and it tells a later
+reader where the remaining search space is. Say so explicitly: if the candidate does not
+hold, the eliminations still do.
+
+Where no extension point fits at all, see #862 — modifying the component's own code is a
+legitimate outcome to plan rather than only a reason to halt.
+
 ## Phase 3 — Observability
 
 Enumerate every quantity the decision rule reads. Classify each:

--- a/.claude/skills/sim2real-specify/tests/test_placement_guidance.py
+++ b/.claude/skills/sim2real-specify/tests/test_placement_guidance.py
@@ -1,0 +1,74 @@
+"""Guard Phase 2's placement-confidence rules against drift (issue #859).
+
+Phase 2 decides where the algorithm plugs into the component, and
+`/sim2real-bootstrap` copies that conclusion into `transfer.yaml:context.text`,
+from which `/sim2real-translate`'s writer reads it as authoritative. So this is
+the origin of the claim, and a wrong claim here propagates through two more
+skills before a compiler contradicts it.
+
+The defect #859 documents happened exactly that way: Phase 2's gate asked only
+whether an extension point could *express* the shape, a placement naming two
+interfaces that share a method name was asserted flatly, and the writer designed
+a port around it before the collision surfaced as a build error.
+
+Nothing downstream can catch that, so these are the guards: the four rules the
+fix added to Phase 2 must not be silently dropped by a later edit. Bounded to the
+Phase 2 section, mirroring `sim2real-bootstrap/tests/test_context_text_guidance.py`.
+"""
+
+import re
+from pathlib import Path
+
+SKILL_DIR = Path(__file__).resolve().parents[1]
+_SKILL_MD = SKILL_DIR / "SKILL.md"
+
+
+def _phase2() -> str:
+    """Return the Phase 2 section of specify's SKILL.md."""
+    text = _SKILL_MD.read_text(encoding="utf-8")
+    m = re.search(
+        r"\n## Phase 2 [^\n]*\n(?P<body>.*?)(?=\n## Phase 3 )",
+        text,
+        re.S,
+    )
+    assert m, "specify SKILL.md has no Phase 2 section -- did the heading change?"
+    return m.group("body")
+
+
+def test_phase2_distinguishes_expressible_from_constructible():
+    """The gate must not collapse back to expressibility alone."""
+    phase2 = _phase2()
+    assert "constructible" in phase2, (
+        "Phase 2 no longer distinguishes expressible from constructible. #859: "
+        "citations showing a value is reachable do not show that one Go type can "
+        "carry the interface set being named."
+    )
+
+
+def test_phase2_requires_placement_stated_as_candidate():
+    """Placement is a declared unknown until its method sets are checked."""
+    phase2 = _phase2()
+    missing = [t for t in ("declared unknown", "candidate") if t not in phase2]
+    assert not missing, (
+        f"Phase 2 dropped {missing}. #859 requires the placement be written as a "
+        "candidate / declared unknown rather than asserted, because bootstrap "
+        "copies it into context.text and the writer treats it as authoritative."
+    )
+
+
+def test_phase2_requires_registration_count():
+    """\"A custom X plus a custom Y\" is ambiguous about how many types."""
+    assert "registration" in _phase2(), (
+        "Phase 2 no longer requires the number of plugin registrations to be "
+        "stated. #859: the ambiguity between one type implementing both and two "
+        "separate registrations is what got resolved the cheap way."
+    )
+
+
+def test_phase2_keeps_the_core_modification_escape_hatch():
+    """Without somewhere to go, \"look elsewhere\" is not actionable."""
+    assert "#862" in _phase2(), (
+        "Phase 2 lost its pointer to #862. If no extension point fits at all, a "
+        "core modification is the legitimate outcome; without that pointer the "
+        "only documented move is to halt."
+    )


### PR DESCRIPTION
Closes #859

## What changed

Task 5 specified `context.text` as `<derived summary>`. That field is substituted into
`/sim2real-translate`'s writer and reviewer prompts as `{CONTEXT_TEXT}` and treated as
authoritative for the science, and **nothing downstream checks it** — no linter, no build
gate, no pipeline validation. So the two defects #859 documents were both within spec as
written, and both were caught by hand.

Replaced with the issue's two accuracy constraints, in bootstrap Task 5 step 9 and the
`context:` output-schema block, plus specify Phase 2.

**Constraint 1 — citations must bound their construct.** Open each cited range and confirm
its first and last line are the construct's own. `lint_citations.py` cannot catch this and
says so in its own docstring: it verifies a path resolves in exactly one pinned tree and
that line numbers fall inside the file, and "cannot detect a correct citation attached to a
wrong transcription."

**Constraint 2 — separate what is ruled out from what is proposed.** Eliminations are
settled conclusions; the placement is a **declared unknown** until its method sets are
checked. Registration count still required. The text must also say what still holds if the
candidate fails.

## Reviewer attention

**1. Constraint 2 is deliberately NOT what the issue body proposed.** The body asks for the
registration count and every interface per type — more detail, stated more confidently. The
discussion on the issue (comment `#issuecomment-5431110453`) argued that aims the wrong way,
and this PR follows the comment. The defect was that the placement was *already* asserted
flatly — `"The extension point that can express it is a custom Picker ... plus a custom
ProfileHandler"` — while being unbuildable, and because the writer treats this text as
authoritative it had no licence to search elsewhere when it failed to compile. A more
detailed wrong answer is harder to escape, not easier. The count requirement is kept; the
confidence marking is what's added.

**2. No new marker convention.** This reuses what already exists rather than inventing
`PARTIAL:` as the body suggested. specify already applies exactly this rule to target-API
adapters — *"declared unknowns rather than guesses, so a wrong guess fails loudly rather
than mis-scoring silently"* (`sim2real-specify/SKILL.md:166-167`) — and its spec-layer
contract explicitly says it "invents no in-source marker conventions" (`:170`). Real bundles
already use `PLACEMENT` and `DECLARED DEGRADATION (Dn)` as prose labels in this very field.
So the fix extends an existing principle to a field it didn't cover.

**3. Scope grew to specify, deliberately, because that's where the claim is born.** Traced
by commit in the `pd-infocomm-2` bundle: `5e4cfca` (specify's output) wrote the placement
into `README.md:71-72`; `449e911` (bootstrap) copied it into `transfer.yaml` two weeks
later, near-verbatim. Phase 2's gate was expressibility-only — *"find an extension point
that can express it"* — and **expressible is not constructible**: the three citations
backing that placement all establish that data can *flow* (unfiltered profile sees both
pools, `TargetEndpoints` is a slice, `ProcessResults` splits the pair), and none asks
whether one Go type can carry both interfaces. Two interfaces declaring the same method
name with different signatures cannot coexist on one type, which is what the compiler
eventually reported. Since specify is *optional*, the constraint also has to hold in
bootstrap independently — hence both files, not just the upstream one.

**4. specify's `HALT` is untouched** — that's #862's scope. Both skills now cross-reference
#862 for the case where no extension point fits at all, since "look elsewhere" needs a
destination.

**5. Step 9 mis-described its own input.** It said "from algorithm source," but in practice
the placement claim is already written in `README.md` and bootstrap transcribes it via
`context.files`. Corrected, with the old wording noted so the change is legible.

**Deferred by agreement:** the mechanical interface-satisfiability check (extract each named
interface's method set, flag same-name/different-signature). It's decidable and worth
automating, but it belongs at translate time and wants a script with tests.

## Test

New `.claude/skills/sim2real-bootstrap/tests/test_context_text_guidance.py` — four
bounded-region guards, mirroring `test_build_commands_guidance.py` from #858:

- the `context:` schema block must not regress to the retired `<derived summary>` placeholder
- it must route to derivation step 9
- step 9 must keep the citation-bounding requirement
- step 9 must keep the settled-vs-declared-unknown split and the registration count

I verified these guard content rather than restate it: run against the pre-change file from
`HEAD`, **all four fail**; after the change, all four pass.

## Verification

- `ruff check pipeline/ .claude/skills/ --select F` → All checks passed
- Full CI suite → **2618 passed, 9 skipped, 2 xfailed** (was 2614; +4 new), coverage **97.68%** (gate 90%)
- specify's own SKILL.md-asserting tests (`test_config_contract.py`, `test_skill_substitution.py`) pass against the Phase 2 edit — they run in CI via `.github/workflows/test.yml:42`

## Stale-reference sweep

Swept `context.text` / `CONTEXT_TEXT` / `derived summary` across `*.md` and `*.py`.

- **Fixed:** `test_defaults_templates.py:302` cited `<derived summary>` as its example of a
  non-YAML placeholder justifying a line-oriented parse. That placeholder no longer exists,
  so the example was stale; switched to `scenario: <derived>`. Its parser keys on
  `"  disable:"` and never touches the `context:` block, so the reshaped block does not
  affect it.
- **Left:** `sim2real-translate/SKILL.md` and `prompts/*` — consumers unchanged.
  `docs/epics/step-2/design.md:220` — an elided illustrative JSON example, no shape claim.
  `docs/superpowers/plans/2026-07-08-*.md:781` — historical plan, records what was true then.

**Flagged, not changed:** `CLAUDE.md`'s documented CI command omits
`.claude/skills/sim2real-specify/tests/`, which the real workflow does run
(`.github/workflows/test.yml:42`). The docs drifted from the workflow, not the reverse — no
workflow change needed. Left alone because CLAUDE.md is the maintainer's instruction file
with its own revise path, and it's outside this issue.

Separately noted: specify's tests fail standalone with
`ModuleNotFoundError: No module named 'pd_plumbing'` and pass when run alongside bootstrap's
tests (which is how CI invokes them). Confirmed pre-existing — identical failure on stashed
`HEAD`. Not addressed here.

## No pipeline behaviour change

`pipeline/` untouched. `manifest.py` does not validate `context.text` content, and this
changes only the guidance that produces it.

Note for future bundle fixes: `context` is inside the translation slice
(`pipeline/lib/slicer.py:58`), so editing it in an existing bundle changes that bundle's
`translation_hash` and orphans images built under the old hash. This PR changes only the
skills that generate a new bundle.
