### PR TITLE
fix(bootstrap): correct invalid HCA name in nic-exclusion default (closes #867)

### DIFF
--- a/.claude/skills/sim2real-bootstrap/templates/defaults/nic-exclusion.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/nic-exclusion.yaml
@@ -9,10 +9,9 @@
 # to a slower transport, silently. THE LIST BELOW IS AN EXAMPLE, NOT A DEFAULT:
 # replace it with your own `ibv_devinfo` output before enabling.
 #
-# `mlxl5_7` IS CARRIED VERBATIM AND IS ALMOST CERTAINLY A TYPO for mlx5_7, which
-# would mean that device is NOT actually excluded. Kept as-is because it is what
-# ran in the configuration this was lifted from; fix it deliberately, together with
-# replacing the rest of the list, rather than by assuming the correction is safe.
+# `mlxl5_7` was not a valid HCA name, so that slot excluded nothing -- eight
+# exclusions from a list of nine. Corrected to `mlx5_7` (#867). Upstream's guides
+# still carry the typo, so a template resync will reintroduce it.
 #
 # Duplicated across decode and prefill because `extraEnvVars` is a per-role key
 # with no vllmCommon equivalent. Keep the two copies in sync.
@@ -35,12 +34,12 @@ scenario:
   decode:
     extraEnvVars:
       - name: NCCL_EXCLUDE_IB_HCA
-        value: "mlx5_0,mlx5_2,mlx5_4,mlx5_8,mlxl5_7,mlx5_10,mlx5_12,mlx5_14,mlx5_16"
+        value: "mlx5_0,mlx5_2,mlx5_4,mlx5_8,mlx5_7,mlx5_10,mlx5_12,mlx5_14,mlx5_16"
       - name: UCX_MAX_RMA_RAILS
         value: "1"
   prefill:
     extraEnvVars:
       - name: NCCL_EXCLUDE_IB_HCA
-        value: "mlx5_0,mlx5_2,mlx5_4,mlx5_8,mlxl5_7,mlx5_10,mlx5_12,mlx5_14,mlx5_16"
+        value: "mlx5_0,mlx5_2,mlx5_4,mlx5_8,mlx5_7,mlx5_10,mlx5_12,mlx5_14,mlx5_16"
       - name: UCX_MAX_RMA_RAILS
         value: "1"


### PR DESCRIPTION
Closes #867.

## What changed

`templates/defaults/nic-exclusion.yaml` shipped `mlxl5_7` in `NCCL_EXCLUDE_IB_HCA` on both the decode and prefill copies. Not a valid HCA name, so that slot excluded nothing — eight exclusions from a list of nine, with `mlx5_7` left in NCCL's candidate set.

Two hunks:

1. Both values corrected to `mlx5_7`.
2. The header paragraph that documented the typo as deliberately preserved is replaced with a three-line note. The correction makes the old paragraph false, so it could not stay.

Issue Option A, minimum scope. Option B (placeholder sentinel so an unconfigured enable fails loudly) is not implemented.

## Not in scope

- **The suggested regex/parity test.** The issue proposes asserting every entry matches `^mlx5_\d+$` and that decode/prefill are identical. Deliberately left out as beyond "just fix the typo" — worth a follow-up, since the resync risk below is otherwise unguarded.
- **Upstream.** The typo is inherited, not introduced here: 4 occurrences in `llm-d-benchmark`'s own guides at the current pin `76473d0` (`config/scenarios/guides/pd-disaggregation.yaml:334,423`, `wide-ep-lws.yaml:392,530`). That submodule is third-party, so this does not fix upstream, and a later template resync against those guides will reintroduce it. The new note says so. No upstream issue filed.

## Reviewer attention

- **Existing bundles are not retroactively fixed.** `copy_framework_defaults` (`.claude/skills/sim2real-bootstrap/byo.py:533`) copies templates at bootstrap time, so already-bootstrapped repos keep their own copies. `pd-infocomm-2` still carries the original typo; `pd-infocomm-3` was hand-patched to `mlx5_7`, which is what motivated the issue. Only future bootstraps (or `--force` re-bootstraps) pick this up. Not addressed here and arguably not worth addressing — the fragment ships in `defaults.disable` per #853 and nothing has rendered from it.
- **Note wording keeps `mlxl5_7` once**, as the historical referent. A grep for the bad token still hits this file at line 12 by design.

## Sweep

Grepped for `mlxl5_7`, `NCCL_EXCLUDE_IB_HCA`, and `nic-exclusion` across `.claude/`, `pipeline/`, and `docs/`. No doc or skill prompt quotes the device list, so nothing else needed updating. The only remaining `mlxl5_7` in the repo outside the submodule is the intentional mention at line 12.

## Verification

- `pytest .claude/skills/sim2real-bootstrap/tests/` — 542 passed, 9 skipped.
- `ruff check pipeline/ .claude/skills/ --select F` — clean.

No test changes were needed: the fragment tests at `test_defaults_templates.py` iterate all fragments and assert merge properties (Tier 2b merge-by-`name` on `extraEnvVars`), never the device string.
