### PR TITLE
docs(bootstrap): shorter default-fragment headers; working RoCE reservation fragment

### DIFF
--- a/.claude/skills/sim2real-bootstrap/templates/defaults/epp-verbosity.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/epp-verbosity.yaml
@@ -1,34 +1,19 @@
-# Raise EPP log verbosity above the framework default for diagnosability.
-# See docs/troubleshooting.md "Increasing logging verbosity / EPP".
+# Raises the EPP's log verbosity so its routing decisions are visible.
 #
-# THE SCALE. llm-d-router's EPP logs through named constants, not raw numbers
-# (pkg/common/observability/logging/const.go:20-23, v0.9.0):
-#   DEFAULT = 2    VERBOSE = 3    DEBUG = 4    TRACE = 5
-# llm-d-benchmark defaults `router.epp.verbosity` to "1"
-# (config/templates/values/defaults.yaml:649 at the pinned SHA), i.e. below even
-# DEFAULT, so the EPP is near-silent out of the box.
+# The framework leaves the EPP near-silent. The scale is DEFAULT 2, VERBOSE 3,
+# DEBUG 4, TRACE 5; this sets 3.
 #
-# WHY "3" AND NOT "5". DEBUG(4) is by far the largest bucket of call sites in the
-# EPP, and the EPP sits in the request path -- so the logging costs CPU on every
-# request as well as disk. "5" turns on every DEBUG and TRACE site at once, which
-# in practice is more log volume than a run can carry.
+# 3 is a floor, not a taste. /sim2real-check reads `objectiveKey` and `priority`
+# off the EPP's "Request handled" lines, and those only appear at 3. Below that the
+# check has nothing to read and reports INAPPLICABLE.
 #
-# "3" IS THE FLOOR, NOT A PREFERENCE. /sim2real-check S5c.6 (InferenceObjective
-# resolution at runtime) reads `objectiveKey` and `priority` off `Request handled`
-# lines, which are attached under V(logging.VERBOSE) -- i.e. exactly 3. At "3"
-# that check runs; below "3" it reports INAPPLICABLE and the run loses its
-# objective-resolution evidence. Do not lower this without accepting that.
+# Chasing a prefill-selection problem, go to 4 -- that is where the P/D decider
+# explains itself. 5 turns on every TRACE site at once, usually more log volume
+# than a run can carry, so use it only for a call site you have already found.
 #
-# ESCALATING. "3" stops BELOW the level where the P/D decider explains itself
-# (prefix_based_pd_decider.go uses V(logging.DEBUG)), so the escalation for
-# prefill-selection problems is "4" -- which keeps the decider diagnostics and
-# still drops every TRACE site. Reach for "5" only for a specific TRACE-level
-# call site you have already identified.
-#
-# WHY THIS IS A FRAGMENT AND NOT PART OF baselines/<name>.yaml. Verbosity is a
-# diagnostic, not part of the measured mechanism, so nothing in config.md declares
-# it. Keeping it here means `transfer.yaml: defaults.disable` can switch it off
-# for a measurement run; a key in baselines/<name>.yaml has no such switch.
+# The EPP sits in the request path, so this costs CPU per request as well as disk.
+# It is a fragment rather than baseline content so a measurement run can switch it
+# off with transfer.yaml's `defaults.disable`.
 #
 # scenario[0].name is realigned to the experiment baseline at merge time.
 scenario:

--- a/.claude/skills/sim2real-bootstrap/templates/defaults/epponly.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/epponly.yaml
@@ -1,61 +1,18 @@
-# Standalone router topology: no Kubernetes Gateway is deployed; the EPP runs with
-# an Envoy sidecar that serves HTTP directly. Sizes and configures that sidecar,
-# because under this topology it becomes the WHOLE data plane.
+# Runs the router with no Kubernetes Gateway: the EPP's own Envoy sidecar serves
+# HTTP directly and is the entire data plane. Sizes and configures that sidecar,
+# since under this topology every request goes through it.
 #
-# THIS FRAGMENT SIZES A DIFFERENT SIDECAR THAN routing-proxy-resources.yaml.
-# The two look like duplicates and are not:
-#   router.proxy   (here)  -> the Envoy sidecar INSIDE THE EPP POD. Maps onto the
-#                             routerlib chart's top-level `proxy:`
-#                             (config/charts/routerlib/values.yaml:76, v0.9.0).
-#   routing.proxy  (there) -> llm-d-benchmark's nixl routing sidecar BESIDE EACH
-#                             MODEL SERVER, the peer of vllmCommon.kvTransfer.
-# They are distinct containers in distinct pods with distinct jobs. Both fragments
-# are intended to coexist; do not "deduplicate" them.
+# Not the same sidecar as routing-proxy-resources.yaml. That one sizes the nixl
+# routing proxy beside each model server; this one sizes the Envoy container inside
+# the EPP pod. Different containers, different pods, both wanted.
 #
-# THE TWO KEYS BELOW ARE COUPLED, which is why they live in one file:
-# `--concurrency 8` is chosen to match the `limits.cpu: "8"` set immediately below.
-# Change one without the other and you either starve Envoy's workers or
-# oversubscribe them.
+# `--concurrency 8` below is chosen to match `limits.cpu: "8"`. Change one and you
+# have to change the other, or Envoy's worker pool and its CPU budget disagree.
 #
