### PR TITLE
fix(health): stop triaging unschedulable pods as pod-health failures

### DIFF
--- a/pipeline/lib/health.py
+++ b/pipeline/lib/health.py
@@ -180,28 +180,28 @@ def triage_pod(
             ),
         )
 
-    # Tier 2: Scheduling failure
-    if pod.phase == "Pending":
-        sched = next((e for e in pod_events if e.reason == "FailedScheduling"), None)
-        if sched:
-            msg_lower = sched.message.lower()
-            if "quota" in msg_lower or "exceeded" in msg_lower:
-                return TriageResult(
-                    tier=2, action="suggest", needs_logs=False,
-                    message=f"{pod.name}: Pending (resource quota exceeded)",
-                    suggestion=f"Resource quota exhausted: {sched.message}",
-                )
-            if "insufficient" in msg_lower or "nodes available" in msg_lower:
-                return TriageResult(
-                    tier=2, action="suggest", needs_logs=False,
-                    message=f"{pod.name}: Pending (no nodes match GPU affinity)",
-                    suggestion=(
-                        f"No schedulable nodes: {sched.message}\n"
-                        "Check nodeAffinity in scenario bundle → "
-                        "model.helmValues.decode.extraConfig.affinity"
-                    ),
-                )
-            # unrecognized scheduling message — falls through to None
+    # NO SCHEDULING BRANCH HERE, DELIBERATELY -- see issue #873.
+    #
+    # A pod that is merely Pending/Unschedulable is NOT a pod-health failure.
+    # The kube-scheduler keeps it queued and retries it, so it recovers on its
+    # own the moment capacity appears; nothing about the deployment is wrong.
+    # Classifying it here made it a tier-2 finding, and every tier-2 finding
+    # escalates to a PipelineRun cancellation (deploy.py:895) with no grace
+    # period -- which pre-empted the deliberate --pending-threshold wait in
+    # _handle_pending_pods (deploy.py:713) that runs earlier in the same
+    # orchestrator cycle, making that threshold unreachable.
+    #
+    # Unschedulable pods are owned solely by pipeline/lib/pod_pending.py, which
+    # is purpose-built for the condition: it distinguishes scarcity (Insufficient
+    # -> wait up to the threshold) from misconfiguration (node affinity, missing
+    # PVC, untolerated taint -> reclaim now). It also keys off the PodScheduled=
+    # False/Unschedulable pod CONDITION rather than a FailedScheduling EVENT, so
+    # it still sees a pod whose scheduling event has aged out of the event TTL.
+    #
+    # Do not reinstate a branch here, and do not add a count budget in the shape
+    # of _OOM_MAX_ATTEMPTS / _STARTUP_PROBE_MIN_EVENT_COUNT: a count encodes
+    # "eventually fatal, tolerate N", which is true of OOM but false of a full
+    # cluster. The correct budget is a DURATION, and pod_pending already has one.
 
     # Tier 2: Startup probe timeout
     if pod.phase == "Running" and not pod.ready:

--- a/pipeline/tests/test_health.py
+++ b/pipeline/tests/test_health.py
@@ -217,24 +217,84 @@ def test_triage_image_pull_backoff():
     assert "run_metadata.json" in result.suggestion
 
 
-def test_triage_failed_scheduling_gpu():
+def test_triage_ignores_unschedulable_pod_scarcity():
+    """Unschedulable-for-scarcity is NOT a pod-health finding (issue #873).
+
+    triage_pod used to return tier 2 here, and every tier-2 finding escalates to
+    a PipelineRun cancellation with no grace period, which pre-empted the
+    --pending-threshold wait in deploy.py's _handle_pending_pods. Ownership of
+    Pending/Unschedulable now sits solely with pipeline/lib/pod_pending.py.
+    """
     from pipeline.lib.health import triage_pod, RemediationTracker
     pod = _make_pod(phase="Pending")
     events = [_make_event(reason="FailedScheduling",
                           message="0/5 nodes available: 5 Insufficient nvidia.com/gpu")]
     result = triage_pod(pod, events, RemediationTracker())