-# WARNING -- THE COUPLING CAN BREAK SILENTLY. `args` is a list of SCALARS, so
-# pipeline/lib/values.py `_merge_lists` Tier 1 has any downstream layer REPLACE it
-# wholesale rather than merge into it. The defaults overlay is the first layer in
-# resolve_baseline's chain, so if your `baselines/<name>.yaml` or the registered
-# treatment overlay sets `router.proxy.args` at all, it takes the whole list -- and
-# `--concurrency 8` goes with it -- while `limits.cpu: "8"` below still applies.
-# That is the failure this file was written to prevent, reappearing one layer up.
-# Set the args HERE, or set BOTH keys in your baseline; never split them.
-# (`.claude/skills/sim2real-bootstrap/tests/test_defaults_templates.py` allowlists
-# this one key so a new fragment cannot add another scalar list unnoticed.)
-#
-# THE ARGS BLOCK IS UPSTREAM BOILERPLATE, not a local invention. It appears
-# byte-for-byte -- comment included -- in 8 of the 9 shipped llm-d-benchmark guide
-# scenarios at the pinned SHA (config/scenarios/guides/: optimized-baseline,
-# flow-control, agentic-serving, predicted-latency-routing, tiered-prefix-cache,
-# precise-prefix-cache-routing, pd-disaggregation, wide-ep-lws; only
-# workload-autoscaling omits it). That every shipped scenario overrides the same
-# chart defaults identically is an argument for them being framework defaults
-# instead. Not yet filed upstream against llm-d/llm-d-benchmark -- if you file it,
-# reference it here.
-#
-# WHAT THIS BLOCK ADDS OVER UPSTREAM: `limits.cpu: "8"`. Upstream sets
-# `--concurrency 8` while leaving CPU unlimited, so the 8 there is arbitrary. The
-# limit below is what makes it mean something.
-#
-# CAVEAT ON THE UPSTREAM COMMENT'S CLAIMS. Those guide scenarios justify the block
-# as overriding chart defaults of `--log-level trace` and no `--concurrency`. That
-# is stale as of routerlib v0.9.0, whose envoy preset already passes
-# `--log-level warn` AND `--cpuset-threads`
-# (config/charts/llm-d-router-standalone/values.yaml:253-265). `--cpuset-threads`
-# makes Envoy size its worker pool from the cgroup's CPU allotment, which is
-# strictly more adaptive than a hardcoded `--concurrency 8` -- and copying the
-# upstream block DROPS it. The args are kept as-is here for byte-parity with
-# upstream rather than because that tradeoff was decided; revisit if the sidecar
-# shows CPU trouble.
-#
-# Keys must sit under scenario[0]: llm-d-benchmark's render_plans.py merges
-# "defaults -> shared -> stack", so only `scenario:` and `shared:` are read from a
-# scenario file's top level and any other top-level key is silently ignored.
+# Careful: `args` is a scalar list, so any later layer that sets
+# `router.proxy.args` replaces the whole list -- taking `--concurrency 8` with it
+# while the CPU limit stays behind. Set the args here, or set both keys in your
+# baseline. Never split them across layers.
 #
 # scenario[0].name is realigned to the experiment baseline at merge time.
 scenario:

--- a/.claude/skills/sim2real-bootstrap/templates/defaults/externally-managed-gateway.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/externally-managed-gateway.yaml
@@ -1,4 +1,8 @@
-# Assume that gateway (istio, agentgateway, etc)
+# Declares that the Gateway is provisioned outside this deployment (Istio,
+# agentgateway, or the epponly Envoy sidecar), so nothing here tries to create or
+# own one.
+#
+# scenario[0].name is realigned to the experiment baseline at merge time.
 scenario:
 - name: defaults
   gateway:

--- a/.claude/skills/sim2real-bootstrap/templates/defaults/model-pvc-size.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/model-pvc-size.yaml
@@ -1,26 +1,16 @@
-# Size the model PVC for a large model.
+# Sizes the shared model PVC large enough for a 70B-class model.
 #
-# The framework defaults `storage.modelPvc.size` to 300Gi
-# (llm-d-benchmark config/templates/values/defaults.yaml:307 at the pinned SHA),
-# which cannot hold a 70B-class model as the download job fetches it: `hf download`
-# takes the WHOLE repo, so e.g. Llama-3.3-70B-Instruct lands as ~132 GiB of
-# safetensors plus ~131 GiB of original/*.pth that vLLM never reads. All nine
-# shipped llm-d-benchmark guide scenarios override this same default to 1Ti.
+# The framework default of 300Gi is smaller than what the download job actually
+# writes: it fetches the whole model repo, so a 70B model arrives as its
+# safetensors plus the original .pth files vLLM never reads.
 #
-# 1Ti IS NOT UNIVERSALLY CORRECT -- it is sized for a 70B-class model and is
-# wasteful for a small one. If your model is small, either lower this value or add
-# `model-pvc-size` to `transfer.yaml: defaults.disable` to fall back to the
-# framework's 300Gi. Deriving the size from the model rather than emitting a
-# constant is tracked as inference-sim/sim2real#840.
+# 1Ti is not universally right -- it is generous for a small model. Lower it, or
+# add `model-pvc-size` to transfer.yaml's `defaults.disable` to fall back to the
+# framework default.
 #
-# THIS ONLY SIZES A PVC THAT DOES NOT YET EXIST. An existing model-pvc is never
-# resized: `_check_existing_pvc` (llmdbenchmark/executor/step.py:331) fails standup
-# with "existing PVC is too small" rather than expanding it. Already-provisioned
-# namespaces need `kubectl patch pvc model-pvc` first.
-#
-# Keys must sit under scenario[0]: llm-d-benchmark's render_plans.py merges
-# "defaults -> shared -> stack", so only `scenario:` and `shared:` are read from a
-# scenario file's top level and any other top-level key is silently ignored.
+# This only sizes a PVC that does not exist yet. An existing model-pvc is never
+# resized; standup fails with "existing PVC is too small" instead. In a namespace
+# that already has one, patch the PVC by hand first.
 #
 # scenario[0].name is realigned to the experiment baseline at merge time.
 scenario:

--- a/.claude/skills/sim2real-bootstrap/templates/defaults/nic-exclusion.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/nic-exclusion.yaml
@@ -1,11 +1,13 @@
+# DISABLED BY DEFAULT.
+#
 # Hides specific InfiniBand/RoCE HCAs from NCCL, so it does not try to use cards
 # that are present but not usable for this traffic.
 #