-    assert result.tier == 2
-    assert "affinity" in result.suggestion.lower() or "nvidia" in result.suggestion.lower()
+    assert result is None
 
 
-def test_triage_quota_exceeded():
+def test_triage_ignores_unschedulable_pod_quota():
+    """Quota-exceeded scheduling messages are also no longer triaged here.
+
+    Behaviour change recorded deliberately (issue #873): pod_pending's
+    classify_pending_reason does not recognise quota messages and falls through
+    to "recoverable", so such a pod now waits --pending-threshold before the
+    slot is reclaimed instead of being cancelled on the first health check.
+    Note that standard ResourceQuota exhaustion is rejected at admission, so no
+    Pending pod exists for either classifier to inspect in that case.
+    """
     from pipeline.lib.health import triage_pod, RemediationTracker
     pod = _make_pod(phase="Pending")
     events = [_make_event(reason="FailedScheduling",
                           message="exceeded quota: requests.nvidia.com/gpu=4")]
     result = triage_pod(pod, events, RemediationTracker())
+    assert result is None
+
+
+def test_triage_still_reports_non_scheduling_pending_failures():
+    """Removing the scheduling branch must not blind triage to other Pending pods.
+
+    A Pending pod with an image-pull failure is matched by the reason-based
+    branch earlier in triage_pod, so it is unaffected by issue #873.
+    """
+    from pipeline.lib.health import triage_pod, RemediationTracker
+    pod = _make_pod(phase="Pending", reason="ImagePullBackOff")
+    result = triage_pod(pod, [], RemediationTracker())
+    assert result is not None
     assert result.tier == 2
-    assert "quota" in result.suggestion.lower()
+
+
+def test_check_pod_health_does_not_escalate_unschedulable(monkeypatch):
+    """The interaction this issue exists for: no cancellation for scarcity.
+
+    This is the coverage gap that let #873 through -- test_health.py asserted
+    triage_pod's output and test_deploy_run.py asserted _handle_pending_pods'
+    timer, but nothing asserted that an unschedulable pod does not trigger the
+    escalation that cancels the PipelineRun. _check_pod_health returning False
+    is what keeps the run alive long enough for pod_pending's threshold (whose
+    wait/reclaim behaviour is covered by test_deploy_run.py's
+    _handle_pending_pods tests) to govern the outcome.
+    """
+    import pipeline.deploy as deploy
+    from pipeline.lib import health as health_mod
+
+    pod = _make_pod(phase="Pending")
+    events = [_make_event(reason="FailedScheduling",
+                          message="0/20 nodes are available: 14 Insufficient nvidia.com/gpu")]
+
+    monkeypatch.setattr(health_mod, "get_all_pods", lambda ns: [pod])
+    monkeypatch.setattr(health_mod, "get_events", lambda ns: events)
+
+    def _fail_delete(ns, name):  # must not be reached
+        raise AssertionError(f"delete_pod called for {name}; scarcity is not remediable here")
+
+    monkeypatch.setattr(health_mod, "delete_pod", _fail_delete)
+
+    escalate = deploy._check_pod_health(
+        namespace="kalantar-0", pair_key="wl-x|baseline|i1",
+        tracker=health_mod.RemediationTracker(), skip_teardown=False,
+    )
+    assert escalate is False
 
 
 def test_triage_crash_loop_tier3():


### PR DESCRIPTION
Closes #873. Base: `main`.

## What changed

Removed the `# Tier 2: Scheduling failure` branch from `triage_pod`
(`pipeline/lib/health.py`), so a pod that is merely `Pending`/`Unschedulable` is
no longer a pod-health finding. Ownership of that condition sits solely with
`pipeline/lib/pod_pending.py` + `_handle_pending_pods`, which already implement
the intended behaviour.

Two files, +87/-27. No production code outside `triage_pod` is touched.

## Why the threshold was unreachable

Both subsystems run in the same orchestrator cycle:

```
deploy.py:2889   _handle_pending_pods(..., pending_threshold=600, ...)
                 if reclaimed: ... continue      # only short-circuits on RECLAIM
deploy.py:2909   _handle_timeout(...)
deploy.py:2926   _check_pod_health(...)          # escalates tier-2 immediately
```

While System 1 is *waiting* it returns `False`, which is indistinguishable from
"nothing wrong", so control falls through to `_check_pod_health`, which cancels
on the first check (`deploy.py:895`). `pending_since` was written to an entry
whose PipelineRun had already been deleted, so `elapsed` never grew toward 600 s.

Observed in practice: four consecutive cells cancelled 2-3 minutes after
dispatch during cluster-wide GPU contention (77 of 96 GPUs held by other
tenants, no node with a free 4-GPU block for a TP=4 pod), each with a decode pod
`Pending` on `0/20 nodes are available: 14 Insufficient nvidia.com/gpu`.