-# Ships disabled, and has to. The list below is one cluster's device names. On any
-# other cluster it excludes the wrong cards, and NCCL then skips working HCAs and
-# falls back to a slower transport without saying so -- worse than excluding
-# nothing. Replace the list with your own `ibv_devinfo` output before enabling it
-# by removing `nic-exclusion` from transfer.yaml's `defaults.disable`.
+# WHY OFF BY DEFAULT: the list below is one cluster's device names. On any other
+# cluster it excludes the wrong cards, and NCCL then skips working HCAs and falls
+# back to a slower transport without saying so -- worse than excluding nothing.
+# Replace the list with your own `ibv_devinfo` output before enabling it by
+# removing `nic-exclusion` from transfer.yaml's `defaults.disable`.
 #
 # The list is repeated for decode and prefill because this key is per-role. Keep
 # the two copies identical.

--- a/.claude/skills/sim2real-bootstrap/templates/defaults/nic-exclusion.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/nic-exclusion.yaml
@@ -1,33 +1,14 @@
-# DISABLED BY DEFAULT. Bootstrap lists this stem in transfer.yaml's
-# `defaults.disable`; enabling it is deleting that one line.
+# Hides specific InfiniBand/RoCE HCAs from NCCL, so it does not try to use cards
+# that are present but not usable for this traffic.
 #
-# Excludes specific InfiniBand/RoCE HCAs from NCCL, and caps UCX RMA rails.
+# Ships disabled, and has to. The list below is one cluster's device names. On any
+# other cluster it excludes the wrong cards, and NCCL then skips working HCAs and
+# falls back to a slower transport without saying so -- worse than excluding
+# nothing. Replace the list with your own `ibv_devinfo` output before enabling it
+# by removing `nic-exclusion` from transfer.yaml's `defaults.disable`.
 #
-# WHY OFF BY DEFAULT: the value is a literal device list for ONE cluster's cards.
-# A shipped default naming another cluster's devices would exclude the wrong ones,
-# which is worse than excluding none -- NCCL would skip working HCAs and fall back
-# to a slower transport, silently. THE LIST BELOW IS AN EXAMPLE, NOT A DEFAULT:
-# replace it with your own `ibv_devinfo` output before enabling.
-#
-# `mlxl5_7` IS CARRIED VERBATIM AND IS ALMOST CERTAINLY A TYPO for mlx5_7, which
-# would mean that device is NOT actually excluded. Kept as-is because it is what
-# ran in the configuration this was lifted from; fix it deliberately, together with
-# replacing the rest of the list, rather than by assuming the correction is safe.
-#
-# Duplicated across decode and prefill because `extraEnvVars` is a per-role key
-# with no vllmCommon equivalent. Keep the two copies in sync.
-#
-# SAFE TO COEXIST with vllm-keepalive.yaml, which also sets `prefill.extraEnvVars`:
-# the list is all-dicts with a common `name` field, so pipeline/lib/values.py
-# `_merge_lists` Tier 2b merges the two lists BY NAME rather than replacing. Both
-# fragments' variables reach the rendered pod. The same is true of the
-# NIXL/NCCL/NVSHMEM variables `sim2real assemble` emits from config.md (issue
-# #848) -- this fragment adds to them rather than displacing them.
-#
-# Provenance: llm-d guides/pd-disaggregation/modelserver/gpu/vllm/base/
-# patch-{decode,prefill}.yaml. NCCL_EXCLUDE_IB_HCA appears in 2 of the 9 shipped
-# upstream guide scenarios and UCX_MAX_RMA_RAILS in 1 -- it is cluster-tuning, not
-# framework boilerplate, which is the other half of why it ships off.
+# The list is repeated for decode and prefill because this key is per-role. Keep
+# the two copies identical.
 #
 # scenario[0].name is realigned to the experiment baseline at merge time.
 scenario:
@@ -35,12 +16,8 @@ scenario:
   decode:
     extraEnvVars:
       - name: NCCL_EXCLUDE_IB_HCA
-        value: "mlx5_0,mlx5_2,mlx5_4,mlx5_8,mlxl5_7,mlx5_10,mlx5_12,mlx5_14,mlx5_16"
-      - name: UCX_MAX_RMA_RAILS
-        value: "1"
+        value: "mlx5_0,mlx5_2,mlx5_4,mlx5_8,mlx5_7,mlx5_10,mlx5_12,mlx5_14,mlx5_16"
   prefill:
     extraEnvVars:
       - name: NCCL_EXCLUDE_IB_HCA
-        value: "mlx5_0,mlx5_2,mlx5_4,mlx5_8,mlxl5_7,mlx5_10,mlx5_12,mlx5_14,mlx5_16"
-      - name: UCX_MAX_RMA_RAILS
-        value: "1"
+        value: "mlx5_0,mlx5_2,mlx5_4,mlx5_8,mlx5_7,mlx5_10,mlx5_12,mlx5_14,mlx5_16"

--- a/.claude/skills/sim2real-bootstrap/templates/defaults/pod-capabilities.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/pod-capabilities.yaml
@@ -1,37 +1,23 @@
-# DISABLED BY DEFAULT. Bootstrap lists this stem in transfer.yaml's
-# `defaults.disable`; enabling it is deleting that one line.
+# Gives the vLLM containers the capabilities NIXL needs to register memory for
+# RDMA transfer, and runs them as root.
 #
-# Elevated pod capabilities for NIXL memory registration.
+# IPC_LOCK is the one with a clear P/D justification: mlock / ibv_reg_mr, for
+# pinning the KV buffers NIXL registers. SYS_RAWIO, NET_ADMIN and NET_RAW are
+# carried because they are what ran, not because they were shown to be needed;
+# trimming to IPC_LOCK alone is worth testing.
 #
-# WHY OFF BY DEFAULT: this fragment cannot grant the permission it depends on. On
-# OpenShift the pod will not admit until someone runs, out of band,
+# This fragment cannot grant the permission it asks for. On OpenShift the pods will
+# not admit until someone widens the SCC out of band:
+#
 #   oc adm policy add-scc-to-user privileged -z <serviceaccount> -n <namespace>
-# so shipping it enabled would produce unschedulable pods on any cluster whose SCC
-# has not been widened. That is a worse failure than not asking for the capability.
 #
-# ONLY `IPC_LOCK` HAS A P/D JUSTIFICATION -- mlock / ibv_reg_mr for NIXL memory
-# registration. The other three are carried because they are what ran, not because
-# they were shown to be needed:
-#   SYS_RAWIO  gated on NCCL_ACS_DISABLE=1, which nothing in the pipeline sets.
-#   NET_ADMIN  applies only on multi-NIC nodes with same-subnet IPs.
-#   NET_RAW    only if the fping smoketest runs.
-# Trimming to IPC_LOCK alone would also shrink the SCC grant this fragment needs,
-# removing a real deployment obstacle. Worth testing; not yet tested.
+# Until that is done, enabling this produces unschedulable pods. To turn it off,
+# add `pod-capabilities` to transfer.yaml's `defaults.disable`.
 #
-# The keys land on the vLLM container (extraContainerConfig), not the pod, and are
-# duplicated across decode and prefill because both are per-role keys with no
-# vllmCommon equivalent. Keep the two copies in sync.
-#
-# `capabilities.add` is a list of SCALARS, so pipeline/lib/values.py `_merge_lists`
-# Tier 1 has any downstream layer REPLACE it wholesale rather than merge into it.
-# The defaults overlay is the first layer in resolve_baseline's chain, so if your
-# baseline or treatment overlay sets the same key it takes the whole list. Set the
-# capabilities HERE or set them entirely in your baseline; never split them.
-# (Allowlisted in tests/test_defaults_templates.py::_ALLOWED_SCALAR_LISTS.)
-#
-# Provenance: llm-d guides/pd-disaggregation/modelserver/gpu/vllm/base/
-# patch-{decode,prefill}.yaml. Upstream's shipped guides carry IPC_LOCK and
-# SYS_RAWIO in 8 of 9 scenarios; NET_ADMIN and NET_RAW in 4 of 9.
+# The keys land on the container, not the pod, and are repeated for decode and
+# prefill because they are per-role. Careful: `capabilities.add` is a scalar list,
+# so any later layer that sets it replaces the whole list. Set the capabilities
+# here, or set them entirely in your baseline; never split them.
 #
 # scenario[0].name is realigned to the experiment baseline at merge time.
 scenario:

--- a/.claude/skills/sim2real-bootstrap/templates/defaults/pod-capabilities.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/pod-capabilities.yaml
@@ -1,3 +1,6 @@
+# DISABLED BY DEFAULT. Enable by removing `pod-capabilities` from transfer.yaml's
+# `defaults.disable`.
+#
 # Gives the vLLM containers the capabilities NIXL needs to register memory for
 # RDMA transfer, and runs them as root.
 #
@@ -11,8 +14,8 @@
 #
 #   oc adm policy add-scc-to-user privileged -z <serviceaccount> -n <namespace>
 #
-# Until that is done, enabling this produces unschedulable pods. To turn it off,
-# add `pod-capabilities` to transfer.yaml's `defaults.disable`.
+# WHY OFF BY DEFAULT: until that is done, enabling this produces unschedulable
+# pods.
 #
 # The keys land on the container, not the pod, and are repeated for decode and
 # prefill because they are per-role. Careful: `capabilities.add` is a scalar list,

--- a/.claude/skills/sim2real-bootstrap/templates/defaults/preserve-request-id.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/preserve-request-id.yaml
@@ -1,19 +1,14 @@
-# DISABLED BY DEFAULT. Bootstrap lists this stem in transfer.yaml's
-# `defaults.disable`; enabling it is deleting that one line.
+# Installs an Istio EnvoyFilter that makes the Gateway keep the caller's
+# request id instead of replacing it, so a request can be traced to the pod and
+# node that served it.
 #
-# Workaround: preserve external request-id so requests can be correlated to pods/nodes.
-# See docs/troubleshooting.md "Correlate requests with pods (and hence nodes)".
+# Ships disabled. It selects a Kubernetes Gateway by label, and this bundle's
+# topology -- epponly with an externally-managed Gateway -- deploys no Gateway at
+# all, so the filter matches nothing. It also needs Istio CRDs present.
 #
-# WHY OFF BY DEFAULT (issue #853): the `workloadSelector` below names a Kubernetes
-# Gateway by label. Under this bundle's default topology — `gateway.className:
-# epponly` (epponly.yaml) with `externallyManaged: true`
-# (externally-managed-gateway.yaml) — no Gateway is deployed at all; the EPP's Envoy
-# sidecar is the whole data plane, so the filter matches nothing. It also requires
-# Istio CRDs to be present.
-#
-# It is additionally the ONLY fragment using `extraObjects` (free-form Kubernetes
-# manifests), which makes it the only one that can fail at *apply* time rather than
-# being silently inert. Enable it only under an Istio-managed Gateway whose name
+# It is the only fragment that ships free-form Kubernetes manifests
+# (`extraObjects`), which makes it the only one that can fail when applied rather
+# than just sit inert. Enable it only under an Istio-managed Gateway whose name
 # matches the selector below.
 #
 # scenario[0].name is realigned to the experiment baseline at merge time.

--- a/.claude/skills/sim2real-bootstrap/templates/defaults/preserve-request-id.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/preserve-request-id.yaml
@@ -1,8 +1,11 @@
+# DISABLED BY DEFAULT. Enable by removing `preserve-request-id` from
+# transfer.yaml's `defaults.disable`.
+#
 # Installs an Istio EnvoyFilter that makes the Gateway keep the caller's
 # request id instead of replacing it, so a request can be traced to the pod and
 # node that served it.
 #
-# Ships disabled. It selects a Kubernetes Gateway by label, and this bundle's
+# WHY OFF BY DEFAULT: it selects a Kubernetes Gateway by label, and this bundle's
 # topology -- epponly with an externally-managed Gateway -- deploys no Gateway at
 # all, so the filter matches nothing. It also needs Istio CRDs present.
 #

--- a/.claude/skills/sim2real-bootstrap/templates/defaults/rdma-device-reservation.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/rdma-device-reservation.yaml
@@ -1,36 +1,63 @@
-# DISABLED BY DEFAULT. Bootstrap lists this stem in transfer.yaml's
-# `defaults.disable`; enabling it is deleting that one line.
+# Puts the model-server pods on the cluster's RDMA fabric, so KV-cache transfer
+# between prefill and decode moves over RoCE instead of the pod network.
 #