## Reviewer attention

**1. This is a reclassification, not a tolerance change — and it deliberately
departs from #387's fix.** #387 was the same bug class in the same function and
was closed by adding `_STARTUP_PROBE_MIN_EVENT_COUNT = 10`, alongside the
existing `_OOM_MAX_ATTEMPTS = 2`. The scheduling branch was the only tier-2
branch without such a budget, so the "consistent" change would have been a third
constant. It isn't, because a count encodes *"eventually fatal, tolerate N"* —
true of a repeatedly-OOMing pod, false of a full cluster. An unschedulable pod
has no natural count (one persistent condition, not N events) and no fatality;
the correct budget is a **duration**, and `pod_pending` already has a
configurable one with a scarcity-vs-misconfiguration distinction a count cannot
express. Adding a budget here would have created a second timer for one
condition in the subsystem that classifies it less precisely. Full argument in
the issue.

**2. `pipeline/README.md:598` already documented the behaviour this restores:**

> Recoverable reasons (e.g. `Insufficient nvidia.com/gpu`) trigger early reclaim
> after `--pending-threshold` seconds. Non-recoverable reasons (e.g. node
> affinity mismatch, PVC not found) fail the pair immediately.

So the documented contract was correct and the code had diverged from it. No
README change was needed — the fix makes it true. Worth verifying you agree with
that reading.

**3. Behaviour change on quota, stated rather than hidden.** The removed branch
also matched `quota`/`exceeded`. `pod_pending`'s `classify_pending_reason` does
not recognise quota messages and falls through to `recoverable` (verified), so
such a pod now waits `--pending-threshold` before reclamation instead of being
cancelled on the first check. I believe this is near-unreachable in practice:
standard `ResourceQuota` exhaustion is rejected at **admission**, so no pod is
created and there is no Pending pod with `PodScheduled=False` for either
classifier to inspect — the event is `FailedCreate` on the ReplicaSet, and both
`triage_pod` and `parse_pod_conditions` require an existing Pending pod. If you
know of a scheduler-level path that does produce such a `FailedScheduling`
message, this is the assumption to challenge.

**4. Incidental robustness improvement.** `pod_pending` keys off the
`PodScheduled=False, reason=Unschedulable` pod **condition**; the removed branch
keyed off a `FailedScheduling` **event**. Conditions persist, events expire
(~1 h TTL), so a long-unschedulable pod whose event has aged out is now still
detected where previously it was not.

## Tests

- `test_triage_ignores_unschedulable_pod_scarcity` / `..._quota` — the two tests
  that asserted the removed branch, **inverted rather than deleted**, so the
  quota behaviour change stays visible in the suite with its rationale.
- `test_triage_still_reports_non_scheduling_pending_failures` — guards against
  the removal blinding triage to other Pending pods (image-pull is matched
  earlier by the reason-based branch).
- `test_check_pod_health_does_not_escalate_unschedulable` — **the coverage gap
  that let this through.** `test_health.py` asserted `triage_pod`'s output and
  `test_deploy_run.py` asserted `_handle_pending_pods`' timer, but nothing
  asserted the interaction: that an unschedulable pod does not trigger the
  escalation that cancels the run. The wait/reclaim half remains covered by the
  existing `_handle_pending_pods` tests in `test_deploy_run.py`, cited rather
  than duplicated.

`python -m pytest pipeline/` → **2057 passed, 2 xfailed**, no failures.
`ruff check pipeline/ --select F` → clean.

## Stale-reference sweep

Grepped `**/*.md`, `docs/`, `.claude/skills/`, `README*` for `FailedScheduling`,
`unschedulable`, the removed suggestion strings, `pending-threshold`, and
`pod health`. Hits: `pipeline/README.md:598` (becomes accurate, see above);
`CLAUDE.md:108` and `pipeline/README.md:881` (generic one-line descriptions of
`health.py`'s role — still accurate); `capacity.py` cordon/taint text and
`sim2real-bootstrap` SKILL.md (unrelated uses of "unschedulable"); two
historical plan docs under `docs/superpowers/` (left as history). Nothing
required updating.

## Not addressed here

By the same reasoning, a startup probe failing while a large model loads from a
cold PVC is arguably also not a fatal pod-health condition, so
`_STARTUP_PROBE_MIN_EVENT_COUNT = 10` may be a threshold papering over the same
misclassification. Explicitly out of scope; noted in the issue so the precedent
is understood as prior art with a known limitation.