-# Reserves an RDMA device on every model-server pod.
+# Four settings, and they only do their job together:
 #
-# WHY OFF BY DEFAULT: it did not work on the cluster it was written for. RoCE
-# derives its GIDs from the associated netdev's IP address, and the pod's network
-# namespace holds only `eth0` (OVN overlay) and `lo` -- so the `mlx5_*` GID tables
-# read all zeros from inside the pod, and adding `rc` to `ucxTls` fails NIXL
-# backend creation outright:
-#   uct_iface_open(rc_verbs/mlx5_0:1) failed: Address not valid
-# In that state these two keys reserve an allocatable `rdma/roce_gdr` device to
-# advertise a capability the pod cannot use, so the reservation is pure cost: the
-# scheduler is asked for a resource that changes nothing.
+#   annotations      Attaches each pod to the SR-IOV network. This is what gives
+#                    the pod a real RDMA device -- a VF and its GID -- inside its
+#                    own network namespace.
+#   networkResource  Reserves one of those devices through the scheduler, so a pod
+#                    only lands on a node that still has one free.
+#   ucxTls           Allows UCX to use RDMA (`rc`) and takes `tcp` off the list, so
+#                    KV payload cannot quietly fall back to the pod network.
+#   UCX_LOG_LEVEL    Make UCX report which transport it actually chose, so "RDMA is
+#   UCX_PROTO_INFO   working" is something you can read rather than assume.
 #
-# BEFORE ENABLING, confirm your cluster gives the pod a usable RDMA path. Using
-# RoCE requires either hostNetwork or an RDMA-capable CNI (e.g. macvlan +
-# rdma-cni) that places a VF and its GID in the pod's netns. Without one of those,
-# leave this disabled and expect KV transfer over TCP-on-overlay -- which is
-# functional but materially slower, so measure `vllm:nixl_xfer_time_seconds`
-# rather than assuming a simulated transfer bandwidth.
+# Why all four: with no annotation the pod has no RDMA device, so the reservation
+# buys nothing and `rc` makes NIXL fail to start. With no ucxTls the device is
+# present but unused and transfers run over TCP. Take the whole fragment or none
+# of it.
 #
-# Both keys are required together: llm-d-benchmark adds the reservation to pod
-# specs only when `networkResource` AND `networkNr` are both non-empty
-# (config/templates/values/defaults.yaml:781-784). They default to "" upstream,
-# which is why this fragment is the thing that turns the reservation on at all.
+# The network name and the resource name below describe one specific cluster.
+# Both have to change for another one.
 #
-# Provenance: llm-d's pd-disaggregation guide, which sets both keys; 3 of the 9
-# shipped upstream guide scenarios carry `networkResource`.
+# To turn this off, add `rdma-device-reservation` to transfer.yaml's
+# `defaults.disable`. Expect KV transfer over TCP when it is off.
 #
 # scenario[0].name is realigned to the experiment baseline at merge time.
+
 scenario:
 - name: defaults
   vllmCommon:
-    networkResource: "auto"
+    ucxTls: rc,sm,cuda_ipc,cuda_copy
+    networkResource: "rdma/roce_gdr"
+    # networkResource: "auto"
     networkNr: "1"
+
+  decode:
+    extraEnvVars:
+      - name: UCX_LOG_LEVEL
+        value: info
+      - name: UCX_PROTO_INFO
+        value: "y"
+      # this is default value
+      # - name: UCX_MAX_RMA_RAILS
+      #   value: "1"
+
+  prefill:
+    extraEnvVars:
+      - name: UCX_LOG_LEVEL
+        value: info
+      - name: UCX_PROTO_INFO
+        value: "y"
+      # this is default value
+      # - name: UCX_MAX_RMA_RAILS
+      #   value: "1"
+
+  annotations:
+    decode:
+      pod:
+        k8s.v1.cni.cncf.io/networks: openshift-sriov-network-operator/multi-nic-compute
+    prefill:
+      pod:
+        k8s.v1.cni.cncf.io/networks: openshift-sriov-network-operator/multi-nic-compute

--- a/.claude/skills/sim2real-bootstrap/templates/defaults/rdma-device-reservation.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/rdma-device-reservation.yaml
@@ -1,3 +1,6 @@
+# DISABLED BY DEFAULT. Enable by removing `rdma-device-reservation` from
+# transfer.yaml's `defaults.disable`.
+#
 # Puts the model-server pods on the cluster's RDMA fabric, so KV-cache transfer
 # between prefill and decode moves over RoCE instead of the pod network.
 #
@@ -18,11 +21,9 @@
 # present but unused and transfers run over TCP. Take the whole fragment or none
 # of it.
 #
-# The network name and the resource name below describe one specific cluster.
-# Both have to change for another one.
-#
-# To turn this off, add `rdma-device-reservation` to transfer.yaml's
-# `defaults.disable`. Expect KV transfer over TCP when it is off.
+# WHY OFF BY DEFAULT: the network name and the resource name below describe one
+# specific cluster. Both have to change for another one. With it off, expect KV
+# transfer over TCP.
 #
 # scenario[0].name is realigned to the experiment baseline at merge time.
 

--- a/.claude/skills/sim2real-bootstrap/templates/defaults/routing-proxy-resources.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/routing-proxy-resources.yaml
@@ -1,18 +1,12 @@
-# Workaround: declare explicit resource requests for the routing proxy sidecar.
-# The chart leaves routing.proxy.resources unset; without requests the proxy
-# can be scheduled with no real CPU/memory budget. See docs/troubleshooting.md
-# "Framework defaults overlay".
+# Gives the nixl routing-proxy sidecar an explicit CPU and memory request.
 #
-# THIS SIZES A DIFFERENT SIDECAR THAN epponly.yaml. The two look like duplicates
-# and are not:
-#   routing.proxy  (here)  -> llm-d-benchmark's nixl routing sidecar BESIDE EACH
-#                             MODEL SERVER, the peer of vllmCommon.kvTransfer
-#                             (defaults.yaml:691 `routing:` at the pinned SHA).
-#   router.proxy   (there) -> the Envoy sidecar INSIDE THE EPP POD, which under
-#                             the epponly topology is the whole data plane
-#                             (defaults.yaml:627 `router:`).
-# Distinct containers, distinct pods, distinct jobs. Both fragments are intended
-# to coexist; do not "deduplicate" them.
+# The chart leaves its resources unset, so without this the proxy can be scheduled
+# with no real budget and gets squeezed on a busy node. It sits on the KV-transfer
+# path beside every model server, so that shows up as transfer latency.
+#
+# Not the same sidecar as epponly.yaml. That one sizes the Envoy container inside
+# the EPP pod; this one sizes the routing proxy beside each model server.
+# Different containers, different pods, both wanted.
 #
 # scenario[0].name is realigned to the experiment baseline at merge time.
 scenario:

--- a/.claude/skills/sim2real-bootstrap/templates/defaults/tokenizer-sidecar.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/tokenizer-sidecar.yaml
@@ -1,67 +1,28 @@
-# Enable the chart's vLLM render sidecar in the EPP pod, so a token-producer
-# plugin's `http://localhost:8000` actually resolves.
+# Runs a CPU-only vLLM "render" container in the EPP pod, so a token-producer
+# plugin's http://localhost:8000 has something answering it. That is what turns a
+# prompt into the token count the EPP needs to make a P/D decision.
 #
-# ONLY NEEDED IF YOUR ARMS USE A token-producer PLUGIN. If no generated
-# `<algo>_config.yaml` declares one, add `tokenizer-sidecar` to
-# `transfer.yaml: defaults.disable` -- this fragment then only costs you a CPU
-# container in the EPP pod. Making the emission conditional on the plugin list is
-# tracked as inference-sim/sim2real#840.
+# Only needed if your arms declare a token-producer plugin. If none do, add
+# `tokenizer-sidecar` to transfer.yaml's `defaults.disable`; leaving it on costs
+# an idle container in the EPP pod and nothing else.
 #
-# WHY IT IS REQUIRED WHEN IT IS REQUIRED, and why the failure is silent. A plugin
-# config that declares
-#   - type: token-producer
-#     parameters: {modelName: ..., vllm: {url: "http://localhost:8000"}}
-# has nothing serving port 8000 inside the EPP pod, because
-# `router.tokenizer.enabled` defaults to false (routerlib values.yaml:78-79,
-# v0.9.0). The consequence is silent rather than loud: with no TokenizedPrompt,
-# `getUserInputLenInTokens` returns 0 WITH NO ERROR, so a P/D decider comparing it
-# against a non-cached-token threshold answers "no disaggregated PD" for EVERY
-# request -- logged only at DEBUG(4), i.e. invisible at the verbosity
-# epp-verbosity.yaml sets. The observable signature is a run with thousands of
-# requests and zero prefill selections.
+# When it is needed and missing, the failure is silent rather than loud. With
+# nothing on port 8000 the token count comes back as 0 with no error, so a decider
+# comparing it against a threshold answers "no disaggregation" for every request.
+# The signature is a run with thousands of requests and zero prefill selections.
 #
-# WHAT THIS ADDS: a `vllm-render` container in the EPP pod running
-# `vllm launch render <modelName> --port=8000` from docker.io/vllm/vllm-openai-cpu
-# -- CPU-only, so it consumes no GPU. `modelName` is deliberately left unset;
-# render_plans `_normalize_router_block` fills it from `model.name`.
+# Two settings below you may need to change:
 #
-# HF_TOKEN OVERRIDE. The chart points this sidecar at secret `llm-d-hf-token`
-# (routerlib values.yaml:89-94). Change the secret name below to whatever your
-# namespace actually has, and note that a gated model repo makes the override
-# mandatory rather than cosmetic -- without a usable token the render container
-# cannot pull the tokenizer.
+#   HF_TOKEN  reads a secret named `hf-secret`. Point it at whatever your namespace
+#             actually has. A gated model repo makes this mandatory -- without a
+#             usable token the container cannot pull the tokenizer.
+#   HF_HOME   is /tmp/hf because the cache has to be writable by whatever UID the
+#             cluster assigns the container. If it is not writable the container
+#             crash-loops, which holds the EPP below ready and fails the whole run
+#             on a sidecar the model servers never needed.
 #
-# HF_HOME. Set explicitly to a world-writable path, and NOT to the chart's own
-# cache mount. The chart mounts an emptyDir named model-cache at
-# /root/.cache/huggingface (routerlib templates/_deployment.yaml) and never sets
-# HF_HOME, so that path is the HF cache ONLY IF HOME=/root -- i.e. only when the
-# container runs as root. Under an OpenShift SCC that forces a high random
-# runAsUser with runAsNonRoot, that UID has no /etc/passwd entry, HOME resolves to
-# `/`, HuggingFace resolves its cache to /.cache, and the download dies with
-#   OSError: PermissionError at /.cache when downloading <model>.
-# Pointing HF_HOME at the chart's mount does not help either: /root is mode 0700
-# owned by root, so a non-root UID cannot traverse into it, and the error just
-# moves to "PermissionError at /root/.cache". The emptyDir itself is writable (the
-# pod fsGroup applies to it) but the path leading to it is not, so no value of
-# HF_HOME makes that mount usable. The volume is therefore left unused and the
-# cache lands in the container's writable layer -- a few MB of config.json +
-# tokenizer.json, re-fetched on restart. /tmp is mode 1777 and the container sets
-# no readOnlyRootFilesystem, so it is writable by any UID.
-#
-# WHY THIS MATTERS FOR STANDUP, not just for the plugin: with the cache
-# unwritable, vllm-render CrashLoopBackOffs, which holds the EPP below ready and
-# makes standup fail fast with "Inference pool not ready: Pod(s) in terminal
-# failure state" -- so the whole run fails on a sidecar the model servers do not
-# need.
-#
-# PREFLIGHT after deploy:
-#   - `curl -s localhost:8000/v1/models` from inside the EPP pod succeeds
-#   - the EPP log does NOT contain "auto-created default producer" naming
-#     token-producer (which would mean the estimate backend is in the path)
-#
-# KNOWN VERSION SKEW: the sidecar image tag defaults to a vllm-openai-cpu build
-# that may lag the vllm-openai tag the model servers run. Token counts normally
-# agree; pin the sidecar tag to match if that assumption matters for your arms.
+# After deploy, `curl -s localhost:8000/v1/models` from inside the EPP pod should
+# succeed.
 #
 # scenario[0].name is realigned to the experiment baseline at merge time.
 scenario:

--- a/.claude/skills/sim2real-bootstrap/templates/defaults/vllm-keepalive.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/vllm-keepalive.yaml
@@ -1,48 +1,18 @@
-# Workaround: raise vLLM's HTTP keep-alive above the routing sidecar's idle
-# connection timeout, on the prefill leg.
+# Raises vLLM's HTTP keep-alive timeout on the prefill leg, so the routing sidecar
+# stops reusing connections vLLM has already closed.
 #
-# THE MISMATCH, both sides verified in source:
-#   - the routing sidecar holds idle connections for 90s:
-#     `t.IdleConnTimeout = 90 * time.Second` on a cloned http.DefaultTransport with
-#     unlimited idle conns (llm-d-router v0.9.0, pkg/sidecar/proxy/proxy.go:415)
-#   - vLLM closes them after 5s: `VLLM_HTTP_TIMEOUT_KEEP_ALIVE: int = 5` in
-#     vllm/envs.py ("Timeout in seconds for keeping HTTP connections alive in API
-#     server")
-# A Go transport pooling sockets for 90s against a server that drops them at 5s
-# reuses connections the server has already closed, and the reuse fails with a
-# TCP RST.
+# The sidecar holds idle connections for 90s and vLLM drops them after 5s. When the
+# sidecar reuses one in that window the request dies on a TCP reset. 120 gives the
+# server the longer timeout of the two.
 #
-# PROVENANCE OF 120. It is llm-d-benchmark's own default, not a number picked here:
-# config/templates/jinja/_macros.j2 emits
-#     - name: VLLM_HTTP_TIMEOUT_KEEP_ALIVE
-#       value: "{{ config.vllm.httpTimeoutKeepAlive | default(120) }}"
-# unconditionally into every model-server container, for both roles. Added in
-# llm-d-benchmark 28cfc06 (#1675).
+# Prefill only: the decode connection sees traffic on nearly every request and
+# rarely idles that long, while the prefill connection idles whenever nothing
+# disaggregates. Extending it to decode would be reasonable.
 #
-# WHY THIS FRAGMENT STILL EXISTS GIVEN THAT MACRO: sim2real's llm-d-benchmark pin
-# predates it. `git grep -i http_timeout_keep_alive` over the pinned tree returns
-# nothing, so on the version that actually renders these pods nothing sets the
-# variable and vLLM's 5s default applies. This fragment is load-bearing today.
-#
-# WHEN TO DELETE IT: once the llm-d-benchmark pin advances past 28cfc06. Tracked
-# with the exact removal conditions as inference-sim/sim2real#838. At that point
-# the macro supplies 120 on both roles and this fragment becomes redundant, and the
-# first-class way to express a NON-default value becomes the per-role key
-# `prefill.vllm.httpTimeoutKeepAlive` rather than an extraEnvVars entry. Setting it
-# via extraEnvVars once the macro exists appends a second env entry for the same
-# name in the rendered container (last one wins) -- harmless but a smell. Do NOT
-# switch to the first-class key before the pin moves: at the pinned version nothing
-# reads it, so the change would silently drop prefill back to 5s.
-#
-# PREFILL ONLY, and why: the decode leg is localhost inside the sidecar's own pod
-# and sees traffic on nearly every request, so its connections rarely idle past 5s,
-# while the prefill connection idles whenever no request disaggregates. Widening
-# this to decode would be defensible and closer to what the macro does.
-#
-# Inert until KV transfer is enabled in baselines/<name>.yaml, and live the moment
-# it is. `extraEnvVars` is a list of dicts carrying `name`, so pipeline/lib/values.py
-# `_merge_lists` merges it by that key (Tier 2b) rather than replacing it -- unlike
-# a scalar list, this key CAN be set from the defaults layer.
+# Inert until KV transfer is enabled in baselines/<name>.yaml, and live as soon as
+# it is. Delete this fragment once the llm-d-benchmark pin sets the variable
+# itself; from then on the per-role `prefill.vllm.httpTimeoutKeepAlive` key is the
+# way to express a non-default value.
 #
 # scenario[0].name is realigned to the experiment baseline at merge time.
 scenario:

--- a/.claude/skills/sim2real-bootstrap/templates/defaults/vllm-logging.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/vllm-logging.yaml
@@ -1,49 +1,19 @@
-# Restore vLLM's own default for the uvicorn access log, which llm-d-benchmark
-# inverts.
+# Turns the uvicorn access log back on, giving one line per HTTP request in the
+# model-server log.
 #
-# WHAT THE LOG IS. uvicorn is the ASGI server under vLLM's OpenAI-compatible API
-# server; its access log emits one line per HTTP request:
-#   INFO: 10.x.x.x:54321 - "POST /v1/completions HTTP/1.1" 400 Bad Request
-# Without it the engine log still shows an exception but not which requests were
-# rejected, on which pod, or at what rate.
+# vLLM enables that log by default and llm-d-benchmark disables it on both roles.
+# Without it the engine log shows that something was rejected but not which
+# requests, on which pod, or how often -- which is most of what you want when
+# requests start failing.
 #
-# THE TWO DEFAULTS, AND THE INVERSION:
-#   vLLM             `disable_uvicorn_access_log: bool = False` on FrontendArgs
-#                    ("Disable uvicorn access log.")             -> log ON
-#   llm-d-benchmark  `vllmCommon.flags.disableUvicornAccessLog: true`
-#                    (config/templates/values/defaults.yaml:789), gated at
-#                    _macros.j2:100 / :364 and emitting
-#                    --disable-uvicorn-access-log at :154 / :397 for BOTH roles
-#                                                                -> log OFF
-# Line refs are against the pinned llm-d-benchmark (see the `llm-d-benchmark`
-# submodule SHA). This fragment puts vLLM back on its own default.
+# Use this typed `vllmCommon.flags` key, not an `additionalFlags` entry.
+# `additionalFlags` is a scalar list and later layers replace it wholesale, so a
+# flag set from this layer never reaches the command line. The typed key is read
+# per-role and covers decode and prefill together.
 #
-# USE THE TYPED KEY, NOT additionalFlags. A previous version of this fragment set
-#     decode: {vllm: {additionalFlags: ["--no-disable-uvicorn-access-log"],
-#                     loggingLevel: INFO}}
-# and both keys were inert:
-#   - `additionalFlags` was decode-only, while the framework's suppression covers
-#     BOTH roles -- so prefill served its requests with no access log at all. The
-#     typed key applies to both roles from one place, which is why it is preferred
-#     here. (Historical note: this entry used to be discarded outright, because
-#     `additionalFlags` is a list of scalars and `_merge_lists` Tier 1 had each
-#     later layer REPLACE the whole list. Issue #851 fixed that -- Tier 0 now
-#     merges `**.vllm.additionalFlags` by flag name, so a flag set in one layer
-#     survives a layer that does not restate it. The per-role limitation above is
-#     the reason that still stands.)
-#   - `loggingLevel: INFO` is already the framework default twice over
-#     (defaults.yaml:51 `logging_level: &logging_level INFO`, plus a
-#     `default('INFO')` fallback at _macros.j2:230).
-# The typed `vllmCommon.flags` key below is read per-role by the macro and so
-# fixes both roles from one place.
-#
-# WHY THIS IS A FRAGMENT AND NOT PART OF baselines/<name>.yaml. It is a
-# framework-default override for diagnosability, not part of the measured
-# mechanism, so nothing in config.md declares it. Keeping it here means
-# `transfer.yaml: defaults.disable` can switch it off -- which matters, because
-# per-request logging is not free at high QPS: this is exactly the kind of
-# diagnostic you want during bring-up and may want off for a measurement run.
-# A key in baselines/<name>.yaml has no such switch.
+# Per-request logging is not free at high QPS, so this is a bring-up diagnostic you
+# may want off for a measurement run -- add `vllm-logging` to transfer.yaml's
+# `defaults.disable`.
 #
 # scenario[0].name is realigned to the experiment baseline at merge time.
 scenario:

--- a/.claude/skills/sim2real-bootstrap/templates/defaults/vllm-logging.yaml
+++ b/.claude/skills/sim2real-bootstrap/templates/defaults/vllm-logging.yaml
@@ -6,10 +6,9 @@
 # requests, on which pod, or how often -- which is most of what you want when
 # requests start failing.
 #
-# Use this typed `vllmCommon.flags` key, not an `additionalFlags` entry.
-# `additionalFlags` is a scalar list and later layers replace it wholesale, so a
-# flag set from this layer never reaches the command line. The typed key is read
-# per-role and covers decode and prefill together.
+# Set it through this typed `vllmCommon.flags` key rather than an
+# `additionalFlags` entry: the typed key is read per-role, so it covers decode and
+# prefill together.
 #
 # Per-request logging is not free at high QPS, so this is a bring-up diagnostic you
 # may want off for a measurement run -- add `vllm-logging` to transfer.yaml's


### PR DESCRIPTION
Rewrites the headers of all twelve `templates/defaults/*.yaml` fragments and updates two of them functionally. Net -175 lines.

## Headers

The headers had grown into justification essays — provenance, upstream counts, merge-semantics asides — which made the description of what each fragment *does* hard to find, and meant almost any change to a fragment broke its own documentation. Each header now leads with the function, then states why it ships disabled if it does.

## Functional changes

**`nic-exclusion.yaml`**
- `mlxl5_7` -> `mlx5_7`. Same fix as #868, which landed on main while this branch was open; see the merge note below.
- Drops `UCX_MAX_RMA_RAILS: "1"`. UCX's default for `MAX_RMA_RAILS` is already `1` (`ucp_context.c`), so the entry restated the default and read as tuning that did something. Multi-rail striping of NIXL KV transfer needs a value above 1 *and* more than one HCA in the pod.

**`rdma-device-reservation.yaml`** — previously reserved an `rdma/roce_gdr` device that the pod could not use, because nothing placed an RDMA device in the pod's network namespace. It now sets the four things that have to be true together: a Multus/SR-IOV pod annotation (so the pod gets a VF and a usable GID), the scheduler reservation, `ucxTls` with `rc` and without `tcp`, and `UCX_LOG_LEVEL`/`UCX_PROTO_INFO` so the chosen transport can be read rather than assumed. Verified on a live OpenShift cluster: KV transfer moves over RoCE instead of falling back to TCP on the pod network. Still ships disabled.

**`vllm-logging.yaml`** — removes the claim that `additionalFlags` is replaced wholesale by later layers. Since #851 those lists merge by flag name.

## Notes for review

- The pod annotation and `networkResource: "rdma/roce_gdr"` name one specific cluster, and the header says so. `networkResource` was `"auto"` before, which resolved per cluster and blanked out when no RDMA was found; the pinned value does not degrade that way, so on a cluster without that resource pool the pod will stay Pending. Worth deciding whether the template should keep `"auto"` and leave only the annotation as the thing to edit.
- `SKILL.md`'s rationale table still says `rdma-device-reservation` "does not work on the cluster it was written for". That is now out of date, and no test covers the table text.
- The merge commit resolves `nic-exclusion.yaml` to this branch's header. #868's functional fix is present in both `value:` lines; only its comment wording is superseded, including its note that upstream's guides still carry the typo so a template resync would reintroduce it.

No corresponding issue.

Tests: `2719 passed`, coverage 97.74%, `ruff --select F` clean.